### PR TITLE
Fixed issue with printing the exception

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -680,9 +680,6 @@ class JobTask(BaseHadoopJobTask):
         outputs = self._reduce_input(self.internal_reader((line[:-1] for line in stdin)), self.combiner, self.final_combiner)
         self.internal_writer(outputs, stdout)
 
-    def _print_exception(self, exc):
-        print >> sys.stderr, 'luigi-exc-hex=%s' % exc.encode('hex')
-
     def internal_reader(self, input_stream):
         """Reader which uses python eval on each part of a tab separated string.
         Yields a tuple of python objects."""


### PR DESCRIPTION
We didn't catch it if some issue happened in the constructor of Runner (like if you forgot to import some module)

Also added a bunch of unit tests to run mrrunner.py and verify it works.
