### PR TITLE
Possible flakiness fix for test_dynamic_dependencies

### DIFF
--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import shutil
 import time
 from luigi.scheduler import CentralPlannerScheduler
 import luigi.worker
@@ -239,14 +240,18 @@ class WorkerTest(unittest.TestCase):
                         for line in d.open('r'):
                             print >>f, '%d: %s' % (i, line.strip())
 
-        t = DynamicRequires(p=tempfile.mktemp())
-        luigi.build([t], local_scheduler=True)
-        self.assertTrue(t.complete())
+        p = tempfile.mkdtemp()
+        try:
+            t = DynamicRequires(p=p)
+            luigi.build([t], local_scheduler=True)
+            self.assertTrue(t.complete())
 
-        # loop through output and verify
-        f = t.output().open('r')
-        for i in xrange(7):
-            self.assertEqual(f.readline().strip(), '%d: Done!' % i)
+            # loop through output and verify
+            f = t.output().open('r')
+            for i in xrange(7):
+                self.assertEqual(f.readline().strip(), '%d: Done!' % i)
+        finally:
+            shutil.rmtree(p)
 
     def test_avoid_infinite_reschedule(self):
         class A(Task):


### PR DESCRIPTION
test_dynamic_dependencies has been flaky lately, see #571. I can't reproduce it
locally, so I assume it has something to do with Travis running things more in
parallel than I do. test_dynamic_dependencies uses mktemp, which according to
the tempfile documentation should not be used and causes race conditions in
which another program may get access to the temp file first. Replacing this with
mkdtemp should fix the issue while also clarifying that a temporary directory is
wanted and not a temporary file. I haven't been able to verify that this will
fix the flakiness, but it should probably be done anyway. I also added cleanup.
