### PR TITLE
directories ending in .egg work

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -93,7 +93,7 @@ def create_packages_archive(packages, filename):
         if hasattr(package, "__path__"):
             p = package.__path__[0]
 
-            if p.find('.egg') != -1:
+            if p.endswith('.egg') and os.path.isfile(p):
                 raise 'egg files not supported!!!'
                 # Add the entire egg file
                 # p = p[:p.find('.egg') + 4]


### PR DESCRIPTION
On both Mac OS X.8 and CentOS 6, luigi fails at this check, because the directory name has .egg in it. For example:

/Library/Python/2.7/site-packages/luigi-1.0.3-py2.7.egg

is a directory in my installation, not an egg file.
