### PR TITLE
Convert isinstance assertions to TypeErrors.

### DIFF
--- a/luigi/contrib/sparkey.py
+++ b/luigi/contrib/sparkey.py
@@ -43,7 +43,8 @@ class SparkeyExportTask(luigi.Task):
 
         infile = self.input()
         outfile = self.output()
-        assert isinstance(outfile, luigi.LocalTarget), "output must be a LocalTarget"
+        if not isinstance(outfile, luigi.LocalTarget):
+            raise TypeError("output must be a LocalTarget")
 
         # write job output to temporary sparkey file
         temp_output = luigi.LocalTarget(is_tmp=True)

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -424,10 +424,12 @@ class HadoopJobRunner(JobRunner):
             arglist += ['-inputformat', self.input_format]
 
         for target in luigi.task.flatten(job.input_hadoop()):
-            assert isinstance(target, luigi.hdfs.HdfsTarget)
+            if not isinstance(target, luigi.hdfs.HdfsTarget):
+                raise TypeError('target must be an HdfsTarget')
             arglist += ['-input', target.path]
 
-        assert isinstance(job.output(), luigi.hdfs.HdfsTarget)
+        if not isinstance(job.output(), luigi.hdfs.HdfsTarget):
+            raise TypeError('outout must be an HdfsTarget')
         arglist += ['-output', output_tmp_fn]
 
         # submit job

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -674,7 +674,8 @@ class HdfsTarget(FileSystemTarget):
         self.format = format
         self.is_tmp = is_tmp
         (scheme, netloc, path, query, fragment) = urlparse.urlsplit(path)
-        assert ":" not in path  # colon is not allowed in hdfs filenames
+        if ":" in path:
+            raise ValueError('colon is not allowed in hdfs filenames')
         self._fs = fs or get_autoconfig_client()
 
     def __del__(self):

--- a/luigi/util.py
+++ b/luigi/util.py
@@ -25,7 +25,8 @@ logger = logging.getLogger('luigi-interface')
 
 def common_params(task_instance, task_cls):
     """Grab all the values in task_instance that are found in task_cls"""
-    assert isinstance(task_cls, task.Register), "task_cls must be an uninstantiated Task"
+    if not isinstance(task_cls, task.Register):
+        raise TypeError("task_cls must be an uninstantiated Task")
 
     task_instance_param_names = dict(task_instance.get_params()).keys()
     task_cls_param_names = dict(task_cls.get_params()).keys()

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -180,7 +180,7 @@ class RequiresTest(unittest.TestCase):
         k.requires()
 
     def test_wrong_common_params_order(self):
-        self.assertRaises(AssertionError, self.k_wrongparamsorder.requires)
+        self.assertRaises(TypeError, self.k_wrongparamsorder.requires)
 
 
 class X(luigi.Task):


### PR DESCRIPTION
Using assert statements can cause subtle bugs when Python
interpreter invoked with the -O option..

See https://code.djangoproject.com/ticket/23924 for an example report.
