### PR TITLE
Add context manager for Mock.open().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ luigi.egg-info
 .nicesetup
 *.rej
 *.orig
+.DS_Store

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -56,6 +56,13 @@ class MockFile(target.Target):
                     MockFile._file_contents[fn] = self2.getvalue()
                 StringIO.StringIO.close(self2)
 
+            def __exit__(self, type, value, traceback):
+                if not type:
+                    self.close()
+
+            def __enter__(self):
+                return self
+
         if mode == 'w':
             return StringBuffer()
         else:

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -26,3 +26,11 @@ class MockFileTest(unittest.TestCase):
         q = t.open('r')
         self.assertEqual(list(q), ['test\n'])
         q.close()
+
+    def test_with(self):
+        t = MockFile("foo")
+        with t.open('w') as b:
+            b.write("bar")
+
+        with t.open('r') as b:
+            self.assertEquals(list(b), ['bar'])


### PR DESCRIPTION
The HdfsTarget's support this, so it makes sense to add to mocks
for compatibility.

Also snuck in a change to gitignore for some MacOS files.
