### PR TITLE
Added support for elasticsearch 1.0 or newer.

### DIFF
--- a/examples/elasticsearch_index.py
+++ b/examples/elasticsearch_index.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+
+from luigi.contrib.esindex import CopyToIndex
+import datetime
+import json
+import luigi
+
+class FakeDocuments(luigi.Task):
+    """ Generate some documents to index. """
+
+    date = luigi.DateParameter(default=datetime.date.today())
+    
+    def run(self):
+        """ Write line-delimited json. `_id` is the default Elasticsearch id
+        field. """
+        today = datetime.date.today()
+        with self.output().open('w') as output:
+            for i in range(5):
+                output.write(json.dumps({'_id': i, 'text': 'Hi %s' % i,
+                                         'date': str(today)}))
+                output.write('\n')
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.date)
+
+class IndexDocuments(CopyToIndex):
+    """
+    Run 
+
+        $ curl "localhost:9200/example_index/_search?pretty"
+
+    after this task, to see the indexed documents. To see the update log, run
+
+        $ curl "localhost:9200/update_log/_search?q=target_index:example_index&pretty"
+
+    To cleanup both indexes run:
+
+        $ curl -XDELETE "localhost:9200/example_index"
+        $ curl -XDELETE "localhost:9200/update_log/_query?q=target_index:example_index"
+    """
+    date = luigi.DateParameter(default=datetime.date.today())
+
+    index = 'example_index'
+    doc_type = 'greetings'
+    host = 'localhost'
+    port = 9200
+
+    def requires(self):
+        return FakeDocuments()
+
+if __name__ == "__main__":
+    luigi.run(['--task', 'IndexDocuments'], use_optparse=True)

