### PR TITLE
Don't have contrib-dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,7 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'boto',
     'pyparsing',
-    'requests',
-    'sqlalchemy',
     'tornado',
     'snakebite>=2.4.10',
 ]

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,5 @@
 mock
 moto
 nose
+boto
+sqlalchemy


### PR DESCRIPTION
Currently, we can't build the luigi debian package. The reason is that
the requirements in setup.py is including dependencies that are for
packages that (at least should) belong to contrib.

I also removed requests as I didn't see it being used anywhere. The test
suite should reveal if it was required or not. :)