### PR TITLE
Add setup_interface_logging() to execution docs.

### DIFF
--- a/doc/programmatic_execution.rst
+++ b/doc/programmatic_execution.rst
@@ -18,6 +18,7 @@ look something like
 .. code:: python
 
     task = MyTask(123, 'xyz')
+    interface.setup_interface_logging()
     sch = scheduler.CentralPlannerScheduler()
     w = worker.Worker(scheduler=sch)
     w.add(task)


### PR DESCRIPTION
Correct the programmatic execution example so that it, like run(),
configures interface logging.

Fixes the runtime error that occurs when following
the current docs/programmatic_execution.rst, namely:

```
No handlers could be found for logger "luigi-interface"
```
