### PR TITLE
Gracefully close worker on term.

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -27,6 +27,7 @@ import re
 import argparse
 import sys
 import os
+import signal
 
 from task import Register
 
@@ -191,6 +192,11 @@ class Interface(object):
             success &= w.add(t)
         logger = logging.getLogger('luigi-interface')
         logger.info('Done scheduling tasks')
+
+        def handler(signum, frame):
+            w.graceful_shutdown()
+        signal.signal(signal.SIGTERM, handler)
+
         success &= w.run()
         w.stop()
         return success


### PR DESCRIPTION
This change (attempts to) add a signal handler to the worker allowing it
to gracefully shutdown on a TERM signal. This means that it will finish
the tasks that it has accepted but not request any more work.

This change is a little less straightforward than my earlier one; we'll be kicking the tires on it over the coming days. Is it clear what the motivation is for this feature? Was I right in trying to get the worker to not call _get_work when it is in the process of shutting down? Would you prefer that the signal the worker listens for be somehow configurable? Thanks for looking!
