### PR TITLE
Remove global parameters

### DIFF
--- a/doc/api_overview.rst
+++ b/doc/api_overview.rst
@@ -128,6 +128,33 @@ order to support command line interaction and make sure to convert the
 input to the corresponding type (i.e. datetime.date instead of a
 string).
 
+Setting parameter value for other classes
+-----------------------------------------
+
+All parameters are also exposed on a class level on the command line
+interface. For instance, say you have classes TaskA and TaskB:
+
+.. code:: python
+
+    class TaskA(luigi.Task):
+        x = luigi.Parameter()
+
+    class TaskB(luigi.Task):
+        y = luigi.Parameter()
+
+
+You can run *TaskB* on the command line: *python script.py TaskB --y 42*.
+But you can also set the class value of *TaskA* by running *python script.py
+TaskB --y 42 --TaskA-x 43*. This sets the value of *TaskA.x* to 43 on a
+*class* level. It is still possible to override it inside Python if you
+instantiate *TaskA(x=44)*.
+
+Parameters are resolved in the following order of decreasing priority:
+1. Any value passed to the constructor, or task level value set on the command line
+2. Any class level value set on the command line
+3. Any configuration option (if using the *config_path* argument)
+4. Any default value provided to the parameter
+
 Task.requires
 ^^^^^^^^^^^^^
 

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -227,14 +227,14 @@ def get_task_parameters(task_cls, args):
     # Parse a str->str dict to the correct types
     params = {}
     for param_name, param in task_cls.get_params():
-        param.parse_from_args(param_name, args, params)
+        param.parse_from_args(param_name, task_cls.task_family, args, params)
     return params
 
 
 def set_global_parameters(args):
     # Note that this is not side effect free
     for task_name, param_name, param in Register.get_all_params():
-        param.set_global_from_args(param_name, args)
+        param.set_global_from_args(param_name, task_name, args)
 
 
 class ArgParseInterface(Interface):

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -211,35 +211,30 @@ class ErrorWrappedArgumentParser(argparse.ArgumentParser):
 
 def add_task_parameters(parser, task_cls, optparse=False):
     for param_name, param in task_cls.get_params():
-        if not param.is_global:
-            param.add_to_cmdline_parser(parser, param_name, task_cls.task_family, optparse=optparse)
+        param.add_to_cmdline_parser(parser, param_name, task_cls.task_family, optparse=optparse, glob=False)
 
 
 def add_global_parameters(parser, optparse=False):
     seen_params = set()
     for task_name, param_name, param in Register.get_all_params():
-        if param.is_global:
-            if param in seen_params:
-                continue
-            seen_params.add(param)
-            param.add_to_cmdline_parser(parser, param_name, task_name, optparse=optparse)
+        if param in seen_params:
+            continue
+        seen_params.add(param)
+        param.add_to_cmdline_parser(parser, param_name, task_name, optparse=optparse, glob=True)
 
 
-def get_task_parameters(task_cls, params_str):
+def get_task_parameters(task_cls, args):
     # Parse a str->str dict to the correct types
     params = {}
     for param_name, param in task_cls.get_params():
-        if param_name in params_str and not param.is_global:
-            params[param_name] = param.parse_from_input(param_name, params_str[param_name])
+        param.parse_from_args(param_name, args, params)
     return params
 
 
-def set_global_parameters(params_str):
+def set_global_parameters(args):
     # Note that this is not side effect free
     for task_name, param_name, param in Register.get_all_params():
-        if param_name in params_str and param.is_global:
-            value = param.parse_from_input(param_name, params_str[param_name])
-            param.set_global(value)
+        param.set_global_from_args(param_name, args)
 
 
 class ArgParseInterface(Interface):
@@ -276,8 +271,8 @@ class ArgParseInterface(Interface):
             task_cls = Register.get_task_cls(args.command)
 
         # Notice that this is not side effect free because it might set global params
-        set_global_parameters(vars(args))
-        task_params = get_task_parameters(task_cls, vars(args))
+        set_global_parameters(args)
+        task_params = get_task_parameters(task_cls, args)
 
         return [task_cls(**task_params)]
 
@@ -364,8 +359,8 @@ class OptParseInterface(Interface):
         # Parse and run
         options, args = parser.parse_args(args=cmdline_args)
 
