### PR TITLE
make FloatParameter accessible just as the others

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -40,6 +40,7 @@ build = interface.build
 DateHourParameter = parameter.DateHourParameter
 DateParameter = parameter.DateParameter
 IntParameter = parameter.IntParameter
+FloatParameter = parameter.FloatParameter
 BooleanParameter = parameter.BooleanParameter
 DateIntervalParameter = parameter.DateIntervalParameter
 


### PR DESCRIPTION
Missed this line, when I [added](https://github.com/spotify/luigi/commit/3afa87f5f19c4a419f3180cb2fe6c34f3b11f404) `FloatParameter`. (And yes, I read the comment above the block: [TODO: how can we get rid of these?](https://github.com/miku/luigi/blob/8f56863c80258dda59e2b9422dadef2cd3113c42/luigi/__init__.py#L39) - but I have no answer ATM.)
