### PR TITLE
Fixes a bug in graph creation for unknown dependencies

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -337,13 +337,20 @@ class CentralPlannerScheduler(Scheduler):
             task = self._tasks.get(task_id)
             if task is None:
                 logger.warn('Missing task for id [%s]', task_id)
+
+                # try to infer family and params from task_id
+                try:
+                    family, _, param_str = task_id.rstrip(')').partition('(')
+                    params = dict(param.split('=') for param in param_str.split(', '))
+                except:
+                    family, params = '', {}
                 serialized[task_id] = {
                     'deps': [],
                     'status': UNKNOWN,
                     'workers': [],
                     'start_time': UNKNOWN,
-                    'params': task.params,
-                    'name': task.family
+                    'params': params,
+                    'name': family
                 }
             else:
                 serialized[task_id] = self._serialize_task(task_id)


### PR DESCRIPTION
There was a bug where graphs with unknown deps couldn't be shown in the visualiser because task.params and task.family can't be called when task is None. This happens if you check a graph during scheduling or scheduling fails partway through. In order to make the graph look nicer, I added some simple code to infer params and family from the task_id. It should work in most cases, avoiding unlabeled nodes on the visualiser graph.

I added a test which triggers the previously broken state by raising an error while scheduling a dependency.
