### PR TITLE
Add task_search api to search for task by task_id

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -111,6 +111,9 @@ class RemoteScheduler(Scheduler):
     def task_list(self, status, upstream_status):
         return self._request('/api/task_list', {'status': status, 'upstream_status': upstream_status})
 
+    def task_search(self, task_str):
+        return self._request('/api/task_search', {'task_str': task_str})
+
     def fetch_error(self, task_id):
         return self._request('/api/fetch_error', {'task_id': task_id})
 
@@ -151,6 +154,9 @@ class RemoteSchedulerResponder(object):
 
     def task_list(self, status, upstream_status, **kwargs):
         return self._scheduler.task_list(status, upstream_status)
+
+    def task_search(self, task_str, **kwargs):
+        return self._scheduler.task_search(task_str)
 
     def fetch_error(self, task_id, **kwargs):
         return self._scheduler.fetch_error(task_id)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import collections
 import datetime
 import os
 import logging
@@ -377,6 +378,16 @@ class CentralPlannerScheduler(Scheduler):
                         serialized[id] = self._serialize_task(id)
                         serialized[id]["deps"] = []
                         stack.append(id)
+
+    def task_search(self, task_str):
+        ''' query for a subset of tasks by task_id '''
+        self.prune()
+        result = collections.defaultdict(dict)
+        for task_id, task in self._tasks.iteritems():
+            if task_id.find(task_str) != -1:
+                serialized = self._serialize_task(task_id)
+                result[task.status][task_id] = serialized
+        return result
 
     def fetch_error(self, task_id):
         if self._tasks[task_id].expl is not None:

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -118,8 +118,11 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertLessEqual(d2[u'start_time'], end)
 
     def _assert_all_done(self, tasks):
+        self._assert_all(tasks, u'DONE')
+
+    def _assert_all(self, tasks, status):
         for task in tasks.values():
-            self.assertEqual(task[u'status'], u'DONE')
+            self.assertEqual(task[u'status'], status)
 
     def test_dep_graph_single(self):
         self._build([FactorTask(1)])
@@ -281,6 +284,15 @@ class SchedulerVisualisationTest(unittest.TestCase):
         all.update(failed)
         self.assertEqual(remote.task_list('', ''), all)
         self.assertEqual(remote.task_list('RUNNING', ''), {})
+
+    def test_task_search(self):
+        self._build([FactorTask(8)])
+        self._build([FailingTask(8)])
+        remote = self._remote()
+        all_tasks = remote.task_search('Task')
+        self.assertEqual(len(all_tasks), 2)
+        self._assert_all(all_tasks['DONE'], 'DONE')
+        self._assert_all(all_tasks['FAILED'], 'FAILED')
 
     def test_fetch_error(self):
         self._build([FailingTask(8)])


### PR DESCRIPTION
I am writing a luigi plugin for hubot (https://github.com/interskh/hubot-scripts/blob/master/src%2Fscripts%2Fluigi.coffee) and find it helpful to be able to search tasks by task id. So I added task_search api. It returns a dictionary as {status: {dict of tasks}}
