### PR TITLE
Uses less stack-intensive map in renderTasks

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -57,7 +57,7 @@ function visualiserApp(luigi) {
     }
 
     function renderTasks(tasks) {
-        var displayTasks = $.map(tasks, taskToDisplayTask);
+        var displayTasks = tasks.map(taskToDisplayTask);
         displayTasks.sort(function(a,b) { return b.displayTimestamp - a.displayTimestamp; });
         var tasksByFamily = entryList(indexByProperty(displayTasks, "taskName"));
         tasksByFamily.sort(function(a,b) { return a.key.localeCompare(b.key); });


### PR DESCRIPTION
$.map causes an exception if called on too large an array. This limit is tough to reach on Firefox, but fairly easy to hit on Chrome. Using array.map fixes this issue, allowing larger task lists to be successfully displayed on all browsers.
