### PR TITLE
- fix serialization of DataHourParameter when the value is None

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -210,6 +210,7 @@ class DateHourParameter(Parameter):
         """
         Converts the datetime to a string usnig the format string ``%Y-%m-%dT%H``.
         """
+        if dt is None: return str(dt)
         return dt.strftime('%Y-%m-%dT%H')
 
 


### PR DESCRIPTION
DateParameter, like most (all?) other Parameter-derived types, can be None, at least for serialization purposes. However, DateHourParameter can't, and this fixes that situation.

Oftentimes I find myself using None as a default and then in 'depends' checking for a value of None and replacing the value with a new value calculated on-the-fly.
