### PR TITLE
Add support for email subject prefix

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -10,6 +10,7 @@ DEBUG = False
 
 
 def send_email(subject, message, sender, recipients, image_png=None):
+    subject = _prefix(subject)
     logger.debug("Emailing:\n"
                  "-------------\n"
                  "To: %s\n"
@@ -95,3 +96,13 @@ def send_error_email(subject, message):
         logger.info("Skipping error email. Set `error-email` in the `core` "
                     "section of the luigi config file to receive error "
                     "emails.")
+
+def _prefix(subject):
+    """If the config has a special prefix for emails then this function adds
+    this prefix
+    """
+    config = configuration.get_config()
+    email_prefix = config.get('core', 'email-prefix', None)
+    if email_prefix is not None:
+        subject = "%s %s" % (email_prefix, subject)
+    return subject

--- a/test/email_test.py
+++ b/test/email_test.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2012 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import unittest
+from luigi import notifications
+from helpers import with_config
+
+
+class TestEmail(unittest.TestCase):
+
+    def testEmailNoPrefix(self):
+        self.assertEquals("subject", notifications._prefix('subject'))
+
+    @with_config({"core": {"email-prefix": "[prefix]"}})
+    def testEmailPrefix(self):
+        self.assertEquals("[prefix] subject", notifications._prefix('subject'))


### PR DESCRIPTION
If you add in the config file:

```
[core]
email-prefix: [test cluster]
```

All email subjects from luigi will be prefixed with [test cluster]. It's useful...
