### PR TITLE
Adds sudo user to worker info when available

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -240,6 +240,12 @@ class Worker(object):
             args += [('pid', os.getpid())]
         except:
             pass
+        try:
+            sudo_user = os.getenv("SUDO_USER")
+            if sudo_user:
+                args.append(('sudo_user', sudo_user))
+        except:
+            pass
         return args
 
     def _validate_task(self, task):


### PR DESCRIPTION
Many of the jobs I use have to be run as hadoop, so it's impossible to tell from
the user who actually ran the job. This adds sudo_user to the worker info so
that it's easier to tell who's running what. This is very handy when I need to
figure out why a large backfill or test job is running if it's causing a lot of
errors or hogging all the resources.
