### PR TITLE
Add tox support to run test suite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26,py27
+
+[testenv]
+deps=tornado
+     argparse
+     nose
+commands=nosetests


### PR DESCRIPTION
This let developers run the test suite using tox locally before pushing changes, this tox configuration file is equivalent to the file used by travis.
