### PR TITLE
Flesh out the MANIFEST.in file and add the 'license' field to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
 include bin/luigid
 include README.md
+include LICENSE
+include examples/*.py
+include test/*.py
 recursive-include luigi/static *
+include luigi/templates/*.html
+

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     author='Erik Bernhardsson',
     author_email='erikbern@spotify.com',
     url='https://github.com/spotify/luigi',
+    license='Apache License 2.0',
     packages=[
         'luigi',
         'luigi.contrib',


### PR DESCRIPTION
- add license field to setup.py
- include tests, examples, luigi/templates/*.html, and LICENSE

It's nice to have the tests and examples in the source archive, and the LICENSE file should be there too.
The setup.py file should also state the license.

I think I got these right.

You can always check to see what using the setup.py file includes with:

python setup.py sdist

which will (usually!) create a tarball which you can examine.
