### PR TITLE
Adding openssh-client as a dependency to make sure ssh tests work.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ Build-Depends:	debhelper (>= 7),
 		python-simplejson,
 		python-tornado (>= 2.3),
 		python-mock,
-		python-ordereddict
+		python-ordereddict,
+		openssh-client
 Standards-Version: 3.7.3
 X-Python-Version: >= 2.6
 


### PR DESCRIPTION
On build systems without the ssh executable some ssh tests would previously fail
