### PR TITLE
more permissive regex for hdfs stat cli response

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -96,7 +96,7 @@ class HdfsClient(FileSystem):
         if p.returncode == 0:
             return True
         else:
-            not_found_pattern = "^stat: `.*': No such file or directory$"
+            not_found_pattern = "^stat: .*`.*': No such file or directory$"
             not_found_re = re.compile(not_found_pattern)
             for line in stderr.split('\n'):
                 if not_found_re.match(line):


### PR DESCRIPTION
I am using Hortonworks' HDP distribution of Hadoop, and needed to make this small patch to luigi in order to have it run tasks with an HDFS output.

```
[root@hadoop1 ~]# yum list installed | grep hadoop
hadoop.x86_64                      1.2.0.1.3.3.0-58.el5               @Updates-HDP-1.x
```

Sample existing stat response:

```
[root@hadoop1 ~]# hadoop fs -stat /data
2013-11-21 21:10:54
```

Sample non-existing stat response:

```
[root@hadoop1 ~]# hadoop fs -stat /path/that/doesnt/exist
stat: cannot stat `/path/that/doesnt/exist': No such file or directory
```
