### PR TITLE
Fixing file existence check to make it compatible with various hadoop releases and distributions 

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -72,7 +72,7 @@ class HdfsClient(FileSystem):
         if p.returncode == 0:
             return True
         else:
-            not_found_pattern = "^stat: cannot stat `.*': No such file or directory$"
+            not_found_pattern = "^stat: `.*': No such file or directory$"
             not_found_re = re.compile(not_found_pattern)
             for line in stderr.split('\n'):
                 if not_found_re.match(line):


### PR DESCRIPTION
hadoop fs -ls -d is not compatible with releases other than CDH4. This update should work in all versions.
