### PR TITLE
Fixes resource tracking bug in scheduler

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -241,6 +241,7 @@ class CentralPlannerScheduler(Scheduler):
             task.deps = set(deps)
 
         task.stakeholders.add(worker)
+        task.resources = resources
 
         # Task dependencies might not exist yet. Let's create dummy tasks for them for now.
         # Otherwise the task dependencies might end up being pruned if scheduling takes a long time

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -204,6 +204,19 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(worker='Y', task_id='D', priority=0)
         self.assertEqual(self.sch.get_work(worker='Y')['task_id'], 'D')
 
+    def test_update_resources(self):
+        self.sch.add_task(WORKER, task_id='A', deps=['B'])
+        self.sch.add_task(WORKER, task_id='B', resources={'r': 2})
+        self.sch.update_resources(r=1)
+
+        # B requires too many resources, we can't schedule
+        self.check_task_order([])
+
+        self.sch.add_task(WORKER, task_id='B', resources={'r': 1})
+
+        # now we have enough resources
+        self.check_task_order(['B', 'A'])
+
     def check_task_order(self, order):
         for expected_id in order:
             self.assertEqual(self.sch.get_work(WORKER)['task_id'], expected_id)


### PR DESCRIPTION
While merging the latest trunk into my fork, I noticed that I was missing a fairly important line to update resources in add_task. Without this, only the root task in the dependency graph will have resources in the scheduler, as we'll never override the empty resources held in the dummy tasks. I've added a test to catch this in the future.
