### PR TITLE
Global parameters can be overridden when instantiating a task

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -63,11 +63,13 @@ class Parameter(object):
     The ``config_path`` argument lets you specify a place where the parameter is read from config
     in case no value is provided.
 
-    Providing ``is_global=True`` changes the behavior of the parameter so that the value is shared
-    across all instances of the task. Global parameters can be provided in several ways. In
-    falling order of precedence:
+    Providing ``is_global=True`` adds the ability to set any parameter on the command line (or using
+    ``set_global``) - this value will be used when instantiating a task object as a default value.
 
-    * A value provided on the command line (eg. ``--my-global-value xyz``)
+    The value of a parameter is used when instantiating a task in this falling order of priority:
+
+    * A value provided when instantiating a task (eg. ``FooTask(my_value=43)``)
+    * A value provided on the command line (eg. ``--my-global-value xyz``) (this only applies to global variables)
     * A value provided via config (using the ``config_path`` argument)
     * A default value set using the ``default`` flag.
     """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -291,7 +291,7 @@ class Task(object):
         exc_desc = '%s[args=%s, kwargs=%s]' % (cls.__name__, args, kwargs)
 
         # Fill in the positional arguments
-        positional_params = [(n, p) for n, p in params if not p.is_global]
+        positional_params = [(n, p) for n, p in params]
         for i, arg in enumerate(args):
             if i >= len(positional_params):
                 raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))
@@ -304,8 +304,6 @@ class Task(object):
                 raise parameter.DuplicateParameterException('%s: parameter %s was already set as a positional parameter' % (exc_desc, param_name))
             if param_name not in params_dict:
                 raise parameter.UnknownParameterException('%s: unknown parameter %s' % (exc_desc, param_name))
-            if params_dict[param_name].is_global:
-                raise parameter.ParameterException('%s: can not override global parameter %s' % (exc_desc, param_name))
             result[param_name] = arg
 
         # Then use the defaults for anything not filled in
@@ -403,7 +401,7 @@ class Task(object):
             cls = self.__class__
         
         new_k = {}
-        for param_name, param_class in cls.get_nonglobal_params():
+        for param_name, param_class in cls.get_params():
             if param_name in k:
                 new_k[param_name] = k[param_name]
 

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -18,14 +18,12 @@ class InterfaceTest(unittest.TestCase):
         self.worker_scheduler_factory.create_worker = Mock(return_value=self.worker)
         self.worker_scheduler_factory.create_local_scheduler = Mock()
 
-        EnvironmentParamsContainer.no_lock = Mock(return_value=True)
-
         class NoOpTask(luigi.Task):
             param = luigi.Parameter()
 
         self.task_a = NoOpTask("a")
         self.task_b = NoOpTask("b")
-
+    
     def test_interface_run_positive_path(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=True)
@@ -45,7 +43,8 @@ class InterfaceTest(unittest.TestCase):
         self.assertFalse(self._run_interface())
 
     def _run_interface(self):
-        return Interface.run([self.task_a, self.task_b], self.worker_scheduler_factory)
+        override_defaults={'no_lock': True}
+        return Interface.run([self.task_a, self.task_b], self.worker_scheduler_factory, override_defaults)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also removed a couple of ways global parameters are special. The only feature separating global variables is now that they can be set on the command line for all tasks. But other than that, global parameters behaves like any other parameter.

There was also some issues with leaky state from one test to another - interface_test.py was leaking a mocked no_lock=True parameter which parameter_test.py was relying on. Removed the leak and added --no-lock everywhere in parameter_test.py
