### PR TITLE
Initial prototype of a "slave" worker

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -32,7 +32,6 @@ from luigi import parameter
 from luigi import rpc
 from luigi import scheduler
 from luigi import task
-from luigi import worker
 from luigi.task import Register
 
 
@@ -40,7 +39,8 @@ def load_task(module, task_name, params_str):
     """
     Imports task dynamically given a module and a task name.
     """
-    __import__(module)
+    if module is not None:
+        __import__(module)
     task_cls = Register.get_task_cls(task_name)
     return task_cls.from_str_params(params_str)
 
@@ -122,6 +122,7 @@ class WorkerSchedulerFactory(object):
         return rpc.RemoteScheduler(host=host, port=port)
 
     def create_worker(self, scheduler, worker_processes):
+        from luigi import worker
         return worker.Worker(
             scheduler=scheduler, worker_processes=worker_processes)
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -604,7 +604,7 @@ class CentralPlannerScheduler(Scheduler):
                 return False
         return True
 
-    def get_work(self, worker, host=None, **kwargs):
+    def get_work(self, worker, host=None, assistant=False, **kwargs):
         # TODO: remove any expired nodes
 
         # Algo: iterate over all nodes, find the highest priority node no dependencies and available
@@ -644,18 +644,18 @@ class CentralPlannerScheduler(Scheduler):
                     more_info.update(other_worker.info)
                     running_tasks.append(more_info)
 
-            if task.status == PENDING and worker in task.workers:
+            if task.status == PENDING and (worker in task.workers or assistant):
                 locally_pending_tasks += 1
                 if len(task.workers) == 1:
                     n_unique_pending += 1
 
-            if task.status == RUNNING and task.worker_running in greedy_workers:
+            if task.status == RUNNING and (task.worker_running in greedy_workers or assistant):
                 greedy_workers[task.worker_running] -= 1
                 for resource, amount in six.iteritems((task.resources or {})):
                     greedy_resources[resource] += amount
 
             if not best_task and self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
-                if worker in task.workers and self._has_resources(task.resources, used_resources):
+                if (worker in task.workers or assistant) and self._has_resources(task.resources, used_resources):
                     best_task = task
                     best_task_id = task.id
                 else:
@@ -670,16 +670,22 @@ class CentralPlannerScheduler(Scheduler):
 
                             break
 
+        reply = {'n_pending_tasks': locally_pending_tasks,
+                 'running_tasks': running_tasks,
+                 'task_id': None,
+                 'n_unique_pending': n_unique_pending}
+
         if best_task:
             self._state.set_status(best_task, RUNNING, self._config)
             best_task.worker_running = worker
             best_task.time_running = time.time()
             self._update_task_history(best_task.id, RUNNING, host=host)
 
-        return {'n_pending_tasks': locally_pending_tasks,
-                'n_unique_pending': n_unique_pending,
-                'task_id': best_task_id,
-                'running_tasks': running_tasks}
+            reply['task_id'] = best_task.id
+            reply['task_family'] = best_task.family
+            reply['task_params'] = best_task.params
+
+        return reply
 
     def ping(self, worker, **kwargs):
         self.update(worker)

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -47,7 +47,7 @@ class CustomizedLocalScheduler(luigi.scheduler.CentralPlannerScheduler):
         super(CustomizedLocalScheduler, self).__init__(*args, **kwargs)
         self.has_run = False
 
-    def get_work(self, worker, host=None):
+    def get_work(self, worker, host=None, **kwargs):
         r = super(CustomizedLocalScheduler, self).get_work(worker, host)
         self.has_run = True
         return r

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -839,6 +839,33 @@ class MultipleWorkersTest(unittest.TestCase):
         self.assertEqual(0, len(w._running_tasks))
 
 
+class Dummy2Task(Task):
+    p = luigi.Parameter()
+
+    def output(self):
+        return MockFile(self.p)
+
+    def run(self):
+        f = self.output().open('w')
+        f.write('test')
+        f.close()
+
+
+class AssistantTest(unittest.TestCase):
+    def setUp(self):
+        self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        self.w = Worker(scheduler=self.sch, worker_id='X')
+        self.assistant = Worker(scheduler=self.sch, worker_id='Y', assistant=True)
+
+    def test_get_work(self):
+        d = Dummy2Task('123')
+        self.w.add(d)
+
+        self.assertFalse(d.complete())
+        self.assistant.run()
+        self.assertTrue(d.complete())
+
+
 class ForkBombTask(luigi.Task):
     depth = luigi.IntParameter()
     breadth = luigi.IntParameter()


### PR DESCRIPTION
If a worker is created using slave=True, then it will pull *any* tasks from the scheduler,
not just tasks that are assigned to it.

The biggest limitation atm is that the slave needs to be aware of what those tasks map to,
i.e. somehow they have to be imported for the worker to know what to do with the tasks.

It also doesn't handle failure very well.

Changed the semantics of how interface.load_task works a bit. It will now rely on the
Register class to locate task classes rather than importing modules dynamically. There is
still an option to import modules but it's not run by default.