### PR TITLE
Adding debug message when using the HDFS existence check

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -120,6 +120,7 @@ class HdfsClient(FileSystem):
         """
 
         cmd = [load_hadoop_cmd(), 'fs', '-stat', path]
+        logger.debug('Running file existence check: %s' % u' '.join(cmd))
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
         stdout, stderr = p.communicate()
         if p.returncode == 0:


### PR DESCRIPTION
Adding some debug ouput in order to track a potential issue with duplicate scheduling of jobs after failing existence checks