-        set_global_parameters(vars(options))
-        task_params = get_task_parameters(task_cls, vars(options))
+        set_global_parameters(options)
+        task_params = get_task_parameters(task_cls, options)
 
         return [task_cls(**task_params)]
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -201,7 +201,6 @@ class Parameter(object):
 
         :param value: the new global value.
         """
-        assert self.is_global
         self.__global = value
 
     def reset_global(self):
@@ -274,15 +273,26 @@ class Parameter(object):
         else:
             return self.serialize(x)
 
-    def add_to_cmdline_parser(self, parser, param_name, task_name=None, optparse=False, glob=False):
-        if glob ^ self.is_global:
+    def parser_dest(self, param_name, task_name, glob=False):
+        if self.is_global:
+            if glob:
+                return param_name
+            else:
+                return None
+        else:
+            if glob:
+                return task_name + '_' + param_name
+            else:
+                return param_name
+
+    def add_to_cmdline_parser(self, parser, param_name, task_name, optparse=False, glob=False):
+        dest = self.parser_dest(param_name, task_name, glob)
+        if not dest:
             return
+        flag = '--' + dest.replace('_', '-')
 
         description = []
-        if task_name:
-            description.append('%s.%s' % (task_name, param_name))
-        else:
-            description.append(param_name)
+        description.append('%s.%s' % (task_name, param_name))
         if self.description:
             description.append(self.description)
         if self.has_value:
@@ -298,20 +308,24 @@ class Parameter(object):
             f = parser.add_option
         else:
             f = parser.add_argument
-        f('--' + param_name.replace('_', '-'),
+        f(flag,
           help=' '.join(description),
           default=None,
-          action=action)
+          action=action,
+          dest=dest)
 
-    def parse_from_args(self, param_name, args, params):
-        if hasattr(args, param_name) and not self.is_global:
-            value = self.parse_from_input(param_name, getattr(args, param_name))
-            params[param_name] = value # Note: modifies arguments
+    def parse_from_args(self, param_name, task_name, args, params):
+        dest = self.parser_dest(param_name, task_name, glob=False)
+        if dest is not None:
+            value = getattr(args, dest, None)
+            params[param_name] = self.parse_from_input(param_name, value) # Note: modifies arguments
 
-    def set_global_from_args(self, param_name, args):
-        if hasattr(args, param_name) and self.is_global:
-            value = self.parse_from_input(param_name, getattr(args, param_name))
-            self.set_global(value) # Note: side effects
+    def set_global_from_args(self, param_name, task_name, args):
+        dest = self.parser_dest(param_name, task_name, glob=True)
+        if dest is not None:
+            value = getattr(args, dest, None)
+            if value is not None:
+                self.set_global(self.parse_from_input(param_name, value)) # Note: side effects
 
 
 class DateHourParameter(Parameter):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -63,13 +63,14 @@ class Parameter(object):
     The ``config_path`` argument lets you specify a place where the parameter is read from config
     in case no value is provided.
 
-    Providing ``is_global=True`` changes the behavior of the parameter so that the value is shared
-    across all instances of the task. Global parameters can be provided in several ways. In
-    falling order of precedence:
+    When a task is instantiated, it will first use any argument as the value of the parameter, eg.
+    if you instantiate a = TaskA(x=44) then a.x == 44. If this does not exist, it will use the value
+    of the Parameter object, which is defined on a class level. This will be resolved in this
+    order of falling priority:
 
-    * A value provided on the command line (eg. ``--my-global-value xyz``)
-    * A value provided via config (using the ``config_path`` argument)
-    * A default value set using the ``default`` flag.
+    * Any value provided on the command line on the class level (eg. ``--TaskA-param xyz``)
+    * Any value provided via config (using the ``config_path`` argument)
+    * Any default value set using the ``default`` flag.
     """
     counter = 0
     """non-atomically increasing counter used for ordering parameters."""

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -112,6 +112,15 @@ class Parameter(object):
 
         if is_global and default == _no_value and config_path is None:
             raise ParameterException('Global parameters need default values')
+
+        if is_global:
+            warnings.warn(
+                'is_global is deprecated. All parameters support global overrides now.'
+                'Just invoke with eg. --MyTask-my-parameter 123',
+                DeprecationWarning,
+                stacklevel=2
+                )
+
         self.description = description
 
         if config_path is not None and ('section' not in config_path or 'name' not in config_path):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -274,7 +274,10 @@ class Parameter(object):
         else:
             return self.serialize(x)
 
-    def add_to_cmdline_parser(self, parser, param_name, task_name=None, optparse=False):
+    def add_to_cmdline_parser(self, parser, param_name, task_name=None, optparse=False, glob=False):
+        if glob ^ self.is_global:
+            return
+
         description = []
         if task_name:
             description.append('%s.%s' % (task_name, param_name))
@@ -299,6 +302,16 @@ class Parameter(object):
           help=' '.join(description),
           default=None,
           action=action)
+
+    def parse_from_args(self, param_name, args, params):
+        if hasattr(args, param_name) and not self.is_global:
+            value = self.parse_from_input(param_name, getattr(args, param_name))
+            params[param_name] = value # Note: modifies arguments
+
+    def set_global_from_args(self, param_name, args):
+        if hasattr(args, param_name) and self.is_global:
+            value = self.parse_from_input(param_name, getattr(args, param_name))
+            self.set_global(value) # Note: side effects
 
 
 class DateHourParameter(Parameter):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -23,6 +23,7 @@ from luigi.parameter import ParameterException
 luigi.notifications.DEBUG = True
 import unittest
 from helpers import with_config
