### PR TITLE
include priority and resource information in visualizer

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -48,6 +48,10 @@
             border:1px solid #DDDDDD;
             overflow:scroll;
         }
+
+        .taskRow {
+          word-break:break-all;
+        }
         </style>
         <script type="text/template" name="rowTemplate">
             {{#tasks}}
@@ -65,9 +69,10 @@
                     {{#value}}
                     <div class="taskRow row-fluid" data-task-id="{{taskId}}">
                         <div class="span4"><strong>{{taskName}}</strong><em> ({{taskParams}})</em></div>
-                        <div class="span2">{{verdict}}</div>
+                        <div class="span1">{{priority}}</div>
+                        <div class="span2">{{resources}}</div>
                         <div class="span3">{{displayTime}}</div>
-                        <div class="span3">
+                        <div class="span2">
                             <a href="#{{taskId}}" class="btn btn-info btn-small" data-action="drawGraph">Dependency Graph</a>
                             {{#error}}<a class="btn btn-primary btn-small error-trace-button" data-task-id="{{taskId}}">Show Error Trace</a>{{/error}}
                         </div>

--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -24,6 +24,7 @@ Graph = (function() {
             trackingUrl: "#"+task.taskId,
             deps: deps,
             params: task.params,
+            priority: task.priority,
             depth: -1
         };
     }
@@ -189,6 +190,7 @@ Graph = (function() {
             $.each(node.params, function (param_name, param_value) {
                 titleText += param_name + "=" + param_value + '<br/>';
             });
+            titleText += "priority" + "=" + node.priority + '<br/>';
             g.attr("title", $.trim(titleText))
                 .tooltip();
         });

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -28,11 +28,16 @@ function visualiserApp(luigi) {
             var current_time = new Date().getTime()
             var minutes_running = Math.round((current_time - task.time_running * 1000) / 1000 / 60)
             displayTime += " | " + minutes_running + " minutes"
+            if ("worker_running" in task) {
+              displayTime += " (" + task.worker_running + ")"
+            }
         }
         return {
             taskId: task.taskId,
             taskName: taskName,
             taskParams: taskParams,
+            priority: task.priority,
+            resources: JSON.stringify(task.resources),
             displayTime: displayTime,
             displayTimestamp : task.start_time,
             trackingUrl: task.trackingUrl,

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -218,7 +218,6 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         t7 = tasks_done.get(u'FactorTask(product=7)')
         self.assertEqual(type(t7), type({}))
-        self.assertEqual(t7[u'deps'], [])
 
         self.assertEqual(remote.task_list('', ''), tasks_done)
         self.assertEqual(remote.task_list('FAILED', ''), {})
@@ -232,7 +231,6 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         f8 = failed.get(u'FailingTask(task_id=8)')
         self.assertEqual(f8[u'status'], u'FAILED')
-        self.assertEqual(f8[u'deps'], [])
 
         self.assertEqual(remote.task_list('DONE', ''), {})
         self.assertEqual(remote.task_list('PENDING', ''), {})
@@ -267,31 +265,26 @@ class SchedulerVisualisationTest(unittest.TestCase):
         done = remote.task_list('DONE', '')
         self.assertEqual(len(done), 1)
         db = done.get('B()')
-        self.assertEqual(db['deps'], [])
         self.assertEqual(db['status'], 'DONE')
 
         missing_input = remote.task_list('PENDING', 'UPSTREAM_MISSING_INPUT')
         self.assertEqual(len(missing_input), 2)
 
         pa = missing_input.get(u'A()')
-        self.assertEqual(pa['deps'], [])
         self.assertEqual(pa['status'], 'PENDING')
         self.assertEqual(remote._upstream_status('A()', {}), 'UPSTREAM_MISSING_INPUT')
 
         pc = missing_input.get(u'C()')
-        self.assertEqual(sorted(pc['deps']), ['A()', 'B()'])
         self.assertEqual(pc['status'], 'PENDING')
         self.assertEqual(remote._upstream_status('C()', {}), 'UPSTREAM_MISSING_INPUT')
 
         upstream_failed = remote.task_list('PENDING', 'UPSTREAM_FAILED')
         self.assertEqual(len(upstream_failed), 2)
         pe = upstream_failed.get(u'E()')
-        self.assertEqual(sorted(pe['deps']), ['C()', 'D()'])
         self.assertEqual(pe['status'], 'PENDING')
         self.assertEqual(remote._upstream_status('E()', {}), 'UPSTREAM_FAILED')
 
         pe = upstream_failed.get(u'D()')
-        self.assertEqual(sorted(pe['deps']), ['F()'])
         self.assertEqual(pe['status'], 'PENDING')
         self.assertEqual(remote._upstream_status('D()', {}), 'UPSTREAM_FAILED')
 
@@ -303,7 +296,6 @@ class SchedulerVisualisationTest(unittest.TestCase):
         failed = remote.task_list('FAILED', '')
         self.assertEqual(len(failed), 1)
         fd = failed.get('F()')
-        self.assertEqual(fd['deps'], [])
         self.assertEqual(fd['status'], 'FAILED')
 
         all = dict(pending)


### PR DESCRIPTION
Also I skip dependency info in the serialize_task when not necessary.

See attachment.
![luigi task visualiser](https://cloud.githubusercontent.com/assets/50040/4514274/7d16a56e-4b63-11e4-9025-c5a1db3ef674.png)
