### PR TITLE
Task history, from https://github.com/spotify/luigi/issues/51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ hadoop_test.py
 *.rej
 *.orig
 .DS_Store
+.idea/
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ python:
 install: 
   - pip install tornado --use-mirrors
   - pip install argparse --use-mirrors
+  - pip install sqlalchemy --use-mirrors
 script: nosetests

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -15,8 +15,12 @@
 import os
 import logging
 import time
+import traceback
 import cPickle as pickle
+import task_history as history
 logger = logging.getLogger("luigi-interface")
+
+from task_status import PENDING, FAILED, DONE, RUNNING
 
 
 class Scheduler(object):
@@ -27,11 +31,6 @@ class Scheduler(object):
     add_task = NotImplemented
     get_work = NotImplemented
     ping = NotImplemented
-
-PENDING = 'PENDING'
-FAILED = 'FAILED'
-DONE = 'DONE'
-RUNNING = 'RUNNING'
 
 UPSTREAM_RUNNING = 'UPSTREAM_RUNNING'
 UPSTREAM_MISSING_INPUT = 'UPSTREAM_MISSING_INPUT'
@@ -64,7 +63,7 @@ class CentralPlannerScheduler(Scheduler):
     Can be run locally or on a server (using RemoteScheduler + server.Server).
     '''
 
-    def __init__(self, retry_delay=900.0, remove_delay=600.0, worker_disconnect_delay=60.0):
+    def __init__(self, retry_delay=900.0, remove_delay=600.0, worker_disconnect_delay=60.0, task_history=None):
         '''
         (all arguments are in seconds)
         Keyword Arguments:
@@ -78,6 +77,7 @@ class CentralPlannerScheduler(Scheduler):
         self._remove_delay = remove_delay
         self._worker_disconnect_delay = worker_disconnect_delay
         self._active_workers = {}  # map from id to timestamp (last updated)
+        self._task_history = task_history or history.NopHistory()
         # TODO: have a Worker object instead, add more data to it
 
     def dump(self):
@@ -173,8 +173,9 @@ class CentralPlannerScheduler(Scheduler):
 
         if expl is not None:
             task.expl = expl
+        self._update_task_history(task_id, status)
 
-    def get_work(self, worker):
+    def get_work(self, worker, host=None):
         # TODO: remove any expired nodes
 
         # Algo: iterate over all nodes, find first node with no dependencies
@@ -212,6 +213,7 @@ class CentralPlannerScheduler(Scheduler):
             t = self._tasks[best_task]
             t.status = RUNNING
             t.worker_running = worker
+            self._update_task_history(best_task, RUNNING, host=host)
 
         return locally_pending_tasks, best_task
 
@@ -296,3 +298,16 @@ class CentralPlannerScheduler(Scheduler):
             return {"taskId": task_id, "error": self._tasks[task_id].expl}
         else:
             return {"taskId": task_id, "error": ""}
+
+    def _update_task_history(self, task_id, status, host=None):
+        try:
+            if status == DONE or status == FAILED:
+                successful = (status == DONE)
+                self._task_history.task_finished(task_id, successful)
+            elif status == PENDING:
+                self._task_history.task_scheduled(task_id)
+            elif status == RUNNING:
+                self._task_history.task_started(task_id, host)
+        except:
+            print 'Error saving Task history'
+            print traceback.format_exc()

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -27,6 +27,25 @@ def namespace(namespace=None):
     Register._default_namespace = namespace
 
 
+def id_to_name_and_params(task_id):
+    ''' Turn a task_id into a (task_family, {params}) tuple.
+        E.g. calling with 'Foo(bar=bar, baz=baz)' returns ('Foo', {'bar': 'bar', 'baz': 'baz'})
+    '''
+    lparen = task_id.index('(')
+    task_family = task_id[:lparen]
+    params = task_id[lparen + 1:-1]
+
+    def split_equals(x):
+        equals = x.index('=')
+        return x[:equals], x[equals + 1:]
+    if params:
+        param_list = map(split_equals, params.split(', '))  # TODO: param values with ', ' in them will break this
+    else:
+        param_list = []
+    return task_family, dict(param_list)
+
+
+
 class Register(abc.ABCMeta):
     # 1. Cache instances of objects so that eg. X(1, 2, 3) always returns the same object
     # 2. Keep track of all subclasses of Task and expose them
