### PR TITLE
hdfs: Use logger rather than print statements

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -596,7 +596,8 @@ class HdfsAtomicWritePipe(luigi.format.OutputPipeProcessWrapper):
         super(HdfsAtomicWritePipe, self).__init__([load_hadoop_cmd(), 'fs', '-put', '-', self.tmppath])
 
     def abort(self):
-        print "Aborting %s('%s'). Removing temporary file '%s'" % (self.__class__.__name__, self.path, self.tmppath)
+        logger.info("Aborting %s('%s'). Removing temporary file '%s'",
+                self.__class__.__name__, self.path, self.tmppath)
         super(HdfsAtomicWritePipe, self).abort()
         remove(self.tmppath)
 
@@ -614,7 +615,8 @@ class HdfsAtomicWriteDirPipe(luigi.format.OutputPipeProcessWrapper):
         super(HdfsAtomicWriteDirPipe, self).__init__([load_hadoop_cmd(), 'fs', '-put', '-', self.datapath])
 
     def abort(self):
-        print "Aborting %s('%s'). Removing temporary dir '%s'" % (self.__class__.__name__, self.path, self.tmppath)
+        logger.info("Aborting %s('%s'). Removing temporary dir '%s'",
+                self.__class__.__name__, self.path, self.tmppath)
         super(HdfsAtomicWriteDirPipe, self).abort()
         remove(self.tmppath)
 


### PR DESCRIPTION
I tested this by running the following on a hdfs-configured machine:

```
import luigi.hdfs
import luigi.interface

luigi.interface.setup_interface_logging()

pipe = luigi.hdfs.HdfsAtomicWritePipe('my_file')
pipe.writeLine('Hello')
pipe.abort()
pipe.writeLine('world')
pipe.close()
```
