### PR TITLE
Capture sigterm to kill hadoop jobs when worker is terminated

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -157,8 +157,9 @@ class HadoopRunContext(object):
         if self.job_id:
             logger.info('Job interrupted, killing job %s', self.job_id)
             subprocess.call(['mapred', 'job', '-kill', self.job_id])
-        if captured_signal == signal.SIGTERM:
-            sys.exit(143)
+        if captured_signal is not None:
+            # adding 128 gives the exit code corresponding to a signal
+            sys.exit(128 + captured_signal)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is KeyboardInterrupt:


### PR DESCRIPTION
If luigi is killed with a keyboard interrupt while running a hadoop job, that job is killed. The job was not killed if luigi was terminated via the sigterm signal. This captures the sigterm in addition to keyboard interrupts in order to better ensure that map-reduce jobs aren't left running.
