### PR TITLE
Add variants of config.get for int/bool/float.

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -67,13 +67,32 @@ class LuigiConfigParser(RawConfigParser):
     def reload(self):
         return self._instance.read(self._config_paths)
 
-    def get(self, section, option, default=NO_DEFAULT):
+    def _get_with_default(self, method, section, option, default, expected_type=None):
+        """ Gets the value of the section/option using method. Returns default if value
+        is not found. Raises an exception if the default value is not None and doesn't match
+        the expected_type.
+        """
         try:
-            return RawConfigParser.get(self, section, option)
+            return method(self, section, option)
         except (NoOptionError, NoSectionError):
             if default is LuigiConfigParser.NO_DEFAULT:
                 raise
+            if expected_type is not None and default is not None and \
+               not isinstance(default, expected_type):
+                raise
             return default
+
+    def get(self, section, option, default=NO_DEFAULT):
+        return self._get_with_default(RawConfigParser.get, section, option, default)
+
+    def getboolean(self, section, option, default=NO_DEFAULT):
+        return self._get_with_default(RawConfigParser.getboolean, section, option, default, bool)
+
+    def getint(self, section, option, default=NO_DEFAULT):
+        return self._get_with_default(RawConfigParser.getint, section, option, default, int)
+
+    def getfloat(self, section, option, default=NO_DEFAULT):
+        return self._get_with_default(RawConfigParser.getfloat, section, option, default, float)
 
 
 def get_config():


### PR DESCRIPTION
I was having issues with get and converting to a bool, so I thought
it might be a good idea to bubble up this functionality from from
RawCOnfigParser.
