### PR TITLE
add init_* handling to LocalJobRunner

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -488,9 +488,7 @@ class LocalJobRunner(JobRunner):
             map_output.close()
             return
 
-        if not job.init_mapper == NotImplemented:
-            job.init_mapper()
-
+        job.init_mapper()
         # run job now...
         map_output = StringIO.StringIO()
         job._run_mapper(map_input, map_output)
@@ -505,9 +503,7 @@ class LocalJobRunner(JobRunner):
             combine_output.seek(0)
             reduce_input = self.group(combine_output)
 
-        if not job.init_reducer == NotImplemented:
-            job.init_reducer()
-
+        job.init_reducer()
         reduce_output = job.output().open('w')
         job._run_reducer(reduce_input, reduce_output)
         reduce_output.close()


### PR DESCRIPTION
For testing/mocking purposes, enable `LocalJobRunner` to call `init_mapper` and `init_reducer` if defined.

Remark: This change could break existing tests if those methods were defined and calling external resources (esp. extra_files). Not sure this scenario is super realistic for classes already under test, though.
