### PR TITLE
[hadoop scheduler] switching between schedulers using hadoop_scheduler config parameter 

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -465,7 +465,12 @@ class BaseHadoopJobTask(luigi.Task):
         jcs.append('mapred.reduce.tasks=%s' % self.n_reduce_tasks)
         pool = self.pool
         if pool is not None:
-            jcs.append('mapred.fairscheduler.pool=%s' % pool)
+            # Supporting two schedulers: fair (default) and capacity using the same option
+            scheduler_type = configuration.get_config().get('hadoop', 'scheduler', 'fair')
+            if scheduler_type == 'fair':
+                jcs.append('mapred.fairscheduler.pool=%s' % pool)
+            elif scheduler_type == 'capacity':
+                jcs.append('mapred.job.queue.name=%s' % pool)
         return jcs
 
 

--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -247,7 +247,7 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         to the hive command line via --hiveconf. By default, sets
         mapred.job.name to task_id and if not None, sets:
         * mapred.reduce.tasks (n_reduce_tasks)
-        * mapred.fairscheduler.pool (pool)
+        * mapred.fairscheduler.pool (pool) or mapred.job.queue.name (pool)
         * hive.exec.reducers.bytes.per.reducer (bytes_per_reducer)
         * hive.exec.reducers.max (reducers_max)
         '''
@@ -256,7 +256,12 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         if self.n_reduce_tasks is not None:
             jcs['mapred.reduce.tasks'] = self.n_reduce_tasks
         if self.pool is not None:
-            jcs['mapred.fairscheduler.pool'] = self.pool
+            # Supporting two schedulers: fair (default) and capacity using the same option
+            scheduler_type = luigi.configuration.get_config().get('hadoop', 'scheduler', 'fair')
+            if scheduler_type == 'fair':
+                jcs['mapred.fairscheduler.pool'] = self.pool
+            elif scheduler_type == 'capacity':
+                jcs['mapred.job.queue.name'] = self.pool
         if self.bytes_per_reducer is not None:
             jcs['hive.exec.reducers.bytes.per.reducer'] = self.bytes_per_reducer
         if self.reducers_max is not None:


### PR DESCRIPTION
Configuration parameter hadoop.scheduler (defaults to "fair") tells which scheduler is used and which pool to set.
