### PR TITLE
Fix race condition in SnakebiteHdfsClient.mkdir()

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -422,11 +422,11 @@ class SnakebiteHdfsClient(HdfsClient):
         :param mode: \*nix style owner/group/other permissions
         :type mode: octal, default 0755
         """
-        bite = self.get_bite()
-        if raise_if_exists and bite.test(path, exists=True):
+        result = list(self.get_bite().mkdir(list_path(path),
+                                            create_parent=parents, mode=mode))
+        if raise_if_exists and "ile exists" in result[0].get('error', ''):
             raise luigi.target.FileAlreadyExists("%s exists" % (path, ))
-        return list(bite.mkdir(list_path(path), create_parent=parents,
-                               mode=mode))
+        return result
 
     def listdir(self, path, ignore_directories=False, ignore_files=False,
                 include_size=False, include_type=False, include_time=False,


### PR DESCRIPTION
Rewritten in EAFP style:
https://docs.python.org/2/glossary.html#term-eafp
