### PR TITLE
Various parameter cleanup

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -311,9 +311,9 @@ class Task(object):
         # Then use the defaults for anything not filled in
         for param_name, param_obj in params:
             if param_name not in result:
-                if not param_obj.has_default:
+                if not param_obj.has_value:
                     raise parameter.MissingParameterException("%s: requires the '%s' parameter to be set" % (exc_desc, param_name))
-                result[param_name] = param_obj.default
+                result[param_name] = param_obj.value
 
         def list_to_tuple(x):
             """ Make tuples out of lists and sets to allow hashing """
@@ -371,7 +371,7 @@ class Task(object):
         """
         for param_name, param in global_params:
             value = param.parse_from_input(param_name, params[param_name])
-            param.set_default(value)
+            param.set_global(value)
 
         kwargs = {}
         for param_name, param in cls.get_nonglobal_params():

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -20,7 +20,6 @@ import mock
 import unittest
 import warnings
 
-
 class SomeTask(luigi.Task):
     n = luigi.IntParameter()
 
@@ -111,7 +110,7 @@ class CmdlineTest(unittest.TestCase):
         self.assertEqual([mock.call(None)], setup_mock.call_args_list)
 
         with mock.patch("luigi.configuration.get_config") as getconf:
-            getconf.return_value.get.return_value = None
+            getconf.return_value.get.side_effect = ConfigParser.NoOptionError(section='foo', option='bar')
             getconf.return_value.get_boolean.return_value = True
 
             luigi.interface.setup_interface_logging.call_args_list = []


### PR DESCRIPTION
There's now three layers of ways to specify parameters, in decreasing order of precedence:
1. Setting global values
2. Reading stuff from config
3. Default values (these should be immutable)

This refactoring avoids the hack we've had where we change the default values for global parameters. It also cleans up how we read from config – it's all just three cascading levels. It also removes some stuff in interface.py to set up config for some environment params
