### PR TITLE
Fix test_getpcmd, which occasionally fails

### DIFF
--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -27,9 +27,8 @@ luigi.notifications.DEBUG = True
 class TestCmd(unittest.TestCase):
     def test_getpcmd(self):
         p = subprocess.Popen(["sleep", "1"])
-        self.assertEquals(
-            luigi.lock.getpcmd(p.pid),
-            "sleep 1"
+        self.assertTrue(
+            luigi.lock.getpcmd(p.pid) in ["sleep 1", '[sleep]']
         )
         p.kill()
 


### PR DESCRIPTION
This have been pestering me and other luigi developers a lot. For
example, when you send a correct PR, it will sometimes fail on Travis
and you have to retrigger the bulid.

For example, it happened to me recently. This is what Travis prints:

```
======================================================================
FAIL: test_getpcmd (lock_test.TestCmd)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/spotify/luigi/test/lock_test.py", line 32, in test_getpcmd
    "sleep 1"
AssertionError: '[sleep]' != 'sleep 1'

----------------------------------------------------------------------
```
