### PR TITLE
Fix deprecation warning

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -375,7 +375,7 @@ class OptParseInterface(Interface):
             if param.description:
                 description.append(param.description)
             if param.has_value:
-                description.append(" [default: %s]" % (param.default,))
+                description.append(" [default: %s]" % (param.value,))
 
             if param.is_list:
                 action = "append"

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -242,7 +242,7 @@ class Parameter(object):
         """
         if not x:
             if self.has_value:
-                return self.default
+                return self.value
             elif self.is_boolean:
                 return False
             elif self.is_list:


### PR DESCRIPTION
```
 INFO:subp.spluigi:/home/arash/spotify/repos/luigis/github_luigi/luigi/parameter.py:190: DeprecationWarning: Use value rather than default. The meaning of "default" has changed
 INFO:subp.spluigi:  warnings.warn('Use value rather than default. The meaning of "default" has changed', DeprecationWarning)
```

I verified this by running a normal Spotify luigi job.
