### PR TITLE
When you want to run tasks but they are currently run by other workers, ...

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -94,13 +94,8 @@ class RemoteScheduler(Scheduler):
                 attempts=1
             )
         except:
-            warnings.warn("Failed call to scheduler.get_work(worker, host), are you running an old scheduler version?")
-            return self._request(
-                '/api/get_work',
-                {'worker': worker},
-                log_exceptions=True,
-                attempts=2
-            )
+            logger.info("get_work RPC call failed, is it possible that you need to update your scheduler?")
+            raise
 
     def graph(self):
         return self._request('/api/graph', {})

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -195,10 +195,14 @@ class CentralPlannerScheduler(Scheduler):
         best_t = float('inf')
         best_task = None
         locally_pending_tasks = 0
+        running_tasks = []
 
         for task_id, task in self._tasks.iteritems():
             if worker not in task.workers:
                 continue
+
+            if task.status == RUNNING:
+                running_tasks.append({'task_id': task_id, 'worker': task.worker_running})
 
             if task.status != PENDING:
                 continue
@@ -222,7 +226,9 @@ class CentralPlannerScheduler(Scheduler):
             t.worker_running = worker
             self._update_task_history(best_task, RUNNING, host=host)
 
-        return locally_pending_tasks, best_task
+        return {'n_pending_tasks': locally_pending_tasks,
+                'task_id': best_task,
+                'running_tasks': running_tasks}
 
     def ping(self, worker):
         self.update(worker)

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -43,9 +43,9 @@ class CustomizedLocalScheduler(luigi.scheduler.CentralPlannerScheduler):
         self.has_run = False
 
     def get_work(self, worker, host=None):
-        locally_pending_tasks, best_task = super(CustomizedLocalScheduler, self).get_work(worker, host)
+        r = super(CustomizedLocalScheduler, self).get_work(worker, host)
         self.has_run = True
-        return locally_pending_tasks, best_task
+        return r
 
     def complete(self):
         return self.has_run
@@ -57,9 +57,9 @@ class CustomizedRemoteScheduler(luigi.rpc.RemoteScheduler):
         self.has_run = False
 
     def get_work(self, worker, host=None):
-        locally_pending_tasks, best_task = super(CustomizedRemoteScheduler, self).get_work(worker, host)
+        r = super(CustomizedRemoteScheduler, self).get_work(worker, host)
         self.has_run = True
-        return locally_pending_tasks, best_task
+        return r
 
     def complete(self):
         return self.has_run


### PR DESCRIPTION
...output a list of those tasks

Had to mend some tests to get this to work

Not fully backwards compatible: if you update the scheduler before the worker, you will have problems
The other way is fine though (updating the worker before the scheduler)

Also removed a workaround for backwards compatible, assuming people have had time to upgrade the scheduler since July
