### PR TITLE
fix recursive delete to use correct cmd

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -135,7 +135,7 @@ class HdfsClient(FileSystem):
 
     def remove(self, path, recursive=True, skip_trash=False):
         if recursive:
-            cmd = [load_hadoop_cmd(), 'fs', '-rm', '-r']
+            cmd = [load_hadoop_cmd(), 'fs', '-rmr']
         else:
             cmd = [load_hadoop_cmd(), 'fs', '-rm']
 


### PR DESCRIPTION
We are pretty sure that `-rmr` is the correct command.

See http://hadoop.apache.org/docs/r1.0.4/file_system_shell.html#rmr

Tested on hadoop 1.0.3 on EMR.
