### PR TITLE
Propagate tox's args to nosetest

### DIFF
--- a/scripts/ci/run_tests.sh
+++ b/scripts/ci/run_tests.sh
@@ -7,4 +7,4 @@ fi
 
 echo "Using ${HADOOP_DISTRO} distribution of Hadoop from ${HADOOP_HOME}"
 
-python test/runtests.py -v
+python test/runtests.py -v $@

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ setenv =
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client.cfg
 commands =
   {toxinidir}/scripts/ci/setup_env.sh
-  {toxinidir}/scripts/ci/run_tests.sh
+  {toxinidir}/scripts/ci/run_tests.sh {posargs:}


### PR DESCRIPTION
In particular, this patch allows you to do

    tox test/only_run_this_test.py

By the way, here's a real life example of how I run the tests on Ubuntu
12.04.

    export TOX_ENV=hdp
    export PYTHONPATH=''
    export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64
    tox -e $TOX_ENV test/snakebite_test.py