### PR TITLE
Another Hadoop native libraries warning fix.

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -174,7 +174,12 @@ class HdfsClient(FileSystem):
     def count(self, path):
         cmd = [load_hadoop_cmd(), 'fs', '-count', path]
         stdout = call_check(cmd)
-        (dir_count, file_count, content_size, ppath) = stdout.split()
+        lines = stdout.split('\n')
+        for line in stdout.split('\n'):
+            if line.startswith("OpenJDK 64-Bit Server VM warning") or line.startswith("It's highly recommended") or not line:
+                lines.pop(lines.index(line))
+            else:
+               (dir_count, file_count, content_size, ppath) = stdout.split() 
         results = {'content_size': content_size, 'dir_count': dir_count, 'file_count': file_count}
         return results
 


### PR DESCRIPTION
By default 64bit Apache Hadoop binaries come with 32bit native libraries, which, unless compiled separately, cause warning header to be appended:

"OpenJDK 64-Bit Server VM warning: You have loaded library /usr/local/hadoop-2.3.0/lib/native/libhadoop.so.1.0.0 which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'."

```
>>> from luigi import hdfs
>>> cmd = ['hadoop', 'fs', '-count', '/cache']
>>> stdout = hdfs.call_check(cmd)
>>> print stdout
OpenJDK 64-Bit Server VM warning: You have loaded library /usr/local/hadoop-2.3.0/lib/native/libhadoop.so.1.0.0 which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
           1            1           50214873 /cache
```

This fix will get rid of this header.
