### PR TITLE
Make task_id parsing support additional ids.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -41,18 +41,20 @@ def id_to_name_and_params(task_id):
         ``('Foo', {'bar': 'bar', 'baz': 'baz'})``
     '''
     name_chars = pp.alphanums + '_'
+    # modified version of pp.printables. Removed '[]', '()', ','
+    value_chars = pp.alphanums + '\'!"#$%&*+-./:;<=>?@\\^_`{|}~'
     parameter = (
         (pp.Word(name_chars) +
          pp.Literal('=').suppress() +
          ((pp.Literal('(').suppress() | pp.Literal('[').suppress()) +
-          pp.ZeroOrMore(pp.Word(name_chars) +
+          pp.ZeroOrMore(pp.Word(value_chars) +
                         pp.ZeroOrMore(pp.Literal(',')).suppress()) +
           (pp.Literal(')').suppress() |
            pp.Literal(']').suppress()))).setResultsName('list_params',
                                                         listAllMatches=True) |
         (pp.Word(name_chars) +
          pp.Literal('=').suppress() +
-         pp.Word(name_chars)).setResultsName('params', listAllMatches=True))
+         pp.Word(value_chars)).setResultsName('params', listAllMatches=True))
 
     parser = (
         pp.Word(name_chars).setResultsName('task') +

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -38,6 +38,23 @@ class TaskTest(unittest.TestCase):
         other = DummyTask.from_str_params(original.to_str_params(), {})
         self.assertEqual(original, other)
 
+    def test_id_to_name_and_params(self):
+        task_id = "InputText(date=2014-12-29)"
+        (name, params) = luigi.task.id_to_name_and_params(task_id)
+        self.assertEquals(name, "InputText")
+        self.assertEquals(params, dict(date="2014-12-29"))
+
+    def test_id_to_name_and_params_multiple_args(self):
+        task_id = "InputText(date=2014-12-29,foo=bar)"
+        (name, params) = luigi.task.id_to_name_and_params(task_id)
+        self.assertEquals(name, "InputText")
+        self.assertEquals(params, dict(date="2014-12-29", foo="bar"))
+
+    def test_id_to_name_and_params_list_args(self):
+        task_id = "InputText(date=2014-12-29,foo=[bar,baz-foo])"
+        (name, params) = luigi.task.id_to_name_and_params(task_id)
+        self.assertEquals(name, "InputText")
+        self.assertEquals(params, dict(date="2014-12-29", foo=["bar","baz-foo"]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds support for tasks with non-alphanumeric values (e.g. dates
with dashes in them).

Discovered this bug as I was testing out task history locally.