### PR TITLE
Uses mkdir function in HdfsAtomicWritePipe init

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -591,13 +591,7 @@ class HdfsAtomicWritePipe(luigi.format.OutputPipeProcessWrapper):
     def __init__(self, path):
         self.path = path
         self.tmppath = tmppath(self.path)
-        tmpdir = os.path.dirname(self.tmppath)
-        if get_configured_hadoop_version() == "cdh4":
-            if subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', '-p', tmpdir], close_fds=True).wait():
-                raise RuntimeError("Could not create directory: %s" % tmpdir)
-        else:
-            if not exists(tmpdir) and subprocess.Popen([load_hadoop_cmd(), 'fs', '-mkdir', tmpdir], close_fds=True).wait():
-                raise RuntimeError("Could not create directory: %s" % tmpdir)
+        mkdir(os.path.dirname(self.tmppath), parents=True, raise_if_exists=True)
         super(HdfsAtomicWritePipe, self).__init__([load_hadoop_cmd(), 'fs', '-put', '-', self.tmppath])
 
     def abort(self):


### PR DESCRIPTION
HdfsAtomicWritePipe started breaking for me after upgrading to cdh5 because the mkdir logic in its init function is incomplete. There doesn't seem to be anything there that hdfs.mkdir doesn't do, so I replaced it with that.
