### PR TITLE
Adds luigi_state tracking to interface

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -22,6 +22,7 @@ import scheduler
 import warnings
 import configuration
 import task
+import luigi_state
 import parameter
 import re
 import argparse
@@ -212,10 +213,12 @@ class Interface(object):
             scheduler=sch, worker_processes=env_params.workers)
 
         success = True
+        luigi_state.set_state(luigi_state.SCHEDULING)
         for t in tasks:
             success &= w.add(t)
         logger = logging.getLogger('luigi-interface')
         logger.info('Done scheduling tasks')
+        luigi_state.set_state(luigi_state.RUNNING)
         success &= w.run()
         w.stop()
         return success

--- a/luigi/luigi_state.py
+++ b/luigi/luigi_state.py
@@ -1,0 +1,16 @@
+UNKNOWN = 'UNKNOWN'
+SCHEDULING = 'SCHEDULING'
+RUNNING = 'RUNNING'
+
+_STATES = frozenset((SCHEDULING, RUNNING))
+_STATE = UNKNOWN
+
+
+def set_state(state):
+    assert state in _STATES
+    global _STATE
+    _STATE = state
+
+
+def get_state():
+    return _STATE


### PR DESCRIPTION
This tracks luigi's global state for worker processes of either scheduling or running. My main use case is to batch and cache complete checks during scheduling and then compute them as normal during running for more safety. For example, when scheduling 24 hours of scp tasks, it can take about a minute to check all 24 output files for existence. However, we can do one ls to check all the files at once and just refer to that until scheduling is over to do all the checks in a few seconds.

To help with this sort of use case, I wrote a decorator that caches a function's output only during scheduling and returns its value without caching after that. I don't know whether that belongs in luigi (and if so, where) so I haven't included it for now.
