### PR TITLE
Adds a worker list view to the visualizer

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -137,6 +137,9 @@ class RemoteScheduler(Scheduler):
     def task_list(self, status, upstream_status):
         return self._request('/api/task_list', {'status': status, 'upstream_status': upstream_status})
 
+    def worker_list(self):
+        return self._request('/api/worker_list', {})
+
     def task_search(self, task_str):
         return self._request('/api/task_search', {'task_str': task_str})
 
@@ -189,6 +192,9 @@ class RemoteSchedulerResponder(object):
 
     def task_list(self, status, upstream_status, **kwargs):
         return self._scheduler.task_list(status, upstream_status)
+
+    def worker_list(self, **kwargs):
+        return self._scheduler.worker_list()
 
     def task_search(self, task_str, **kwargs):
         return self._scheduler.task_search(task_str)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -72,6 +72,7 @@ class Worker(object):
         self.id = id
         self.reference = None  # reference to the worker in the real world. (Currently a dict containing just the host)
         self.last_active = last_active  # seconds since epoch
+        self.started = time.time()  # seconds since epoch
         self.info = {}
 
     def add_info(self, info):
@@ -469,6 +470,36 @@ class CentralPlannerScheduler(Scheduler):
                     serialized = self._serialize_task(task_id, False)
                     result[task_id] = serialized
         return result
+
+    def worker_list(self, include_running=True):
+        self.prune()
+        workers = [
+            dict(
+                name=worker.id,
+                last_active=worker.last_active,
+                started=getattr(worker, 'started', None),
+                **worker.info
+            ) for worker in self._active_workers.values()]
+        workers.sort(key=lambda worker: worker['started'], reverse=True)
+        if include_running:
+            running = collections.defaultdict(dict)
+            num_pending = collections.defaultdict(int)
+            num_uniques = collections.defaultdict(int)
+            for task_id, task in self._tasks.items():
+                if task.status == RUNNING and task.worker_running:
+                    running[task.worker_running][task_id] = self._serialize_task(task_id, False)
+                elif task.status == PENDING:
+                    for worker in task.workers:
+                        num_pending[worker] += 1
+                    if len(task.workers) == 1:
+                        num_uniques[list(task.workers)[0]] += 1
+            for worker in workers:
+                tasks = running[worker['name']]
+                worker['num_running'] = len(tasks)
+                worker['num_pending'] = num_pending[worker['name']]
+                worker['num_uniques'] = num_uniques[worker['name']]
+                worker['running'] = tasks
+        return workers
 
     def inverse_dependencies(self, task_id):
         self.prune()

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -93,6 +93,29 @@
                 <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
             </div>
         </script>
+        <script type="text/template" name="workerTemplate">
+            {{#workers}}
+                <h3>{{name}}</h3>
+                <p><b>Started</b>: {{start_time}}</p>
+                <p><b>Last Checkin</b>: {{active}}</p>
+                <p><b>Root Task</b>: <a href="#{{{first_task}}}">{{first_task}}</a></p>
+                <p><b>Pending Tasks</b>: {{num_pending}}</p>
+                <p><b>Unique Pending Tasks</b>: {{num_uniques}}</p>
+                <p><b>Running Tasks</b>: {{num_running}}</p>
+                {{#tasks}}
+                <div class="taskRow row-fluid" data-task-id="{{taskId}}">
+                    <div class="span4"><strong>{{taskName}}</strong><em> ({{taskParams}})</em></div>
+                    <div class="span1">{{priority}}</div>
+                    <div class="span2">{{resources}}</div>
+                    <div class="span3">{{displayTime}}</div>
+                    <div class="span2">
+                        <a href="#{{taskId}}" class="btn btn-info btn-small" data-action="drawGraph">Dependency Graph</a>
+                        {{#error}}<a class="btn btn-primary btn-small error-trace-button" data-task-id="{{taskId}}">Show Error Trace</a>{{/error}}
+                    </div>
+                </div>
+                {{/tasks}}
+            {{/workers}}
+        </script>
     </head>
     <body>
         <div class="page-header custom-header">
@@ -102,6 +125,7 @@
         <ul class="nav nav-tabs">
             <li class="active"><a href="#" data-tab="taskList" class="tabButton">Task List</a></li>
             <li><a href="#g" data-tab="dependencyGraph" class="tabButton">Dependency Graph</a></li>
+            <li><a href="#w" data-tab="workerList" class="tabButton">Workers</a></li>
         </ul>
         <div class="tab-content">
             <section id="taskList" class="container-fluid tab-pane active">
@@ -138,6 +162,8 @@
                     <div id="graphPlaceholder">
                     </div>
                 </div>
+            </section>
+            <section id="workerList" class="container-fluid tab-pane active">
             </section>
         </div>
         <div id="errorModal" class="modal" style="display:none;">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -19,6 +19,13 @@ var LuigiAPI = (function() {
         return flattened;
     }
 
+    function flatten_running(response) {
+        $.each(response, function(key, value) {
+            value.running = flatten(value.running);
+        });
+        return response;
+    }
+
     function jsonRPC(url, paramObject, callback) {
         return $.ajax(url, {
             data: {data: JSON.stringify(paramObject)},
@@ -73,6 +80,12 @@ var LuigiAPI = (function() {
     LuigiAPI.prototype.getPendingTaskList = function(callback) {
         jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: ""}, function(response) {
             callback(flatten(response.response));
+        });
+    };
+
+    LuigiAPI.prototype.getWorkerList = function(callback) {
+        jsonRPC(this.urlRoot + "/worker_list", {}, function(response) {
+            callback(flatten_running(response.response));
         });
     };
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -178,6 +178,8 @@ class Worker(object):
         self._scheduled_tasks = {}
         self._suspended_tasks = {}
 
+        self._first_task = None
+
         self.add_succeeded = True
         self.run_succeeded = True
         self.unfulfilled_counts = collections.defaultdict(int)
@@ -279,6 +281,8 @@ class Worker(object):
     def add(self, task):
         """ Add a Task for the worker to check and possibly schedule and run.
          Returns True if task and its dependencies were successfully scheduled or completed before"""
+        if self._first_task is None and hasattr(task, 'task_id'):
+            self._first_task = task.task_id
         self.add_succeeded = True
         stack = [task]
         self._validate_task(task)
@@ -371,6 +375,7 @@ class Worker(object):
             raise Exception("Return value of Task.complete() must be boolean (was %r)" % is_complete)
 
     def _add_worker(self):
+        self._worker_info.append(('first_task', self._first_task))
         try:
             self._scheduler.add_worker(self._id, self._worker_info)
         except:


### PR DESCRIPTION
This gives you a quick view into what each worker is up to. Since adding it to my own fork last week, it has become the most useful page on the visualizer for me.

![image](https://cloud.githubusercontent.com/assets/2091885/4550970/fba9d8aa-4e6b-11e4-9f07-74d170f84501.png)

Note: the screenshot includes #488 for number of worker processes.
