### PR TITLE
have the track process return (stdout, stderr) tuple

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -234,7 +234,7 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
 
         if proc.returncode == 0:
             write_luigi_history(arglist, {'job_id': job_id})
-            return
+            return (out, err)
 
         # Try to fetch error logs if possible
         message = 'Streaming job failed with exit code %d. ' % proc.returncode
@@ -255,7 +255,7 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
     if tracking_url_callback is None:
         tracking_url_callback = lambda x: None
 
-    track_process(arglist, tracking_url_callback, env)
+    return track_process(arglist, tracking_url_callback, env)
 
 
 def fetch_task_failures(tracking_url):

--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -344,7 +344,7 @@ class HiveQueryRunner(luigi.hadoop.JobRunner):
                     arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
 
             logger.info(arglist)
-            luigi.hadoop.run_and_track_hadoop_job(arglist)
+            return luigi.hadoop.run_and_track_hadoop_job(arglist)
 
 
 class HiveTableTarget(luigi.Target):


### PR DESCRIPTION
added to Hive module as well.

This allows you to capture the output of a hive query directly, eg:

``` python
class TestTask(luigi.hive.HiveQueryTask):
  def query(self):
    return """ select count(1) from test """
  def run(self):
    out = self.output().open('w')
    (stdout, stderr) = self.job_runner().run_job(self)
    out.write(stdout)
    out.close()

  def output(self):
    return luigi.LocalTarget("test_data/hive_output.log")
```
