### PR TITLE
Fix scheduling tasks with many deps/params.

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -136,7 +136,7 @@ def _init_api(sched, responder, api_port, address):
     api = responder or RemoteSchedulerResponder(sched)
     api_app = app(api)
     api_sockets = tornado.netutil.bind_sockets(api_port, address=address)
-    server = tornado.httpserver.HTTPServer(api_app)
+    server = tornado.httpserver.HTTPServer(api_app, max_header_size=2097152)
     server.add_sockets(api_sockets)
 
     # Return the bound socket names.  Useful for connecting client in test scenarios.


### PR DESCRIPTION
Tornado limits maximum size of HTTP request (without body) to 65536 bytes by default. If there is a task with many parameters and/or dependencies, it could fail to be scheduled. Luigi server just closes RPC connection, logging this:

```
2014-08-27 08:40:37,728 tornado.general[2159] INFO: Unsatisfiable read, closing connection: delimiter <_sre.SRE_Pattern object at 0x27dd6a8> not found within 65536 bytes
```

This commit increases that limit to 2MB. "Two megabytes ought to be enough for anyone."
