### PR TITLE
Removes deleted workers from task.workers

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -181,7 +181,12 @@ class SimpleTaskState(object):
         # Mark workers as inactive
         for worker in delete_workers:
             self._active_workers.pop(worker)
-        
+
+        # remove workers from tasks
+        for task in self.get_active_tasks():
+            task.stakeholders.difference_update(delete_workers)
+            task.workers.difference_update(delete_workers)
+
 
 class CentralPlannerScheduler(Scheduler):
     ''' Async scheduler that can handle multiple workers etc
@@ -230,7 +235,6 @@ class CentralPlannerScheduler(Scheduler):
         remove_tasks = []
         for task in self._state.get_active_tasks():
             # Mark tasks with no remaining active stakeholders for deletion
-            task.stakeholders.difference_update(delete_workers)
             if not task.stakeholders:
                 if task.remove is None:
                     logger.info("Task %r has stakeholders %r but none remain connected -> will remove task in %s seconds", task.id, task.stakeholders, self._remove_delay)


### PR DESCRIPTION
Removes deleted workers from task.workers

After deleting workers, they remain in each task's worker list. This breaks the
unique pending counts in the scheduler, as tasks have appear to have multiple
workers even when only one of those workers is active. This fixes that issue by
removing deleted workers from each task's active list.

I also moved the stakeholders update into SimpleTaskState, as that should really
be the only place where we modify task properties.
