### PR TITLE
Fix deprecation warnings being emitted

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -374,7 +374,7 @@ class OptParseInterface(Interface):
             description = [param_name]
             if param.description:
                 description.append(param.description)
-            if param.has_default:
+            if param.has_value:
                 description.append(" [default: %s]" % (param.default,))
 
             if param.is_list:

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -241,7 +241,7 @@ class Parameter(object):
         :raises MissingParameterException: if x is false-y and no default is specified.
         """
         if not x:
-            if self.has_default:
+            if self.has_value:
                 return self.default
             elif self.is_boolean:
                 return False


### PR DESCRIPTION
~arash/luigi/parameter.py:168: DeprecationWarning: Use has_value rather than has_default. The meaning of "default" has changed
  warnings.warn('Use has_value rather than has_default. The meaning of "default" has changed', DeprecationWarning)

I verified that it works for me by running a normal Spotify luigi job.
