### PR TITLE
Improve scheduler-side parameter parsing

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -38,6 +38,7 @@ UPSTREAM_FAILED = 'UPSTREAM_FAILED'
 
 UPSTREAM_SEVERITY_ORDER = ('', UPSTREAM_RUNNING, UPSTREAM_MISSING_INPUT, UPSTREAM_FAILED)
 
+
 class Task(object):
     def __init__(self, status, deps):
         self.stakeholders = set()  # workers that are somehow related to this task (i.e. don't prune while any of these workers are still active)
@@ -112,7 +113,7 @@ class CentralPlannerScheduler(Scheduler):
         # Mark tasks with no remaining active stakeholders for deletion
         for task_id, task in self._tasks.iteritems():
             if not task.stakeholders.intersection(remaining_workers):
-                if task.remove == None:
+                if task.remove is None:
                     print 'task', task_id, 'has stakeholders', task.stakeholders, 'but only', remaining_workers, 'remain -> will remove task in', self._remove_delay, 'seconds'
                     task.remove = time.time() + self._remove_delay
 
@@ -264,9 +265,15 @@ class CentralPlannerScheduler(Scheduler):
 
     def _get_task_params(self, task_id):
         params = {}
-        params_strings =  task_id.split('(')[1].strip(')').split()
+        params_part = task_id.split('(')[1].strip(')')
+        params_strings = params_part.split(", ")
+
         for param in params_strings:
-            split_param = param.strip(',').split('=')
+            if not param:
+                continue
+            split_param = param.split('=')
+            if len(split_param) != 2:
+                return {'<complex parameters>': params_part}
             params[split_param[0]] = split_param[1]
         return params
 

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -145,5 +145,21 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(task_id=t, worker='Y')
         self.assertEqual(self.sch.get_work(worker='Y')[1], None)
 
+
+class TestParameterSplit(unittest.TestCase):
+    task_id_examples = [
+        "TrackIsrcs()",
+        "CrazyTask(foo=foo_table_id, bar={'keyName': 'com.my.org', 'parameters': {'this.is.tricky': '1'}}, what_is_dis=foo bar, oh hippo)",
+        "MyOldDateHourTask(datehour=2013-07-21 11:00:00)",
+        "MyOldDateHourTask(datehour=2013-07-21T11:00:00)"
+    ]
+
+    def setUp(self):
+        self.sch = CentralPlannerScheduler()
+
+    def test_parameter_split(self):
+        for task_id in self.task_id_examples:
+            self.sch._get_task_params(task_id)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
So it doesn't break the scheduler on weird parameter values

Adds failing unit test exposing broken parameter split
