### PR TITLE
Don't try to mail errors when missing config.

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -76,14 +76,22 @@ def send_email(subject, message, sender, recipients, image_png=None):
 
 
 def send_error_email(subject, message):
-    """ Sends an email to the configured error-email """
+    """ Sends an email to the configured error-email.
+
+    If no error-email is configured, then a message is logged
+    """
     config = configuration.get_config()
     receiver = config.get('core', 'error-email', None)
-    sender = config.get('core', 'email-sender', DEFAULT_CLIENT_EMAIL)
-    logger.info("Sending warning email to %r", receiver)
-    send_email(
-        subject=subject,
-        message=message,
-        sender=sender,
-        recipients=(receiver,)
-    )
+    if receiver:
+        sender = config.get('core', 'email-sender', DEFAULT_CLIENT_EMAIL)
+        logger.info("Sending warning email to %r", receiver)
+        send_email(
+            subject=subject,
+            message=message,
+            sender=sender,
+            recipients=(receiver,)
+        )
+    else:
+        logger.info("Skipping error email. Set `error-email` in the `core` "
+                    "section of the luigi config file to receive error "
+                    "emails.")

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -24,6 +24,8 @@ luigi.notifications.DEBUG = True
 import unittest
 from helpers import with_config
 
+EMAIL_CONFIG = {"core": {"error-email": "not-a-real-email-address-for-test-only"}}
+
 
 class A(luigi.Task):
     p = luigi.IntParameter()
@@ -158,6 +160,7 @@ class ParameterTest(EmailTest):
     def test_forgot_param(self):
         self.assertRaises(luigi.parameter.MissingParameterException, luigi.run, ['--local-scheduler', 'ForgotParam'],)
 
+    @with_config(EMAIL_CONFIG)
     def test_forgot_param_in_dep(self):
         # A programmatic missing parameter will cause an error email to be sent
         luigi.run(['--local-scheduler', 'ForgotParamDep'])

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -17,6 +17,7 @@ from luigi.scheduler import CentralPlannerScheduler
 import luigi.worker
 from luigi.worker import Worker
 from luigi import Task, ExternalTask, RemoteScheduler
+from helpers import with_config
 import unittest
 import logging
 import threading
@@ -351,6 +352,8 @@ class WorkerPingThreadTests(unittest.TestCase):
         w.stop()  # should stop within 0.01 s
         self.assertFalse(w._keep_alive_thread.is_alive())
 
+EMAIL_CONFIG = {"core": {"error-email": "not-a-real-email-address-for-test-only"}}
+
 
 class EmailTest(unittest.TestCase):
     def setUp(self):
@@ -376,6 +379,7 @@ class WorkerEmailTest(EmailTest):
     def tearDown(self):
         self.worker.stop()
 
+    @with_config(EMAIL_CONFIG)
     def test_connection_error(self):
         sch = RemoteScheduler(host="this_host_doesnt_exist", port=1337)
         worker = Worker(scheduler=sch)
@@ -398,6 +402,7 @@ class WorkerEmailTest(EmailTest):
         self.assertEquals(self.last_email[0], "Luigi: Framework error while scheduling %s" % (a,))
         worker.stop()
 
+    @with_config(EMAIL_CONFIG)
     def test_complete_error(self):
         class A(DummyTask):
             def complete(self):
@@ -411,6 +416,7 @@ class WorkerEmailTest(EmailTest):
         self.assertEquals(("Luigi: %s failed scheduling" % (a,)), self.last_email[0])
         self.assertFalse(a.has_run)
 
+    @with_config(EMAIL_CONFIG)
     def test_complete_return_value(self):
         class A(DummyTask):
             def complete(self):
@@ -424,6 +430,7 @@ class WorkerEmailTest(EmailTest):
         self.assertEquals(("Luigi: %s failed scheduling" % (a,)), self.last_email[0])
         self.assertFalse(a.has_run)
 
+    @with_config(EMAIL_CONFIG)
     def test_run_error(self):
         class A(luigi.Task):
             def complete(self):


### PR DESCRIPTION
Avoid a bogus log entry like:

```
INFO: Sending warning email to None
DEBUG: Emailing:
-------------
To: (None,)
From: luigi-client@Joes-MacBook-Pro.local
... lots more debug logging ...
```

Which now becomes:
`INFO: Skipping error email. Set `error-email` in the `core` section of the luigi config file to receive error emails.`
