### PR TITLE
Add ON DUPLICATE KEY UPDATE clause to the MySQL target touch method. 

### DIFF
--- a/luigi/contrib/mysqldb.py
+++ b/luigi/contrib/mysqldb.py
@@ -54,6 +54,8 @@ class MySqlTarget(luigi.Target):
         connection.cursor().execute(
             """INSERT INTO {marker_table} (update_id, target_table)
                VALUES (%s, %s)
+               ON DUPLICATE KEY UPDATE
+               update_id = VALUES(update_id)
             """.format(marker_table=self.marker_table),
             (self.update_id, self.table)
         )


### PR DESCRIPTION
This will prevent errors and do a no-op in case the update marker already exists
