### PR TITLE
Add support for is_list to default_from_config.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -90,7 +90,12 @@ class Parameter(object):
             raise MissingParameterException("No default specified")
         if self.__default != _no_default:
             return self.__default
-        return self.parse(self._get_default_from_config(safe=False))
+
+        value = self._get_default_from_config(safe=False)
+        if self.is_list:
+            return tuple(self.parse(p.strip()) for p in value.strip().split('\n'))
+        else:
+            return self.parse(value)
 
     def set_default(self, value):
         self.__default = value
@@ -216,4 +221,3 @@ class TimeDeltaParameter(Parameter):
             return result
         else:
             raise ParameterException("Invalid time delta - could not parse %s" % input)
-

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -320,5 +320,15 @@ class TestParamWithDefaultFromConfig(unittest.TestCase):
     def testHasDefaultWithBoth(self):
         self.assertTrue(luigi.Parameter(default_from_config=dict(section="foo", name="bar")).has_default)
 
+    @with_config({"foo": {"bar": "one\n\ttwo\n\tthree\n"}})
+    def testDefaultList(self):
+        p = luigi.Parameter(is_list=True, default_from_config=dict(section="foo", name="bar"))
+        self.assertEquals(('one', 'two', 'three'), p.default)
+
+    @with_config({"foo": {"bar": "1\n2\n3"}})
+    def testDefaultIntList(self):
+        p = luigi.IntParameter(is_list=True, default_from_config=dict(section="foo", name="bar"))
+        self.assertEquals((1, 2, 3), p.default)
+
 if __name__ == '__main__':
     luigi.run(use_optparse=True)


### PR DESCRIPTION
Parse multiple values from the config file if `is_list` is `True` for a
parameter. For example:

```
[foo]
bar = one
      two
      three
```
