### PR TITLE
Display how long a task has been running instead of its start time

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -25,7 +25,9 @@ function visualiserApp(luigi) {
         var taskParams = taskIdParts[2];
         var displayTime = new Date(Math.floor(task.start_time*1000)).toLocaleString();
         if (task.status == "RUNNING" && "time_running" in task) {
-          displayTime += " | " + new Date(Math.floor(task.time_running*1000)).toLocaleString();
+            var current_time = new Date().getTime()
+            var minutes_running = Math.round((current_time - task.time_running * 1000) / 1000 / 60)
+            displayTime += " | " + minutes_running + " minutes"
         }
         return {
             taskId: task.taskId,


### PR DESCRIPTION
Improvement on https://github.com/spotify/luigi/pull/353: instead of displaying when a task started, instead it should display the number of minutes it's been running for.
