### PR TITLE
Allow multiple hiverc files.

### DIFF
--- a/luigi/hive.py
+++ b/luigi/hive.py
@@ -237,6 +237,7 @@ class HiveQueryTask(luigi.hadoop.BaseHadoopJobTask):
         """ Location of an rc file to run before the query
             if hiverc-location key is specified in client.cfg, will default to the value there
             otherwise returns None
+            Returning a list of rc files will load all of them in order.
         """
         return luigi.configuration.get_config().get('hive', 'hiverc-location', default=None)
 


### PR DESCRIPTION
Allow a Hive task to specify multiple hiverc files, all of which are loaded in order. When the hiverc method returns a list of file paths, the hive command "hive -i rcfile1 -i rcfile2 ..." is generated. This allows users to maintain snippets of hiverc files that can be combined easily for different hive environments.  
