### PR TITLE
Make default_from_config less strict.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -63,9 +63,26 @@ class Parameter(object):
         self.counter = Parameter.counter  # We need to keep track of this to get the order right (see Task class)
         Parameter.counter += 1
 
+    def _get_default_from_config(self, safe):
+        """Loads the default from the config. If safe=True, then returns None if missing. Otherwise,
+           raises an UnknownConfigException."""
+
+        conf = configuration.get_config()
+        (section, name) = (self.default_from_config['section'], self.default_from_config['name'])
+        try:
+            return conf.get(section, name)
+        except (NoSectionError, NoOptionError), e:
+            if safe:
+                return None
+            raise UnknownConfigException("Couldn't find value for section={0} name={1}. Search config files: '{2}'".format(
+                section, name, ", ".join(conf._config_paths)), e)
+
     @property
     def has_default(self):
-        return self.__default != _no_default or self.default_from_config is not None
+        """True if a default was specified or if default_from_config references a valid entry in the conf."""
+        if self.default_from_config is not None:
+            return self._get_default_from_config(safe=True) is not None
+        return self.__default != _no_default
 
     @property
     def default(self):
@@ -73,15 +90,7 @@ class Parameter(object):
             raise MissingParameterException("No default specified")
         if self.__default != _no_default:
             return self.__default
-
-        conf = configuration.get_config()
-        (section, name) = (self.default_from_config['section'], self.default_from_config['name'])
-        try:
-            return self.parse(conf.get(section, name))
-        except (NoSectionError, NoOptionError), e:
-            raise UnknownConfigException("Couldn't find value for section={0} name={1}. Search config files: '{2}'".format(
-                section, name, ", ".join(conf._config_paths)), e)
-
+        return self.parse(self._get_default_from_config(safe=False))
 
     def set_default(self, value):
         self.__default = value

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -260,5 +260,17 @@ class TestParamWithDefaultFromConfig(unittest.TestCase):
     def testTwoDefaults(self):
         self.assertRaises(luigi.parameter.ParameterException, lambda: luigi.Parameter(default="baz", default_from_config=dict(section="foo", name="bar")))
 
+    def testHasDefaultNoSection(self):
+        luigi.Parameter(default_from_config=dict(section="foo", name="bar")).has_default
+        self.assertFalse(luigi.Parameter(default_from_config=dict(section="foo", name="bar")).has_default)
+
+    @with_config({"foo": {}})
+    def testHasDefaultNoValue(self):
+        self.assertFalse(luigi.Parameter(default_from_config=dict(section="foo", name="bar")).has_default)
+
+    @with_config({"foo": {"bar": "baz"}})
+    def testHasDefaultWithBoth(self):
+        self.assertTrue(luigi.Parameter(default_from_config=dict(section="foo", name="bar")).has_default)
+
 if __name__ == '__main__':
     luigi.run(use_optparse=True)


### PR DESCRIPTION
If the section/name specified in default_from_config isn't found,
then has_default returns False. This makes default_from_config
easier to use in tests or if you are trying to run an unrelated
Task.
