### PR TITLE
Don't import luigi.worker from __init__.py

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -20,9 +20,9 @@ import parameter
 import configuration
 import interface
 import target
-import worker
+import event
 
-Event = worker.Event
+Event = event.Event
 
 Task = task.Task
 ExternalTask = task.ExternalTask

--- a/luigi/event.py
+++ b/luigi/event.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2014 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+class Event:
+    # TODO nice descriptive subclasses of Event instead of strings? pass their instances to the callback instead of an undocumented arg list?
+    DEPENDENCY_DISCOVERED = "event.core.dependency.discovered"  # triggered for every (task, upstream task) pair discovered in a jobflow
+    DEPENDENCY_MISSING = "event.core.dependency.missing"
+    DEPENDENCY_PRESENT = "event.core.dependency.present"
+    BROKEN_TASK = "event.core.task.broken"
+    START = "event.core.start"
+    FAILURE = "event.core.failure"
+    SUCCESS = "event.core.success"
+    PROCESSING_TIME = "event.core.processing_time"
+
+

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -25,9 +25,10 @@ import logging
 import warnings
 import notifications
 import getpass
-import multiprocessing
+import multiprocessing # Note: this seems to have some stability issues: https://github.com/spotify/luigi/pull/438
 from target import Target
 from task import Task
+from event import Event
 
 try:
     import simplejson as json
@@ -39,18 +40,6 @@ logger = logging.getLogger('luigi-interface')
 
 class TaskException(Exception):
     pass
-
-
-class Event:
-    # TODO nice descriptive subclasses of Event instead of strings? pass their instances to the callback instead of an undocumented arg list?
-    DEPENDENCY_DISCOVERED = "event.core.dependency.discovered"  # triggered for every (task, upstream task) pair discovered in a jobflow
-    DEPENDENCY_MISSING = "event.core.dependency.missing"
-    DEPENDENCY_PRESENT = "event.core.dependency.present"
-    BROKEN_TASK = "event.core.task.broken"
-    START = "event.core.start"
-    FAILURE = "event.core.failure"
-    SUCCESS = "event.core.success"
-    PROCESSING_TIME = "event.core.processing_time"
 
 
 class TaskProcess(multiprocessing.Process):


### PR DESCRIPTION
There's some really fishy bug going on with multiprocessing that we are investigating. It _seems_ like (but still to be confirmed) that luigi.hadoop ends up importing luigi.worker which in turn imports multiprocessing. multiprocessing _seems_ to have a bug causing an exception in the global scope in case the temporary directory is too long (bind() fails if the temp path is > 107 characters, this is a known UNIX issue)

Even if the theory above isn't correct, this still cleans some import dependencies, by moving Event to its own module
