### PR TITLE
Fixes scheduler bug caused by updating priority on pruned tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -276,8 +276,8 @@ class CentralPlannerScheduler(Scheduler):
         """
         task.priority = prio = max(prio, task.priority)
         for dep in task.deps or []:
-            t = self._state.get_task(dep) # This should always exist, see add_task
-            if prio > t.priority:
+            t = self._state.get_task(dep)
+            if t is not None and prio > t.priority:
                 self._update_priority(t, prio, worker)
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -204,6 +204,25 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(worker='Y', task_id='D', priority=0)
         self.assertEqual(self.sch.get_work(worker='Y')['task_id'], 'D')
 
+    def test_priority_update_with_pruning(self):
+        self.setTime(0)
+        self.sch.add_task(task_id='A', worker='X')
+
+        self.setTime(50)  # after worker disconnects
+        self.sch.prune()
+        self.sch.add_task(task_id='B', deps=['A'], worker='X')
+
+        self.setTime(2000)  # after remove for task A
+        self.sch.prune()
+
+        # Here task A that B depends on is missing
+        self.sch.add_task(WORKER, task_id='C', deps=['B'], priority=100)
+        self.sch.add_task(WORKER, task_id='B', deps=['A'])
+        self.sch.add_task(WORKER, task_id='A')
+        self.sch.add_task(WORKER, task_id='D', priority=10)
+
+        self.check_task_order('ABCD')
+
     def test_update_resources(self):
         self.sch.add_task(WORKER, task_id='A', deps=['B'])
         self.sch.add_task(WORKER, task_id='B', resources={'r': 2})


### PR DESCRIPTION
If a task is pruned in the scheduler but a task that depends on it still exists,
the priority update recursion in add_task becomes vulnerable to encountering the
pruned task before it has been added back. Even worse, if the task that depends
on the pruned task is done, the pruned task will never be rescheduled.

This adds a test to demonstrate the code flaw and fixes it by skipping over
missing tasks in priority update. The test also shows that the priority will
still be updated appropriately if the task is eventually added back.

This resolves #498 
