### PR TITLE
Running hdfs tests locally with minicluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: python
 python:
   - "2.7"
   - "2.6"
+jdk: oraclejdk7
+env:
+  - TOX_ENV=cdh
+  - TOX_ENV=hdp
 install:
-  - pip install tornado --use-mirrors
-  - pip install argparse --use-mirrors
-  - pip install sqlalchemy --use-mirrors
-  - pip install mock --use-mirrors
-  - pip install boto --use-mirrors
-  - pip install moto --use-mirrors
-  - pip install ordereddict --use-mirrors
-  - pip install pyparsing --use-mirrors
-script: nosetests -v
+  - pip install virtualenv
+  - pip install tox
+script: python setup.py test --tox-args="-e $TOX_ENV"

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -373,13 +373,13 @@ class HadoopJobRunner(JobRunner):
         output_tmp_fn = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
         tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn, is_tmp=True)
 
-        arglist = [luigi.hdfs.load_hadoop_cmd(), 'jar', self.streaming_jar]
+        arglist = luigi.hdfs.load_hadoop_cmd() + ['jar', self.streaming_jar]
 
         # 'libjars' is a generic option, so place it first
         libjars = [libjar for libjar in self.libjars]
 
         for libjar in self.libjars_in_hdfs:
-            subprocess.call([luigi.hdfs.load_hadoop_cmd(), 'fs', '-get', libjar, self.tmp_dir])
+            subprocess.call(luigi.hdfs.load_hadoop_cmd() + ['fs', '-get', libjar, self.tmp_dir])
             libjars.append(os.path.join(self.tmp_dir, os.path.basename(libjar)))
 
         if libjars:

--- a/luigi/hadoop_jar.py
+++ b/luigi/hadoop_jar.py
@@ -45,7 +45,7 @@ class HadoopJarJobRunner(luigi.hadoop.JobRunner):
             logger.error("Can't find jar: {0}, full path {1}".format(job.jar(),
                          os.path.abspath(job.jar())))
             raise Exception("job jar does not exist")
-        arglist = [luigi.hdfs.load_hadoop_cmd(), 'jar', job.jar()]
+        arglist = luigi.hdfs.load_hadoop_cmd() + ['jar', job.jar()]
         if job.main():
             arglist.append(job.main())
 

--- a/scripts/ci/run_tests.sh
+++ b/scripts/ci/run_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [ -z "$HADOOP_HOME" ]; then
+    echo "HADOOP_HOME not set - abort" >&2
+    exit 1
+fi
+
+echo "Using ${HADOOP_DISTRO} distribution of Hadoop from ${HADOOP_HOME}"
+
+nosetests -v $@

--- a/scripts/ci/setup_env.sh
+++ b/scripts/ci/setup_env.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+HADOOP_DISTRO=${HADOOP_DISTRO:-"hdp"}
+
+ONLY_DOWNLOAD=${ONLY_DOWNLOAD:-false}
+ONLY_EXTRACT=${ONLY_EXTRACT:-false}
+
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "Setup environment for snakebite tests"
+            echo " "
+            echo "options:"
+            echo -e "\t-h, --help            show brief help"
+            echo -e "\t-o, --only-download   just download hadoop tar(s)"
+            echo -e "\t-e, --only-extract    just extract hadoop tar(s)"
+            echo -e "\t-d, --distro          select distro (hdp|cdh)"
+            exit 0
+            ;;
+        -o|--only-download)
+            shift
+            ONLY_DOWNLOAD=true
+            ;;
+        -e|--only-extract)
+            shift
+            ONLY_EXTRACT=true
+            ;;
+        -d|--distro)
+            shift
+            if test $# -gt 0; then
+                HADOOP_DISTRO=$1
+            else
+                echo "No Hadoop distro specified - abort" >&2
+                exit 1
+            fi
+            shift
+            ;;
+        *)
+            echo "Unknown options: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+HADOOP_HOME=/tmp/hadoop-${HADOOP_DISTRO}
+
+if $ONLY_DOWNLOAD && $ONLY_EXTRACT; then
+    echo "Both only-download and only-extract specified - abort" >&2
+    exit 1
+fi
+
+mkdir -p $HADOOP_HOME
+
+if [ $HADOOP_DISTRO = "cdh" ]; then
+    URL="http://archive.cloudera.com/cdh5/cdh/5/hadoop-latest.tar.gz"
+elif [ $HADOOP_DISTRO = "hdp" ]; then
+    URL="http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.0.6.0/tars/hadoop-2.2.0.2.0.6.0-76.tar.gz"
+else
+    echo "No/bad HADOOP_DISTRO='${HADOOP_DISTRO}' specified" >&2
+    exit 1
+fi
+
+if ! $ONLY_EXTRACT; then
+    echo "Downloading Hadoop from $URL to ${HADOOP_HOME}/hadoop.tar.gz"
+    curl -z ${HADOOP_HOME}/hadoop.tar.gz -o ${HADOOP_HOME}/hadoop.tar.gz -L $URL
+
+    if [ $? != 0 ]; then
+        echo "Failed to download Hadoop from $URL - abort" >&2
+        exit 1
+    fi
+fi
+
+if $ONLY_DOWNLOAD; then
+    exit 0
+fi
+
+echo "Extracting ${HADOOP_HOME}/hadoop.tar.gz into $HADOOP_HOME"
+tar zxf ${HADOOP_HOME}/hadoop.tar.gz --strip-components 1 -C $HADOOP_HOME
+
+if [ $? != 0 ]; then
+    echo "Failed to extract Hadoop from ${HADOOP_HOME}/hadoop.tar.gz to ${HADOOP_HOME} - abort" >&2
+    exit 1
+fi

