### PR TITLE
Updating debian/control with dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,9 @@ Build-Depends:	debhelper (>= 7),
 		python-mock,
 		python-ordereddict,
 		openssh-client,
-		python-sqlalchemy
+		python-sqlalchemy,
+		python-unittest2,
+		snakebite
 Standards-Version: 3.7.3
 X-Python-Version: >= 2.6
 


### PR DESCRIPTION
Adding missing dependencies that were left out when writing tests using the minicluster
