### PR TITLE
Fix partial HdfsTarget read - close stream and send SIGPIPE

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -13,11 +13,13 @@
 # the License.
 
 import subprocess
+import signal
 
 
 class FileWrapper(object):
     """Wrap `file` in a "real" so stuff can be added to it after creation
     """
+
     def __init__(self, file_object):
         self._subpipe = file_object
 
@@ -48,23 +50,39 @@ class InputPipeProcessWrapper(object):
         '''
         self._command = command
         self._input_pipe = input_pipe
-        self._process = command if isinstance(command, subprocess.Popen) else subprocess.Popen(command,
-            stdin=input_pipe,
-            stdout=subprocess.PIPE,
-            close_fds=True)
+        self._process = command if isinstance(command, subprocess.Popen) else self.create_subprocess(command)
         # we want to keep a circular reference to avoid garbage collection
         # when the object is used in, e.g., pipe.read()
         self._process._selfref = self
 
+    def create_subprocess(self, command):
+        """
+        http://www.chiark.greenend.org.uk/ucgi/~cjwatson/blosxom/2009-07-02-python-sigpipe.html
+        """
+
+        def subprocess_setup():
+            # Python installs a SIGPIPE handler by default. This is usually not what
+            # non-Python subprocesses expect.
+            signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+        return subprocess.Popen(command,
+                                stdin=self._input_pipe,
+                                stdout=subprocess.PIPE,
+                                preexec_fn=subprocess_setup,
+                                close_fds=True)
+
     def _finish(self):
+        # Need to close this before input_pipe to get all SIGPIPE messages correctly
+        self._process.stdout.close()
+
         if self._input_pipe is not None:
             self._input_pipe.close()
-        # FIXME: why not self._process.communicate()
-        for line in self._process.stdout:  # exhaust all output...
-            pass
+
         self._process.wait()  # deadlock?
-        if self._process.returncode != 0:
-            raise RuntimeError('Error reading from pipe. Subcommand exited with non-zero exit status.')
+        if self._process.returncode not in (0, 141, 128 - 141):
+            # 141 == 128 + 13 == 128 + SIGPIPE - normally processes exit with 128 + {reiceived SIG}
+            # 128 - 141 == -13 == -SIGPIPE, sometimes python receives -13 for some subprocesses
+            raise RuntimeError('Error reading from pipe. Subcommand exited with non-zero exit status %s.' % self._process.returncode)
 
     def close(self):
         self._finish()
@@ -109,9 +127,9 @@ class OutputPipeProcessWrapper(object):
         self._command = command
         self._output_pipe = output_pipe
         self._process = subprocess.Popen(command,
-            stdin=subprocess.PIPE,
-            stdout=output_pipe,
-            close_fds=True)
+                                         stdin=subprocess.PIPE,
+                                         stdout=output_pipe,
+                                         close_fds=True)
         self._flushcount = 0
 
     def write(self, *args, **kwargs):
@@ -193,6 +211,7 @@ class Gzip(Format):
     @classmethod
     def pipe_writer(cls, output_pipe):
         return OutputPipeProcessWrapper(['gzip'], output_pipe)
+
 
 class Bzip2(Format):
     @classmethod

--- a/test/test_sigpipe.py
+++ b/test/test_sigpipe.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2014 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import os
+from unittest import TestCase
+from luigi.format import InputPipeProcessWrapper
+
+BASH_SCRIPT = """
+#!/bin/bash
+
+trap "touch /tmp/luigi_sigpipe.marker; exit 141" SIGPIPE
+
+
+for i in {1..3}
+do
+    sleep 0.1
+    echo "Welcome $i times"
+done
+"""
+
+FAIL_SCRIPT = BASH_SCRIPT + """
+exit 1
+"""
+
+
+class TestSigpipe(TestCase):
+    def setUp(self):
+        with open("/tmp/luigi_test_sigpipe.sh", "w") as fp:
+            fp.write(BASH_SCRIPT)
+
+    def tearDown(self):
+        os.remove("/tmp/luigi_test_sigpipe.sh")
+        if os.path.exists("/tmp/luigi_sigpipe.marker"):
+            os.remove("/tmp/luigi_sigpipe.marker")
+
+    def test_partial_read(self):
+        p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
+        self.assertEqual(p1.readline(), "Welcome 1 times\n")
+        p1.close()
+        self.assertTrue(os.path.exists("/tmp/luigi_sigpipe.marker"))
+
+    def test_full_read(self):
+        p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
+        counter = 1
+        for line in p1:
+            self.assertEqual(line, "Welcome %i times\n" % counter)
+            counter += 1
+        p1.close()
+        self.assertFalse(os.path.exists("/tmp/luigi_sigpipe.marker"))
+
+
+class TestSubprocessException(TestCase):
+    def setUp(self):
+        with open("/tmp/luigi_test_sigpipe.sh", "w") as fp:
+            fp.write(FAIL_SCRIPT)
+
+    def tearDown(self):
+        os.remove("/tmp/luigi_test_sigpipe.sh")
+        if os.path.exists("/tmp/luigi_sigpipe.marker"):
+            os.remove("/tmp/luigi_sigpipe.marker")
+
+    def test_partial_read(self):
+        p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
+        self.assertEqual(p1.readline(), "Welcome 1 times\n")
+        p1.close()
+        self.assertTrue(os.path.exists("/tmp/luigi_sigpipe.marker"))
+
+    def test_full_read(self):
+        def run():
+            p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
+            counter = 1
+            for line in p1:
+                self.assertEqual(line, "Welcome %i times\n" % counter)
+                counter += 1
+            p1.close()
+
+        self.assertRaises(RuntimeError, run)


### PR DESCRIPTION
We had problem with reading some sample lines (top 3) from HdfsTarget but subprocess continues to read rest of data.
This should solve it.
But someone more knowledgeable must review implementation...
