### PR TITLE
Don't crash if loading a corrupt pickle state file

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -116,8 +116,13 @@ class CentralPlannerScheduler(Scheduler):
     def load(self):
         if os.path.exists(self._state_path):
             logger.info("Attempting to load state from %s", self._state_path)
-            with open(self._state_path) as fobj:
-                state = pickle.load(fobj)
+            try:
+                with open(self._state_path) as fobj:
+                    state = pickle.load(fobj)
+            except:
+                logger.exception("Error when loading state. Starting from clean slate.")
+                return
+
             self._tasks, self._active_workers = state
 
             # Convert from old format

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -20,6 +20,7 @@ import time
 
 luigi.notifications.DEBUG = True
 
+
 class SchedulerTest(unittest.TestCase):
     def test_load_old_state(self):
         tasks = {}
@@ -30,12 +31,25 @@ class SchedulerTest(unittest.TestCase):
                 state = (tasks, active_workers)
                 pickle.dump(state, fobj)
 
-            scheduler = luigi.scheduler.CentralPlannerScheduler(state_path=fn.name)
+            scheduler = luigi.scheduler.CentralPlannerScheduler(
+                state_path=fn.name)
             scheduler.load()
 
             scheduler.prune()
 
-            self.assertEquals(list(scheduler._active_workers.keys()), ['Worker2'])
+            self.assertEquals(list(scheduler._active_workers.keys()),
+                              ['Worker2'])
+
+    def test_load_broken_state(self):
+        with tempfile.NamedTemporaryFile(delete=True) as fn:
+            with open(fn.name, 'w') as fobj:
+                print >> fobj, "b0rk"
+
+            scheduler = luigi.scheduler.CentralPlannerScheduler(
+                state_path=fn.name)
+            scheduler.load()  # bad if this crashes
+
+            self.assertEquals(list(scheduler._active_workers.keys()), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously the luigi server would crash on startup if the pickle file that stores its state is corrupt for some reason
