### PR TITLE
Support setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 *~
 client.cfg
+build
+dist
+luigi.egg-info

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from distutils.core import setup
+try:
+  from setuptools import setup
+except:
+  from distutils.core import setup
 
 long_description = []
 for line in open('README.md'):


### PR DESCRIPTION
Fall back to distutil if setuptools isn't around. Useful for
bundling as an egg with bdist_egg, for example.
