### PR TITLE
Removal of pid file can cause error

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -13,7 +13,6 @@
 # the License.
 
 import os
-import errno
 import hashlib
 
 
@@ -33,17 +32,6 @@ def get_info(pid_dir):
     pid_file = os.path.join(pid_dir, hashlib.md5(my_cmd).hexdigest()) + '.pid'
 
     return my_pid, my_cmd, pid_file
-
-
-def rm_if_exists(filename):
-    """Remove file, don't throw when file is missing.
-
-    Taken from http://stackoverflow.com/a/10840586/621449 """
-    try:
-        os.remove(filename)
-    except OSError as e:
-        if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
-            raise # re-raise exception if a different error occured
 
 
 def acquire_for(pid_dir, num_available=1):
@@ -81,12 +69,12 @@ def acquire_for(pid_dir, num_available=1):
 
     # Write pids
     pids.add(str(my_pid))
-    rm_if_exists(pid_file)  # So we become owner on write, otherwise chmod fails
     with open(pid_file, 'w') as f:
         f.writelines('%s\n' % (pid, ) for pid in filter(pid_cmds.__getitem__, pids))
 
     # Make the file writable by all
     s = os.stat(pid_file)
-    os.chmod(pid_file, s.st_mode | 0777)
+    if os.getuid() == s.st_uid:
+        os.chmod(pid_file, s.st_mode | 0777)
 
     return True


### PR DESCRIPTION
I ran into the same issue that #497 was trying to fix, but I don't think the merged solution will work.  The problem is that the old pid file is owned by the previous user(abc123 in #497) and thus, the file cannot be removed by the new user (xyz789).  A solution is to check if the current user owns the file and only performs the chmod if that is the case.  
