### PR TITLE
Remove deprecated interface.LuigiConfigParser

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -447,11 +447,6 @@ class OptParseInterface(Interface):
         return [task]
 
 
-class LuigiConfigParser(configuration.LuigiConfigParser):
-    ''' Deprecated class, use configuration.LuigiConfigParser instead. Left for backwards compatibility '''
-    pass
-
-
 def run(cmdline_args=None, existing_optparse=None, use_optparse=False, main_task_cls=None, worker_scheduler_factory=None, use_dynamic_argparse=False):
     ''' Run from cmdline.
 

--- a/test/_webhdfs_test.py
+++ b/test/_webhdfs_test.py
@@ -4,14 +4,14 @@ import posixpath
 import time
 import unittest
 import luigi.hdfs
-import luigi.interface
+import luigi.configuration
 import luigi.webhdfs
 import whoops
 
 
 class TestConfig(unittest.TestCase):
     def test_no_config(self):
-        class TestConfigParser(luigi.interface.LuigiConfigParser):
+        class TestConfigParser(luigi.configuration.LuigiConfigParser):
             _config_paths = []
             _instance = None
 
@@ -22,7 +22,7 @@ class TestConfig(unittest.TestCase):
             config)
 
     def test_config(self):
-        class TestConfigParser(luigi.interface.LuigiConfigParser):
+        class TestConfigParser(luigi.configuration.LuigiConfigParser):
             _config_paths = []
             _instance = None
         host = "webhdfs-test"
@@ -40,7 +40,7 @@ class TestGetWhoops(unittest.TestCase):
     port = "9999"
 
     def setUp(self):
-        class TestConfigParser(luigi.interface.LuigiConfigParser):
+        class TestConfigParser(luigi.configuration.LuigiConfigParser):
             _config_paths = []
             _instance = None
         self.config = TestConfigParser.instance()


### PR DESCRIPTION
It's been depreceated for > 1 year.

Instead use luigi.configuration.LuigiConfigParser
