### PR TITLE
Limit number of shown tasks in visualiser

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -71,6 +71,13 @@ max-reschedules
   reschedule a job if it is found to not be done when attempting to run
   a dependent job. This defaults to 1.
 
+max-shown-tasks
+  .. versionadded:: 1.0.20
+  The maximum number of tasks returned in a task_list api call. This
+  will restrict the number of tasks shown in any section in the
+  visualiser. Small values can alleviate frozen browsers when there are
+  too many done tasks. This defaults to 100000 (one hundred thousand).
+
 no_configure_logging
   If true, logging is not configured. Defaults to false.
 

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -45,6 +45,7 @@ def _create_scheduler():
     disable_window = config.getint('scheduler', 'disable-window-seconds', 3600)
     disable_failures = config.getint('scheduler', 'disable-num-failures', None)
     disable_persist = config.getint('scheduler', 'disable-persist-seconds', 86400)
+    max_shown_tasks = config.getint('scheduler', 'max-shown-tasks', 100000)
 
     resources = config.getintdict('resources')
     if config.getboolean('scheduler', 'record_task_history', False):
@@ -54,7 +55,8 @@ def _create_scheduler():
         task_history_impl = task_history.NopHistory()
     return scheduler.CentralPlannerScheduler(
         retry_delay, remove_delay, worker_disconnect_delay, state_path, task_history_impl,
-        resources, disable_persist, disable_window, disable_failures)
+        resources, disable_persist, disable_window, disable_failures, max_shown_tasks,
+    )
 
 
 class RPCHandler(tornado.web.RequestHandler):

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -82,6 +82,9 @@
             </div>
             {{/tasks}}
         </script>
+        <script type="text/template" name="rowCountTemplate">
+            <h4>Too many tasks to display: {{num_tasks}}</h4>
+        </script>
         <script type="text/template" name="errorTemplate">
             <div class="modal-header">
                 <h3>Traceback for {{taskId}}</h3>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -185,8 +185,16 @@ function visualiserApp(luigi) {
     }
 
     function getTaskList(id, tasks, expand) {
-        $(id).append(renderTasks(tasks));
-        $(id).prev("h3").append(" (" + tasks.length + ")");
+        if (tasks.length == 1 && typeof(tasks[0]) === "number") {
+            var length = tasks[0];
+            var rendered = renderTemplate("rowCountTemplate", {'num_tasks': length});
+            $(id).parent().addClass('emptyTaskGroup');
+        } else {
+            var length = tasks.length;
+            var rendered = renderTasks(tasks);
+        }
+        $(id).append(rendered);
+        $(id).prev("h3").append(" (" + length + ")");
         bindTaskEvents(id, expand);
         filterTasks();
     }
@@ -215,7 +223,7 @@ function visualiserApp(luigi) {
     }
 
     function updateCount() {
-        taskGroups = $('#taskList .taskGroup');
+        taskGroups = $('#taskList .taskGroup:not(.emptyTaskGroup)');
         for (i=0; i<taskGroups.length; i++) {
             groupCount = 0;
 

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -480,6 +480,28 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(WORKER, 'A')
         self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
 
+    def test_task_list_beyond_limit(self):
+        sch = CentralPlannerScheduler(max_shown_tasks=3)
+        for c in 'ABCD':
+            sch.add_task(WORKER, c)
+        self.assertEqual(set('ABCD'), set(sch.task_list('PENDING', '', False).keys()))
+        self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', ''))
+
+    def test_task_list_within_limit(self):
+        sch = CentralPlannerScheduler(max_shown_tasks=4)
+        for c in 'ABCD':
+            sch.add_task(WORKER, c)
+        self.assertEqual(set('ABCD'), set(sch.task_list('PENDING', '').keys()))
+
+    def test_task_lists_some_beyond_limit(self):
+        sch = CentralPlannerScheduler(max_shown_tasks=3)
+        for c in 'ABCD':
+            sch.add_task(WORKER, c, 'DONE')
+        for c in 'EFG':
+            sch.add_task(WORKER, c)
+        self.assertEqual(set('EFG'), set(sch.task_list('PENDING', '').keys()))
+        self.assertEqual({'num_tasks': 4}, sch.task_list('DONE', ''))
+
     def test_priority_update_dependency_chain(self):
         self.sch.add_task(WORKER, 'A', priority=10, deps=['B'])
         self.sch.add_task(WORKER, 'B', priority=5, deps=['C'])


### PR DESCRIPTION
I've noticed that my visualiser has become unusable recently when it has too
many done tasks scheduled. The tab freezes up for a long time while processing
all the tasks, and then is very sluggish afterward. When I have this many done
tasks, it's too much to really browse through anyway, so this limits the
information shown to just the count. This trades off available information with
usability of the tool.

The maximum number of shown tasks is controlled by the scheduler and can be
adjusted in client.cfg. It may be better to make this part of the query so that
it could potentially be controlled by the end user. We may also in the future
want to add additional server queries to update larger sections for searches,
as this removes useful search information.

![image](https://cloud.githubusercontent.com/assets/2091885/5559173/b598a95c-8cf7-11e4-9931-801029955492.png)
