### PR TITLE
Give better message in case of missing param.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -73,7 +73,8 @@ class Parameter(object):
             elif self.is_list:
                 return []
             else:
-                raise MissingParameterException("No value for '%s' submitted and no default value has been assigned." % param_name)
+                raise MissingParameterException("No value for '%s' (%s) submitted and no default value has been assigned." % \
+                    (param_name, "--" + param_name.replace('_', '-')))
         elif self.is_list:
             return tuple(self.parse(p) for p in x)
         else:


### PR DESCRIPTION
We've had a number of user trip up because you have to specify
e.g. --foo-bar rather than --foo_bar. So I think this'll help
avoid the common confusion.

Example error message looks like:

luigi.parameter.MissingParameterException: No value for
'date_interval' (--date-interval) submitted and no default value
has been assigned.
