### PR TITLE
Subprocess exceptions in format that are ultimately caused by format consumer/production should not mask original exception

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -73,8 +73,20 @@ class InputPipeProcessWrapper(object):
     def __enter__(self):
         return self
 
+    def _abort(self):
+        "Call _finish, but eat the exception (if any)."
+        try:
+            self._finish()
+        except KeyboardInterrupt:
+            raise
+        except:
+            pass
+
     def __exit__(self, type, value, traceback):
-        self._finish()
+        if type:
+            self._abort()
+        else:
+            self._finish()
 
     def __getattr__(self, name):
         if name == '_process':


### PR DESCRIPTION
Subprocess exceptions in format that are ultimately caused by format consumer/production should not mask original exception.

Should SystemExit also be caught and re-raised here?
