### PR TITLE
Show the timestamp when tasks are picked up by workers

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -54,6 +54,7 @@ class Task(object):
         self.retry = None
         self.remove = None
         self.worker_running = None  # the worker id that is currently running the task or None
+        self.time_running = None  # Timestamp when picked up by worker
         self.expl = None
         self.priority = priority
 
@@ -250,6 +251,7 @@ class CentralPlannerScheduler(Scheduler):
             t = self._tasks[best_task]
             t.status = RUNNING
             t.worker_running = worker
+            t.time_running = time.time()
             self._update_task_history(best_task, RUNNING, host=host)
 
         return {'n_pending_tasks': locally_pending_tasks,
@@ -291,6 +293,8 @@ class CentralPlannerScheduler(Scheduler):
             'deps': list(task.deps),
             'status': task.status,
             'workers': list(task.workers),
+            'worker_running': task.worker_running,
+            'time_running': getattr(task, "time_running", None),
             'start_time': task.time,
             'params': self._get_task_params(task_id),
             'name': self._get_task_name(task_id)

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -23,7 +23,10 @@ function visualiserApp(luigi) {
         var taskIdParts = /([A-Za-z0-9_]*)\((.*)\)/.exec(task.taskId);
         var taskName = taskIdParts[1];
         var taskParams = taskIdParts[2];
-        var displayTime = new Date(Math.floor(task.start_time*1000)).toLocaleTimeString();
+        var displayTime = new Date(Math.floor(task.start_time*1000)).toLocaleString();
+        if (task.status == "RUNNING" && "time_running" in task) {
+          displayTime += " | " + new Date(Math.floor(task.time_running*1000)).toLocaleString();
+        }
         return {
             taskId: task.taskId,
             taskName: taskName,


### PR DESCRIPTION
Unlike task.start_time, this one is to show when the task actually starts running. This is helpful when I sometimes notice a task scheduled for a long time in the dashboard and wonder how long it actually runs.

Also I chimed in worker_running attributes in the api return. It is nice to have sometimes when trying to debug hanging tasks.
