### PR TITLE
Add “priority” property to task, to take into account in scheduler.get_work

### DIFF
--- a/doc/api_overview.rst
+++ b/doc/api_overview.rst
@@ -244,6 +244,49 @@ You can use the hdfs.HdfsTarget class anywhere by just instantiating it:
     # ...
     f.close() # needed
 
+
+Task priority
+^^^^^^^^^^^^^
+
+The scheduler decides which task to run next from the set of all task
+that have all their dependencies met. By default, this choice is pretty
+arbitrary, which is fine for most workflows and situations.
+
+If you want to have some control on the order of execution
+of available tasks, you can set the *priority* property of a task,
+for example as follows:
+
+.. code:: python
+
+    # A static priority value as a class contant:
+    class MyTask(luigi.Task):
+        priority = 100
+        # ...
+
+    # A dynamic priority value with a "@property" decorated method:
+    class OtherTask(luigi.Task):
+        @property
+        def priority(self):
+            if self.date > some_threshold:
+                return 80
+            else:
+                return 40
+        # ...
+
+Tasks with a higher priority value will be picked before tasks
+with a lower priority value.
+There is no predefined range of priorities, you can choose whatever
+(int or float) values you want to use. The default value is 0.
+Note that it is perfectly valid to choose negative priorities for
+tasks that should have less priority than default.
+
+Warning: task execution order in Luigi is influenced by both dependencies
+and priorities, but in Luigi dependencies come first. For example:
+if there is a task A with priority 1000 but still with unmet dependencies
+and a task B with priority 1 without any pending dependencies,
+task B will be picked first.
+
+
 Instance caching
 ^^^^^^^^^^^^^^^^
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -73,7 +73,7 @@ class RemoteScheduler(Scheduler):
         # just one attemtps, keep-alive thread will keep trying anyway
         self._request('/api/ping', {'worker': worker}, attempts=1)
 
-    def add_task(self, worker, task_id, status=PENDING, runnable=False, deps=None, expl=None):
+    def add_task(self, worker, task_id, status=PENDING, runnable=False, deps=None, expl=None, priority=0):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -81,6 +81,7 @@ class RemoteScheduler(Scheduler):
             'runnable': runnable,
             'deps': deps,
             'expl': expl,
+            'priority': priority,
         })
 
     def get_work(self, worker, host=None):
@@ -128,8 +129,8 @@ class RemoteSchedulerResponder(object):
     def __init__(self, scheduler):
         self._scheduler = scheduler
 
-    def add_task(self, worker, task_id, status, runnable, deps, expl, **kwargs):
-        return self._scheduler.add_task(worker, task_id, status, runnable, deps, expl)
+    def add_task(self, worker, task_id, status, runnable, deps, expl, priority, **kwargs):
+        return self._scheduler.add_task(worker, task_id, status, runnable, deps, expl, priority)
 
     def get_work(self, worker, host=None, **kwargs):
         return self._scheduler.get_work(worker, host)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -211,6 +211,10 @@ class Task(object):
 
     _event_callbacks = {}
 
+    # Priority of the task: the scheduler should favor available
+    # tasks with higher priority values first.
+    priority = 0
+
     @classmethod
     def event_handler(cls, event):
         """ Decorator for adding event handlers """

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -208,7 +208,7 @@ class Worker(object):
     def _add_external(self, external_task):
         self._scheduled_tasks[external_task.task_id] = external_task
         self._scheduler.add_task(self._id, external_task.task_id, status=PENDING,
-                                  runnable=False)
+                                  runnable=False, priority=external_task.priority)
         external_task.trigger_event(Event.DEPENDENCY_MISSING, external_task)
         logger.warning('Task %s is not complete and run() is not implemented. Probably a missing external dependency.', external_task.task_id)
 
@@ -227,7 +227,7 @@ class Worker(object):
 
         deps = [d.task_id for d in deps]
         self._scheduler.add_task(self._id, task.task_id, status=PENDING,
-                                  deps=deps, runnable=True)
+                                  deps=deps, runnable=True, priority=task.priority)
         logger.info('Scheduled %s', task.task_id)
 
         for d in task.deps():

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -157,6 +157,39 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(s['task_id'], 'A')
         self.assert_(s['worker'].startswith('X on '))
 
+    def test_priorities(self):
+        self.sch.add_task(WORKER, 'A', priority=10)
+        self.sch.add_task(WORKER, 'B', priority=5)
+        self.sch.add_task(WORKER, 'C', priority=15)
+        self.sch.add_task(WORKER, 'D', priority=9)
+        for expected_id in ['C', 'A', 'D', 'B']:
+            self.assertEqual(self.sch.get_work(WORKER)['task_id'], expected_id)
+            self.sch.add_task(WORKER, expected_id, status=DONE)
+        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+
+    def test_priorities_default_and_negative(self):
+        self.sch.add_task(WORKER, 'A', priority=10)
+        self.sch.add_task(WORKER, 'B')
+        self.sch.add_task(WORKER, 'C', priority=15)
+        self.sch.add_task(WORKER, 'D', priority=-20)
+        self.sch.add_task(WORKER, 'E', priority=1)
+        for expected_id in ['C', 'A', 'E', 'B', 'D']:
+            self.assertEqual(self.sch.get_work(WORKER)['task_id'], expected_id)
+            self.sch.add_task(WORKER, expected_id, status=DONE)
+        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+
+    def test_priorities_and_dependencies(self):
+        self.sch.add_task(WORKER, 'A', deps=['Z'], priority=10)
+        self.sch.add_task(WORKER, 'B', priority=5)
+        self.sch.add_task(WORKER, 'C', deps=['Z'], priority=3)
+        self.sch.add_task(WORKER, 'D', priority=2)
+        self.sch.add_task(WORKER, 'Z', priority=1)
+        for expected_id in ['B', 'D', 'Z', 'A', 'C']:
+            self.assertEqual(self.sch.get_work(WORKER)['task_id'], expected_id)
+            self.sch.add_task(WORKER, expected_id, status=DONE)
+        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+
+
 class TestParameterSplit(unittest.TestCase):
     task_id_examples = [
         "TrackIsrcs()",


### PR DESCRIPTION
Hi,
this is a proof of concept implementation for adding "priorities" to tasks, to be taken into account by the scheduler.

A bit of context for this feature request:
Here at work we are considering to start using luigi. FYI: we have a cumbersome azkaban setup at the moment with lot of independent tasks, but where dependencies mostly misused to impose order of execution (hi prio jobs, low prio jobs, ...).

With luigi we would have the same issue, as the scheduler apparently picks "the next task to do" pretty arbitrary (based on timestamp that task was added to scheduler).

This feature branch enables setting tasks priorities, taken into account by scheduler.get_work(): pick the first task with highest priority. Doing so, we can stop misusing dependencies as vehicle to manage order of execution and just use priorities for that.

example usages:

``` python
class TaskA(luigi.Task)
    priority = 100

class TaskB(luigi.Task):
    @property
    def priority(self):
        return some_calculated_priority
```

Priorities are 0 by default, and the legacy behaviour (using timestamp of adding to scheduler) is preserved if all tasks have same priority.

I probably have some more tweaking to do (e.g. adding tests), but wanted to collect some initial feedback on this feature request first.
