### PR TITLE
Add rename2 for snakebite

### DIFF
--- a/luigi/contrib/target.py
+++ b/luigi/contrib/target.py
@@ -16,7 +16,9 @@ class CascadingClient():
     # created, pass the kwarg to the constructor.
     ALL_METHOD_NAMES = ['exists', 'rename', 'remove', 'chmod', 'chown',
                         'count', 'copy', 'get', 'put', 'mkdir', 'listdir',
-                        'isdir']
+                        'isdir',
+                        'rename_dont_move',
+                        ]
 
     def __init__(self, clients, method_names=ALL_METHOD_NAMES):
         self.clients = clients

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -374,7 +374,7 @@ class HadoopJobRunner(JobRunner):
         # replace output with a temporary work directory
         output_final = job.output().path
         output_tmp_fn = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
-        tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn, is_tmp=True)
+        tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn)
 
         arglist = luigi.hdfs.load_hadoop_cmd() + ['jar', self.streaming_jar]
 
@@ -442,7 +442,7 @@ class HadoopJobRunner(JobRunner):
 
         run_and_track_hadoop_job(arglist)
 
-        tmp_target.move(output_final, raise_if_exists=True)
+        tmp_target.move_dir(output_final)
         self.finish()
 
     def finish(self):

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -339,6 +339,24 @@ class SnakebiteHdfsClient(HdfsClient):
                 self.mkdir(dir_path, parents=True)
         return list(self.get_bite().rename(list_path(path), dest))
 
+    def rename_dont_move(self, path, dest):
+        """
+        Use snakebite.rename_dont_move, if available.
+
+        :param path: source path (single input)
+        :type path: string
+        :param dest: destination path
+        :type dest: string
+        :return: True if succeeded
+        :raises: snakebite.errors.FileAlreadyExistsException
+        """
+        from snakebite.errors import FileAlreadyExistsException
+        try:
+            self.get_bite().rename2(path, dest, overwriteDest=False)
+            return True
+        except FileAlreadyExistsException:
+            return False
+
     def remove(self, path, recursive=True, skip_trash=False):
         """
         Use snakebite.delete, if available.

--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -142,6 +142,22 @@ class HdfsClient(FileSystem):
             warnings.warn("Renaming multiple files at once is not atomic.")
         call_check(load_hadoop_cmd() + ['fs', '-mv'] + path + [dest])
 
+    def rename_dont_move(self, path, dest):
+        """
+        Override this method with an implementation that uses rename2, which is
+        a rename operation that never moves. For instance, `rename2 a b` never
+        moves `a` into `b` folder.  Currently, the hadoop cli does not support
+        this operation.  We keep the interface simple by just aliasing this to
+        normal rename and let individual implementations redefine the method.
+
+        rename2: https://github.com/apache/hadoop/blob/ae91b13/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java#L483-L523
+        """
+        warnings.warn("Configured HDFS client doesn't support rename_dont_move, using normal mv operation instead.")
+        if self.exists(dest):
+            return False
+        self.rename(path, dest)
+        return True
+
     def remove(self, path, recursive=True, skip_trash=False):
         if recursive:
             cmd = load_hadoop_cmd() + ['fs', '-rm', '-r']

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open('README.rst') as fobj:
 install_requires = [
     'pyparsing',
     'tornado',
-    'snakebite>=2.4.10',
+    'snakebite>=2.5.0',
 ]
 
 if sys.version_info[:2] < (2, 7):

--- a/test/snakebite_test.py
+++ b/test/snakebite_test.py
@@ -67,3 +67,19 @@ class TestSnakebiteClient(MiniClusterTestCase):
         finally:
             if self.snakebite.exists(rel_test_dir):
                 self.snakebite.remove(rel_test_dir, True)
+
+    def test_rename_dont_move(self):
+        foo = posixpath.join(self.testDir, "foo")
+        bar = posixpath.join(self.testDir, "bar")
+        self.assertTrue(self.snakebite.mkdir(foo))
+        self.assertTrue(self.snakebite.mkdir(bar))
+        self.assertTrue(self.snakebite.exists(foo))  # For sanity
+        self.assertTrue(self.snakebite.exists(bar))  # For sanity
+
+        self.assertFalse(self.snakebite.rename_dont_move(foo, bar))
+        self.assertTrue(self.snakebite.exists(foo))
+        self.assertTrue(self.snakebite.exists(bar))
+
+        self.assertTrue(self.snakebite.rename_dont_move(foo, foo + '2'))
+        self.assertFalse(self.snakebite.exists(foo))
+        self.assertTrue(self.snakebite.exists(foo + '2'))


### PR DESCRIPTION
Note that the tests definetly should fail. As `snakebite 2.5.0` is not even released yet.

I wanted to push this out for review still and I checked that the tests I added passed with my local snakebite version with `rename_dont_move()` support.