### PR TITLE
Fix marking a task as PENDING while it is still running 

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -192,6 +192,11 @@ class CentralPlannerScheduler(Scheduler):
 
         if not (task.status == RUNNING and status == PENDING):
             # don't allow re-scheduling of task while it is running, it must either fail or succeed first
+            if status == PENDING or status != task.status:
+                # Update the DB only if there was a acctual change, to prevent noise.
+                # We also check for status == PENDING b/c that's the default value
+                # (so checking for status != task.status woule lie)
+                self._update_task_history(task_id, status)
             task.status = status
             if status == FAILED:
                 task.retry = time.time() + self._retry_delay
@@ -206,7 +211,6 @@ class CentralPlannerScheduler(Scheduler):
 
         if expl is not None:
             task.expl = expl
-        self._update_task_history(task_id, status)
 
     def get_work(self, worker, host=None):
         # TODO: remove any expired nodes


### PR DESCRIPTION
There was a bug with the history DB where tasks that were already running, and then triggered again (by a different worker) were getting back to state PENDING. They should have stayed at RUNNING. 
The UI was behaving properly but the history db wasn't. 
This PR fixes this. 
