### PR TITLE
String formatting issues in console

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -418,7 +418,7 @@ class Task(object):
         outputs = flatten(self.output())
         if len(outputs) == 0:
             # TODO: unclear if tasks without outputs should always run or never run
-            warning = "Task `{}` without outputs has no custom complete() method".format(self)
+            warning = "WARNING: Task `{}` without outputs has no custom complete() method".format(self)
             warnings.warn(warning)
             return False
         for output in outputs:


### PR DESCRIPTION
Warning message printed as  `warnings.warn("Task %r without outputs has no custom complete() method" % self)`
 -changed the warning printing so that string formatting works correctly.`

`__repr__` for a Task didn't clean the arguments beforehand: a `\n` would cause formatting issues. Cleaned up self.task_id.
