### PR TITLE
Adapts visualizer graph width to screen size

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -126,7 +126,7 @@ Graph = (function() {
         };
     }
 
-    var graphWidth = 1110;
+    var graphWidth = window.innerWidth - 51;
 
     function DependencyGraph(containerElement) {
         this.svg = $(svgElement("svg")).appendTo($(containerElement));


### PR DESCRIPTION
This uses window.innerWidth - 51 to scale the graph to the screen size and allow
a 20-pixel padding on either side. This should be innerWidth - 40, but the graph
exceeds graphWidth by 11 pixels for some reason.
