### PR TITLE
Fix incorrect hadoop stat msg match

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -99,7 +99,7 @@ class HdfsClient(FileSystem):
         if p.returncode == 0:
             return True
         else:
-            not_found_pattern = "^stat: `.*': No such file or directory$"
+            not_found_pattern = "^.*No such file or directory$"
             not_found_re = re.compile(not_found_pattern)
             for line in stderr.split('\n'):
                 if not_found_re.match(line):


### PR DESCRIPTION
This fixes a bug that causes a luigi Hadoop jobs to fail due to an exception being thrown when luigi checks if a file already exists.
