### PR TITLE
Cleanup of luigi.mock

### DIFF
--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -77,7 +77,7 @@ class CmdlineTest(unittest.TestCase):
     def setUp(self):
         global File
         File = MockFile
-        MockFile._file_contents.clear()
+        MockFile.fs.clear()
 
     def test_expose_deprecated(self):
         with warnings.catch_warnings(record=True) as w:
@@ -88,12 +88,12 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch("logging.getLogger")
     def test_cmdline_main_task_cls(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', '--n', '100'], main_task_cls=SomeTask)
-        self.assertEqual(dict(MockFile._file_contents), {'/tmp/test_100': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_100': 'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_other_task(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', 'SomeTask', '--n', '1000'])
-        self.assertEqual(dict(MockFile._file_contents), {'/tmp/test_1000': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_1000': 'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_ambiguous_class(self, logger):

--- a/test/copy_test.py
+++ b/test/copy_test.py
@@ -41,7 +41,7 @@ class ACopy(Copy(A)):
 class UtilTest(unittest.TestCase):
     def test_a(self):
         luigi.build([ACopy(date=datetime.date(2012, 1, 1))], local_scheduler=True)
-        self.assertEqual(MockFile._file_contents['/tmp/data-2012-01-01.txt'], 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), 'hello, world\n')
 
 if __name__ == '__main__':
     luigi.run()

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -255,8 +255,8 @@ class PCopy(luigi.Task):
 class CopyTest(unittest.TestCase):
     def test_copy(self):
         luigi.build([PCopy(date=datetime.date(2012, 1, 1))], local_scheduler=True)
-        self.assertEqual(MockFile._file_contents['/tmp/data-2012-01-01.txt'], 'hello, world\n')
-        self.assertEqual(MockFile._file_contents['/tmp/copy-data-2012-01-01.txt'], 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2012-01-01.txt'), 'hello, world\n')
 
 
 class PickleTest(unittest.TestCase):
@@ -267,8 +267,8 @@ class PickleTest(unittest.TestCase):
         p = pickle.loads(p_pickled)
 
         luigi.build([p], local_scheduler=True)
-        self.assertEqual(MockFile._file_contents['/tmp/data-2013-01-01.txt'], 'hello, world\n')
-        self.assertEqual(MockFile._file_contents['/tmp/copy-data-2013-01-01.txt'], 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2013-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2013-01-01.txt'), 'hello, world\n')
 
 
 class Subtask(luigi.Task):

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -54,7 +54,7 @@ class FibTestBase(unittest.TestCase):
     def setUp(self):
         global File
         File = MockFile
-        MockFile._file_contents.clear()
+        MockFile.fs.clear()
 
 
 class FibTest(FibTestBase):
@@ -63,20 +63,20 @@ class FibTest(FibTestBase):
         w.add(Fib(100))
         w.run()
         w.stop()
-        self.assertEqual(MockFile._file_contents['/tmp/fib_10'], '55\n')
-        self.assertEqual(MockFile._file_contents['/tmp/fib_100'], '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
 
     def test_cmdline(self):
         luigi.run(['--local-scheduler', 'Fib', '--n', '100'])
 
-        self.assertEqual(MockFile._file_contents['/tmp/fib_10'], '55\n')
-        self.assertEqual(MockFile._file_contents['/tmp/fib_100'], '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
 
     def test_build_internal(self):
         luigi.build([Fib(100)], local_scheduler=True)
 
-        self.assertEqual(MockFile._file_contents['/tmp/fib_10'], '55\n')
-        self.assertEqual(MockFile._file_contents['/tmp/fib_100'], '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
 
 if __name__ == '__main__':
     luigi.run()

--- a/test/hadoop_test.py
+++ b/test/hadoop_test.py
@@ -119,7 +119,7 @@ class UnicodeJob(TestJobTask):
 
 class HadoopJobTest(unittest.TestCase):
     def setUp(self):
-        MockFile._file_contents.clear()
+        MockFile.fs.clear()
 
     def read_output(self, p):
         count = {}

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -45,7 +45,7 @@ class MockFileSystemTest(unittest.TestCase):
             pass
 
     def setUp(self):
-        MockFile._file_contents.clear()
+        self.fs.clear()
         self.path = "/tmp/foo"
         self.path2 = "/tmp/bar"
         self._touch(self.path)

--- a/test/optparse_test.py
+++ b/test/optparse_test.py
@@ -21,8 +21,8 @@ class OptParseTest(FibTestBase):
     def test_cmdline_optparse(self):
         luigi.run(['--local-scheduler', '--task', 'Fib', '--n', '100'], use_optparse=True)
 
-        self.assertEqual(MockFile._file_contents['/tmp/fib_10'], '55\n')
-        self.assertEqual(MockFile._file_contents['/tmp/fib_100'], '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
 
     def test_cmdline_optparse_existing(self):
         import optparse
@@ -31,5 +31,5 @@ class OptParseTest(FibTestBase):
 
         luigi.run(['--local-scheduler', '--task', 'Fib', '--n', '100'], use_optparse=True, existing_optparse=parser)
 
-        self.assertEqual(MockFile._file_contents['/tmp/fib_10'], '55\n')
-        self.assertEqual(MockFile._file_contents['/tmp/fib_100'], '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -41,7 +41,7 @@ class Popularity(luigi.Task):
 
 class RecursionTest(unittest.TestCase):
     def setUp(self):
-        MockFile._file_contents['/tmp/popularity/2009-01-01.txt'] = '0\n'
+        MockFile.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = '0\n'
 
     def test_invoke(self):
         w = luigi.worker.Worker()
@@ -49,10 +49,10 @@ class RecursionTest(unittest.TestCase):
         w.run()
         w.stop()
 
-        self.assertEquals(MockFile._file_contents['/tmp/popularity/2010-01-01.txt'], '365\n')
+        self.assertEquals(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')
 
     def test_cmdline(self):
         luigi.interface.reset()
         luigi.run(['--local-scheduler', 'Popularity', '--date', '2010-01-01'])
 
-        self.assertEquals(MockFile._file_contents['/tmp/popularity/2010-01-01.txt'], '365\n')
+        self.assertEquals(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')

--- a/test/wrap_test.py
+++ b/test/wrap_test.py
@@ -76,15 +76,15 @@ class WrapperTest(unittest.TestCase):
     See instance_wrap_test.py for an example of how instances can wrap each other. '''
     workers = 1
     def setUp(self):
-        MockFile._file_contents.clear()
+        MockFile.fs.clear()
 
     def test_a(self):
         luigi.build([AXML()], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile._file_contents['/tmp/a.xml'], '<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/a.xml'), '<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
 
     def test_b(self):
         luigi.build([BXML(datetime.date(2012, 1, 1))], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile._file_contents['/tmp/b-2012-01-01.xml'], '<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/b-2012-01-01.xml'), '<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
 
 
 class WrapperWithMultipleWorkersTest(WrapperTest):


### PR DESCRIPTION
Some issues with multiprocessing causes random bugs. This change makes sure the manager (needed by MockFile) isn't instantiated in the global scope. Also a bunch of other cleanup to avoid pulling out internal variables in tests etc
