### PR TITLE
HiveQueryTask automatically creates parent directory of output if it doesn't exist

### DIFF
--- a/luigi/target.py
+++ b/luigi/target.py
@@ -20,8 +20,62 @@ class Target(object):  # interface
 
     @abc.abstractmethod
     def exists(self):
-        raise NotImplementedError
+        pass
+
+
+class FileSystemException(Exception):
+    """Base class for generic file system exceptions """
+    pass
+
+
+class FileExists(FileSystemException):
+    """ Raised when a file system operation can't be performed because a direcoty exists but is required to not exist
+    """
+    pass
+
+
+class FileSystem(object):
+    """ File system abstraction class """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def exists(self, path):
+        """ Return `True` if file or directory at `path` exist, False otherwise """
+        pass
+
+    @abc.abstractmethod
+    def remove(self, path, recursive=True):
+        """ Remove file or directory at location `path` """
+        pass
+
+    def mkdir(self, path):
+        """ Create directory at location `path`
+        Create parent catalogs if they don't exist
+
+        Not an abstract method, since not all File System-like storage systems support mkdir
+        """
+        raise NotImplementedError("mkdir() not implemented on {0}".format(self.__class__.__name__))
+
+    def isdir(self, path):
+        raise NotImplementedError("isdir() not implemented on {0}".format(self.__class__.__name__))
+
+
+class FileSystemTarget(Target):
+    """Common target abstract base class for file system targets like LocalTarget and HdfsTarget
+    """
+    def __init__(self, path):
+        self.path = path
+
+    @abc.abstractproperty
+    def fs(self):
+        raise
 
     @abc.abstractmethod
     def open(self, mode):
-        raise NotImplementedError
+        pass
+
+    def exists(self):
+        return self.fs.exists(self.path)
+
+    def remove(self):
+        self.fs.remove(self.path)

--- a/test/hive_test.py
+++ b/test/hive_test.py
@@ -3,6 +3,9 @@ import unittest
 
 import luigi.hive
 
+from luigi import LocalTarget
+import os
+
 
 class HiveTest(unittest.TestCase):
     count = 0
@@ -37,3 +40,13 @@ class HiveTest(unittest.TestCase):
             self.assertEquals(["-f", f.name], self.last_hive_cmd)
             self.assertEquals("statement{0}".format(pre_count+1), res)
 
+    def test_create_parent_dirs(self):
+        dirname = "/tmp/hive_task_test_dir"
+
+        class FooHiveTask(object):
+            def output(self):
+                return LocalTarget(os.path.join(dirname, "foo"))
+
+        runner = luigi.hive.HiveQueryRunner()
+        runner.prepare_outputs(FooHiveTask())
+        self.assertTrue(os.path.exists(dirname))

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -11,12 +11,11 @@ class TargetTest(unittest.TestCase):
         self.assertRaises(TypeError, instantiate_target)
 
     def test_abstract_subclass(self):
-        class ExistsTarget(luigi.target.Target):
-            def exists(self):
-                return True
+        class ExistsLessTarget(luigi.target.Target):
+            pass
 
         def instantiate_target():
-            ExistsTarget()
+            ExistsLessTarget()
 
         self.assertRaises(TypeError, instantiate_target)
 


### PR DESCRIPTION
Previously, an `INSERT OVERWRITE` would fail if the parent directory didn't exist.
As part of this, I started working on a more generic file system abstraction for the local
file system in addition to the existing one for HDFS (`HdfsClient`)
