### PR TITLE
Actually use column_separator at CopyToTable.rows

### DIFF
--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -228,7 +228,7 @@ class CopyToTable(luigi.Task):
         """Return/yield tuples or lists corresponding to each row to be inserted """
         with self.input().open('r') as fobj:
             for line in fobj:
-                yield line.strip('\n').split('\t')
+                yield line.strip('\n').split(column_separator)
 
     def create_table(self, connection):
         """ Override to provide code for creating the target table.


### PR DESCRIPTION
The value `'\t'` was hard coded. Should have been `column_separator`...
