### PR TITLE
small bug in last commit

### DIFF
--- a/luigi/hadoop_jar.py
+++ b/luigi/hadoop_jar.py
@@ -23,7 +23,7 @@ def fix_paths(job):
             else:  # output
                 x_path_no_slash = x.path[:-1] if x.path[-1] == '/' else x.path
                 y = luigi.hdfs.HdfsTarget(x_path_no_slash + '-luigi-tmp-%09d' % random.randrange(0, 1e10))
-                tmp_files.append((y, x))
+                tmp_files.append((y, x_path_no_slash))
                 logger.info("Using temp path: {0} for path {1}".format(y.path, x.path))
                 args.append(y.path)
         else:


### PR DESCRIPTION
Hey. That was my first pull request - didn't realise it would happen so quickly.

Tested my previous commit and it doesn't move directories with trailing slashes properly - if you do hadoop fs -mv /a/b/c /d/e/g/ it will move c so that you end up with /d/e/f/c/. I changed what i'd written so that that never happens on atomic writes, and instead you get /d/e/c as the result.

Also confirmed that without trailing slashes it works as before.
