### PR TITLE
- don't disable existing loggers when logging.config.fileConfig is called by luigi

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -48,7 +48,7 @@ def setup_interface_logging(conf_file=None):
 
         logger.addHandler(streamHandler)
     else:
-        logging.config.fileConfig(conf_file)
+        logging.config.fileConfig(conf_file, disable_existing_loggers=False)
 
     setup_interface_logging.has_run = True
 


### PR DESCRIPTION
Originally #246.
Per your request, I've rebased this.

Original text:

When asking luigi to set up logging (by way of a logging config file), luigi will use logging.config.fileConfig(some_filename). However, it's also not passing in disable_existing_loggers=False (which, sadly, defaults to True). What happens is if you use the pattern where each module has a global logger instance, by the time luigi gets around to calling fileConfig, these logger instances have already been created, and then fileConfig (without disable_existing_loggers=False) goes ahead and disables them, making them useless.

Therefore, don't disable existing loggers when luigi starts up and configures logging.
