### PR TITLE
Allows workers to keep alive only for unique pending tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -321,6 +321,7 @@ class CentralPlannerScheduler(Scheduler):
         used_resources = self._used_resources()
         potential_resources = collections.defaultdict(int)
         potential_workers = set([worker])
+        n_unique_pending = 0
 
         for task_id, task in sorted(self._tasks.iteritems(), key=self._rank(worker), reverse=True):
             if task.status == RUNNING and worker in task.workers:
@@ -334,6 +335,8 @@ class CentralPlannerScheduler(Scheduler):
 
             if task.status == PENDING and worker in task.workers:
                 locally_pending_tasks += 1
+                if len(task.workers) == 1:
+                    n_unique_pending += 1
 
             if self._not_schedulable(task, potential_resources) or best_task:
                 continue
@@ -355,6 +358,7 @@ class CentralPlannerScheduler(Scheduler):
             self._update_task_history(best_task, RUNNING, host=host)
 
         return {'n_pending_tasks': locally_pending_tasks,
+                'n_unique_pending': n_unique_pending,
                 'task_id': best_task,
                 'running_tasks': running_tasks}
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -131,7 +131,7 @@ class Worker(object):
 
     def __init__(self, scheduler=CentralPlannerScheduler(), worker_id=None,
                  worker_processes=1, ping_interval=None, keep_alive=None,
-                 wait_interval=None, max_reschedules=None):
+                 wait_interval=None, max_reschedules=None, count_uniques=None):
         self._worker_info = self._generate_worker_info()
 
         if not worker_id:
@@ -145,6 +145,12 @@ class Worker(object):
         if keep_alive is None:
             keep_alive = config.getboolean('core', 'worker-keep-alive', False)
         self.__keep_alive = keep_alive
+
+        # worker-count-uniques means that we will keep a worker alive only if it has a unique
+        # pending task, as well as having keep-alive true
+        if count_uniques is None:
+            count_uniques = config.getboolean('core', 'worker-count-uniques', False)
+        self.__count_uniques = count_uniques
 
         if wait_interval is None:
             wait_interval = config.getint('core', 'worker-wait-interval', 1)
@@ -354,7 +360,7 @@ class Worker(object):
         except:
             logger.exception('Exception adding worker - scheduler might be running an older version')
 
-    def _log_remote_tasks(self, running_tasks, n_pending_tasks):
+    def _log_remote_tasks(self, running_tasks, n_pending_tasks, n_unique_pending):
         logger.info("Done")
         logger.info("There are no more tasks to run at this time")
         if running_tasks:
@@ -362,6 +368,8 @@ class Worker(object):
                 logger.info('%s is currently run by worker %s', r['task_id'], r['worker'])
         elif n_pending_tasks:
             logger.info("There are %s pending tasks possibly being run by other workers", n_pending_tasks)
+            if n_unique_pending:
+                logger.info("There are %i pending tasks unique to this worker", n_unique_pending)
 
     def _get_work(self):
         logger.debug("Asking scheduler for work...")
@@ -370,11 +378,14 @@ class Worker(object):
         if isinstance(r, tuple) or isinstance(r, list):
             n_pending_tasks, task_id = r
             running_tasks = []
+            n_unique_pending = 0
         else:
             n_pending_tasks = r['n_pending_tasks']
             task_id = r['task_id']
             running_tasks = r['running_tasks']
-        return task_id, running_tasks, n_pending_tasks
+            # support old version of scheduler
+            n_unique_pending = r.get('n_unique_pending', 0)
+        return task_id, running_tasks, n_pending_tasks, n_unique_pending
 
     def _run_task(self, task_id):
         task = self._scheduled_tasks[task_id]
@@ -466,6 +477,16 @@ class Worker(object):
             time.sleep(wait_interval)
             yield
 
+    def _keep_alive(self, n_pending_tasks, n_unique_pending):
+        """ Returns true if a worker should stay alive given
+
+        If worker-keep-alive is not set, this will always return false. Otherwise, it will return
+        true for nonzero n_pending_tasks. If worker-count-uniques is true, it will also
+        require that one of the tasks is unique to this worker.
+        """
+        return (self.__keep_alive and n_pending_tasks
+                and (n_unique_pending or not self.__count_uniques))
+
     def run(self):
         """Returns True if all scheduled tasks were executed successfully"""
         logger.info('Running Worker with %d processes', self.worker_processes)
@@ -480,12 +501,12 @@ class Worker(object):
                 logger.debug('%d running tasks, waiting for next task to finish', len(self._running_tasks))
                 self._handle_next_task()
 
-            task_id, running_tasks, n_pending_tasks = self._get_work()
+            task_id, running_tasks, n_pending_tasks, n_unique_pending = self._get_work()
 
             if task_id is None:
-                self._log_remote_tasks(running_tasks, n_pending_tasks)
+                self._log_remote_tasks(running_tasks, n_pending_tasks, n_unique_pending)
                 if len(self._running_tasks) == 0:
-                    if self.__keep_alive and n_pending_tasks:
+                    if self._keep_alive(n_pending_tasks, n_unique_pending):
                         sleeper.next()
                         continue
                     else:

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -267,6 +267,16 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(WORKER, 'D', priority=6)
         self.check_task_order(['A', 'B', 'D', 'C'])
 
+    def test_unique_tasks(self):
+        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(WORKER, 'B')
+        self.sch.add_task(WORKER, 'C')
+        self.sch.add_task(WORKER + "_2", 'B')
+
+        response = self.sch.get_work(WORKER)
+        self.assertEqual(3, response['n_pending_tasks'])
+        self.assertEqual(2, response['n_unique_pending'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With resource limitations, it's very easy to have a lot of workers sitting around just waiting for resources. This is problematic for people using locks to prevent scheduling, as it will stop new tasks from getting scheduled. To limit this behavior, this PR adds an option to keep alive only if there is a pending task with all requirements done which no other worker can work on. So older workers whose tasks are all being waited on by newer workers can just die. I require the unique tasks to be ready because all of my workers have a unique WrapperTask at the root, and I don't want to wait for those. Having a unique ready task tends to mean the same thing as having a unique pending task other than the root one for me, so this works well for my scheduling patterns.

Since this won't work well for all scheduling patterns, it has to be activated via a config parameter, worker-require-unique-ready as well as enabling worker-keep-alive.
