### PR TITLE
Change automatic packaging to not use __package__

### DIFF
--- a/test/create_packages_archive_root/module.py
+++ b/test/create_packages_archive_root/module.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2014 Spotify AB

--- a/test/create_packages_archive_root/package/__init__.py
+++ b/test/create_packages_archive_root/package/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2014 Spotify AB

--- a/test/create_packages_archive_root/package/submodule.py
+++ b/test/create_packages_archive_root/package/submodule.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2014 Spotify AB
+import os

--- a/test/create_packages_archive_root/package/submodule_with_absolute_import.py
+++ b/test/create_packages_archive_root/package/submodule_with_absolute_import.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2014 Spotify AB
+from __future__ import absolute_import
+import os

--- a/test/create_packages_archive_root/package/submodule_without_imports.py
+++ b/test/create_packages_archive_root/package/submodule_without_imports.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2014 Spotify AB

--- a/test/create_packages_archive_root/package/subpackage/__init__.py
+++ b/test/create_packages_archive_root/package/subpackage/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2014 Spotify AB

--- a/test/create_packages_archive_root/package/subpackage/submodule.py
+++ b/test/create_packages_archive_root/package/subpackage/submodule.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2014 Spotify AB
+import os


### PR DESCRIPTION
- Fixes #285
- Don't rely on **package**. It does not exist for modules without
  imports or modules that has absolute_import
  http://legacy.python.org/dev/peps/pep-0366/
- Added unit tests to clearly describe what gets added. Still not
  intuitive to understand what gets added. We could make sure to add
  everything in a package "just to be safe", but then you might
  accidently add the entire universe of a namespaced package.
