### PR TITLE
Allows co-scheduling of tasks without dependency

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -514,6 +514,23 @@ class Task(object):
         '''
         return flatten(self.requires())  # base impl
 
+    def co_schedule(self):
+        """The tasks that will be scheduled alongside this one
+
+        When a task is scheduled, you may want to always schedule another
+        complementary task that this one does not depend on. For example, you
+        may want to schedule a cleanup task that depends on this one and removes
+        any unneeded output.
+        """
+        return []  # default impl
+
+    def co_schedule_iterable(self):
+        """ Internal method used by the scheduler
+
+        Returns the flattened list of co_schedule
+        """
+        return flatten(self.co_schedule())
+
     def process_resources(self):
         '''
         Override in "template" tasks which provide common resource functionality

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -329,6 +329,9 @@ class Worker(object):
 
             deps = [d.task_id for d in deps]
 
+        for t in task.co_schedule_iterable():
+            yield t
+
         self._scheduled_tasks[task.task_id] = task
         self._scheduler.add_task(self._id, task.task_id, status=status,
                                  deps=deps, runnable=runnable, priority=task.priority,

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -259,6 +259,22 @@ class WorkerTest(unittest.TestCase):
         self.assertTrue(self.w.add(B()))
         self.assertFalse(self.w.run())
 
+    def test_co_schedule(self):
+        dummy = DummyTask()
+
+        class A(DummyTask):
+            def co_schedule(self):
+                return dummy
+        a = A()
+
+        self.assertTrue(self.w.add(a))
+        self.assertFalse(dummy.complete())
+        self.assertFalse(a.complete())
+
+        self.w.run()
+        self.assertTrue(a.complete())
+        self.assertTrue(dummy.complete())
+
     def test_interleaved_workers(self):
         class A(DummyTask):
             pass


### PR DESCRIPTION
Currently, the only way to guarantee that task B runs whenever we schedule task A is to make A depend on B. This is not always feasible. For example, it may already be the case that B depends on A. We may also want to schedule them together without requiring that one runs before the other. For this usage, I've added a co_schedule function to Task. If A.co_schedule() returns B, then B will be scheduled whenever A is without affecting either of their dependencies.

The main use case I have is to schedule automatic cleanups. Currently, I have a setup where I'll have one mapreduce task M, with many consumers C1,...,Cn that each depend on M. I then have a purge task P that depends on C1,...,Cn which removes all of M's output after all the consumers have used it. This works fine normally, as I regularly schedule P going forward. It causes problems when someone creates or changes a consumer Ci and has to do a backfill. When Ci is run, we end up running M but not P, so we're left with a lot of garbage at the end of the backfill which won't necessarily be cleaned up by my regularly scheduled tasks. To fix this, we set M to co-schedule P. Now when I backfill Ci, P will be scheduled as well and I won't be left with any cruft.
