### PR TITLE
introduce ABCMeta for Target and Task.

### DIFF
--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import abc
 import logging
 import luigi
 import luigi.interface
@@ -74,6 +75,7 @@ class HiveQueryTask(BaseHadoopJobTask):
     ''' Task to run a hive query
     '''
 
+    @abc.abstractmethod
     def query(self):
         ''' Text of query to run in hive
         '''
@@ -126,6 +128,9 @@ class HiveTableTarget(luigi.Target):
             raise Exception("Couldn't find location for table: {0}".format(str(self)))
         return location
 
+    def open(self, mode):
+        return NotImplementedError("open() is not supported for HiveTableTarget")
+
 
 class HivePartitionTarget(luigi.Target):
     ''' exists returns true if the table's partition exists
@@ -154,6 +159,9 @@ class HivePartitionTarget(luigi.Target):
             raise Exception("Couldn't find location for table: {0}".format(str(self)))
         return location
 
+    def open(self, mode):
+        return NotImplementedError("open() is not supported for HivePartitionTarget")
+
 
 class ExternalHiveTask(luigi.ExternalTask):
     ''' External task that depends on a Hive table/partition.
@@ -168,7 +176,7 @@ class ExternalHiveTask(luigi.ExternalTask):
         if self.partition is not None:
             assert self.partition, "partition required"
             return HivePartitionTarget(database=self.database,
-                table=self.table,
-                partition=self.partition)
+                                       table=self.table,
+                                       partition=self.partition)
         else:
             return HiveTableTarget(self.database, self.table)

--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-
+import abc
 import datetime
 import logging
 import tempfile
@@ -175,6 +175,9 @@ class PostgresTarget(luigi.Target):
                 raise
         connection.close()
 
+    def open(self, mode):
+        raise NotImplementedError("Cannot open() PostgresTarget")
+
 
 class CopyToTable(luigi.Task):
     """
@@ -189,11 +192,25 @@ class CopyToTable(luigi.Task):
 
     """
 
-    host = None
-    database = None
-    user = None
-    password = None
-    table = None
+    @abc.abstractproperty
+    def host(self):
+        return None
+
+    @abc.abstractproperty
+    def database(self):
+        return None
+
+    @abc.abstractproperty
+    def user(self):
+        return None
+
+    @abc.abstractproperty
+    def password(self):
+        return None
+
+    @abc.abstractproperty
+    def table(self):
+        return None
 
     # specify the columns that are to be inserted (same as are returned by columns)
     # overload this in subclasses with the either column names of columns to import:
@@ -262,8 +279,7 @@ class CopyToTable(luigi.Task):
             password=self.password,
             table=self.table,
             update_id=self.update_id()
-         )
-
+        )
 
     def copy(self, cursor, file):
         if isinstance(self.columns[0], basestring):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -12,10 +12,16 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-class Target(object):  # interface
+import abc
 
+
+class Target(object):  # interface
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
     def exists(self):
         raise NotImplementedError
 
+    @abc.abstractmethod
     def open(self, mode):
         raise NotImplementedError

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import abc
 import parameter
 import warnings
 import traceback
@@ -26,7 +27,7 @@ def namespace(namespace=None):
     Register._default_namespace = namespace
 
 
-class Register(type):
+class Register(abc.ABCMeta):
     # 1. Cache instances of objects so that eg. X(1, 2, 3) always returns the same object
     # 2. Keep track of all subclasses of Task and expose them
     __instance_cache = {}
@@ -39,11 +40,10 @@ class Register(type):
 
         Set the task namespace to whatever the currently declared namespace is
         """
-
         if "task_namespace" not in classdict:
             classdict["task_namespace"] = metacls._default_namespace
 
-        cls = type.__new__(metacls, classname, bases, classdict)
+        cls = super(Register, metacls).__new__(metacls, classname, bases, classdict)
         if cls.run != NotImplemented:
             metacls._reg.append(cls)
         return cls

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -1,0 +1,31 @@
+import unittest
+
+import luigi.target
+
+
+class TargetTest(unittest.TestCase):
+    def test_cannot_instantiate(self):
+        def instantiate_target():
+            luigi.target.Target()
+
+        self.assertRaises(TypeError, instantiate_target)
+
+    def test_abstract_subclass(self):
+        class ExistsTarget(luigi.target.Target):
+            def exists(self):
+                return True
+
+        def instantiate_target():
+            ExistsTarget()
+
+        self.assertRaises(TypeError, instantiate_target)
+
+    def test_instantiate_subclass(self):
+        class GoodTarget(luigi.target.Target):
+            def exists(self):
+                return True
+
+            def open(self, mode):
+                return None
+
+        GoodTarget()


### PR DESCRIPTION
Task's metaclass inherits ABCMeta and Target uses ABCMeta as its
metaclass. This lets you define abstract targets and tasks that
can't be instantiated directly.

I have a few simple tests to demonstrate the expected usage and
to make sure that things still work ok.

Open question: Does it make sense for Target.open() to exist? It
only seems to be applicable to HDFS and File Targets (maybe an
OpenableTarget interface?). Or should we leave it without the
@abstractmethod annotation.

There was a discussion about this in https://github.com/spotify/luigi/issues/18 Hoping for feedback on some of the issues discussed above.
