### PR TITLE
make hdfs cdh3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *~
+client.cfg


### PR DESCRIPTION
These are the only changes necessary to make the tests pass on CDH3. The `-rmr` command change introduces a new deprecation warning to stderr, so I'm not sure if you'll want to merge that in.
