### PR TITLE
Fixed an issue introduced in 6330e9d0332e6152996292a39c42f752b9288c96

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -30,19 +30,12 @@ def common_params(task_instance, task_cls):
 
 
 def task_wraps(P):
-    # Makes sure the subclass overrides the base class in the register so that when
-    # the user tries to instantiate P by name, it refers to the subclass and doesn't
-    # create any ambiguity problems.
-    P.unregister()
-
     # In order to make the behavior of a wrapper class nicer, we set the name of the
     # new class to the wrapped class, and copy over the docstring and module as well.
     # This makes it possible to pickle the wrapped class etc.
     # Btw, this is a slight abuse of functools.wraps. It's meant to be used only for
     # functions, but it works for classes too, if you pass updated=[]
-    P = functools.wraps(P, updated=[])
-
-    return P
+    return functools.wraps(P, updated=[])
 
 
 class inherits(object):
@@ -164,7 +157,7 @@ def delegates(task_that_delegates):
             for t in task.flatten(self.subtasks()):
                 t.run()
             task_that_delegates.run(self)
-        
+
     return Wrapped
 
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -50,12 +50,7 @@ class NonAmbiguousClass(luigi.Task):
         NonAmbiguousClass.has_run = True
 
 
-class DontRegisterThisOne(luigi.Task):
-    register_cls = False
-
-
 class TaskWithSameName(luigi.Task):
-    register_cls = False
     def run(self):
         self.x = 42
 
@@ -126,14 +121,6 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch('argparse.ArgumentParser.print_usage')
     def test_non_existent_class(self, print_usage):
         self.assertRaises(SystemExit, luigi.run, ['--local-scheduler', 'XYZ'])
-
-    @mock.patch('argparse.ArgumentParser.print_usage')
-    def test_not_registered_class(self, print_usage):
-        self.assertRaises(SystemExit, luigi.run, ['--local-scheduler', 'DontRegisterThisOne'])
-
-    def test_unregistered_class(self):
-        luigi.run(['--local-scheduler', 'TaskWithSameName'])
-        self.assertEqual(TaskWithSameName().x, 43)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -305,8 +305,8 @@ class SubtaskTest(unittest.TestCase):
     def test_cmdline(self):
         # Exposes issue where wrapped tasks are registered twice under
         # the same name
-        interface = ArgParseInterface()
-        tasks = interface.parse(['SubtaskDelegator'])
+        from luigi.task import Register
+        self.assertEquals(Register.get_reg().get('SubtaskDelegator', None), SubtaskDelegator)
 
 
 if __name__ == '__main__':

--- a/test/set_task_name_test.py
+++ b/test/set_task_name_test.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2012 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import luigi
+import unittest
+
+def create_class(cls_name):
+    class NewTask(luigi.WrapperTask):
+        pass
+
+    NewTask.__name__ = cls_name
+
+    return NewTask
+
+
+my_new_task = luigi.expose(create_class('MyNewTask'))
+
+class SetTaskNameTest(unittest.TestCase):
+    ''' I accidentally introduced an issue in this commit:
+    https://github.com/spotify/luigi/commit/6330e9d0332e6152996292a39c42f752b9288c96
+
+    This causes tasks not to get exposed if they change name later. Adding a unit test
+    to resolve the issue. '''
+
+    def test_set_task_name(self):
+        luigi.run(['--local-scheduler', 'MyNewTask'])
+
+
+if __name__ == '__main__':
+    luigi.run()


### PR DESCRIPTION
- Previous commit introduced a bug that would cause tasks not to be exposed if they changed name after creation
- Added a new unit test for this case
- Ended up removing a lot of the code introduced in the previous commit and replaced it with a much simpler mechanism
- Removed some unit tests for unregister() since I decided that method wasn't a good idea to have
