### PR TITLE
Fixes multiple purging bug.

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -512,9 +512,9 @@ class Worker(object):
                 return
 
             task = self._scheduled_tasks[task_id]
-            if not task:
+            if not task or task_id not in self._running_tasks:
                 continue
-                # Not a scheduled task. Probably already removed.
+                # Not a running task. Probably already removed.
                 # Maybe it yielded something?
             new_deps = []
             if new_requirements:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -637,5 +637,20 @@ class MultipleWorkersTest(unittest.TestCase):
     def test_kill_worker(self):
         luigi.build([SuicidalWorker(signal.SIGKILL)], workers=2, local_scheduler=True)
 
+    def test_purge_multiple_workers(self):
+        w = Worker(worker_processes=2, wait_interval=0.01)
+        t1 = SuicidalWorker(signal.SIGTERM)
+        t2 = SuicidalWorker(signal.SIGKILL)
+        w.add(t1)
+        w.add(t2)
+
+        w._run_task(t1.task_id)
+        w._run_task(t2.task_id)
+        time.sleep(1.0)
+
+        w._handle_next_task()
+        w._handle_next_task()
+        w._handle_next_task()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If two worker processes get killed at the same time, we'll add them both to the
task handling queue as failures, then remove one of them from running tasks.
After this, we'll add the other one to the queue and remove it. On the third
attempt at task handling, we'll have the second task in the queue but not in
the running dict, resulting in duplicated error messages and a KeyError when
popping from running.

Even if we cut off the purge loop after it finds its first item, this could
still happen if there is already stuff in the queue or other workers insert
into the queue during/after the loop. In order to cleanly avoid removing items
multiple times, this ignores queue items that aren't in the running dict.
