### PR TITLE
doc - remove colons from sample decorator usage

### DIFF
--- a/doc/api_overview.rst
+++ b/doc/api_overview.rst
@@ -205,14 +205,14 @@ from a specific class (e.g. for hadoop jobs).
 
 .. code:: python
 
-    @luigi.Task.event_handler(luigi.Event.SUCCESS):
+    @luigi.Task.event_handler(luigi.Event.SUCCESS)
     def celebrate_success(task):
         """Will be called directly after a successful execution
            of `run` on any Task subclass (i.e. all luigi Tasks)
         """
         ...
 
-    @luigi.hadoop.JobTask.event_handler(luigi.Event.FAILURE):
+    @luigi.hadoop.JobTask.event_handler(luigi.Event.FAILURE)
     def mourn_failure(task, exception):
         """Will be called directly after a failed execution
            of `run` on any JobTask subclass


### PR DESCRIPTION
Fix two examples in api_overview.rst where decorators are terminated
with a colon.