@@ -244,7 +263,7 @@ class Task(object):
         There's at least two scenarios where this is useful (see test/clone_test.py)
         - Remove a lot of boiler plate when you have recursive dependencies and lots of args
         - There's task inheritance and some logic is on the base class
-        '''            
+        '''
         k = self.param_kwargs.copy()
         k.update(kwargs.items())
 

--- a/luigi/task_history.py
+++ b/luigi/task_history.py
@@ -1,0 +1,264 @@
+# Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
+
+import abc
+import traceback
+import configuration
+import datetime
+import json
+import logging
+import task
+import tornado.ioloop
+import tornado.web
+import tornado.httpclient
+import tornado.httpserver
+
+
+from contextlib import contextmanager
+from task_status import PENDING, FAILED, DONE, RUNNING
+
+logger = logging.getLogger('luigi-interface')
+
+
+class Task(object):
+    ''' Interface for methods on TaskHistory
+    '''
+    def __init__(self, task_id, status, host=None):
+        self.task_family, self.parameters = task.id_to_name_and_params(task_id)
+        self.status = status
+        self.record_id = None
+        self.host = host
+
+
+class TaskHistory(object):
+    ''' Abstract Base Class for updating the run history of a task
+    '''
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def task_scheduled(self, task_id):
+        pass
+
+    @abc.abstractmethod
+    def task_finished(self, task_id, successful):
+        pass
+
+    @abc.abstractmethod
+    def task_started(self, task_id, worker_host):
+        pass
+
+
+class NopHistory(TaskHistory):
+    def task_scheduled(self, task_id):
+        pass
+
+    def task_finished(self, task_id, successful):
+        pass
+
+    def task_started(self, task_id, worker_host):
+        pass
+
+
+class DbTaskHistory(TaskHistory):
+    """ Task History that writes to a database using sqlalchemy. Also has methods for useful db queries
+    """
+    @contextmanager
+    def _session(self, session=None):
+        if session:
+            yield session
+        else:
+            session = self.session_factory()
+            try:
+                yield session
+            except:
+                session.rollback()
+                raise
+            else:
+                session.commit()
+
+    def __init__(self):
+        config = configuration.get_config()
+        connection_string = config.get('task_history', 'db_connection')
+        try:
+            self.engine = create_engine(connection_string)
+            self.session_factory = sessionmaker(bind=self.engine, expire_on_commit=False)
+            Base.metadata.create_all(self.engine)
+        except NameError:
+            raise Exception("Using DbTaskHistory without sqlalchemy module!")
+        self.tasks = {}  # task_id -> TaskRecord
+
+    def task_scheduled(self, task_id):
+        task = self._get_task(task_id, status=PENDING)
+        self._add_task_event(task, TaskEvent(event_name=PENDING, ts=datetime.datetime.now()))
+
+    def task_finished(self, task_id, successful):
+        event_name = DONE if successful else FAILED
+        task = self._get_task(task_id, status=event_name)
+        self._add_task_event(task, TaskEvent(event_name=event_name, ts=datetime.datetime.now()))
+
+    def task_started(self, task_id, worker_host):
+        task = self._get_task(task_id, status=RUNNING, host=worker_host)
+        self._add_task_event(task, TaskEvent(event_name=RUNNING, ts=datetime.datetime.now()))
+
+    def _get_task(self, task_id, status, host=None):
+        if task_id in self.tasks:
+            task = self.tasks[task_id]
+            task.status = status
+            if host:
+                task.host = host
+        else:
+            task = self.tasks[task_id] = Task(task_id, status, host)
+        return task
+
+    def _add_task_event(self, task, event):
+        for (task_record, session) in self._find_or_create_task(task):
+            task_record.events.append(event)
+
+    def _find_or_create_task(self, task):
+        with self._session() as session:
+            if task.record_id is not None:
+                logger.debug("Finding task with record_id [%d]" % task.record_id)
+                task_record = session.query(TaskRecord).get(task.record_id)
+                if not task_record:
+                    raise Exception("Task with record_id, but no matching Task record!")
+                yield (task_record, session)
+            else:
+                task_record = TaskRecord(name=task.task_family, host=task.host)
+                task_record.events = [TaskEvent(event_name=PENDING, ts=datetime.datetime.now())]
+                for (k, v) in task.parameters.iteritems():
+                    task_record.parameters[k] = TaskParameter(name=k, value=v)
+                session.add(task_record)
+                yield (task_record, session)
+            if task.host:
+                task_record.host = task.host
+        task.record_id = task_record.id
+
+    def find_all_by_parameters(self, task_name, session=None, **task_params):
+        ''' Find tasks with the given task_name and the same parameters as the kwargs
+        '''
+        with self._session(session) as session:
+            tasks = session.query(TaskRecord).join(TaskEvent).filter(TaskRecord.name == task_name).order_by(TaskEvent.ts).all()
+            for task in tasks:
+                if all(k in task.parameters and v[0] == str(task.parameters[k].value) for (k, v) in task_params.iteritems()):
+                    yield task
+
+    def find_all_by_name(self, task_name, session=None):
+        ''' Find all tasks with the given task_name
+        '''
+        return self.find_all_by_parameters(task_name, session)
+
+    def find_latest_runs(self, session=None):
+        ''' Return tasks that have been updated in the past 24 hours.
+        '''
+        with self._session(session) as session:
+            yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+            return session.query(TaskRecord).\
+                join(TaskEvent).\
+                filter(TaskEvent.ts >= yesterday).\
+                group_by(TaskRecord.id, TaskEvent.event_name).\
+                order_by(TaskEvent.ts.desc()).\
+                all()
+
+    def find_task_by_id(self, id, session=None):
+        ''' Find task with the given record ID
+        '''
+        with self._session(session) as session:
+            return session.query(TaskRecord).get(id)
+
+try:
+    from sqlalchemy.orm.collections import attribute_mapped_collection
+    from sqlalchemy import Column, Integer, String, ForeignKey, TIMESTAMP, create_engine
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import sessionmaker, relationship
+
+    Base = declarative_base()
+
+    class TaskParameter(Base):
+        """ Table to track luigi.Parameter()s of a Task
+        """
+        __tablename__ = 'task_parameters'
+        task_id = Column(Integer, ForeignKey('tasks.id'), primary_key=True)
+        name = Column(String, primary_key=True)
+        value = Column(String)
+
+        def __repr__(self):
+            return "TaskParameter(task_id=%d, name=%s, value=%s)" % (self.task_id, self.name, self.value)
+
+    class TaskEvent(Base):
+        """ Table to track when a task is scheduled, starts, finishes, and fails
+        """
+        __tablename__ = 'task_events'
+        id = Column(Integer, primary_key=True)
+        task_id = Column(Integer, ForeignKey('tasks.id'))
+        event_name = Column(String)
+        ts = Column(TIMESTAMP, index=True)
+
+        def __repr__(self):
+            return "TaskEvent(task_id=%s, event_name=%s, ts=%s" % (self.task_id, self.event_name, self.ts)
+
+    class TaskRecord(Base):
+        """ Base table to track information about a luigi.Task. References to other tables are available through
+            task.events, task.parameters, etc.
+        """
+        __tablename__ = 'tasks'
+        id = Column(Integer, primary_key=True)
+        name = Column(String, index=True)
+        host = Column(String)
+        parameters = relationship('TaskParameter', collection_class=attribute_mapped_collection('name'),
+                                  cascade="all, delete-orphan")
+        events = relationship("TaskEvent", order_by=lambda: TaskEvent.ts.desc(), backref="task")
+
+        def __repr__(self):
+            return "TaskRecord(name=%s, host=%s)" % (self.name, self.host)
+
+except ImportError as e:
+    logger.error(e, exc_info=True)
+
+
+class BaseTaskHistoryHandler(tornado.web.RequestHandler):
+    def initialize(self, task_history):
+        self.task_history = task_history
+
+    def get_template_path(self):
+        return 'luigi/templates'
+
+
+class RecentRunHandler(BaseTaskHistoryHandler):
+    def get(self):
+        tasks = self.task_history.find_latest_runs()
+        self.render("recent.html", tasks=tasks)
+
+
+class ByNameHandler(BaseTaskHistoryHandler):
+    def get(self, name):
+        tasks = self.task_history.find_all_by_name(name)
+        self.render("recent.html", tasks=tasks)
+
+
+class ByIdHandler(BaseTaskHistoryHandler):
+    def get(self, id):
+        task = self.task_history.find_task_by_id(id)
+        self.render("show.html", task=task)
+
+
+class ByParamsHandler(BaseTaskHistoryHandler):
+    def get(self, name):
+        payload = self.get_argument('data', default="{}")
+        arguments = json.loads(payload)
+        tasks = self.task_history.find_all_by_parameters(name, session=None, **arguments)
+        self.render("recent.html", tasks=tasks)
+
+
+def handlers(prefix):
+    try:
+        return [
+            tornado.web.url(r'/%s/' % prefix, RecentRunHandler, dict(task_history=DbTaskHistory()), name='recent_runs'),
+            tornado.web.url(r'/%s/by_name/(.*)' % prefix, ByNameHandler, dict(task_history=DbTaskHistory()), name='by_name'),
+            tornado.web.url(r'/%s/by_id/(.*)' % prefix, ByIdHandler, dict(task_history=DbTaskHistory()), name='by_id'),
+            tornado.web.url(r'/%s/by_params/(.*)' % prefix, ByParamsHandler, dict(task_history=DbTaskHistory()), name='by_params')
+        ]
+    except:
+        print "Error loading Task history handlers, history viewer won't work."
+        print traceback.format_exc()
+        return [
+            (r'/%s/(.*)' % prefix, tornado.web.ErrorHandler, dict(status_code=500))
+        ]