+from luigi.mock import MockFile, MockFileSystem
 
 EMAIL_CONFIG = {"core": {"error-email": "not-a-real-email-address-for-test-only"}}
 
@@ -101,14 +102,38 @@ class SharedGlobalParamB(luigi.Task):
 
 
 class BananaDep(luigi.Task):
-    ppp = luigi.Parameter()
-    qqq = luigi.Parameter()
+    x = luigi.Parameter()
+    y = luigi.Parameter(default='def')
+
+    def output(self):
+        return MockFile('banana-dep-%s-%s' % (self.x, self.y))
+
+    def run(self):
+        self.output().open('w').close()
 
 
 class Banana(luigi.Task):
-    ppp = luigi.Parameter()
+    x = luigi.Parameter()
+    y = luigi.Parameter()
+    style = luigi.Parameter(default=None)
+
     def requires(self):
-        return BananaDep(self.ppp)
+        if self.style is None:
+            return BananaDep() # will fail
+        elif self.style == 'x-arg':
+            return BananaDep(self.x)
+        elif self.style == 'y-kwarg':
+            return BananaDep(y=self.y)
+        elif self.style == 'x-arg-y-arg':
+            return BananaDep(self.x, self.y)
+        else:
+            raise Exception('unknown style')
+
+    def output(self):
+        return MockFile('banana-%s-%s' % (self.x, self.y))
+
+    def run(self):
+        self.output().open('w').close()
 
 
 class ParameterTest(EmailTest):
@@ -229,8 +254,51 @@ class ParameterTest(EmailTest):
         t = InsignificantParameterTask(foo='x', bar='y')
         self.assertEqual(t.task_id, 'InsignificantParameterTask(bar=y)')
 
-    def test_override_parameter_globally(self):
-        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--ppp', '42', '--BananaDep-qqq', '73'])
+
+class TestNewStyleGlobalParameters(EmailTest):
+    def setUp(self):
+        super(TestNewStyleGlobalParameters, self).setUp()
+        MockFile.fs.clear()
+        BananaDep.y.reset_global()
+
+    def expect_keys(self, expected):
+        self.assertEquals(set(MockFile.fs.get_all_data().keys()), set(expected))
+
+    def test_x_arg(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-def'])
+
+    def test_x_arg_override(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg', '--BananaDep-y', 'xyz'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-xyz'])
+
+    def test_x_arg_override_stupid(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg', '--BananaDep-x', 'blabla'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-def'])
+
+    def test_x_arg_y_arg(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg-y-arg'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-bar'])
+
+    def test_x_arg_y_arg_override(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg-y-arg', '--BananaDep-y', 'xyz'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-bar'])
+
+    def test_x_arg_y_arg_override_all(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg-y-arg', '--BananaDep-y', 'xyz', '--BananaDep-x', 'blabla'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-foo-bar'])
+
+    def test_y_arg_override(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'y-kwarg', '--BananaDep-x', 'xyz'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-xyz-bar'])
+
+    def test_y_arg_override_both(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--x', 'foo', '--y', 'bar', '--style', 'y-kwarg', '--BananaDep-x', 'xyz', '--BananaDep-y', 'blah'])
+        self.expect_keys(['banana-foo-bar', 'banana-dep-xyz-bar'])
+
+    def test_y_arg_override_banana(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--y', 'bar', '--style', 'y-kwarg', '--BananaDep-x', 'xyz', '--Banana-x', 'baz'])
+        self.expect_keys(['banana-baz-bar', 'banana-dep-xyz-bar'])
 
 
 class TestParamWithDefaultFromConfig(unittest.TestCase):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -100,6 +100,17 @@ class SharedGlobalParamB(luigi.Task):
     shared_global_param = _shared_global_param
 
 
+class BananaDep(luigi.Task):
+    ppp = luigi.Parameter()
+    qqq = luigi.Parameter()
+
+
+class Banana(luigi.Task):
+    ppp = luigi.Parameter()
+    def requires(self):
+        return BananaDep(self.ppp)
+
+
 class ParameterTest(EmailTest):
     def setUp(self):
         super(ParameterTest, self).setUp()
@@ -217,6 +228,9 @@ class ParameterTest(EmailTest):
 
         t = InsignificantParameterTask(foo='x', bar='y')
         self.assertEqual(t.task_id, 'InsignificantParameterTask(bar=y)')
+
+    def test_override_parameter_globally(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--ppp', '42', '--BananaDep-qqq', '73'])
 
 
 class TestParamWithDefaultFromConfig(unittest.TestCase):


### PR DESCRIPTION
This PR makes global parameters obsolete. Instead, there's a mechanism to override any parameter from the command line. By running `--SomeTask-some-parameter 42` you override the default value for `SomeTask`. Previous global parameters still work as before.
