### PR TITLE
List done tasks in visualizer

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -106,6 +106,8 @@
                 <div id="runningTasks" class="taskList"></div>
                 <h3>Pending Tasks</h3>
                 <div id="pendingTasks" class="taskList"></div>
+                <h3>Done Tasks</h3>
+                <div id="doneTasks" class="taskList"></div>
             </section>
             <section id="dependencyGraph" class="tab-pane">
                 <div class="navbar">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -46,6 +46,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getDoneTaskList = function(callback) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "DONE", upstream_status: ""}, function(response) {
+            callback(flatten(response.response));
+        });
+    };
+
     LuigiAPI.prototype.getErrorTrace = function(taskId, callback) {
         jsonRPC(this.urlRoot + "/fetch_error", {task_id: taskId}, function(response) {
             callback(response.response);

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -31,7 +31,7 @@ function visualiserApp(luigi) {
             displayTimestamp : task.start_time,
             trackingUrl: task.trackingUrl,
             status: task.status,
-            graph: (task.status == "PENDING" || task.status == "RUNNING"),
+            graph: (task.status == "PENDING" || task.status == "RUNNING" || task.status == "DONE"),
             error: task.status == "FAILED"
         };
     }
@@ -149,15 +149,18 @@ function visualiserApp(luigi) {
         
         luigi.getFailedTaskList(function(failedTasks) {
             luigi.getUpstreamFailedTaskList(function(upstreamFailedTasks) {
-            	luigi.getRunningTaskList(function(runningTasks) {
-                luigi.getPendingTaskList(function(pendingTasks) {
-                	$("#failedTasks").append(renderTasks(failedTasks));
-                	$("#upstreamFailedTasks").append(renderTasks(upstreamFailedTasks));
-                	$("#runningTasks").append(renderTasks(runningTasks));
-                  $("#pendingTasks").append(renderTasks(pendingTasks));
-                	bindListEvents();
-             	  });
-              });
+                luigi.getRunningTaskList(function(runningTasks) {
+                    luigi.getPendingTaskList(function(pendingTasks) {
+                        luigi.getDoneTaskList(function(doneTasks) {
+                            $("#failedTasks").append(renderTasks(failedTasks));
+                            $("#upstreamFailedTasks").append(renderTasks(upstreamFailedTasks));
+                            $("#runningTasks").append(renderTasks(runningTasks));
+                            $("#pendingTasks").append(renderTasks(pendingTasks));
+                            $("#doneTasks").append(renderTasks(doneTasks));
+                            bindListEvents();
+                        });
+                    });
+                });
             });
         });
         


### PR DESCRIPTION
List done tasks in visualizer as well as upstream failed and failed.

Show "Dependency graph" button for done tasks

Show "Dependency graph" not "Show error trace" button for done tasks in
task list.

![done_tasks](https://f.cloud.github.com/assets/2633943/746904/4c8f43c0-e43e-11e2-8274-645b13118c58.png)
