### PR TITLE
use best practices when using subprocess.Popen.  Also fix a bug in hdfs.listdir.

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -50,7 +50,8 @@ class InputPipeProcessWrapper(object):
         self._input_pipe = input_pipe
         self._process = command if isinstance(command, subprocess.Popen) else subprocess.Popen(command,
             stdin=input_pipe,
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE,
+            close_fds=True)
         # we want to keep a circular reference to avoid garbage collection
         # when the object is used in, e.g., pipe.read()
         self._process._selfref = self
@@ -58,6 +59,7 @@ class InputPipeProcessWrapper(object):
     def _finish(self):
         if self._input_pipe is not None:
             self._input_pipe.close()
+        # FIXME: why not self._process.communicate()
         for line in self._process.stdout:  # exhaust all output...
             pass
         self._process.wait()  # deadlock?
@@ -108,7 +110,8 @@ class OutputPipeProcessWrapper(object):
         self._output_pipe = output_pipe
         self._process = subprocess.Popen(command,
             stdin=subprocess.PIPE,
-            stdout=output_pipe)
+            stdout=output_pipe,
+            close_fds=True)
         self._flushcount = 0
 
     def write(self, *args, **kwargs):

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -173,7 +173,7 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
     def track_process(arglist, tracking_url_callback, env=None):
         # Dump stdout to a temp file, poll stderr and log it
         temp_stdout = tempfile.TemporaryFile()
-        proc = subprocess.Popen(arglist, stdout=temp_stdout, stderr=subprocess.PIPE, env=env)
+        proc = subprocess.Popen(arglist, stdout=temp_stdout, stderr=subprocess.PIPE, env=env, close_fds=True)
 
         # We parse the output to try to find the tracking URL.
         # This URL is useful for fetching the logs of the job.

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -41,7 +41,7 @@ class HDFSCliError(Exception):
 
 
 def call_check(command):
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         raise HDFSCliError(command, p.returncode, stdout, stderr)
@@ -91,7 +91,7 @@ class HdfsClient(FileSystem):
         """
 
         cmd = [load_hadoop_cmd(), 'fs', '-stat', path]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
         if p.returncode == 0:
             return True
@@ -181,16 +181,16 @@ class HdfsClient(FileSystem):
             cmd = [load_hadoop_cmd(), 'fs', '-ls', '-R', path]
         else:
             cmd = [load_hadoop_cmd(), 'fs', '-ls', path]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        lines = proc.stdout
+        lines = call_check(cmd).split('\n')
 
         for line in lines:
-            if line.startswith('Found'):
-                continue  # "hadoop fs -ls" outputs "Found %d items" as its first line
-            line = line.rstrip("\n")
-            if ignore_directories and line[0] == 'd':
+            if not line:
                 continue
-            if ignore_files and line[0] == '-':
+            elif line.startswith('Found'):
+                continue  # "hadoop fs -ls" outputs "Found %d items" as its first line
+            elif ignore_directories and line[0] == 'd':
+                continue
+            elif ignore_files and line[0] == '-':
                 continue
             data = line.split(' ')
 
@@ -449,7 +449,7 @@ class HdfsClientApache1(HdfsClientCdh3):
     which are similar to CDH3 except for the file existence check"""
     def exists(self, path):
         cmd = [load_hadoop_cmd(), 'fs', '-test', '-e', path]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
         if p.returncode == 0:
             return True
@@ -498,10 +498,10 @@ class HdfsAtomicWritePipe(luigi.format.OutputPipeProcessWrapper):
         self.tmppath = tmppath(self.path)
         tmpdir = os.path.dirname(self.tmppath)
         if get_hdfs_syntax() == "cdh4":
-            if subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', '-p', tmpdir]).wait():
+            if subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', '-p', tmpdir], close_fds=True).wait():
                 raise RuntimeError("Could not create directory: %s" % tmpdir)
         else:
-            if not exists(tmpdir) and subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', tmpdir]).wait():
+            if not exists(tmpdir) and subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', tmpdir], close_fds=True).wait():
                 raise RuntimeError("Could not create directory: %s" % tmpdir)
         super(HdfsAtomicWritePipe, self).__init__([load_hadoop_cmd(), 'fs', '-put', '-', self.tmppath])
 


### PR DESCRIPTION
- whenever using subprocess.Popen, use close_fds=True
- make sure to catch errors in hdfs listdir
  (and make some minor improvements there)
- add one FIXME question

Most of the changes are simply adding "close_fds=True" to calls to subprocess.Popen.
However, I found a bug in hdfs.listdir wherein if the hadoop process failed, luigi did not notice (because it didn't check the return code of the process).  A cursory examination led me to believe that this was the only place where the returncode was not checked explicitly, or the nice wrapper (call_check) was not used.

I also added a FIXME, mostly as a reminder to see if using the .communicate() method might not be better in that particular case. That issue should probably be resolved before merging.
