### PR TITLE
luigid: allow empty state-path and logdir for development

### DIFF
--- a/bin/luigid
+++ b/bin/luigid
@@ -14,13 +14,17 @@ parser.add_option('--logdir', help='logdir')
 parser.add_option('--state-path', help='Pickled state file')
 opts, args = parser.parse_args()
 
-config = luigi.configuration.get_config()
-config.set('scheduler', 'state-path', opts.state_path)
+if opts.state_path:
+    config = luigi.configuration.get_config()
+    config.set('scheduler', 'state-path', opts.state_path)
 
 if opts.background:
     # daemonize sets up logging to spooled log files
     logging.getLogger().setLevel(logging.INFO)
     luigi.process.daemonize(luigi.server.run, pidfile=opts.pidfile, logdir=opts.logdir)
 else:
-    logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format(), filename=os.path.join(logdir, "luigi-server.log"))
+    if opts.logdir:
+        logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format(), filename=os.path.join(opts.logdir, "luigi-server.log"))
+    else:
+        logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format())
     luigi.server.run()


### PR DESCRIPTION
Since d54a15a2e1453c36a6470d08efd01e23d0b26233 it was not possible to run `luigid` from the command line without specifying a `state_path` and a `log_dir`. This PR fixes this (under the assumption, that running `luigid` in non-deamon mode should _by default_ log to stderr and should not require a `state_path`).
