### PR TITLE
Simplified some worker logic

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -301,7 +301,7 @@ class ArgParseInterface(Interface):
             raise Exception('%s is ambigiuous' % args.command)
 
         # Notice that this is not side effect free because it might set global params
-        task = task_cls.from_input(params, Register.get_global_params())
+        task = task_cls.from_str_params(params, Register.get_global_params())
 
         return [task]
 
@@ -425,7 +425,7 @@ class OptParseInterface(Interface):
             if k != 'task':
                 params[k] = v
 
-        task = task_cls.from_input(params, global_params)
+        task = task_cls.from_str_params(params, global_params)
 
         return [task]
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -255,6 +255,12 @@ class Parameter(object):
         else:
             return self.parse(x)
 
+    def serialize_to_input(self, x):
+        if self.is_list:
+            return tuple(self.serialize(p) for p in x)
+        else:
+            return self.serialize(x)
+
 
 class DateHourParameter(Parameter):
     """Parameter whose value is a :py:class:`~datetime.datetime` specified to the hour.

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -73,7 +73,7 @@ class RemoteScheduler(Scheduler):
         # just one attemtps, keep-alive thread will keep trying anyway
         self._request('/api/ping', {'worker': worker}, attempts=1)
 
-    def add_task(self, worker, task_id, status=PENDING, runnable=False, deps=None, expl=None, priority=0):
+    def add_task(self, worker, task_id, status=PENDING, runnable=False, deps=None, expl=None, priority=0, family='', params={}):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -82,6 +82,8 @@ class RemoteScheduler(Scheduler):
             'deps': deps,
             'expl': expl,
             'priority': priority,
+            'family': family,
+            'params': params,
         })
 
     def get_work(self, worker, host=None):
@@ -135,8 +137,8 @@ class RemoteSchedulerResponder(object):
     def __init__(self, scheduler):
         self._scheduler = scheduler
 
-    def add_task(self, worker, task_id, status, runnable, deps, expl, priority=0, **kwargs):
-        return self._scheduler.add_task(worker, task_id, status, runnable, deps, expl, priority)
+    def add_task(self, worker, task_id, status, runnable, deps, expl, priority=0, family='', params={}, **kwargs):
+        return self._scheduler.add_task(worker, task_id, status, runnable, deps, expl, priority, family, params)
 
     def add_worker(self, worker, info, **kwargs):
         return self._scheduler.add_worker(worker, info)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -360,25 +360,34 @@ class Task(object):
         return hasattr(self, 'task_id')
 
     @classmethod
-    def from_input(cls, params, global_params):
+    def from_str_params(cls, params_str, global_params):
         """Creates an instance from a str->str hash
 
         This method is for parsing of command line arguments or other
         non-programmatic invocations.
 
-        :param params: dict of param name -> value.
+        :param params_str: dict of param name -> value.
         :param global_params: dict of param name -> value, the global params.
         """
         for param_name, param in global_params:
-            value = param.parse_from_input(param_name, params[param_name])
+            value = param.parse_from_input(param_name, params_str[param_name])
             param.set_global(value)
 
         kwargs = {}
         for param_name, param in cls.get_nonglobal_params():
-            value = param.parse_from_input(param_name, params[param_name])
+            value = param.parse_from_input(param_name, params_str[param_name])
             kwargs[param_name] = value
 
         return cls(**kwargs)
+
+    def to_str_params(self):
+        """Opposite of from_str_params"""
+        params_str = {}
+        params = dict(self.get_params())
+        for param_name, param_value in self.param_kwargs.iteritems():
+            params_str[param_name] = params[param_name].serialize(param_value)
+
+        return params_str
 
     def clone(self, cls=None, **kwargs):
         ''' Creates a new instance from an existing instance where some of the args have changed.

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -190,20 +190,5 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
 
 
-class TestParameterSplit(unittest.TestCase):
-    task_id_examples = [
-        "TrackIsrcs()",
-        "CrazyTask(foo=foo_table_id, bar={'keyName': 'com.my.org', 'parameters': {'this.is.tricky': '1'}}, what_is_dis=foo bar, oh hippo)",
-        "MyOldDateHourTask(datehour=2013-07-21 11:00:00)",
-        "MyOldDateHourTask(datehour=2013-07-21T11:00:00)"
-    ]
-
-    def setUp(self):
-        self.sch = CentralPlannerScheduler()
-
-    def test_parameter_split(self):
-        for task_id in self.task_id_examples:
-            self.sch._get_task_params(task_id)
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Don't do string magic on the scheduler to break down a task into a task family and parameters
   Instead, send it as an argument when scheduling the task
   This is useful because it's a step towards remote execution
2. Cleanup of worker code
   There was three different code paths leading up to add_task(...) - cleaned up so that there's only one
