### PR TITLE
Wrap file in python object to allow run-time extensions by Format classes

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -17,6 +17,7 @@ import random
 import tempfile
 import shutil
 from target import FileSystem, FileSystemTarget
+from luigi.format import FileWrapper
 
 
 class atomic_file(file):
@@ -93,10 +94,10 @@ class File(FileSystemTarget):
                 return atomic_file(self.path)
 
         elif mode == 'r':
+            fileobj = FileWrapper(open(self.path, 'r'))
             if self.format:
-                return self.format.pipe_reader(file(self.path))
-            else:
-                return open(self.path, mode)
+                return self.format.pipe_reader(fileobj)
+            return fileobj
         else:
             raise Exception('mode must be r/w')
 

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -15,6 +15,30 @@
 import subprocess
 
 
+class FileWrapper(object):
+    """Wrap `file` in a "real" so stuff can be added to it after creation
+    """
+    def __init__(self, file_object):
+        self._subpipe = file_object
+
+    def __getattr__(self, name):
+        # forward calls to 'write', 'close' and other methods not defined below
+        return getattr(self._subpipe, name)
+
+    def __enter__(self, *args, **kwargs):
+        # instead of returning whatever is returned by __enter__ on the subpipe
+        # this returns self, so whatever custom injected methods are still available
+        # this might cause problems with custom file_objects, but seems to work
+        # fine with standard python `file` objects which is the only default use
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        return self._subpipe.__exit__(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self._subpipe)
+
+
 class InputPipeProcessWrapper(object):
     def __init__(self, command, input_pipe=None):
         self._command = command

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -109,6 +109,24 @@ class FileTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.copy))
         self.assertEqual(t.open('r').read(), File(self.copy).open('r').read())
 
+    def test_format_injection(self):
+        class CustomFormat(luigi.format.Format):
+            def pipe_reader(self, input_pipe):
+                input_pipe.foo = "custom read property"
+                return input_pipe
+
+            def pipe_writer(self, output_pipe):
+                output_pipe.foo = "custom write property"
+                return output_pipe
+
+        t = File(self.path, format=CustomFormat())
+        with t.open("w") as f:
+            self.assertEqual(f.foo, "custom write property")
+
+        with t.open("r") as f:
+            self.assertEqual(f.foo, "custom read property")
+
+
 class FileCreateDirectoriesTest(FileTest):
     path = '/tmp/%s/xyz/test.txt' % random.randint(0, 999999999)
 


### PR DESCRIPTION
As is exemplified in the unit test included here, this allows you to set new properties and methods on the pipe object passed to a `Format`. This is already possible on luigi-generated pipes, but notably has not been possible on `file` objects as are generated for LocalTarget/File objects on `open('r')`.
This will allow for less boiler plate when creating new `Format`s by injecting methods.
