### PR TITLE
Make TaskProcess catch all Exceptions

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -60,6 +60,9 @@ class TaskProcess(multiprocessing.Process):
             # Need to have different random seeds if running in separate processes
             random.seed((os.getpid(), time.time()))
 
+        status = FAILED
+        error_message = ''
+        missing = []
         try:
             # Verify that all the tasks are fulfilled!
             missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]


### PR DESCRIPTION
"except Exception" will not catch all types of exceptions.

To trigger the bug:

``` python
import luigi

class BugGenerator(luigi.Task):
    p = luigi.IntParameter()

    def output(self):
        luigi.LocalTarget('/tmp/bug/{}'.format(self.p))

    def run(self):
        raise SystemExit("I'm gonna fuck you up!")


class BugSpam(luigi.Task):

    def requires(self):
        return {i: BugGenerator(p=i) for i in range(30)}

if __name__ == '__main__':
    luigi.run()
```
