### PR TITLE
Fixes to history page templates

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -68,7 +68,7 @@ class BaseTaskHistoryHandler(tornado.web.RequestHandler):
         self._api = api
 
     def get_template_path(self):
-        return 'luigi/templates'
+        return pkg_resources.resource_filename(__name__, 'templates')
 
 
 class RecentRunHandler(BaseTaskHistoryHandler):

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,12 @@ try:
 except:
     from distutils.core import setup
 
-luigi_package_data = [os.path.join(dirpath.replace("luigi/", ""), ext)
-                      for (dirpath, dirnames, filenames) in os.walk("luigi/static")
-                      for ext in ["*.html", "*.js", "*.css", "*.png"]]
+def get_static_files(path):
+    return [os.path.join(dirpath.replace("luigi/", ""), ext) 
+            for (dirpath, dirnames, filenames) in os.walk(path)
+            for ext in ["*.html", "*.js", "*.css", "*.png"]]
+
+luigi_package_data = sum(map(get_static_files, ["luigi/static", "luigi/templates"]), [])
 
 long_description = ['Note: For the latest source, discussion, etc, please visit the `Github repository <https://github.com/spotify/luigi>`_\n\n']
 for line in open('README.rst'):


### PR DESCRIPTION
As of now, the (excellent) job history page will only work if luigi is run out of a cloned repo. That is, if I install luigi in a virtualenv called `vendor` and run the scheduler as `vendor/bin/luigid`, the history pages won't render because they can't find the requisite templates. This is because setup.py doesn't add them as package data, and `server.py` isn't looking for them there anyway. I made the following changes which fixed that behavior for me:
- Get templates from dir relative to install (with pkg_resources, like the static files)
- Include templates in package data from setup.py (again like the static files)
