### PR TITLE
Added a flag to HivePartitionTarget to prevent failure if a table doesn't exist

### DIFF
--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -286,13 +286,26 @@ class HivePartitionTarget(luigi.Target):
     ''' exists returns true if the table's partition exists
     '''
 
-    def __init__(self, table, partition, database='default'):
+    def __init__(self, table, partition, database='default', fail_missing_table=True):
         self.database = database
         self.table = table
         self.partition = partition
 
+        self.fail_missing_table = fail_missing_table
+
     def exists(self):
-        return table_exists(self.table, self.database, self.partition)
+        try:
+            return table_exists(self.table, self.database, self.partition)
+        except HiveCommandError, e:
+            if self.fail_missing_table:
+                raise
+            else:
+                if table_exists(self.table, self.database)
+                    # a real error occured
+                    raise
+                else:
+                    # oh the table just doesn't exist
+                    return False
 
     @property
     def path(self):


### PR DESCRIPTION
This enables the following dependency graph:

{Generate Data} -> {Generate Schema} -> {Create Table} -> {Add Partition}

The Add Partition task has an output type of HivePartitionTarget, however the DAG doesn't execute (errors) if the table isn't created before that target is evaluated.

My change allows you to override this behavior and return 'False' instead of raising an exception.
