### PR TITLE
Fixed an hanging unit tests

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -32,9 +32,10 @@ class RPCError(Exception):
 class RemoteScheduler(Scheduler):
     ''' Scheduler proxy object. Talks to a RemoteSchedulerResponder '''
 
-    def __init__(self, host='localhost', port=8082):
+    def __init__(self, host='localhost', port=8082, connect_timeout=None):
         self._host = host
         self._port = port
+        self._connect_timeout = connect_timeout
 
     def _wait(self):
         time.sleep(30)
@@ -52,7 +53,7 @@ class RemoteScheduler(Scheduler):
                 logger.info("Retrying...")
                 self._wait()  # wait for a bit and retry
             try:
-                response = urllib2.urlopen(req)
+                response = urllib2.urlopen(req, None, self._connect_timeout)
                 break
             except urllib2.URLError, last_exception:
                 if log_exceptions:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -381,7 +381,7 @@ class WorkerEmailTest(EmailTest):
 
     @with_config(EMAIL_CONFIG)
     def test_connection_error(self):
-        sch = RemoteScheduler(host="this_host_doesnt_exist", port=1337)
+        sch = RemoteScheduler(host="this_host_doesnt_exist", port=1337, connect_timeout=1)
         worker = Worker(scheduler=sch)
 
         self.waits = 0


### PR DESCRIPTION
(At least one my computer)
urlib2.urlopen probably has weird defaults on my OS.
Maybe rpc.RemoteScheduler should read connect_timeout from config?
