### PR TITLE
Allow configuration of smtp for notifications.

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -40,7 +40,21 @@ def send_email(subject, message, sender, recipients, image_png=None):
     # Replace original recipients with the clean list
     recipients = recipients_tmp
 
-    smtp = smtplib.SMTP('localhost')
+    config = configuration.get_config()
+    smtp_ssl = config.getboolean('core', 'smtp_ssl', False)
+    smtp_host = config.get('core', 'smtp_host', 'localhost')
+    smtp_port = config.getint('core', 'smtp_port', 0)
+    smtp_local_hostname = config.get('core', 'smtp_local_hostname', None)
+    smtp_timeout = config.getfloat('core', 'smtp_timeout', None)
+    kwargs = dict(host=smtp_host, port=smtp_port, local_hostname=smtp_local_hostname)
+    if smtp_timeout:
+        kwargs['timeout'] = smtp_timeout
+
+    smtp_login = config.get('core', 'smtp_login', None)
+    smtp_password = config.get('core', 'smtp_password', None)
+    smtp = smtplib.SMTP(**kwargs) if not smtp_ssl else smtplib.SMTP_SSL(**kwargs)
+    if smtp_login and smtp_password:
+        smtp.login(smtp_login, smtp_password)
 
     msg_root = email.mime.multipart.MIMEMultipart('related')
 


### PR DESCRIPTION
Defaults are all the same as before, but you can now
specify ssl, login, server host, etc.
