### PR TITLE
update MANIFEST.in for new README.rst

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include bin/luigid
-include README.md
+include README.rst
 include LICENSE
 include examples/*.py
 include test/*.py


### PR DESCRIPTION
pip install from pypi failed after this morning's version bump, since it couldn't find README.rst in the distribution. This MANIFEST update should fix it.
