### PR TITLE
Create parent directories on HDFS

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -171,7 +171,7 @@ class HdfsClient(FileSystem):
 
     def mkdir(self, path):
         try:
-            call_check([load_hadoop_cmd(), 'fs', '-mkdir', path])
+            call_check([load_hadoop_cmd(), 'fs', '-mkdir', '-p', path])
         except HDFSCliError, ex:
             if "File exists" in ex.stderr:
                 raise FileAlreadyExists(ex.stderr)


### PR DESCRIPTION
When HdfsAtomicWritePipe closes the pipe, it renames the temporary file to the final name, and tries to ensure the directory exists.  However, it was not creating the parent directories correctly.
