### PR TITLE
Enable support for boto config in S3Client

### DIFF
--- a/test/_s3_test.py
+++ b/test/_s3_test.py
@@ -117,6 +117,13 @@ class TestS3Client(unittest.TestCase):
     def tearDown(self):
         os.remove(self.tempFilePath)
 
+    def test_init(self):
+        os.environ['AWS_ACCESS_KEY_ID'] = 'foo'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
+        s3_client = S3Client()
+        self.assertEqual(s3_client.s3.gs_access_key_id, 'foo')
+        self.assertEqual(s3_client.s3.gs_secret_access_key, 'bar')
+
     @mock_s3
     def test_put(self):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)


### PR DESCRIPTION
Instead of throwing an exception when the AWS options are not found in `/etc/luigi/client.cfg`, pass `None` to `connect_s3` and let boto try other methods of discovering the credentials. For example, it could find them in the environment variables, in `~/.boto`, or from Amazon's metadata service.

In particular, I need this to use luigi with IAM roles in AWS.