--- a/luigi/contrib/esindex.py
+++ b/luigi/contrib/esindex.py
@@ -1,0 +1,347 @@
+# coding: utf-8
+
+"""
+Support for Elasticsearch (1.0.0 or newer).
+
+Provides an `ElasticsearchTarget` and a `CopyToIndex` template task.
+
+Modeled after `luigi.contrib.rdbms.CopyToTable`.
+----
+
+A minimal example (assuming elasticsearch is running on localhost:9200):
+
+    class ExampleIndex(CopyToIndex):
+        index = 'example'
+
+        def docs(self):
+            return [{'_id': 1, 'title': 'An example document.'}]
+
+    if __name__ == '__main__':
+        task = ExampleIndex()
+        luigi.build([task], local_scheduler=True)
+
+----
+
+All options:
+
+    class ExampleIndex(CopyToIndex):
+        host = 'localhost'
+        port = 9200
+        index = 'example'
+        doc_type = 'default'
+        purge_existing_index = True
+        marker_index_hist_size = 1
+
+        def docs(self):
+            return [{'_id': 1, 'title': 'An example document.'}]
+
+    if __name__ == '__main__':
+        task = ExampleIndex()
+        luigi.build([task], local_scheduler=True)
+
+----
+
+`Host`, `port`, `index`, `doc_type` parameters are standard elasticsearch.
+
+`purge_existing_index` will delete the index, whenever an update is required.
+This is useful, when one deals with "dumps" that represent the whole data,
+not just updates.
+
+`marker_index_hist_size` sets the maximum number of entries in the 'marker'
+index. Keep all updates by default (0). Use 1 to only remember the most recent
+update to the index. This can be useful, if an index needs to recreated, even
+though the corresponding indexing task has been run sometime in the past - but
+a later indexing task might have altered the index in the meantime.
+
+There are a two luigi `client.cfg` configuration options:
+
+    [elasticsearch]
+
+    marker-index = update_log
+    marker-doc-type = entry
+
+"""
+
+# pylint: disable=F0401,E1101,C0103
+import abc
+import datetime
+import hashlib
+import json
+import logging
+import luigi
+
+logger = logging.getLogger('luigi-interface')
+
+try:
+    from elasticsearch.helpers import bulk_index
+    import elasticsearch
+    if elasticsearch.__version__ < (1, 0, 0):
+        logger.warning("This module works with elasticsearch 1.0.0 "
+                       "or newer only.")
+except ImportError:
+    logger.warning("Loading esindex module without elasticsearch installed. "
+                   "Will crash at runtime if esindex functionality is used.")
+
+
+class ElasticsearchTarget(luigi.Target):
+    """ Target for a resource in Elasticsearch. """
+
+    marker_index = luigi.configuration.get_config().get('elasticsearch',
+                                        'marker-index', 'update_log')
+    marker_doc_type = luigi.configuration.get_config().get('elasticsearch',
+                                        'marker-doc-type', 'entry')
+
+    def __init__(self, host, port, index, doc_type, update_id,
+                 marker_index_hist_size=0):
+        """
+        Args:
+            host (str): Elasticsearch server host
+            port (int): Elasticsearch server port
+            index (str): Index name
+            doc_type (str): Doctype name
+            update_id (str): An identifier for this data set
+            marker_index_hist_size (int): List of changes to the index to remember
+        """
+        self.host = host
+        self.port = port
+        self.index = index
+        self.doc_type = doc_type
+        self.update_id = update_id
+        self.marker_index_hist_size = marker_index_hist_size
+
+        self.es = elasticsearch.Elasticsearch([{'host': self.host,
+                                                'port': self.port}])
+
+    def marker_index_document_id(self):
+        """ Generate an id for the indicator document. """
+        params = '%s:%s:%s' % (self.index, self.doc_type, self.update_id)
+        return hashlib.sha1(params).hexdigest()
+
+    def touch(self):
+        """ Mark this update as complete. The document id would be sufficent,
+        but we index the parameters
+
+            (update_id, target_index, target_doc_type, date)
+
+        as well for documentation. """
+        self.create_marker_index()
+        self.es.index(index=self.marker_index, doc_type=self.marker_doc_type,
+                      id=self.marker_index_document_id(), body={
+                      'update_id': self.update_id, 'target_index': self.index,
+                      'target_doc_type': self.doc_type,
+                      'date': datetime.datetime.now()})
+        self.es.indices.flush(index=self.marker_index)
+        self.ensure_hist_size()
+
+    def exists(self):
+        """ Test, if this task has been run. """
+        try:
+            _ = self.es.get(index=self.marker_index,
+                            doc_type=self.marker_doc_type,
+                            id=self.marker_index_document_id())
+            return True
+        except elasticsearch.NotFoundError:
+            logger.debug('Marker document not found.')
+        except elasticsearch.ElasticsearchException as err:
+            logger.warn(err)
+        return False
+
+    def create_marker_index(self):
+        """ Create the index that will keep track of the tasks if necessary. """
+        if not self.es.indices.exists(index=self.marker_index):
+            self.es.indices.create(index=self.marker_index)
+
+    def ensure_hist_size(self):
+        """ Shrink the history of updates for a `index/doc_type` combination
+        down to `self.marker_index_hist_size`. """
+        if self.marker_index_hist_size == 0:
+            return
+        result = self.es.search(index=self.marker_index,
+                                doc_type=self.marker_doc_type,
+                                body={'query': {
+                                    'term': {'target_index': self.index}}},
+                                sort=('date:desc',))
+
+        for i, hit in enumerate(result.get('hits').get('hits'), start=1):
+            if i > self.marker_index_hist_size:
+                marker_document_id = hit.get('_id')
+                self.es.delete(id=marker_document_id, index=self.marker_index,
+                               doc_type=self.marker_doc_type)
+        self.es.indices.flush(index=self.marker_index)
+
+
+class CopyToIndex(luigi.Task):
+    """
+    Template task for inserting a data set into Elasticsearch.
+
+    Usage:
+
+    1. Subclass and override the required `index` attribute.
+
+    2. Implement a custom `docs` method, that returns an iterable over
+    the documents. A document can be a JSON string, e.g. from
+    a newline-delimited JSON (ldj) file (default implementation) or some
+    dictionary.
+
+    Optional attributes:
+
+    * doc_type (default),
+    * host (localhost),
+    * port (9200),
+    * settings ({'settings': {}})
+    * mapping (None),
+    * chunk_size (2000),
+    * raise_on_error (True),
+    * purge_existing_index (False),
+    * marker_index_hist_size (0)
+
+    If settings are defined, they are only applied at index creation time.
+    """
+
+    @property
+    def host(self):
+        """ ES hostname """
+        return 'localhost'
+
+    @property
+    def port(self):
+        """ ES port """
+        return 9200
+
+    @abc.abstractproperty
+    def index(self):
+        """ The target index. May exists or not. """
+        return None
+
+    @property
+    def doc_type(self):
+        """ The target doc_type. """
+        return 'default'
+
+    @property
+    def mapping(self):
+        """ Dictionary with custom mapping or `None`. """
+        return None
+
+    @property
+    def settings(self):
+        """ Settings to be used at index creation time. """
+        return {'settings': {}}
+
+    @property
+    def chunk_size(self):
+        """ Single API call for this number of docs. """
+        return 2000
+
+    @property
+    def raise_on_error(self):
+        """ Whether to fail fast. """
+        return True
+
+    @property
+    def purge_existing_index(self):
+        """ Whether to delete the `index` completely before any indexing. """
+        return False
+
+    @property
+    def marker_index_hist_size(self):
+        """ Number of event log entries in the marker index. 0: unlimited. """
+        return 0
+
+    @property
+    def timeout(self):
+        """ Timeout. """
+        return 10
+
+    def docs(self):
+        """ Return the documents to be indexed. Beside the user defined
+        fields, the document may contain an `_index`, `_type` and `_id`. """
+        with self.input().open('r') as fobj:
+            for line in fobj:
+                yield line
+
+# everything below will rarely have to be overridden
+
+    def _docs(self):
+        """ Since `self.docs` may yield documents that do not explicitly
+        contain `_index` or `_type`, add those attributes here, if necessary.
+        """
+        first = iter(self.docs()).next()
+        needs_parsing = False
+        if isinstance(first, basestring):
+            needs_parsing = True
+        elif isinstance(first, dict):
+            pass
+        else:
+            raise RuntimeError('Document must be either JSON strings or dict.')
+        for doc in self.docs():
+            if needs_parsing:
+                doc = json.loads(doc)
+            if not '_index' in doc:
+                doc['_index'] = self.index
+            if not '_type' in doc:
+                doc['_type'] = self.doc_type
+            yield doc
+
+    def create_index(self):
+        """ Override to provide code for creating the target index.
+
+        By default it will be created without any special settings or mappings.
+        """
+        es = elasticsearch.Elasticsearch([{'host': self.host,
+                                           'port': self.port}])
+        if not es.indices.exists(index=self.index):
+            es.indices.create(index=self.index, body=self.settings)
+
+    def delete_index(self):
+        """ Delete the index, if it exists. """
+        es = elasticsearch.Elasticsearch([{'host': self.host,
+                                           'port': self.port}])
+        if es.indices.exists(index=self.index):
+            es.indices.delete(index=self.index)
+
+    def update_id(self):
+        """ This id will be a unique identifier for this indexing task."""
+        return self.task_id
+
+    def output(self):
+        """ Returns a ElasticsearchTarget representing the inserted dataset.
+
+        Normally you don't override this.
+        """
+        return ElasticsearchTarget(
+            host=self.host,
+            port=self.port,
+            index=self.index,
+            doc_type=self.doc_type,
+            update_id=self.update_id(),
+            marker_index_hist_size=self.marker_index_hist_size
+         )
+
+    def run(self):
+        """ Purge existing index, if requested (`purge_existing_index`).
+        Create the index, if missing. Apply mappings, if given.
+        Set refresh interval to -1 (disable) for performance reasons.
+        Bulk index in batches of size `chunk_size` (2000).
+        Set refresh interval to 1s. Refresh Elasticsearch.
+        Create entry in marker index.
+        """
+        if self.purge_existing_index:
+            self.delete_index()
+        self.create_index()
+        es = elasticsearch.Elasticsearch([{'host': self.host,
+                                           'port': self.port}],
+                                         timeout=self.timeout)
+        if self.mapping:
+            es.indices.put_mapping(index=self.index, doc_type=self.doc_type,
+                                   body=self.mapping)
+        es.indices.put_settings({"index": {"refresh_interval": "-1"}},
+                                index=self.index)
+
+        bulk_index(es, self._docs(), chunk_size=self.chunk_size,
+                   raise_on_error=self.raise_on_error)
+
+        es.indices.put_settings({"index": {"refresh_interval": "1s"}},
+                                index=self.index)
+        es.indices.refresh()
+        self.output().touch()

