### PR TITLE
Fixed issue with grouping keys when running locally

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -753,8 +753,8 @@ class JobTask(BaseHadoopJobTask):
 
     def _reduce_input(self, inputs, reducer, final=NotImplemented):
         """Iterate over input, collect values with the same key, and call the reducer for each uniqe key."""
-        for key, values in groupby(inputs, itemgetter(0)):
-            for output in reducer(key, (v[1] for v in values)):
+        for key, values in groupby(inputs, key=lambda x: repr(x[0])):
+            for output in reducer(eval(key), (v[1] for v in values)):
                 yield output
         if final != NotImplemented:
             for output in final():


### PR DESCRIPTION
When running a job on the hadoop cluster unicode strings and str strings
are grouped to different reducers since we wrap repr() around the key.
This patch simulates that behaviour when running locally.
