### PR TITLE
Remove whoops from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ install_requires = [
     'requests',
     'sqlalchemy',
     'tornado',
-    'whoops',
     'snakebite>=2.4.10',
 ]
 


### PR DESCRIPTION
It's not a used dependency anymore since
https://github.com/spotify/luigi/pull/504

Thanks @danielfrg !!!!

    ~/spotify/repos/luigis/github_luigi
    ❯ ag whoops
    setup.py
    48:    'whoops',