### PR TITLE
Lessen verbosity of tests

### DIFF
--- a/test/testconfig/client.cfg
+++ b/test/testconfig/client.cfg
@@ -1,3 +1,6 @@
+[core]
+logging_conf_file: test/testconfig/logging.cfg
+
 [hdfs]
 client: hadoopcli
 snakebite_autoconfig: false

--- a/test/testconfig/logging.cfg
+++ b/test/testconfig/logging.cfg
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(levelname)s: %(message)s

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
   cdh: HADOOP_HOME=/tmp/hadoop-cdh
   hdp: HADOOP_DISTRO=hdp
   hdp: HADOOP_HOME=/tmp/hadoop-hdp
-  LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client_hadoopcli.cfg
+  LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client.cfg
 commands =
   {toxinidir}/scripts/ci/setup_env.sh
   {toxinidir}/scripts/ci/run_tests.sh []


### PR DESCRIPTION
The problem at hand is that the travis logs get truncated to 10'000
lines.  Even though you can download the whole log file, you still get
completely log blind due to the super-verbose output.

The reason we get so much output is because the python logging module
defaults to outputting to stderr which nosetests does not capture. We
want it to capture the output from the loggers, since you only care
about the output if the test fails.

My solution is nice in the sense that it doesn't touch the code at all.
Instead, we configure the logger through the built in way of doing
configuration files in luigi.

I ping @jcrobak since he added client.cfg in `.gitignore` in commit
c642a9ec. I found this use case for commiting client.cfg sensible.

The logging config file was inspired by
https://docs.python.org/2/howto/logging.html
