### PR TITLE
include worker id and host in log output

### DIFF
--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -155,7 +155,7 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(r['task_id'], None)  # Worker Y is pending on A to be done
         s = r['running_tasks'][0]
         self.assertEqual(s['task_id'], 'A')
-        self.assertEqual(s['worker'], 'X')
+        self.assert_(s['worker'].startswith('X on '))
 
 class TestParameterSplit(unittest.TestCase):
     task_id_examples = [


### PR DESCRIPTION
Makes log output more usable for troubleshooting when somewhere a worker process is hung. The "is currently run by worker-RANDOM_NUMBER" error message will now include the host, and logs on that host will let associate the worker id with its pid.
