### PR TITLE
Revert "Changing HadoopJobRunner to use move_dir

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -370,7 +370,7 @@ class HadoopJobRunner(JobRunner):
         run_and_track_hadoop_job(arglist)
 
         # rename temporary work directory to given output
-        tmp_target.move_dir(output_final)
+        tmp_target.move(output_final, fail_if_exists=True)
         self.finish()
 
     def finish(self):

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -65,9 +65,6 @@ class MockFile(target.FileSystemTarget):
         contents = MockFile._file_contents.pop(self._fn)
         MockFile._file_contents[path] = contents
 
-    def move_dir(self, path):
-        self.move(path, fail_if_exists=True)
-
     @property
     def path(self):
         return self._fn


### PR DESCRIPTION
Change created issues as well since we will have an empty output dir that will trigger other jobs to run.

This reverts commit daa6e6368706759622e60db98c0ec73c7198fc0c.