--- a/luigi/task_status.py
+++ b/luigi/task_status.py
@@ -1,0 +1,17 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+''' Possible values for a Task's status in the Scheduler
+'''
+PENDING = 'PENDING'
+FAILED = 'FAILED'
+DONE = 'DONE'
+RUNNING = 'RUNNING'

--- a/luigi/templates/header.html
+++ b/luigi/templates/header.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Luigi Task History</title>
+<link href="/static/visualiser/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+<script src="/static/visualiser/lib/bootstrap/js/bootstrap.min.js"></script>

--- a/luigi/templates/recent.html
+++ b/luigi/templates/recent.html
@@ -1,0 +1,21 @@
+{% include "header.html" %}
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+    <th>Name</th>
+    <th>Host</th>
+    <th>Last Action</th>
+    <th>Status</th>
+  </tr>
+  </thead>
+  <tbody>
+    {% for task in tasks %}
+      <tr>
+        <td><a href="{{ reverse_url('by_id', task.id) }}">{{task.name}}</a></td>
+        <td>{{task.host}}</td>
+        <td>{{task.events[0].ts}}</td>
+        <td>{{task.events[0].event_name}}</td>
+      </tr>
+    {% end %}
+  </tbody>
+</table>

--- a/luigi/templates/show.html
+++ b/luigi/templates/show.html
@@ -1,0 +1,61 @@
+{% include "header.html" %}
+<div class="row">
+  <div class="span6">
+    <h3>Info</h3>
+    <table class="table table-striped table-bordered">
+      <tbody>
+        <tr>
+          <td>Task Id</td>
+          <td>{{task.id}}</td>
+        </tr>
+        <tr>
+          <td>Task Name</td>
+          <td>{{task.name}}</td>
+        </tr>
+        <tr>
+          <td>Host</td>
+          <td>{{task.host}}</td>
+        </tr>
+        <tr>
+          <td>More</td>
+          <td><a href="{{reverse_url('by_name', task.name)}}">All "{{task.name}}" runs</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<h3>Parameters</h3>
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for (k, param) in task.parameters.iteritems() %}
+      <tr>
+        <td>{{k}}</td>
+        <td>{{param.value}}</td>
+      </tr>
+    {% end %}
+  </tbody>
+</table>
+<h3>Actions</h3>
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>Action Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for event in task.events %}
+      <tr>
+        <td>{{event.event_name}}</td>
+        <td>{{event.ts}}</td>
+      </tr>
+    {% end %}
+
+  </tbody>
+</table>

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -41,8 +41,8 @@ class CustomizedScheduler(luigi.scheduler.CentralPlannerScheduler):
         super(CustomizedScheduler, self).__init__(*args, **kwargs)
         self.has_run = False
 
-    def get_work(self, worker):
-        locally_pending_tasks, best_task = super(CustomizedScheduler, self).get_work(worker)
+    def get_work(self, worker, host=None):
+        locally_pending_tasks, best_task = super(CustomizedScheduler, self).get_work(worker, host)
         self.has_run = True
         return locally_pending_tasks, best_task
 


### PR DESCRIPTION
All the tables are added as per the RFC, though currently
only Task, TaskEvent, and TaskParameters is being used right now.

Added a simple HTML front-end using Flask. I'd be open to using tornado
to be consistent with server.py, I just used flask because I've used
it before.

Some screenshots of the pages:
- Recent runs: http://cl.ly/image/1h01133g1Q07
- Task details: http://cl.ly/image/1P1i3T0C1y42
- All "A" runs: http://cl.ly/image/2X3h0X3k3P2h
