### PR TITLE
Refactor of WrapperTask to avoid repated complete() calls

### DIFF
--- a/luigi/devutil.py
+++ b/luigi/devutil.py
@@ -1,0 +1,34 @@
+import warnings
+
+
+def deprecate_kwarg(old_name, new_name, kw_value):
+    """ Rename keyword arguments, but keep backwards compatibility.
+
+    Usage:
+
+    >>> @deprecate_kwarg('old', 'new', 'defval')
+    ... def some_func(old='defval'):
+    ...     print(old)
+    ...
+    >>> some_func(new='yay')
+    yay
+    >>> some_func(old='yaay')
+    yaay
+    >>> some_func()
+    defval
+
+    """
+    def real_decorator(function):
+        def new_function(*args, **kwargs):
+            value = kw_value
+            if old_name in kwargs:
+                warnings.warn('Keyword argument {0} is deprecated, use {1}'
+                              .format(old_name, new_name))
+                value = kwargs[old_name]
+            if new_name in kwargs:
+                value = kwargs[new_name]
+                del kwargs[new_name]
+            kwargs[old_name] = value
+            return function(*args, **kwargs)
+        return new_function
+    return real_decorator

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -16,7 +16,7 @@ import os
 import random
 import tempfile
 import shutil
-import luigi.util
+import luigi.devutil
 from target import FileSystem, FileSystemTarget
 from luigi.format import FileWrapper
 
@@ -102,7 +102,7 @@ class File(FileSystemTarget):
         else:
             raise Exception('mode must be r/w')
 
-    @luigi.util.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
+    @luigi.devutil.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
     def move(self, new_path, fail_if_exists=False):
         if fail_if_exists and os.path.exists(new_path):
             raise RuntimeError('Destination exists: %s' % new_path)
@@ -117,7 +117,7 @@ class File(FileSystemTarget):
     def remove(self):
         self.fs.remove(self.path)
 
-    @luigi.util.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
+    @luigi.devutil.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
     def copy(self, new_path, fail_if_exists=False):
         if fail_if_exists and os.path.exists(new_path):
             raise RuntimeError('Destination exists: %s' % new_path)

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -15,19 +15,18 @@
 import subprocess
 import os
 import random
-import tempfile
 import urlparse
 import luigi.format
 import luigi.contrib.target
 import datetime
 import re
+import luigi.devutil
 import warnings
 from luigi.target import FileSystem, FileSystemTarget, FileAlreadyExists
 import configuration
 import logging
 import getpass
 logger = logging.getLogger('luigi-interface')
-import sys
 
 
 class HDFSCliError(Exception):
@@ -710,7 +709,7 @@ class HdfsTarget(FileSystemTarget):
     def remove(self, skip_trash=False):
         remove(self.path, skip_trash=skip_trash)
 
-    @luigi.util.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
+    @luigi.devutil.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
     def rename(self, path, fail_if_exists=False):
         """ Rename does not change self.path, so be careful with assumptions
 
@@ -722,7 +721,7 @@ class HdfsTarget(FileSystemTarget):
             raise RuntimeError('Destination exists: %s' % path)
         rename(self.path, path)
 
-    @luigi.util.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
+    @luigi.devutil.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
     def move(self, path, fail_if_exists=False):
         """ Move does not change self.path, so be careful with assumptions
 

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -16,7 +16,7 @@ import StringIO
 import target
 import sys
 import os
-import luigi.util
+import luigi.devutil
 import multiprocessing
 
 
@@ -73,7 +73,7 @@ class MockFile(target.FileSystemTarget):
     def exists(self,):
         return self._fn in self.fs.get_all_data()
 
-    @luigi.util.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
+    @luigi.devutil.deprecate_kwarg('fail_if_exists', 'raise_if_exists', False)
     def rename(self, path, fail_if_exists=False):
         if fail_if_exists and path in self.fs.get_all_data():
             raise RuntimeError('Destination exists: %s' % path)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -12,12 +12,14 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import print_function
 import abc
 import logging
 import parameter
 import warnings
 import traceback
 import itertools
+from luigi.mock import MockFile
 import pyparsing as pp
 
 Parameter = parameter.Parameter
@@ -585,8 +587,14 @@ class WrapperTask(Task):
     """Use for tasks that only wrap other tasks and that by definition are done
     if all their requirements exist.
     """
-    def complete(self):
-        return all(r.complete() for r in flatten(self.requires()))
+    def output(self):
+        return MockFile(
+            "WrapperTask://{task_id}".format(task_id=self.task_id)
+        )
+
+    def run(self):
+        with self.output().open('w') as f:
+            print("completed", file=f)
 
 
 def getpaths(struct):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -587,7 +587,7 @@ class _WrapperMarker(MockFile):
     fs = MockFileSystem()  # separate from the user space mockfile system
 
     def __init__(self, task):
-        super(_WrapperMarker, self).__init__(self, task.task_id)
+        super(_WrapperMarker, self).__init__(task.task_id)
 
 
 class WrapperTask(Task):
@@ -652,15 +652,3 @@ def flatten(struct):
         pass
 
     return [struct]
