### PR TITLE
Add mock to __init__.py so it can be used when using "import luigi".

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -19,6 +19,7 @@ import parameter
 import configuration
 import interface
 import target
+import mock
 
 Task = task.Task
 ExternalTask = task.ExternalTask


### PR DESCRIPTION
Hello! 

I think it would be great if the mock module could be from the luigi namespace. For example

``` python
import luigi
hoho_mock = luigi.mock.MockFile('hoho')
```

Now I do the following because I'm using more than just the mock module.

``` python
import luigi
from luigi import mock
hoho_mock = mock.MockFile('hoho')
# further down
luigi.build[something], local_scheduler=True, test=True)
```

Another area where it's also good to keep it under the luigi namespace is when using the popular [Mock framework](http://www.voidspace.org.uk/python/mock/). I would prefer to not do for example this workaround.

``` python
import luigi
from luigi import mock as luigi_mock
import mock
hoho_mock = luigi_mock.MockFile('hoho')
# further down
mock = mock.Mock()
```

P.S. Thanks for Luigi. It's great. :+1:  
