### PR TITLE
Made hadoop_jar fix_paths able to handle trailing slashes

### DIFF
--- a/luigi/hadoop_jar.py
+++ b/luigi/hadoop_jar.py
@@ -21,7 +21,8 @@ def fix_paths(job):
             if x.exists() or not job.atomic_output():  # input
                 args.append(x.path)
             else:  # output
-                y = luigi.hdfs.HdfsTarget(x.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10))
+                x_path_no_slash = x.path[:-1] if x.path[-1] == '/' else x.path
+                y = luigi.hdfs.HdfsTarget(x_path_no_slash + '-luigi-tmp-%09d' % random.randrange(0, 1e10))
                 tmp_files.append((y, x))
                 logger.info("Using temp path: {0} for path {1}".format(y.path, x.path))
                 args.append(y.path)


### PR DESCRIPTION
I began using luigi and got caught out by the fact that fix_paths in hadoop_jar.py assumes that directories given for a hadoop job as arguments do not contain trailing slashes. If you give a trailing slash then the eventual move from the "temp" directory to the real one will give an error, as you are moving from /a/b/c/luigi-tmp-19i403/ to /a/b/c/ (what we wanted was to use /a/b/c-luigi-tmp-19i403/ as a temporary directory instead).

I added a line which should sort this out, I'm assuming that other people use trailing slashes and it is not a weird thing that only I do. I may be wrong there.
