### PR TITLE
add config value for default hiverc file

### DIFF
--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -273,8 +273,11 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         raise RuntimeError("Must implement query!")
 
     def hiverc(self):
-        """ Location of an rc file to run before the query """
-        return None
+        """ Location of an rc file to run before the query 
+            if hiverc-location key is specified in client.cfg, will default to the value there
+            otherwise returns None
+        """
+        return luigi.configuration.get_config().get('hive', 'hiverc-location', default=None)
 
     def hiveconfs(self):
         """


### PR DESCRIPTION
PR allows a user to specify the "default" hiverc file in client.cfg. 

Example use case: we use a hiverc file to load UDF jars and run multiple "create temporary function" commands. This would allow us (or others) to auto load these UDFs via client.cfg instead of requiring the end user to override the hiverc() function themselves everytime.
