### PR TITLE
Fix the top_artists example

### DIFF
--- a/examples/top_artists.py
+++ b/examples/top_artists.py
@@ -22,9 +22,9 @@ class Streams(luigi.Task):
     date = luigi.DateParameter()
 
     def run(self):
-        with open(self.output(), 'w') as output:
+        with self.output().open('w') as output:
             for i in xrange(1000):
-                output.write('{}{}{}\n'.format(
+                output.write('{} {} {}\n'.format(
                     random.randint(0, 999),
                     random.randint(0, 999),
                     random.randint(0, 999)))
@@ -75,7 +75,7 @@ class AggregateArtistsHadoop(luigi.hadoop.JobTask):
     def mapper(self, line):
         _, artist, _ = line.strip().split()
         yield artist, 1
-        
+
     def reducer(self, key, values):
         yield key, sum(values)
 
@@ -105,7 +105,7 @@ class Top10Artists(luigi.Task):
                 out_file.write(out_line + '\n')
 
     def _input_iterator(self):
-        with open(self.input(), 'r') as in_file:
+        with self.input().open('r') as in_file:
             for line in in_file:
                 artist, streams = line.strip().split()
                 yield int(streams), artist


### PR DESCRIPTION
Hi, I've noticed two types of errors when running top_artists:
- The open() function wasn't working as expected with `TypeError: coercing to Unicode: need string or buffer, File found`. Is this my python version? I'm not sure... but my commit fixes it to behave similar to other places
- Line 27 was missing a few spaces as a result of probably previous bogus commit (I guess 11eb06b35e10ceaecb584234643b14ce2dfbc59d) 
