### PR TITLE
Remove ancient luigi.expose{,_main} methods

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -35,8 +35,6 @@ Parameter = parameter.Parameter
 RemoteScheduler = rpc.RemoteScheduler
 RPCError = rpc.RPCError
 
-expose = interface.expose
-expose_main = interface.expose_main
 run = interface.run
 build = interface.build
 

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -133,20 +133,6 @@ class EnvironmentParamsContainer(task.Task):
         return cls()  # instantiate an object with the global params set on it
 
 
-def expose(cls):
-    warnings.warn('expose is no longer used, everything is autoexposed', DeprecationWarning)
-    return cls
-
-
-def expose_main(cls):
-    warnings.warn('expose_main is no longer supported, use luigi.run(..., main_task_cls=cls) instead', DeprecationWarning)
-    return cls
-
-
-def reset():
-    warnings.warn('reset is no longer supported')
-
-
 class WorkerSchedulerFactory(object):
     def create_local_scheduler(self):
         return scheduler.CentralPlannerScheduler()

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -79,12 +79,6 @@ class CmdlineTest(unittest.TestCase):
         File = MockFile
         MockFile.fs.clear()
 
-    def test_expose_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            luigi.expose(SomeTask)
-            self.assertEqual(w[-1].category, DeprecationWarning)
-
     @mock.patch("logging.getLogger")
     def test_cmdline_main_task_cls(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', '--n', '100'], main_task_cls=SomeTask)

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -50,9 +50,3 @@ class RecursionTest(unittest.TestCase):
         w.stop()
 
         self.assertEquals(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')
-
-    def test_cmdline(self):
-        luigi.interface.reset()
-        luigi.run(['--local-scheduler', 'Popularity', '--date', '2010-01-01'])
-
-        self.assertEquals(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')

--- a/test/set_task_name_test.py
+++ b/test/set_task_name_test.py
@@ -24,7 +24,8 @@ def create_class(cls_name):
     return NewTask
 
 
-my_new_task = luigi.expose(create_class('MyNewTask'))
+create_class('MyNewTask')
+
 
 class SetTaskNameTest(unittest.TestCase):
     ''' I accidentally introduced an issue in this commit:


### PR DESCRIPTION
I got motivated to do this when I saw some test starting to fail as of spotify/luigi#530.
