### PR TITLE
Add python-pyparsing as runtime dependency in deb

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,8 @@ Depends: ${shlibs:Depends},
 	 ${misc:Depends},
 	 ${python:Depends},
 	 python-argparse,
+	 python-pyparsing,
+	 python-sqlalchemy,
 	 python-mechanize
 Description: Workflow mgmgt + task scheduling + dependency resolution
 
@@ -32,5 +34,7 @@ Depends:	${shlibs:Depends},
 		${python:Depends},
 		python-daemon,
 		python-pip,
+		python-pyparsing,
+		python-sqlalchemy,
 		python-tornado (>= 2.3)
 Description: Luigi central planner server


### PR DESCRIPTION
Packages that depend on luigi, like company internal versions of luigi, will fail, as it's not sufficient to only have pyparsing as a build dependency.
