### PR TITLE
Trim whitespace, fix a few typos in examples

### DIFF
--- a/examples/elasticsearch_index.py
+++ b/examples/elasticsearch_index.py
@@ -9,7 +9,7 @@ class FakeDocuments(luigi.Task):
     """ Generate some documents to index. """
 
     date = luigi.DateParameter(default=datetime.date.today())
-    
+
     def run(self):
         """ Write line-delimited json. `_id` is the default Elasticsearch id
         field. """
@@ -25,7 +25,7 @@ class FakeDocuments(luigi.Task):
 
 class IndexDocuments(CopyToIndex):
     """
-    Run 
+    Run
 
         $ curl "localhost:9200/example_index/_search?pretty"
 

--- a/examples/ssh_remote_execution.py
+++ b/examples/ssh_remote_execution.py
@@ -24,7 +24,7 @@ class CreateRemoteData(luigi.Task):
 
 
 class ProcessRemoteData(luigi.Task):
-    """ Create a toplist of users based on how many running processed they have
+    """ Create a toplist of users based on how many running processes they have
         on a remote machine
 
     In this example the processed data is stored in a MockFile

--- a/examples/top_artists.py
+++ b/examples/top_artists.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 class ExternalStreams(luigi.ExternalTask):
     ''' Example of a possible external data dump
 
-    To depend on external targets (typically at the top of your dependency grpah), you can define
+    To depend on external targets (typically at the top of your dependency graph), you can define
     an ExternalTask like this.
     '''
     date = luigi.DateParameter()


### PR DESCRIPTION
Just some small fixes for examples.
