### PR TITLE
fix renaming a list of HDFS files to a single dest

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -109,6 +109,9 @@ class HdfsClient(FileSystem):
             self.mkdir(parent_dir)
         if type(path) not in (list, tuple):
             path = [path]
+        else:
+            import warnings
+            warnings.warn("Renaming multiple files at once is not atomic.")
         call_check([load_hadoop_cmd(), 'fs', '-mv'] + path + [dest])
 
     def remove(self, path, recursive=True, skip_trash=False):


### PR DESCRIPTION
I just ran into a problem renaming a list of files to a single destination folder:

```
Runtime error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/luigi/worker.py", line 240, in _run_task
    task.run()
  File "./parse-nginx.py", line 170, in run
    hdfs.rename(paths, dest)
  File "/usr/lib/python2.7/site-packages/luigi/hdfs.py", line 111, in rename
    call_check([load_hadoop_cmd(), 'fs', '-mv', path, dest])
  File "/usr/lib/python2.7/site-packages/luigi/hdfs.py", line 44, in call_check
    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib64/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1308, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings
```

This patch fixed it for me.