--- a/setup.py
+++ b/setup.py
@@ -13,23 +13,46 @@
 # the License.
 
 import os
+import sys
 
 try:
     from setuptools import setup
+    from setuptools.command.test import test as TestCommand
 except:
     from distutils.core import setup
+    from distutils.cmd import Command as TestCommand
+
+
+class Tox(TestCommand):
+    user_options = [('tox-args=', None, "Arguments to pass to tox")]
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = ''
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import tox
+        errno = tox.cmdline(args=self.tox_args.split())
+        sys.exit(errno)
+
 
 def get_static_files(path):
     return [os.path.join(dirpath.replace("luigi/", ""), ext) 
             for (dirpath, dirnames, filenames) in os.walk(path)
             for ext in ["*.html", "*.js", "*.css", "*.png"]]
 
+
 luigi_package_data = sum(map(get_static_files, ["luigi/static", "luigi/templates"]), [])
+
 
 long_description = ['Note: For the latest source, discussion, etc, please visit the `Github repository <https://github.com/spotify/luigi>`_\n\n']
 for line in open('README.rst'):
     long_description.append(line)
 long_description = ''.join(long_description)
+
 
 setup(
     name='luigi',
@@ -50,5 +73,7 @@ setup(
     scripts=[
         'bin/luigid',
         'bin/luigi'
-    ]
+    ],
+    tests_require=['tox', 'virtualenv'],
+    cmdclass={'test': Tox},
 )

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -30,13 +30,13 @@ class SchedulerTest(unittest.TestCase):
             with open(fn.name, 'w') as fobj:
                 state = (tasks, active_workers)
                 pickle.dump(state, fobj)
-                
+
             state= luigi.scheduler.SimpleTaskState(
                 state_path=fn.name)
             state.load()
 
-            self.assertEquals(list(state.get_worker_ids()),
-                              ['Worker1', 'Worker2'])
+            self.assertEquals(set(state.get_worker_ids()),
+                              set(['Worker1', 'Worker2']))
 
     def test_load_broken_state(self):
         with tempfile.NamedTemporaryFile(delete=True) as fn:

--- a/test/testconfig/client_hadoopcli.cfg
+++ b/test/testconfig/client_hadoopcli.cfg
@@ -1,0 +1,5 @@
+[hdfs]
+client: hadoopcli
+snakebite_autoconfig: false
+namenode_host: localhost
+namenode_port: 50030

--- a/test/testconfig/core-site.xml
+++ b/test/testconfig/core-site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost:50030/</value>
+  </property>
+</configuration>

--- a/test/testconfig/log4j.properties
+++ b/test/testconfig/log4j.properties
@@ -1,0 +1,7 @@
+hadoop.root.logger=INFO,stderr
+log4j.logger.org.apache.hadoop=INFO,stderr
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=Off
+
+log4j.appender.stderr = org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout = org.apache.log4j.PatternLayout
+log4j.appender.stderr.Target = System.err

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,23 @@
 [tox]
-envlist = py26,py27
+envlist = {cdh,hdp}
 
 [testenv]
-deps=tornado
-     argparse
-     nose
-     mock
-commands=nosetests
+deps=
+  tornado
+  argparse
+  nose
+  mock
+  sqlalchemy
+  pyparsing
+  unittest2
+  ordereddict
+  snakebite>=2.4.10
+setenv =
+  cdh: HADOOP_DISTRO=cdh
+  cdh: HADOOP_HOME=/tmp/hadoop-cdh
+  hdp: HADOOP_DISTRO=hdp
+  hdp: HADOOP_HOME=/tmp/hadoop-hdp
+  LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client_hadoopcli.cfg
+commands =
+  {toxinidir}/scripts/ci/setup_env.sh
+  {toxinidir}/scripts/ci/run_tests.sh []


### PR DESCRIPTION
Modifying tests needing access to HDFS to use a local minicluster. This allows us to run the snakebite and hdfs tests as part of the build process and not only manually.

The tests uses the minicluster wrapper in https://github.com/spotify/snakebite and the same testing setup as used there. Thanks to @ravwojdyla for setting up the testing scripts in snakebite.
