### PR TITLE
Reschedules unfulfilled dependencies

### DIFF
--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -35,3 +35,6 @@ class WorkerTaskTest(unittest.TestCase):
         def f():
             luigi.build([None], local_scheduler=True)
         self.assertRaises(TaskException, f)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reschedules unfulfilled dependencies during runs. In order to prevent infinite rescheduling, a max-reschedules config parameter is added, which defaults to 1.
