### PR TITLE
Remove trailing slash when using snakebite rename

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -332,7 +332,7 @@ class SnakebiteHdfsClient(HdfsClient):
         :type dest: string
         :return: list of renamed items
         """
-        parts = dest.split('/')
+        parts = dest.rstrip('/').split('/')
         if len(parts) > 1:
             dir_path = '/'.join(parts[0:-1])
             if not self.exists(dir_path):


### PR DESCRIPTION
Old functionality caused odd behavior when doing:

```
snakebite.rename('foo/', 'bar/')
```

and the bar did not exist. As result it created the 'bar' first and
then moved 'foo' in there, resulting in 'bar/foo'.

By stripping the slashes on the right, the behavior works as one would
think: renames 'foo' to 'bar'.
