### PR TITLE
Changing HadoopJobRunner to use move_dir

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -370,7 +370,7 @@ class HadoopJobRunner(JobRunner):
         run_and_track_hadoop_job(arglist)
 
         # rename temporary work directory to given output
-        tmp_target.move(output_final, fail_if_exists=True)
+        tmp_target.move_dir(output_final)
         self.finish()
 
     def finish(self):

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -65,6 +65,9 @@ class MockFile(target.FileSystemTarget):
         contents = MockFile._file_contents.pop(self._fn)
         MockFile._file_contents[path] = contents
 
+    def move_dir(self, path):
+        self.move(path, fail_if_exists=True)
+
     @property
     def path(self):
         return self._fn


### PR DESCRIPTION
HadoopJobRunner used to use move which is not atomic and caused some problems when duplicate jobs were running (another issue). move_dir is atomic since it is doing a mkdir of the path first and should be used instead of move for that reason.
