### PR TITLE
Fixes a typo in a variable name in fix_time

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -66,7 +66,7 @@ def fix_time(x):
     # Backwards compatibility for a fix in Dec 2014. Prior to the fix, pickled state might store datetime objects
     # Let's remove this function soon
     if isinstance(x, datetime.datetime):
-        return time.mktime(d.timetuple())
+        return time.mktime(x.timetuple())
     else:
         return x
 


### PR DESCRIPTION
This would probably cause issues for anyone who didn't clear their pickle state after an upgrade.
