### PR TITLE
Fix test failure if client.cfg defines a logging_conf_file.

### DIFF
--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -107,8 +107,10 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch("warnings.warn")
     @mock.patch("luigi.interface.setup_interface_logging")
     def test_cmdline_logger(self, setup_mock, warn):
-        luigi.run(['Task', '--local-scheduler'])
-        self.assertEqual([mock.call(None)], setup_mock.call_args_list)
+        with mock.patch("luigi.interface.EnvironmentParamsContainer.env_params") as env_params:
+            env_params.return_value.logging_conf_file = None
+            luigi.run(['Task', '--local-scheduler'])
+            self.assertEqual([mock.call(None)], setup_mock.call_args_list)
 
         with mock.patch("luigi.configuration.get_config") as getconf:
             getconf.return_value.get.return_value = None


### PR DESCRIPTION
When `/etc/luigi/client.cfg` had a `logging_conf_file` entry, like

```
logging_conf_file = /etc/luigi/logging.ini
```

`test_cmdline_logger` would fail with something like

```
AssertionError: [call(None)] != [call('/etc/luigi/logging.ini')]
```
