### PR TITLE
Remove --lock warning when it's not passed

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -77,7 +77,7 @@ class EnvironmentParamsContainer(task.Task):
         is_global=True, default=None,
         description='Port of remote scheduler api process')
     lock = parameter.BooleanParameter(
-        is_global=True, default=True,
+        is_global=True, default=False,
         description='(Deprecated, replaced by no_lock)'
                     'Do not run if similar process is already running')
     lock_size = parameter.IntParameter(


### PR DESCRIPTION
Previously you would _always_ get the deprecation warning. Regardless if
it was passed.

Note however that it still can have an effect to pass the flag.
Unfortunately, the hash of the lock-file is based on even the
non-semantical flags like --lock (I want to kill myself).
