### PR TITLE
Unchecks the upstream dependencies checkbox by default

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -120,7 +120,7 @@
                     </form>
                     <form class="navbar-form pull-left">
                         <label for="invertCheckbox">Show Upstream Dependencies
-                        <input type="checkbox" class="checkbox" checked="checked" id="invertCheckbox"/>
+                        <input type="checkbox" class="checkbox" id="invertCheckbox"/>
                         </label>
                     </form>
                   </div>


### PR DESCRIPTION
Removes the checked property from invertCheckbox to match the default behavior of showing a downstream dependency graph in the task visualiser.
