### PR TITLE
fixes to the task register to support multiple tasks with the same name

### DIFF
--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -50,6 +50,22 @@ class NonAmbiguousClass(luigi.Task):
         NonAmbiguousClass.has_run = True
 
 
+class DontRegisterThisOne(luigi.Task):
+    register_cls = False
+
+
+class TaskWithSameName(luigi.Task):
+    register_cls = False
+    def run(self):
+        self.x = 42
+
+
+class TaskWithSameName(luigi.Task):
+    # there should be no ambiguity
+    def run(self):
+        self.x = 43
+
+
 class CmdlineTest(unittest.TestCase):
     def setUp(self):
         global File
@@ -106,6 +122,18 @@ class CmdlineTest(unittest.TestCase):
             luigi.interface.setup_interface_logging.call_args_list = []
             luigi.run(['Task', '--local-scheduler'])
             self.assertEqual([], setup_mock.call_args_list)
+
+    @mock.patch('argparse.ArgumentParser.print_usage')
+    def test_non_existent_class(self, print_usage):
+        self.assertRaises(SystemExit, luigi.run, ['--local-scheduler', 'XYZ'])
+
+    @mock.patch('argparse.ArgumentParser.print_usage')
+    def test_not_registered_class(self, print_usage):
+        self.assertRaises(SystemExit, luigi.run, ['--local-scheduler', 'DontRegisterThisOne'])
+
+    def test_unregistered_class(self):
+        luigi.run(['--local-scheduler', 'TaskWithSameName'])
+        self.assertEqual(TaskWithSameName().x, 43)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -7,6 +7,7 @@ from luigi.parameter import MissingParameterException
 luigi.notifications.DEBUG = True
 from luigi.util import inherits, common_params, requires, copies, delegates
 from luigi.mock import MockFile
+from luigi.interface import ArgParseInterface
 
 class A(luigi.Task):
     param1 = luigi.Parameter("class A-specific default")
@@ -300,6 +301,12 @@ class SubtaskTest(unittest.TestCase):
                 pass
 
         self.assertRaises(AttributeError, trigger_failure)
+
+    def test_cmdline(self):
+        # Exposes issue where wrapped tasks are registered twice under
+        # the same name
+        interface = ArgParseInterface()
+        tasks = interface.parse(['SubtaskDelegator'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is needed in some cases where you have task wrappers and you wanted the wrapped task to be exposed over cmd line
