### PR TITLE
fix HdfsTarget call in docs

### DIFF
--- a/doc/example_top_artists.rst
+++ b/doc/example_top_artists.rst
@@ -118,7 +118,7 @@ here is how this could look like, instead of the class above.
         date_interval = luigi.DateIntervalParameter()
 
         def output(self):
-            return luigi.HdfsTarget("data/artist_streams_%s.tsv" % self.date_interval)
+            return luigi.hdfs.HdfsTarget("data/artist_streams_%s.tsv" % self.date_interval)
 
         def requires(self):
             return [StreamsHdfs(date) for date in self.date_interval]

--- a/doc/execution_model.rst
+++ b/doc/execution_model.rst
@@ -34,14 +34,14 @@ dependency graph.
 
     class DataDump(luigi.ExternalTask):
         date = luigi.DateParameter()
-        def output(self): return luigi.HdfsTarget(self.date.strftime('/var/log/dump/%Y-%m-%d.txt'))
+        def output(self): return luigi.hdfs.HdfsTarget(self.date.strftime('/var/log/dump/%Y-%m-%d.txt'))
         
     class AggregationTask(luigi.Task):
         date = luigi.DateParameter()
         window = luigi.IntParameter()
         def requires(self): return [DataDump(self.date - datetime.timedelta(i)) for i in xrange(self.window)]
         def run(self): run_some_cool_stuff(self.input())
-        def output(self): return luigi.HdfsTarget('/aggregated-%s-%d' % (self.date, self.window))
+        def output(self): return luigi.hdfs.HdfsTarget('/aggregated-%s-%d' % (self.date, self.window))
         
     class RunAll(luigi.Task):
         ''' Dummy task that triggers execution of a other tasks'''


### PR DESCRIPTION
Found a mistake in the documentation example for using HdfsTarget. It's calling it from luigi.HdfsTarget instead of luigi.hdfs.HdfsTarget
