### PR TITLE
add scheduler_port param

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -91,6 +91,8 @@ class EnvironmentParamsContainer(task.Task):
                                                  description='Use local scheduling')
     scheduler_host = parameter.Parameter(is_global=True, default=get_config().get('core', 'default-scheduler-host', default='localhost'),
                                          description='Hostname of machine running remote scheduler')
+    scheduler_port = parameter.IntParameter(is_global=True, default=8082,
+                                            description='Port of remote scheduler api process')
     lock = parameter.BooleanParameter(is_global=True, default=False,
                                       description='Do not run if the task is already running')
     lock_pid_dir = parameter.Parameter(is_global=True, default='/var/tmp/luigi',
@@ -136,7 +138,7 @@ class Interface(object):
         if env_params.local_scheduler:
             sch = scheduler.CentralPlannerScheduler()
         else:
-            sch = rpc.RemoteScheduler(host=env_params.scheduler_host)
+            sch = rpc.RemoteScheduler(host=env_params.scheduler_host, port=env_params.scheduler_port)
 
         w = worker.Worker(scheduler=sch, worker_processes=env_params.workers)
         for task in tasks:


### PR DESCRIPTION
This commit adds a `scheduler_port` parameter to the `EnvironmentParamsContainer` class, allowing tasks to communicate with a scheduler api process listening on aport other than 8082. This was already allowed in `rpc.RemoteScheduler`, I'm just making it possible to access that functionality through `Interface.run`. 

I haven't tested this super extensively, just by passing it as a kwarg to `interface.build`. Presumably it would work as a command line param as well.

Please let me know if there's anything else you'd like me to add, such as perhaps mimicking the `scheduler_host` param to read a config file. Thanks!
