### PR TITLE
Adds dependencies on the mock library from pypi/debian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ install:
   - pip install tornado --use-mirrors
   - pip install argparse --use-mirrors
   - pip install sqlalchemy --use-mirrors
+  - pip install mock --use-mirrors
 script: nosetests

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:	debhelper (>= 7),
 		python-pip,
 		python-simplejson,
 		python-tornado (>= 2.3)
+		python-mock
 Standards-Version: 3.7.3
 X-Python-Version: >= 2.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ envlist = py26,py27
 deps=tornado
      argparse
      nose
+     mock
 commands=nosetests


### PR DESCRIPTION
Dependency on mock was silently introduced in #152 
If that PR built in travis it was probably the result of mock being pre-installed in the test environment, since no dependency on it was added in the PR. 
At first I was thinking about removing the dependency (I like to keep dependencies on non-standard-library modules to a minimum), but since it has nice features, is only used in tests and has been incorporporated into the standard library as of Python 3.3 (unittest.mock) I'm adding it as a debian build dependency and in travis config files as well.

Btw, what's the difference between tox.ini and .travis.yml and why do we need both?
