### PR TITLE
Make MapReduce python executable configurable

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -341,9 +341,11 @@ class HadoopJobRunner(JobRunner):
         logger.debug("Tmp dir: %s", self.tmp_dir)
 
         # build arguments
-        map_cmd = 'python mrrunner.py map'
-        cmb_cmd = 'python mrrunner.py combiner'
-        red_cmd = 'python mrrunner.py reduce'
+        config = configuration.get_config()
+        python_executable = config.get('hadoop', 'python-executable', 'python')
+        map_cmd = '{0} mrrunner.py map'.format(python_executable)
+        cmb_cmd = '{0} mrrunner.py combiner'.format(python_executable)
+        red_cmd = '{0} mrrunner.py reduce'.format(python_executable)
 
         # replace output with a temporary work directory
         output_final = job.output().path


### PR DESCRIPTION
For nodes with multiple Python installations, this allows the Python executable to be specified for Luigi MapReduce jobs.

Example client.cfg:

``` ini
[hadoop]
python-executable=python2.7
```
