### PR TITLE
Apache HiveCommandClient 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include bin/luigid

--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ default-scheduler-host: luigi-host.mycompany.foo
 error-email: foo@bar.baz
 ```
 
+All sections are optional based on what parts of Luigi you are actually using.  By default, Luigi will not send error emails when running through a tty terminal.  If using the Apache release of Hive, there are slight differences when compared to the CDH release, so specify this configuration setting accordingly.
+
 ## More info
 
 Luigi is the sucessor to a couple of attempts that we weren't fully happy with. We learned a lot from our mistakes and some design decisions include:

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -307,13 +307,13 @@ class HadoopJobRunner(JobRunner):
         output_tmp_fn = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
         tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn, is_tmp=True)
 
-        arglist = ['hadoop', 'jar', self.streaming_jar]
+        arglist = [luigi.hdfs.load_hadoop_cmd(), 'jar', self.streaming_jar]
 
         # 'libjars' is a generic option, so place it first
         libjars = [libjar for libjar in self.libjars]
 
         for libjar in self.libjars_in_hdfs:
-            subprocess.call(['hadoop', 'fs', '-get', libjar, self.tmp_dir])
+            subprocess.call([luigi.hdfs.load_hadoop_cmd(), 'fs', '-get', libjar, self.tmp_dir])
             libjars.append(os.path.join(self.tmp_dir, os.path.basename(libjar)))
 
         if libjars:

--- a/luigi/hadoop_jar.py
+++ b/luigi/hadoop_jar.py
@@ -45,7 +45,7 @@ class HadoopJarJobRunner(luigi.hadoop.JobRunner):
             logger.error("Can't find jar: {0}, full path {1}".format(job.jar(),
                          os.path.abspath(job.jar())))
             raise Exception("job jar does not exist")
-        arglist = ['hadoop', 'jar', job.jar()]
+        arglist = [luigi.hdfs.load_hadoop_cmd(), 'jar', job.jar()]
         if job.main():
             arglist.append(job.main())
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -50,7 +50,7 @@ class Parameter(object):
         self.is_boolean = is_boolean and not is_list  # Only BooleanParameter should ever use this. TODO(erikbern): should we raise some kind of exception?
         self.is_global = is_global  # It just means that the default value is exposed and you can override it
         self.significant = significant
-        if is_global and default == _no_default:
+        if is_global and default == _no_default and default_from_config is None:
             raise ParameterException('Global parameters need default values')
         self.description = description
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -13,11 +13,13 @@
 # the License.
 
 import abc
+import logging
 import parameter
 import warnings
 import traceback
 
 Parameter = parameter.Parameter
+logger = logging.getLogger('luigi-interface')
 
 
 def namespace(namespace=None):
@@ -88,6 +90,7 @@ class Register(abc.ABCMeta):
         try:
             hash(k)
         except TypeError:
+            logger.debug("Not all parameter values are hashable so instance isn't coming from the cache")
             return instantiate()  # unhashable types in parameters
 
         if k not in h:
@@ -211,8 +214,8 @@ class Task(object):
                 result[param_name] = param_obj.default
 
         def list_to_tuple(x):
-            """ Make tuples out of lists to allow hashing """
-            if isinstance(x, list):
+            """ Make tuples out of lists and sets to allow hashing """
+            if isinstance(x, list) or isinstance(x, set):
                 return tuple(x)
             else:
                 return x

--- a/test/hive_test.py
+++ b/test/hive_test.py
@@ -1,16 +1,17 @@
+import mock
+import os
+import sys
 import tempfile
 import unittest
 
 import luigi.hive
-
 from luigi import LocalTarget
-import os
 
 
 class HiveTest(unittest.TestCase):
     count = 0
 
-    def mock_hive_cmd(self, args):
+    def mock_hive_cmd(self, args, check_return=True):
         self.last_hive_cmd = args
         self.count += 1
         return "statement{0}".format(self.count)
@@ -22,18 +23,18 @@ class HiveTest(unittest.TestCase):
     def tearDown(self):
         luigi.hive.run_hive = self.run_hive_cmd_saved
 
-    def testRunHiveCommand(self):
+    def test_run_hive_command(self):
         pre_count = self.count
         res = luigi.hive.run_hive_cmd("foo")
         self.assertEquals(["-e", "foo"], self.last_hive_cmd)
         self.assertEquals("statement{0}".format(pre_count+1), res)
 
-    def testRunHiveScriptNotExists(self):
+    def test_run_hive_script_not_exists(self):
         def test():
             luigi.hive.run_hive_script("/tmp/some-non-existant-file______")
         self.assertRaises(RuntimeError, test)
 
-    def testRunHiveScriptExists(self):
+    def test_run_hive_script_exists(self):
         with tempfile.NamedTemporaryFile(delete=True) as f:
             pre_count = self.count
             res = luigi.hive.run_hive_script(f.name)
@@ -50,3 +51,184 @@ class HiveTest(unittest.TestCase):
         runner = luigi.hive.HiveQueryRunner()
         runner.prepare_outputs(FooHiveTask())
         self.assertTrue(os.path.exists(dirname))
+
+class HiveCommandClientTest(unittest.TestCase):
+    """Note that some of these tests are really for the CDH releases of Hive, to which I do not currently have access.
+    Hopefully there are no significant differences in the expected output"""
+
+    def setUp(self):
+        self.client = luigi.hive.HiveCommandClient()
+        self.apacheclient = luigi.hive.ApacheHiveCommandClient()
+
+    @mock.patch("luigi.hive.run_hive_cmd")
+    def test_default_table_location(self, run_command):
+        run_command.return_value = "Protect Mode:       	None                	 \n" \
+                                   "Retention:          	0                   	 \n" \
+                                   "Location:           	hdfs://localhost:9000/user/hive/warehouse/mytable	 \n" \
+                                   "Table Type:         	MANAGED_TABLE       	 \n"
+
+        returned = self.client.table_location("mytable")
+        self.assertEquals('hdfs://localhost:9000/user/hive/warehouse/mytable', returned)
+
+    @mock.patch("luigi.hive.run_hive_cmd")
+    def test_table_exists(self, run_command):
+        run_command.return_value = "FAILED: SemanticException [Error 10001]: blah does not exist\nSome other stuff"
+        returned = self.client.table_exists("mytable")
+        self.assertFalse(returned)
+
+        run_command.return_value = "OK\n" \
+                                   "col1       	string              	None                \n" \
+                                   "col2            	string              	None                \n" \
+                                   "col3         	string              	None  \n"
+        returned = self.client.table_exists("mytable")
+        self.assertTrue(returned)
+
+        run_command.return_value = "day=2013-06-28/hour=3\n" \
+                                   "day=2013-06-28/hour=4\n" \
+                                   "day=2013-07-07/hour=2\n"
+        self.client.partition_spec = mock.Mock(name="partition_spec")
+        self.client.partition_spec.return_value = "somepart"
+        returned = self.client.table_exists("mytable", partition={'a':'b'})
+        self.assertTrue(returned)
+
+        run_command.return_value = ""
+        returned = self.client.table_exists("mytable", partition={'a':'b'})
+        self.assertFalse(returned)
+
+    @mock.patch("luigi.hive.run_hive_cmd")
+    def test_table_schema(self, run_command):
+        run_command.return_value = "FAILED: SemanticException [Error 10001]: blah does not exist\nSome other stuff"
+        returned = self.client.table_schema("mytable")
+        self.assertFalse(returned)
+
+        run_command.return_value = "OK\n" \
+                                   "col1       	string              	None                \n" \
+                                   "col2            	string              	None                \n" \
+                                   "col3         	string              	None                \n" \
+                                   "day                 	string              	None                \n" \
+                                   "hour                	smallint            	None                \n\n" \
+                                   "# Partition Information	 	 \n" \
+                                   "# col_name            	data_type           	comment             \n\n" \
+                                   "day                 	string              	None                \n" \
+                                   "hour                	smallint            	None                \n" \
+                                   "Time taken: 2.08 seconds, Fetched: 34 row(s)\n"
+        expected = [('OK',),
+                    ('col1', 'string', 'None'),
+                    ('col2', 'string', 'None'),
+                    ('col3', 'string', 'None'),
+                    ('day', 'string', 'None'),
+                    ('hour', 'smallint', 'None'),
+                    ('',),
+                    ('# Partition Information',),
+                    ('# col_name', 'data_type', 'comment'),
+                    ('',),
+                    ('day', 'string', 'None'),
+                    ('hour', 'smallint', 'None'),
+                    ('Time taken: 2.08 seconds, Fetched: 34 row(s)',)]
+        returned = self.client.table_schema("mytable")
+        self.assertEquals(expected, returned)
+
+    def test_partition_spec(self):
+        returned = self.client.partition_spec({'a': 'b', 'c': 'd'})
+        self.assertEquals("a='b',c='d'", returned)
+
+    @mock.patch("luigi.hive.run_hive_cmd")
+    def test_apacheclient_table_exists(self, run_command):
+        run_command.return_value = "FAILED: SemanticException [Error 10001]: Table not found mytable\nSome other stuff"
+        returned = self.apacheclient.table_exists("mytable")
+        self.assertFalse(returned)
+
+        run_command.return_value = "OK\n" \
+                                   "col1       	string              	None                \n" \
+                                   "col2            	string              	None                \n" \
+                                   "col3         	string              	None  \n"
+        returned = self.apacheclient.table_exists("mytable")
+        self.assertTrue(returned)
+
+        run_command.return_value = "day=2013-06-28/hour=3\n" \
+                                   "day=2013-06-28/hour=4\n" \
+                                   "day=2013-07-07/hour=2\n"
+        self.apacheclient.partition_spec = mock.Mock(name="partition_spec")
+        self.apacheclient.partition_spec.return_value = "somepart"
+        returned = self.apacheclient.table_exists("mytable", partition={'a':'b'})
+        self.assertTrue(returned)
+
+        run_command.return_value = ""
+        returned = self.apacheclient.table_exists("mytable", partition={'a':'b'})
+        self.assertFalse(returned)
+
+    @mock.patch("luigi.hive.run_hive_cmd")
+    def test_apacheclient_table_schema(self, run_command):
+        run_command.return_value = "FAILED: SemanticException [Error 10001]: Table not found mytable\nSome other stuff"
+        returned = self.apacheclient.table_schema("mytable")
+        self.assertFalse(returned)
+
+        run_command.return_value = "OK\n" \
+                                   "col1       	string              	None                \n" \
+                                   "col2            	string              	None                \n" \
+                                   "col3         	string              	None                \n" \
+                                   "day                 	string              	None                \n" \
+                                   "hour                	smallint            	None                \n\n" \
+                                   "# Partition Information	 	 \n" \
+                                   "# col_name            	data_type           	comment             \n\n" \
+                                   "day                 	string              	None                \n" \
+                                   "hour                	smallint            	None                \n" \
+                                   "Time taken: 2.08 seconds, Fetched: 34 row(s)\n"
+        expected = [('OK',),
+                    ('col1', 'string', 'None'),
+                    ('col2', 'string', 'None'),
+                    ('col3', 'string', 'None'),
+                    ('day', 'string', 'None'),
+                    ('hour', 'smallint', 'None'),
+                    ('',),
+                    ('# Partition Information',),
+                    ('# col_name', 'data_type', 'comment'),
+                    ('',),
+                    ('day', 'string', 'None'),
+                    ('hour', 'smallint', 'None'),
+                    ('Time taken: 2.08 seconds, Fetched: 34 row(s)',)]
+        returned = self.apacheclient.table_schema("mytable")
+        self.assertEquals(expected, returned)
+
+    @mock.patch("luigi.configuration")
+    def test_client_def(self, hive_syntax):
+        hive_syntax.get_config.return_value.get.return_value = "cdh4"
+
+        del sys.modules['luigi.hive']
+        import luigi.hive
+        self.assertEquals(luigi.hive.HiveCommandClient, type(luigi.hive.client))
+
+        hive_syntax.get_config.return_value.get.return_value = "cdh3"
+        del sys.modules['luigi.hive']
+        import luigi.hive
+        self.assertEquals(luigi.hive.HiveCommandClient, type(luigi.hive.client))
+
+        hive_syntax.get_config.return_value.get.return_value = "apache"
+        del sys.modules['luigi.hive']
+        import luigi.hive
+        self.assertEquals(luigi.hive.ApacheHiveCommandClient, type(luigi.hive.client))
+
+    @mock.patch('subprocess.Popen')
+    def test_run_hive_command(self, popen):
+        # I'm testing this again to check the return codes
+        # I didn't want to tear up all the existing tests to change how run_hive is mocked
+        comm = mock.Mock(name='communicate_mock')
+        comm.return_value = "some return stuff", ""
+
+        preturn = mock.Mock(name='open_mock')
+        preturn.returncode = 0
+        preturn.communicate = comm
+        popen.return_value = preturn
+
+        returned = luigi.hive.run_hive(["blah", "blah"])
+        self.assertEquals("some return stuff", returned)
+
+        preturn.returncode = 17
+        self.assertRaises(luigi.hive.HiveCommandError, luigi.hive.run_hive, ["blah", "blah"])
+
+        comm.return_value = "", "some stderr stuff"
+        returned = luigi.hive.run_hive(["blah", "blah"], False)
+        self.assertEquals("", returned)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding MANIFEST.in file so that bin/luigid gets included in the dist tarball
Hadoop binary path can now be specified in config.  
Sets are converted to tuples in Task class.
Additional unit tests in the hdfs module and a new hive client command class supporting the Apache release of Hive, which returns a non-zero exit status if tables and partitions dont exist
