### PR TITLE
[job conf] add support for job queue parameter (Capacity Scheduler)

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -465,7 +465,9 @@ class BaseHadoopJobTask(luigi.Task):
         jcs.append('mapred.reduce.tasks=%s' % self.n_reduce_tasks)
         pool = self.pool
         if pool is not None:
+            # Supporting two schedulers (Fair and Capacity) using the same option
             jcs.append('mapred.fairscheduler.pool=%s' % pool)
+            jcs.append('mapred.job.queue.name=%s' % pool)
         return jcs
 
 

--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -248,6 +248,7 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         mapred.job.name to task_id and if not None, sets:
         * mapred.reduce.tasks (n_reduce_tasks)
         * mapred.fairscheduler.pool (pool)
+        * mapred.job.queue.name (pool)
         * hive.exec.reducers.bytes.per.reducer (bytes_per_reducer)
         * hive.exec.reducers.max (reducers_max)
         '''
@@ -256,7 +257,9 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         if self.n_reduce_tasks is not None:
             jcs['mapred.reduce.tasks'] = self.n_reduce_tasks
         if self.pool is not None:
+            # supports two schedulers using the same option (Fair and Capacity)
             jcs['mapred.fairscheduler.pool'] = self.pool
+            jcs['mapred.job.queue.name'] = self.pool
         if self.bytes_per_reducer is not None:
             jcs['hive.exec.reducers.bytes.per.reducer'] = self.bytes_per_reducer
         if self.reducers_max is not None:


### PR DESCRIPTION
To make it easy, the pool or queue is set using the same option "--pool" (thanks to that we get backward compatibility, if you switch from one scheduler to another).

It sets two configuration settings mapred.fairscheduler.pool and mapred.job.queue.name, and only one will be used by your scheduler.
