### PR TITLE
Allows complete functions to be computed in parallel during scheduling

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -74,6 +74,11 @@ max-reschedules
 no_configure_logging
   If true, logging is not configured. Defaults to false.
 
+parallel-scheduling
+  If true, the scheduler will compute complete functions of tasks in
+  parallel using multiprocessing. This can significantly speed up
+  scheduling, but requires that all tasks can be pickled.
+
 rpc-connect-timeout
   Number of seconds to wait before timing out when making an API call.
   Defaults to 10.0

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -122,6 +122,11 @@ class EnvironmentParamsContainer(task.Task):
     module = parameter.Parameter(
         is_global=True, default=None,
         description='Used for dynamic loading of modules') # see DynamicArgParseInterface
+    parallel_scheduling = parameter.BooleanParameter(
+        is_global=True, default=False,
+        description='Use multiprocessing to do scheduling in parallel.',
+        config_path={'section': 'core', 'name': 'parallel-scheduling'},
+    )
 
     @classmethod
     def env_params(cls, override_defaults={}):
@@ -209,7 +214,7 @@ class Interface(object):
 
         success = True
         for t in tasks:
-            success &= w.add(t)
+            success &= w.add(t, env_params.parallel_scheduling)
         logger = logging.getLogger('luigi-interface')
         logger.info('Done scheduling tasks')
         success &= w.run()

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -135,6 +135,45 @@ class TaskProcess(multiprocessing.Process):
                 (self.task.task_id, status, error_message, missing, new_deps))
 
 
