### PR TITLE
added File.copy

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -114,6 +114,14 @@ class File(FileSystemTarget):
     def remove(self):
         self.fs.remove(self.path)
 
+    def copy(self, new_path, fail_if_exists=False):
+        if fail_if_exists and os.path.exists(new_path):
+            raise RuntimeError('Destination exists: %s' % new_path)
+        tmp = File(is_tmp=True)
+        tmp.open('w')
+        shutil.copy(self.path, tmp.fn)
+        tmp.move(new_path)
+
     @property
     def fn(self):
         return self.path

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -25,14 +25,19 @@ import shutil
 
 class FileTest(unittest.TestCase):
     path = '/tmp/test.txt'
+    copy = '/tmp/test.copy.txt'
 
     def setUp(self):
         if os.path.exists(self.path):
             os.remove(self.path)
+        if os.path.exists(self.copy):
+            os.remove(self.copy)
 
     def tearDown(self):
         if os.path.exists(self.path):
             os.remove(self.path)
+        if os.path.exists(self.copy):
+            os.remove(self.copy)
 
     def test_close(self):
         t = File(self.path)
@@ -91,6 +96,18 @@ class FileTest(unittest.TestCase):
         self.assertTrue(test_data == f.read())
         f.close()
 
+    def test_copy(self):
+        t = File(self.path)
+        f = t.open('w')
+        test_data = 'test'
+        f.write(test_data)
+        f.close()
+        self.assertTrue(os.path.exists(self.path))
+        self.assertFalse(os.path.exists(self.copy))
+        t.copy(self.copy)
+        self.assertTrue(os.path.exists(self.path))
+        self.assertTrue(os.path.exists(self.copy))
+        self.assertEqual(t.open('r').read(), File(self.copy).open('r').read())
 
 class FileCreateDirectoriesTest(FileTest):
     path = '/tmp/%s/xyz/test.txt' % random.randint(0, 999999999)


### PR DESCRIPTION
Use case: when a file, e.g. from an ExternalTask lives
on a read-only filesystem, you cannot `move` it.

This is more a question, with some code attached. I came across such a situation, but I am not sure it really belongs here.
