### PR TITLE
Remove hadoop_test.py from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ dist
 luigi.egg-info
 packages.tar
 test/data
-hadoop_test.py
 .nicesetup
 .tox
 *.pickle


### PR DESCRIPTION
No idea why it was added. My grep-tool ag didn't search in that file
because of it. Hopefully nobody else need to waste time on this.