### PR TITLE
Remove SkipTest which isn't Python 2.6-compatible.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,8 @@ Build-Depends:	debhelper (>= 7),
 		python-tornado (>= 2.3),
 		python-mock,
 		python-ordereddict,
-		openssh-client
+		openssh-client,
+		python-sqlalchemy
 Standards-Version: 3.7.3
 X-Python-Version: >= 2.6
 

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -18,11 +18,7 @@ import unittest
 import luigi
 
 from luigi.task_status import PENDING, RUNNING, DONE
-
-try:
-    from luigi.db_task_history import DbTaskHistory
-except ImportError as e:
-    raise unittest.SkipTest('Could not test db_task_history: %s' % e)
+from luigi.db_task_history import DbTaskHistory
 
 
 class DummyTask(luigi.Task):


### PR DESCRIPTION
Adding python-sqlalchemy debian dependency as to not break db_task_history tests

Replaces #476
