### PR TITLE
Times out long-running workers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -126,6 +126,15 @@ worker-ping-interval
   Number of seconds to wait between pinging scheduler to let it know
   that the worker is still alive. Defaults to 1.0.
 
+worker-timeout
+  .. versionadded:: 1.0.20
+  Number of seconds after which to kill a task which has been running
+  for too long. This provides a default value for all tasks, which can
+  be overridden by setting the worker-timeout property in any task. This
+  only works when using multiple workers, as the timeout is implemented
+  by killing worker subprocesses. Default value is 0, meaning no
+  timeout.
+
 worker-wait-interval
   Number of seconds for the worker to wait before asking the scheduler
   for another job after the scheduler has said that it does not have any

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -258,6 +258,10 @@ class Task(object):
     # task requires 1 unit of the scp resource.
     resources = {}
 
+    # Number of seconds after which to time out the run function. No timeout if set to 0. Defaults
+    # to 0 or value in client.cfg
+    worker_timeout = None
+
     @classmethod
     def event_handler(cls, event):
         """ Decorator for adding event handlers """

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import mock
 import shutil
 import time
 from luigi.scheduler import CentralPlannerScheduler
@@ -615,6 +616,17 @@ class SuicidalWorker(luigi.Task):
         os.kill(os.getpid(), self.signal)
 
 
+class HungWorker(luigi.Task):
+    worker_timeout = luigi.IntParameter(default=None)
+
+    def run(self):
+        while True:
+            pass
+
+    def complete(self):
+        return False
+
+
 class MultipleWorkersTest(unittest.TestCase):
     def test_multiple_workers(self):
         # Test using multiple workers
@@ -656,6 +668,40 @@ class MultipleWorkersTest(unittest.TestCase):
         w._handle_next_task()
         w._handle_next_task()
         w._handle_next_task()
+
+    def test_time_out_hung_worker(self):
+        luigi.build([HungWorker(0.1)], workers=2, local_scheduler=True)
+
+    @mock.patch('luigi.worker.time')
+    def test_purge_hung_worker_default_timeout_time(self, mock_time):
+        w = Worker(worker_processes=2, wait_interval=0.01, worker_timeout=5)
+        mock_time.time.return_value = 0
+        w.add(HungWorker())
+        w._run_task('HungWorker(worker_timeout=None)')
+
+        mock_time.time.return_value = 5
+        w._handle_next_task()
+        self.assertEqual(1, len(w._running_tasks))
+
+        mock_time.time.return_value = 6
+        w._handle_next_task()
+        self.assertEqual(0, len(w._running_tasks))
+
+    @mock.patch('luigi.worker.time')
+    def test_purge_hung_worker_override_timeout_time(self, mock_time):
+        w = Worker(worker_processes=2, wait_interval=0.01, worker_timeout=5)
+        mock_time.time.return_value = 0
+        w.add(HungWorker(10))
+        w._run_task('HungWorker(worker_timeout=10)')
+
+        mock_time.time.return_value = 10
+        w._handle_next_task()
+        self.assertEqual(1, len(w._running_tasks))
+
+        mock_time.time.return_value = 11
+        w._handle_next_task()
+        self.assertEqual(0, len(w._running_tasks))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I woke up this morning to find that very few jobs had run overnight because
something weird happened with our hadoop cluster that caused all of our jobs to
hang permanently. When I checked in the morning, all workers were busy running
jobs that had been going for about 10 hours, and thousands of pending jobs that
would normally have been run overnight had piled up.

After killing and restarting all of my workers, everything started running fine
again because whatever weird issue had caused everything to hang was over. In
order to automate this fix, I've added a worker_timeout property to tasks that
tells the worker how long to attempt to run the task before killing it.

This property defaults to 0, meaning do not time tasks out. It can be changed
individually for a task by override or globally for all non-overridden tasks
via client.cfg. This only applies when running with more than 1 worker process,
as we need to run the task in a separate process in order to be able to kill it
after the timeout.
