### PR TITLE
Changed ordering of tasks in the task list to be most recently submitted...

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -28,6 +28,7 @@ function visualiserApp(luigi) {
             taskName: taskName,
             taskParams: taskParams,
             displayTime: displayTime,
+            displayTimestamp : task.start_time,
             trackingUrl: task.trackingUrl,
             status: task.status,
             graph: (task.status == "PENDING" || task.status == "RUNNING")
@@ -55,7 +56,7 @@ function visualiserApp(luigi) {
 
     function renderTasks(tasks) {
         var displayTasks = $.map(tasks, taskToDisplayTask);
-        displayTasks.sort(function(a,b) { return a.taskId.localeCompare(b.taskId); });
+        displayTasks.sort(function(a,b) { return b.displayTimestamp - a.displayTimestamp; });
         var tasksByFamily = entryList(indexByProperty(displayTasks, "taskName"));
         tasksByFamily.sort(function(a,b) { return a.key.localeCompare(b.key); });
         return renderTemplate("rowTemplate", {tasks: tasksByFamily});


### PR DESCRIPTION
... first (within each grouped list of tasks)

![order_by_time_submitted](https://f.cloud.github.com/assets/2633943/746761/a6019964-e437-11e2-97ec-74844f54d73a.png)

Not entirely sure what the original sort was for on line 58. Hope no-one is going to miss that.
