### PR TITLE
Sketch for how to make things unit testable (work in progress, just rfc)

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -55,6 +55,10 @@ class File(Target):
         self.format = format
         self.is_tmp = is_tmp
 
+    def mock(self):
+        import mock
+        return mock.MockFile(self.path)
+
     def exists(self):
         return os.path.exists(self.path)
 

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -264,6 +264,10 @@ class HdfsTarget(luigi.Target):
         if self.is_tmp and self.exists():
             self.remove()
 
+    def mock(self):
+        import mock
+        return mock.MockFile(self.path)
+
     @property
     def fn(self):
         """ Deprecated. Use path property instead """

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -25,6 +25,9 @@ class MockFile(target.Target):
         self._mirror_on_stderr = mirror_on_stderr
         self._fn = fn
 
+    def mock(self):
+        raise Exception('can not mock a MockFile!')
+
     def exists(self,):
         return self._fn in MockFile._file_contents
 

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -25,3 +25,8 @@ class Target(object):  # interface
     @abc.abstractmethod
     def open(self, mode):
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def mock(self):
+        raise NotImplementedError
+

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -43,7 +43,7 @@ class Worker(object):
     - Asks for stuff to do (pulls it in a loop and runs it)
     """
 
-    def __init__(self, scheduler=CentralPlannerScheduler(), worker_id=None, worker_processes=1):
+    def __init__(self, scheduler=CentralPlannerScheduler(), worker_id=None, worker_processes=1, mock=False):
         if not worker_id:
             worker_id = 'worker-%09d' % random.randrange(0, 999999999)
 
@@ -57,6 +57,8 @@ class Worker(object):
         self.__scheduled_tasks = {}
 
         self._previous_tasks = []  # store the previous tasks executed by the same worker for debugging reasons
+
+        self.__mock = mock
 
         class KeepAliveThread(threading.Thread):
             """ Periodically tell the scheduler that the worker still lives """
@@ -82,6 +84,9 @@ class Worker(object):
             raise TaskException('Task of class %s not initialized. Did you override __init__ and forget to call super(...).__init__?' % task.__class__.__name__)
 
         try:
+            if self.__mock:
+                task.mockify()
+
             task_id = task.task_id
 
             if task_id in self.__scheduled_tasks:

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -13,6 +13,7 @@
 # the License.
 
 from luigi.mock import MockFile
+import luigi, luigi.hdfs, luigi.hadoop
 import unittest
 
 
@@ -26,3 +27,66 @@ class MockFileTest(unittest.TestCase):
         q = t.open('r')
         self.assertEqual(list(q), ['test\n'])
         q.close()
+
+
+class X(luigi.Task):
+    x = luigi.Parameter()
+    def output(self):
+        return luigi.hdfs.HdfsTarget('blah/%s' % self.x)
+
+    def run(self):
+        f = self.output().open('w')
+        for i in xrange(1000):
+            print >>f, i % 73
+        f.close()
+
+
+class Mapred(luigi.hadoop.JobTask):
+    x = luigi.Parameter()
+    def requires(self):
+        return X(self.x)
+
+    def mapper(self, line):
+        yield line.strip(), 1
+
+    def reducer(self, key, values):
+        yield key, sum(values)
+
+    def output(self):
+        return luigi.hdfs.HdfsTarget('mapred/%s' % self.x)
+
+
+class External(luigi.ExternalTask):
+    def output(self):
+        return luigi.hdfs.HdfsTarget('e')
+
+
+class Recursive(luigi.Task):
+    x = luigi.IntParameter()
+    def requires(self):
+        if self.x > 1:
+            yield Recursive(self.x - 1)
+        else:
+            yield External()
+
+    def output(self):
+        return luigi.hdfs.HdfsTarget('y/%d' % self.x)
+
+    def run(self):
+        self.output().open('w').close()
+
+class MockChainTest(unittest.TestCase):
+    def test_mapred(self):
+        m = Mapred(42)
+        luigi.build([m], mock=True, local_scheduler=True)
+        self.assertTrue(m.complete())
+
+    def test_recursive(self):
+        r = Recursive(100)
+        luigi.build([r], mock=True, local_scheduler=True)
+        self.assertFalse(r.complete()) # because Recursive(0) can't be built
+
+        MockFile('e').open('w').close()
+        luigi.build([r], mock=True, local_scheduler=True)
+        self.assertTrue(r.complete())
+        

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -28,4 +28,7 @@ class TargetTest(unittest.TestCase):
             def open(self, mode):
                 return None
 
+            def mock(self):
+                return None
+
         GoodTarget()


### PR DESCRIPTION
By passing mock=True to luigi.build, it will swap out all Targets to mocked targets. This means it will run mapreduce jobs locally, etc.

Had to fix an unrelated issue in interface.py to get the unit tests to run. Up until now, the environment parameters were mutable, meaning they would not be reset between invocations.