-
-
-def flatten_output(task):
-    """Lists all output targets by recursively walking output-less (wrapper) tasks.
-
-    FIXME order consistently.
-    """
-    r = flatten(task.output())
-    if not r:
-        for dep in flatten(task.requires()):
-            r += flatten_output(dep)
-    return r

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -167,6 +167,10 @@ class RangeHourlyBase(luigi.WrapperTask):
         self._cached_requires = [task_cls(d) for d in required_datehours]
         return self._cached_requires
 
+    def complete(self):
+        base_exist = super(RangeHourlyBase, self).complete()
+        return base_exist or all(t.complete() for t in self.requires())
+
 
 def _constrain_glob(glob, paths, limit=5):
     """Tweaks glob into a list of more specific globs that together still cover

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -25,11 +25,25 @@ import logging
 import luigi
 from luigi.parameter import ParameterException
 from luigi.target import FileSystemTarget
-from luigi.task import Register, flatten_output
+from luigi.task import Register, WrapperTask, flatten
 import re
 import time
 
 logger = logging.getLogger('luigi-interface')
+
+
+def _flatten_output(task):
+    """Lists all output targets by recursively walking wrapper tasks (if any)
+
+    FIXME order consistently.
+    """
+    if isinstance(task, WrapperTask):
+        r = []
+        for dep in flatten(task.requires()):
+            r += _flatten_output(dep)
+    else:
+        r = flatten(task.output())
+    return r
 
 
 class RangeEvent(luigi.Event):  # Not sure if subclassing currently serves a purpose. Stringly typed, events are.
@@ -54,7 +68,7 @@ class RangeEvent(luigi.Event):  # Not sure if subclassing currently serves a pur
 
 
 class RangeHourlyBase(luigi.WrapperTask):
-    """Produces a contiguous completed range of a hourly recurring task.
+    """Produces a contiguous comple ted range of a hourly recurring task.
 
     Made for the common use case where a task is parameterized by datehour and
     assurance is needed that any gaps arising from downtime are eventually
@@ -167,10 +181,6 @@ class RangeHourlyBase(luigi.WrapperTask):
         self._cached_requires = [task_cls(d) for d in required_datehours]
         return self._cached_requires
 
-    def complete(self):
-        base_exist = super(RangeHourlyBase, self).complete()
-        return base_exist or all(t.complete() for t in self.requires())
-
 
 def _constrain_glob(glob, paths, limit=5):
     """Tweaks glob into a list of more specific globs that together still cover
@@ -277,7 +287,7 @@ class RangeHourly(RangeHourlyBase):
         sample_datehours = [datetime(y, m, d, h) for y in range(2000, 2050, 10) for m in range(1, 4) for d in range(5, 8) for h in range(21, 24)]
         regexes = [re.compile('(%04d).*(%02d).*(%02d).*(%02d)' % (d.year, d.month, d.day, d.hour)) for d in sample_datehours]
         sample_tasks = [task_cls(d) for d in sample_datehours]
-        sample_outputs = [flatten_output(t) for t in sample_tasks]
+        sample_outputs = [_flatten_output(t) for t in sample_tasks]
 
         for o, t in zip(sample_outputs, sample_tasks):
             if len(o) != len(sample_outputs[0]):
@@ -307,7 +317,7 @@ class RangeHourly(RangeHourlyBase):
         """Infers them by listing the task output target(s) filesystem.
         """
         filesystems_and_globs_by_location = self._get_filesystems_and_globs(task_cls)
-        paths_by_datehour = [[o.path for o in flatten_output(task_cls(d))] for d in finite_datehours]
+        paths_by_datehour = [[o.path for o in _flatten_output(task_cls(d))] for d in finite_datehours]
         listing = set()
         for (f, g), p in zip(filesystems_and_globs_by_location, zip(*paths_by_datehour)):  # transposed, so here we're iterating over logical outputs, not datehours
             listing |= self._list_existing(f, g, p)

--- a/luigi/util.py
+++ b/luigi/util.py
@@ -271,39 +271,6 @@ class CompositionTask(task.Task):
     #    ...
 
 
-def deprecate_kwarg(old_name, new_name, kw_value):
-    """ Rename keyword arguments, but keep backwards compatibility.
-
-    Usage:
-
-    >>> @deprecate_kwarg('old', 'new', 'defval')
-    ... def some_func(old='defval'):
-    ...     print(old)
-    ...
-    >>> some_func(new='yay')
-    yay
-    >>> some_func(old='yaay')
-    yaay
-    >>> some_func()
-    defval
-
-    """
-    def real_decorator(function):
-        def new_function(*args, **kwargs):
-            value = kw_value
-            if old_name in kwargs:
-                warnings.warn('Keyword argument {0} is deprecated, use {1}'
-                              .format(old_name, new_name))
-                value = kwargs[old_name]
-            if new_name in kwargs:
-                value = kwargs[new_name]
-                del kwargs[new_name]
-            kwargs[old_name] = value
-            return function(*args, **kwargs)
-        return new_function
-    return real_decorator
-
-
 def previous(task):
     """Return a previous Task of the same family.
 


### PR DESCRIPTION
Instead uses the in-memory mock file system in MockFile to keep state
and rely on luigi's task execution order to assume task completeness
of dependencies