### PR TITLE
Groups tasks that supersede each other together in the scheduler

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -94,7 +94,7 @@ class RemoteScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=False,
                  deps=None, new_deps=None, expl=None, resources={},priority=0,
-                 family='', params={}):
+                 family='', params={}, supersedes_bucket=None, supersedes_priority=None):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -107,6 +107,8 @@ class RemoteScheduler(Scheduler):
             'priority': priority,
             'family': family,
             'params': params,
+            'supersedes_bucket': supersedes_bucket,
+            'supersedes_priority': supersedes_priority,
         })
 
     def get_work(self, worker, host=None):
@@ -164,10 +166,11 @@ class RemoteSchedulerResponder(object):
         self._scheduler = scheduler
 
     def add_task(self, worker, task_id, status, runnable, deps, new_deps, expl,
-                 resources=None, priority=0, family='', params={}, **kwargs):
+                 resources=None, priority=0, family='', params={}, supersedes_bucket=None,
+                 supersedes_priority=None, **kwargs):
         return self._scheduler.add_task(
             worker, task_id, status, runnable, deps, new_deps, expl,
-            resources, priority, family, params)
+            resources, priority, family, params, supersedes_bucket, supersedes_priority)
 
     def add_worker(self, worker, info, **kwargs):
         return self._scheduler.add_worker(worker, info)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -107,7 +107,8 @@ class Failures(object):
 
 class Task(object):
     def __init__(self, id, status, deps, resources={}, priority=0, family='', params={},
-                 disable_failures=None, disable_window=None):
+                 disable_failures=None, disable_window=None, supersedes_bucket=None,
+                 supersedes_priority=None):
         self.id = id
         self.stakeholders = set()  # workers ids that are somehow related to this task (i.e. don't prune while any of these workers are still active)
         self.workers = set()  # workers ids that can perform task - task is 'BROKEN' if none of these workers are active
@@ -123,6 +124,8 @@ class Task(object):
         self.time_running = None  # Timestamp when picked up by worker
         self.expl = None
         self.priority = priority
+        self.supersedes_bucket = supersedes_bucket
+        self.supersedes_priority = supersedes_priority
         self.resources = resources
         self.family = family
         self.params = params
@@ -290,9 +293,22 @@ class SimpleTaskState(object):
         for task in self._tasks.itervalues():
             yield task
 
+    def get_running_tasks(self):
+        for task in self._tasks.itervalues():
+            if task.status == RUNNING:
+                yield task
+
     def get_pending_tasks(self):
         for task in self._tasks.itervalues():
             if task.status in [PENDING, RUNNING]:
+                yield task
+
+    def get_supersedes_bucket_tasks(self, supersedes_task):
+        if supersedes_task.supersedes_bucket is None:
+            return
+        for task in self._tasks.values():
+            if (task.supersedes_bucket == supersedes_task.supersedes_bucket
+                    and task.supersedes_priority <= supersedes_task.supersedes_priority):
                 yield task
 
     def get_task(self, task_id, default=None, setdefault=None):
@@ -332,6 +348,13 @@ class SimpleTaskState(object):
         for task in self.get_active_tasks():
             task.stakeholders.difference_update(delete_workers)
             task.workers.difference_update(delete_workers)
+
+    def task_priority(self, task):
+        if task.supersedes_bucket is None:
+            return task.priority
+
+        # a task has at least as high priority as things below it in the same supersedes bucket
+        return max(t.priority for t in self.get_supersedes_bucket_tasks(task))
 
 
 class CentralPlannerScheduler(Scheduler):