+class SingleProcessPool(object):
+    """ Dummy process pool for using a single processor
+
+    Imitates the api of multiprocessing.Pool using single-processor equivalents
+    """
+
+    def apply_async(self, function, args):
+        return apply(function, args)
+
+
+class DequeQueue(collections.deque):
+    """ deque wrapper implementing the Queue interface """
+
+    put = collections.deque.append
+    get = collections.deque.pop
+
+
+class AsyncCompletionException(Exception):
+    """ Exception indicating that something went wrong with checking complete """
+    def __init__(self, trace):
+        self.trace = trace
+
+
+class TracebackWrapper(object):
+    """ Class to wrap tracebacks so we can know they're not just strings """
+    def __init__(self, trace):
+        self.trace = trace
+
+
+def check_complete(task, out_queue):
+    """ Checks if task is complete, puts the result to out_queue """
+    logger.debug("Checking if %s is complete", task)
+    try:
+        is_complete = task.complete()
+    except:
+        is_complete = TracebackWrapper(traceback.format_exc())
+    out_queue.put((task, is_complete))
+
+
 class Worker(object):
     """ Worker object communicates with a scheduler.
 
@@ -266,9 +305,9 @@ class Worker(object):
             # we can't get the repr of it since it's not initialized...
             raise TaskException('Task of class %s not initialized. Did you override __init__ and forget to call super(...).__init__?' % task.__class__.__name__)
 
-    def _log_complete_error(self, task):
-        log_msg = "Will not schedule {task} or any dependencies due to error in complete() method:".format(task=task)
-        logger.warning(log_msg, exc_info=1)  # Needs to be called from except-clause to work
+    def _log_complete_error(self, task, tb):
+        log_msg = "Will not schedule {task} or any dependencies due to error in complete() method:\n{tb}".format(task=task, tb=tb)
+        logger.warning(log_msg)
 
     def _log_unexpected_error(self, task):
         logger.exception("Luigi unexpected framework error while scheduling %s", task) # needs to be called from within except clause
@@ -286,23 +325,35 @@ class Worker(object):
         message = "Luigi framework error:\n{traceback}".format(traceback=formatted_traceback)
         notifications.send_error_email(subject, message)
 
-    def add(self, task):
+    def add(self, task, multiprocess=False):
         """ Add a Task for the worker to check and possibly schedule and run.
          Returns True if task and its dependencies were successfully scheduled or completed before"""
         if self._first_task is None and hasattr(task, 'task_id'):
             self._first_task = task.task_id
         self.add_succeeded = True
-        stack = [task]
+        if multiprocess:
+            queue = multiprocessing.Manager().Queue()
+            pool = multiprocessing.Pool()
+        else:
+            queue = DequeQueue()
+            pool = SingleProcessPool()
         self._validate_task(task)
-        seen = set([task.task_id])
+        pool.apply_async(check_complete, [task, queue])
+
+        # we track queue size ourselves because len(queue) won't work for multiprocessing
+        queue_size = 1
         try:
-            while stack:
-                current = stack.pop()
-                for next in self._add(current):
+            seen = set([task.task_id])
+            while queue_size:
+                current = queue.get()
+                queue_size -= 1
+                item, is_complete = current
+                for next in self._add(item, is_complete):
                     if next.task_id not in seen:
                         self._validate_task(next)
                         seen.add(next.task_id)
-                        stack.append(next)
+                        pool.apply_async(check_complete, [next, queue])
+                        queue_size += 1
         except (KeyboardInterrupt, TaskException):
             raise
         except Exception as ex:
@@ -313,21 +364,20 @@ class Worker(object):
             self._email_unexpected_error(task, formatted_traceback)
         return self.add_succeeded
 
-    def _check_complete(self, task):
-        return task.complete()
-
-    def _add(self, task):
-        logger.debug("Checking if %s is complete", task)
-        is_complete = False
+    def _add(self, task, is_complete):
+        formatted_traceback = None
         try:
-            is_complete = self._check_complete(task)
             self._check_complete_value(is_complete)
         except KeyboardInterrupt:
             raise
+        except AsyncCompletionException as ex:
+            formatted_traceback = ex.trace
         except:
-            self.add_succeeded = False
             formatted_traceback = traceback.format_exc()
-            self._log_complete_error(task)
+
+        if formatted_traceback is not None:
+            self.add_succeeded = False
+            self._log_complete_error(task, formatted_traceback)
             task.trigger_event(Event.DEPENDENCY_MISSING, task)
             self._email_complete_error(task, formatted_traceback)
             # abort, i.e. don't schedule any subtasks of a task with
@@ -383,6 +433,8 @@ class Worker(object):
 
     def _check_complete_value(self, is_complete):
         if is_complete not in (True, False):
+            if isinstance(is_complete, TracebackWrapper):
+                raise AsyncCompletionException(is_complete.trace)
             raise Exception("Return value of Task.complete() must be boolean (was %r)" % is_complete)
 
     def _add_worker(self):

--- a/test/worker_parallel_scheduling_test.py
+++ b/test/worker_parallel_scheduling_test.py
@@ -1,0 +1,114 @@
+import pickle
+import time
+import unittest
+import mock
+
+import luigi
+
+from luigi.worker import Worker
+
+
+class SlowCompleteWrapper(luigi.WrapperTask):
+    def requires(self):
+        return [SlowCompleteTask(i) for i in range(4)]
+
+
+class SlowCompleteTask(luigi.Task):
+    n = luigi.IntParameter()
+
+    def complete(self):
+        time.sleep(0.1)
+        return True
+
+
+class OverlappingSelfDependenciesTask(luigi.Task):
+    n = luigi.IntParameter()
+    k = luigi.IntParameter()
+
+    def complete(self):
+        return self.n < self.k or self.k == 0
+
+    def requires(self):
+        return [OverlappingSelfDependenciesTask(self.n-1, k) for k in range(self.k+1)]
+
+
+class ExceptionCompleteTask(luigi.Task):
+    def complete(self):
+        assert False
+
+
+class ExceptionRequiresTask(luigi.Task):
+    def requires(self):
+        assert False
+
+
+class UnpicklableExceptionTask(luigi.Task):
+    def complete(self):
+        class UnpicklableException(Exception):
+            pass
+        raise UnpicklableException()
+
+
+class ParallelSchedulingTest(unittest.TestCase):
+    def setUp(self):
+        self.sch = mock.Mock()
+        self.w = Worker(scheduler=self.sch, worker_id='x')
+
+    def added_tasks(self, status):
+        return [args[1] for args, kw in self.sch.add_task.call_args_list if kw['status'] == status]
+
+    def test_multiprocess_scheduling_with_overlapping_dependencies(self):
+        self.w.add(OverlappingSelfDependenciesTask(5, 2), True)
+        self.assertEqual(15, self.sch.add_task.call_count)
+        self.assertEqual(set((
+            'OverlappingSelfDependenciesTask(n=1, k=1)',
+            'OverlappingSelfDependenciesTask(n=2, k=1)',
+            'OverlappingSelfDependenciesTask(n=2, k=2)',
+            'OverlappingSelfDependenciesTask(n=3, k=1)',
+            'OverlappingSelfDependenciesTask(n=3, k=2)',
+            'OverlappingSelfDependenciesTask(n=4, k=1)',
+            'OverlappingSelfDependenciesTask(n=4, k=2)',
+            'OverlappingSelfDependenciesTask(n=5, k=2)',
+        )), set(self.added_tasks('PENDING')))
+        self.assertEqual(set((
+            'OverlappingSelfDependenciesTask(n=0, k=0)',
+            'OverlappingSelfDependenciesTask(n=0, k=1)',
+            'OverlappingSelfDependenciesTask(n=1, k=0)',
+            'OverlappingSelfDependenciesTask(n=1, k=2)',
+            'OverlappingSelfDependenciesTask(n=2, k=0)',
+            'OverlappingSelfDependenciesTask(n=3, k=0)',
+            'OverlappingSelfDependenciesTask(n=4, k=0)',
+        )), set(self.added_tasks('DONE')))
+
+    @mock.patch('luigi.notifications.send_error_email')
+    def test_raise_exception_in_complete(self, send):
+        self.w.add(ExceptionCompleteTask(), multiprocess=True)
+        send.assert_called_once()
+        self.assertEqual(0, self.sch.add_task.call_count)
+        self.assertTrue('assert False' in send.call_args[0][1])
+
+    @mock.patch('luigi.notifications.send_error_email')
+    def test_raise_unpicklable_exception_in_complete(self, send):
+        # verify exception can't be pickled
+        self.assertRaises(Exception, UnpicklableExceptionTask().complete)
+        try:
+            UnpicklableExceptionTask().complete()
+        except Exception as ex:
+            pass
+        self.assertRaises(pickle.PicklingError, pickle.dumps, ex)
+
+        # verify this can run async
+        self.w.add(UnpicklableExceptionTask(), multiprocess=True)
+        send.assert_called_once()
+        self.assertEqual(0, self.sch.add_task.call_count)
+        self.assertTrue('raise UnpicklableException()' in send.call_args[0][1])
+
+    @mock.patch('luigi.notifications.send_error_email')
+    def test_raise_exception_in_requires(self, send):
+        self.w.add(ExceptionRequiresTask(), multiprocess=True)
+        send.assert_called_once()
+        self.assertEqual(0, self.sch.add_task.call_count)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I've noticed that most of the time spent during scheduling is spend computing
complete functions, as these can involve various kinds of expensive checks
against remote file systems and services. This modifies the add function in
worker to allow complete functions to be computed asynchronously while
traversing the dependency graph. This can result in significant savings,
lowering the time needed for my twice-hourly scheduling from about 9 minutes to
about 3.5 minutes.

Using multiprocess requires picklable tasks, and this is incompatible with many
of the unit tests in worker_test. In order to get around this issue and allow
maximum compatibility with client code, multiprocess is not used at all unless
enabled via the command line or client.cfg. In order to minimize the code
difference between these cases, I added wrapper objects simulating the necessary
pool and queue interfaces for the single-processor case. This also allows the
existing unit tests to test most of the new code path, and I've only had to
write a few new unit tests to exercise the multiprocessing code.
