### PR TITLE
Manually revert parts of spotify/luigi#522

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -370,7 +370,7 @@ class HadoopJobRunner(JobRunner):
         # replace output with a temporary work directory
         output_final = job.output().path
         output_tmp_fn = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
-        tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn)
+        tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn, is_tmp=True)
 
         arglist = luigi.hdfs.load_hadoop_cmd() + ['jar', self.streaming_jar]
 
@@ -438,7 +438,7 @@ class HadoopJobRunner(JobRunner):
 
         run_and_track_hadoop_job(arglist)
 
-        tmp_target.move_dir(output_final)
+        tmp_target.move(output_final, raise_if_exists=True)
         self.finish()
 
     def finish(self):


### PR DESCRIPTION
Apparently, a much more serious bug was introduced due to that PR.

In summary, the move-dir strategy introduced in the spotify/luigi#522
does fix the "nested directory" problem. But it introduces the
non-atomicity problems. Users of luigi who don't use ExternalTasks
should not be affected, as the centralized scheduler will not let you
run the dependent tasks too early. However, if you use ExternalTasks or
say --local-scheduler, then you can get the serious issue of starting
tasks with half-finished input. The culprit here is  step 2 of the
used move-dir schema:

```
    1.   mkdir abc
    2.   mv    abc-luigi-tmp-12346/* abc
    3.   rmdir abc-luigi-tmp-12346
```

Right after 1 and anytime before 2 has finished (which is not that short of a
time either!), a Task with an ExternalTask-dependency on `abc` can be
scheduled. In Spotify's case, we had map reduce tasks starting too early
without all input, seeing suspiciously little output and not as many
mappers as input.  If this has affected you, it's probably easiest
to just nuke the output folders and reprocess the tasks.
