### PR TITLE
Remove deprecated apply() builtin.

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -142,7 +142,7 @@ class SingleProcessPool(object):
     """
 
     def apply_async(self, function, args):
-        return apply(function, args)
+        return function(*args)
 
 
 class DequeQueue(collections.deque):


### PR DESCRIPTION
apply() has been deprecated in Python 2.3 and removed in Python 3. I've noticed this when I try to add Python 3 support to Luigi.