--- a/test/_esindex_test.py
+++ b/test/_esindex_test.py
@@ -1,0 +1,281 @@
+# coding: utf-8
+
+"""
+Tests for Elasticsearch index (esindex) target and indexing.
+"""
+
+# pylint: disable=C0103,E1101,F0401
+from luigi.contrib.esindex import ElasticsearchTarget, CopyToIndex
+import collections
+import datetime
+import elasticsearch
+import luigi
+import unittest
+
+
+HOST = 'localhost'
+PORT = 9200
+INDEX = 'esindex_luigi_test'
+DOC_TYPE = 'esindex_test_type'
+MARKER_INDEX = 'esindex_luigi_test_index_updates'
+MARKER_DOC_TYPE = 'esindex_test_entry'
+
+
+def _create_test_index():
+    """ Create content index, if if does not exists. """
+    es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+    if not es.indices.exists(INDEX):
+        es.indices.create(INDEX)
+
+
+_create_test_index()
+target = ElasticsearchTarget(HOST, PORT, INDEX, DOC_TYPE, 'update_id')
+target.marker_index = MARKER_INDEX
+target.marker_doc_type = MARKER_DOC_TYPE
+
+
+class ElasticsearchTargetTest(unittest.TestCase):
+    """ Test touch and exists. """
+    def test_touch_and_exists(self):
+        """ Basic test. """
+        delete()
+        self.assertFalse(target.exists(),
+                         'Target should not exist before touching it')
+        target.touch()
+        self.assertTrue(target.exists(),
+                        'Target should exist after touching it')
+        delete()
+
+
+def delete():
+    """ Delete marker_index, if it exists. """
+    es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+    if es.indices.exists(MARKER_INDEX):
+        es.indices.delete(MARKER_INDEX)
+    es.indices.refresh()
+
+
+class CopyToTestIndex(CopyToIndex):
+    """ Override the default `marker_index` table with a test name. """
+    host = HOST
+    port = PORT
+    index = INDEX
+    doc_type = DOC_TYPE
+    marker_index_hist_size = 0
+
+    def output(self):
+        """ Use a test target with an own marker_index. """
+        target = ElasticsearchTarget(
+            host=self.host,
+            port=self.port,
+            index=self.index,
+            doc_type=self.doc_type,
+            update_id=self.update_id(),
+            marker_index_hist_size=self.marker_index_hist_size
+         )
+        target.marker_index = MARKER_INDEX
+        target.marker_doc_type = MARKER_DOC_TYPE
+        return target
+
+
+class IndexingTask1(CopyToTestIndex):
+    """ Test the redundant version, where `_index` and `_type` are
+    given in the `docs` as well. A more DRY example is `IndexingTask2`. """
+    def docs(self):
+        """ Return a list with a single doc. """
+        return [{'_id': 123, '_index': self.index, '_type': self.doc_type,
+                'name': 'sample', 'date': 'today'}]
+
+
+class IndexingTask2(CopyToTestIndex):
+    """ Just another task. """
+    def docs(self):
+        """ Return a list with a single doc. """
+        return [{'_id': 234, '_index': self.index, '_type': self.doc_type,
+                 'name': 'another', 'date': 'today'}]
+
+
+class IndexingTask3(CopyToTestIndex):
+    """ This task will request an empty index to start with. """
+    purge_existing_index = True
+    def docs(self):
+        """ Return a list with a single doc. """
+        return [{'_id': 234, '_index': self.index, '_type': self.doc_type,
+                 'name': 'yet another', 'date': 'today'}]
+
+
+def _cleanup():
+    """ Delete both the test marker index and the content index. """
+    es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+    if es.indices.exists(MARKER_INDEX):
+        es.indices.delete(MARKER_INDEX)
+    if es.indices.exists(INDEX):
+        es.indices.delete(INDEX)
+
+
+class CopyToIndexTest(unittest.TestCase):
+    """ Test indexing tasks. """
+
+    def setUp(self):
+        """ Cleanup before each test. """
+        _cleanup()
+
+    def tearDown(self):
+        """ Remove residues after each test. """
+        _cleanup()
+
+    def test_copy_to_index(self):
+        """ Test a single document upload. """
+        task = IndexingTask1()
+        es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+        self.assertFalse(es.indices.exists(task.index))
+        self.assertFalse(task.complete())
+        luigi.build([task], local_scheduler=True)
+        self.assertTrue(es.indices.exists(task.index))
+        self.assertTrue(task.complete())
+        self.assertEquals(1, es.count(index=task.index).get('count'))
+        self.assertEquals({u'date': u'today', u'name': u'sample'},
+                          es.get_source(index=task.index,
+                                        doc_type=task.doc_type, id=123))
+
+    def test_copy_to_index_incrementally(self):
+        """ Test two tasks that upload docs into the same index. """
+        task1 = IndexingTask1()
+        task2 = IndexingTask2()
+        es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+        self.assertFalse(es.indices.exists(task1.index))
+        self.assertFalse(es.indices.exists(task2.index))
+        self.assertFalse(task1.complete())
+        self.assertFalse(task2.complete())
+        luigi.build([task1, task2], local_scheduler=True)
+        self.assertTrue(es.indices.exists(task1.index))
+        self.assertTrue(es.indices.exists(task2.index))
+        self.assertTrue(task1.complete())
+        self.assertTrue(task2.complete())
+        self.assertEquals(2, es.count(index=task1.index).get('count'))
+        self.assertEquals(2, es.count(index=task2.index).get('count'))
+
+        self.assertEquals({u'date': u'today', u'name': u'sample'},
+                          es.get_source(index=task1.index,
+                                        doc_type=task1.doc_type, id=123))
+
+        self.assertEquals({u'date': u'today', u'name': u'another'},
+                          es.get_source(index=task2.index,
+                                        doc_type=task2.doc_type, id=234))
+
+    def test_copy_to_index_purge_existing(self):
+    	""" Test purge_existing_index purges index. """
+        task1 = IndexingTask1()
+        task2 = IndexingTask2()
+        task3 = IndexingTask3()
+        luigi.build([task1, task2], local_scheduler=True)
+        luigi.build([task3], local_scheduler=True)
+        es = elasticsearch.Elasticsearch([{'host': HOST, 'port': PORT}])
+        self.assertTrue(es.indices.exists(task3.index))
+        self.assertTrue(task3.complete())
+        self.assertEquals(1, es.count(index=task3.index).get('count'))
+
+        self.assertEquals({u'date': u'today', u'name': u'yet another'},
+                          es.get_source(index=task3.index,
+                                        doc_type=task3.doc_type, id=234))
+
+
+class MarkerIndexTest(unittest.TestCase):
+
+    def setUp(self):
+        """ Cleanup before each test. """
+        _cleanup()
+
+    def tearDown(self):
+        """ Remove residues after each test. """
+        _cleanup()
+
+    def test_update_marker(self):
+        es = elasticsearch.Elasticsearch()
+        with self.assertRaises(elasticsearch.NotFoundError):
+            result = es.count(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                              body={'query': {'match_all': {}}})
+
+        task1 = IndexingTask1()
+        luigi.build([task1], local_scheduler=True)
+
+        result = es.count(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                           body={'query': {'match_all': {}}})
+        self.assertEquals(1, result.get('count'))
+
+        result = es.search(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                           body={'query': {'match_all': {}}})
+        marker_doc = result.get('hits').get('hits')[0].get('_source')
+        self.assertEquals('IndexingTask1()', marker_doc.get('update_id'))
+        self.assertEquals(INDEX, marker_doc.get('target_index'))
+        self.assertEquals(DOC_TYPE, marker_doc.get('target_doc_type'))
+        self.assertTrue('date' in marker_doc)
+
+        task2 = IndexingTask2()
+        luigi.build([task2], local_scheduler=True)
+
+        result = es.count(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                           body={'query': {'match_all': {}}})
+        self.assertEquals(2, result.get('count'))
+
+
+        result = es.search(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                           body={'query': {'match_all': {}}})
+        hits = result.get('hits').get('hits')
+        Entry = collections.namedtuple('Entry', ['date', 'update_id'])
+        dates_update_id = []
+        for hit in hits:
+            source = hit.get('_source')
+            update_id = source.get('update_id')
+            date = source.get('date')
+            dates_update_id.append(Entry(date, update_id))
+
+        it = iter(sorted(dates_update_id))
+        first = it.next()
+        second = it.next()
+        self.assertTrue(first.date < second.date)
+        self.assertEquals(first.update_id, 'IndexingTask1()')
+        self.assertEquals(second.update_id, 'IndexingTask2()')
+
+
+class IndexingTask4(CopyToTestIndex):
+    """ Just another task. """
+    date = luigi.DateParameter(default=datetime.date(1970, 1, 1))
+    marker_index_hist_size = 1
+
+    def docs(self):
+        """ Return a list with a single doc. """
+        return [{'_id': 234, '_index': self.index, '_type': self.doc_type,
+                 'name': 'another', 'date': 'today'}]
+
+class IndexHistSizeTest(unittest.TestCase):
+
+    def setUp(self):
+        """ Cleanup before each test. """
+        _cleanup()
+
+    def tearDown(self):
+        """ Remove residues after each test. """
+        _cleanup()
+
+    def test_limited_history(self):
+
+        task4_1 = IndexingTask4(date=datetime.date(2000, 1, 1))
+        luigi.build([task4_1], local_scheduler=True)
+
+        task4_2 = IndexingTask4(date=datetime.date(2001, 1, 1))
+        luigi.build([task4_2], local_scheduler=True)
+
+        task4_3 = IndexingTask4(date=datetime.date(2002, 1, 1))
+        luigi.build([task4_3], local_scheduler=True)
+
+        es = elasticsearch.Elasticsearch()
+
+        result = es.count(index=MARKER_INDEX, doc_type=MARKER_DOC_TYPE,
+                          body={'query': {'match_all': {}}})
+        self.assertEquals(1, result.get('count'))
+        marker_index_document_id = task4_3.output().marker_index_document_id()
+        result = es.get(id=marker_index_document_id, index=MARKER_INDEX,
+                        doc_type=MARKER_DOC_TYPE)
+        self.assertEquals('IndexingTask4(date=2002-01-01)',
+                          result.get('_source').get('update_id'))


### PR DESCRIPTION
Provides an `ElasticsearchTarget` and a `CopyToIndex` template task.

Modeled after `luigi.contrib.rdbms.CopyToTable`.

A minimal example (assuming elasticsearch is running on localhost:9200):

```
class ExampleIndex(CopyToIndex):
    index = 'example'

    def docs(self):
        return [{'_id': 1, 'title': 'An example document.'}]

if __name__ == '__main__':
    task = ExampleIndex()
    luigi.build([task], local_scheduler=True)
```

Tests can be run against a local elasticsearch index.
