### PR TITLE
Allow multiple comma separated email addresses for error-email in client...

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -30,6 +30,15 @@ def send_email(subject, message, sender, recipients, image_png=None):
     import email.mime.text
     import email.mime.image
 
+    # Clean the recipients lists to allow multiple error-email addresses, comma
+    # separated in client.cfg
+    recipients_tmp = []
+    for r in recipients:
+        recipients_tmp.extend(r.split(','))
+
+    # Replace original recipients with the clean list
+    recipients = recipients_tmp
+
     smtp = smtplib.SMTP('localhost')
 
     msg_root = email.mime.multipart.MIMEMultipart('related')


### PR DESCRIPTION
This solves an issue where if a comma separated string of emails was used for error-email in client.cfg, only the first  email address would receive the email alert.

nb. This fix is also included in https://github.com/VisualDNA/luigi/tree/visualdna_hackday_2013-06-20