@@ -413,7 +436,8 @@ class CentralPlannerScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
-                 priority=0, family='', params={}):
+                 priority=0, family='', params={}, supersedes_bucket=None,
+                 supersedes_priority=None):
         """
         * Add task identified by task_id if it doesn't exist
         * If deps is not None, update dependency list
@@ -424,8 +448,9 @@ class CentralPlannerScheduler(Scheduler):
         self.update(worker)
 
         task = self._state.get_task(task_id, setdefault=self._make_task(
-                id=task_id, status=PENDING, deps=deps, resources=resources,
-                priority=priority, family=family, params=params))
+            id=task_id, status=PENDING, deps=deps, resources=resources,
+            priority=priority, family=family, params=params, supersedes_bucket=supersedes_bucket,
+            supersedes_priority=supersedes_priority))
 
         # for setting priority, we'll sometimes create tasks with unset family and params
         if not task.family:
@@ -444,6 +469,10 @@ class CentralPlannerScheduler(Scheduler):
                 # (so checking for status != task.status woule lie)
                 self._update_task_history(task_id, status)
             task.set_status(PENDING if status == SUSPENDED else status, self._config)
+            if status == DONE and task.supersedes_bucket:
+                for superseded_task in self._state.get_supersedes_bucket_tasks(task):
+                    if superseded_task.status != DONE:
+                        superseded_task.set_status(DONE, self._config)
             if status == FAILED:
                 task.retry = time.time() + self._config.retry_delay
 
@@ -455,6 +484,8 @@ class CentralPlannerScheduler(Scheduler):
 
         task.stakeholders.add(worker)
         task.resources = resources
+        task.supersedes_bucket = supersedes_bucket
+        task.supersedes_priority = supersedes_priority
 
         # Task dependencies might not exist yet. Let's create dummy tasks for them for now.
         # Otherwise the task dependencies might end up being pruned if scheduling takes a long time
@@ -491,11 +522,14 @@ class CentralPlannerScheduler(Scheduler):
     def _used_resources(self):
         used_resources = collections.defaultdict(int)
         if self._resources is not None:
-            for task in self._state.get_active_tasks():
+            for task in self._state.get_running_tasks():
                 if task.status == RUNNING and task.resources:
                     for resource, amount in task.resources.items():
                         used_resources[resource] += amount
         return used_resources
+
+    def _supersedes_buckets(self):
+        return set(t.supersedes_bucket for t in self._state.get_running_tasks()) - set([None])
 
     def _rank(self):
         ''' Return worker's rank function for task scheduling '''
@@ -510,7 +544,12 @@ class CentralPlannerScheduler(Scheduler):
                 for dep in deps:
                     dependents[dep] += inverse_num_deps
 
-        return lambda task: (task.priority, dependents[task.id], -task.time)
+        return lambda t: (
+            self._state.task_priority(t),
+            t.supersedes_priority,
+            dependents[t.id],
+            -t.time,
+        )
 
     def _schedulable(self, task):
         if task.status != PENDING:
@@ -544,6 +583,7 @@ class CentralPlannerScheduler(Scheduler):
 
         used_resources = self._used_resources()
         greedy_resources = collections.defaultdict(int)
+        supersedes_buckets = self._supersedes_buckets()
         n_unique_pending = 0
         greedy_workers = dict((worker.id, worker.info.get('workers', 1))
                               for worker in self._state.get_active_workers())
@@ -566,12 +606,16 @@ class CentralPlannerScheduler(Scheduler):
                 if len(task.workers) == 1:
                     n_unique_pending += 1
 
-            if task.status == RUNNING and task.worker_running in greedy_workers:
+            check_greedy = lambda: (self._has_resources(task.resources, greedy_resources)
+                                    and task.supersedes_bucket not in supersedes_buckets)
+            if task.status == RUNNING and task.worker_running in greedy_workers and check_greedy():
                 greedy_workers[task.worker_running] -= 1
                 for resource, amount in (task.resources or {}).items():
                     greedy_resources[resource] += amount
+                if task.supersedes_bucket is not None:
+                    supersedes_buckets.add(task.supersedes_bucket)
 
-            if not best_task and self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
+            if not best_task and self._schedulable(task) and check_greedy():
                 if worker in task.workers and self._has_resources(task.resources, used_resources):
                     best_task = task
                     best_task_id = task.id
@@ -580,6 +624,10 @@ class CentralPlannerScheduler(Scheduler):
                         if greedy_workers.get(task_worker, 0) > 0:
                             # use up a worker
                             greedy_workers[task_worker] -= 1
+
+                            # add the supersedes bucket
+                            if task.supersedes_bucket is not None:
+                                supersedes_buckets.add(task.supersedes_bucket)
 
                             # keep track of the resources used in greedy scheduling
                             for resource, amount in (task.resources or {}).items():

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -254,6 +254,17 @@ class Task(object):
     priority = 0
     disabled = False
 
+    # If multiple items from the same bucket are ready to run, the scheduler
+    # will pick the one with highest bucket priority. When it is marked done,
+    # so is everything else in the bucket with lower priority. bucket_priority
+    # should have a consistent type within a bucket.
+    def supersedes_bucket(self):
+        return None
+
+    def supersedes_priority(self):
+        assert self.supersedes_bucket() is None
+        return None
+
     # Resources used by the task. Should be formatted like {"scp": 1} to indicate that the
     # task requires 1 unit of the scp resource.
     resources = {}

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -418,7 +418,10 @@ class Worker(object):
                                  deps=deps, runnable=runnable, priority=task.priority,
                                  resources=task.process_resources(),
                                  params=task.to_str_params(),
-                                 family=task.task_family)
+                                 family=task.task_family,
+                                 supersedes_bucket=task.supersedes_bucket(),
+                                 supersedes_priority=task.supersedes_priority(),
+                                 )
 
         logger.info('Scheduled %s (%s)', task.task_id, status)
 
@@ -532,7 +535,10 @@ class Worker(object):
                                      runnable=None,
                                      params=task.to_str_params(),
                                      family=task.task_family,
-                                     new_deps=new_deps)
+                                     new_deps=new_deps,
+                                     supersedes_bucket=task.supersedes_bucket(),
+                                     supersedes_priority=task.supersedes_priority(),
+                                     )
 
             if status == RUNNING:
                 continue

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -494,6 +494,56 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(WORKER, 'D', priority=6)
         self.check_task_order(['A', 'B', 'D', 'C'])
 
+    def test_run_one_from_bucket(self):
+        self.sch.add_task(WORKER, 'A', supersedes_bucket='b', supersedes_priority=0)
+        self.sch.add_task(WORKER, 'B', supersedes_bucket='b', supersedes_priority=1)
+        self.sch.add_task(WORKER, 'C', supersedes_bucket='b', supersedes_priority=2)
+        self.sch.add_task(WORKER, 'D', supersedes_bucket='b', supersedes_priority=3)
+        self.sch.add_task(WORKER, 'E', supersedes_bucket='b', supersedes_priority=4)
+        self.sch.add_task(WORKER, 'F')
+        self.check_task_order('EF')
+
+    def test_run_one_from_bucket_with_priority(self):
+        self.sch.add_task(WORKER, 'A', supersedes_bucket='b', supersedes_priority=0, priority=10)
+        self.sch.add_task(WORKER, 'B', supersedes_bucket='b', supersedes_priority=1, priority=1)
+        self.check_task_order('B')
+
+    def test_run_two_buckets(self):
+        self.sch.add_task(WORKER, 'A', supersedes_bucket='b1', supersedes_priority=0)
+        self.sch.add_task(WORKER, 'B', supersedes_bucket='b1', supersedes_priority=1)
+        self.sch.add_task(WORKER, 'C', supersedes_bucket='b1', supersedes_priority=2)
+        self.sch.add_task(WORKER, 'D', supersedes_bucket='b2', supersedes_priority=3)
+        self.sch.add_task(WORKER, 'E', supersedes_bucket='b2', supersedes_priority=4)
+        self.sch.add_task(WORKER, 'F', supersedes_bucket='b2', supersedes_priority=5)
+        self.check_task_order('FC')
+
+    def test_run_partial_bucket(self):
+        self.sch.add_task(WORKER, 'A', supersedes_bucket='b', supersedes_priority=0)
+        self.sch.add_task(WORKER, 'B', supersedes_bucket='b', supersedes_priority=1)
+        self.sch.add_task(WORKER, 'C', supersedes_bucket='b', supersedes_priority=2)
+        self.sch.add_task(WORKER, 'D', supersedes_bucket='b', supersedes_priority=3)
+        self.sch.add_task(WORKER, 'E', supersedes_bucket='b', supersedes_priority=4, deps=['G'])
+        self.sch.add_task(WORKER, 'F', supersedes_bucket='b', supersedes_priority=5, deps=['G'])
+        self.sch.add_task(WORKER, 'G')
+        self.check_task_order('DGF')
+
+    def test_string_bucket_priority(self):
+        self.sch.add_task(WORKER, 'A', supersedes_bucket='b', supersedes_priority='2014-10-23')
+        self.sch.add_task(WORKER, 'B', supersedes_bucket='b', supersedes_priority='2014-10-24')
+        self.check_task_order('B')
+
+    def test_only_one_bucket_item_at_once(self):
+        self.sch.add_task('X', 'A', supersedes_bucket='b', supersedes_priority=0)
+        self.assertEqual('A', self.sch.get_work('X')['task_id'])
+        self.sch.add_task('Y', 'B', supersedes_bucket='b', supersedes_priority=1)
+        self.assertFalse(self.sch.get_work('Y')['task_id'])
+
+    def test_hold_bucket_for_higher_priority_worker(self):
+        self.sch.add_task('X', 'A', supersedes_bucket='b', supersedes_priority=0)
+        self.sch.add_task('Y', 'B', supersedes_bucket='b', supersedes_priority=1)
+        self.assertFalse(self.sch.get_work('X')['task_id'])
+        self.assertEqual('B', self.sch.get_work('Y')['task_id'])
+
     def test_unique_tasks(self):
         self.sch.add_task(WORKER, 'A')
         self.sch.add_task(WORKER, 'B')


### PR DESCRIPTION
Many tasks supersede older versions of the same job. For example, if I do an
hourly sqoop job to copy data from a production db to a hive table, completing
the 8am copy means I don't need to run the 7am copy. If both the 7am copy and
the 8am copy are pending and ready, I should run the 8am copy and consider them
both complete.

This commit achieves these goals by allowing jobs to define two optional
properties. The first is supersedes_bucket. Tasks with the same supersedes
bucket (if not None) are considered by the scheduler to supersede each other.
The scheduler will mark all earlier versions of the task DONE when one of them
completes. It us up to the user to ensure that earlier versions of the task
become complete when a later version is run.

Earlier tasks are identified by having a lower supersedes_priority. The
scheduler will prefer to schedule tasks with higher supersedes_priority.
Supersedes priority can be any type, but most be comparable between tasks in
the same bucket.