### PR TITLE
Explicitly note that examples work with local_scheduler only.

### DIFF
--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -21,9 +21,9 @@ Any task can be instantiated and run from the command line:
 
 You can run this task from the command line like this::
 
-    $ python my_task.py MyTask --x 123 --y 456
+    $ python my_task.py MyTask --local-scheduler --x 123 --y 456
 
-You can also pass ``main_task_cls=MyTask`` to ``luigi.run()`` and that way
+You can also pass ``main_task_cls=MyTask`` and ``local_scheduler=True`` to ``luigi.run()`` and that way
 you can invoke it simply using
 
 ::

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -364,7 +364,7 @@ def load_task(module, task_name, params_str):
     return task_cls.from_str_params(params_str)
 
 
-def run(cmdline_args=None, existing_optparse=None, use_optparse=False, main_task_cls=None, worker_scheduler_factory=None, use_dynamic_argparse=False):
+def run(cmdline_args=None, existing_optparse=None, use_optparse=False, main_task_cls=None, worker_scheduler_factory=None, use_dynamic_argparse=False, local_scheduler=False):
     ''' Run from cmdline.
 
     The default parser uses argparse.
@@ -378,7 +378,10 @@ def run(cmdline_args=None, existing_optparse=None, use_optparse=False, main_task
     else:
         interface = ArgParseInterface()
     tasks = interface.parse(cmdline_args, main_task_cls=main_task_cls)
-    return interface.run(tasks, worker_scheduler_factory)
+    override_defaults = {}
+    if local_scheduler:
+        override_defaults['local_scheduler'] = True
+    return interface.run(tasks, worker_scheduler_factory, override_defaults=override_defaults)
 
 
 def build(tasks, worker_scheduler_factory=None, **env_params):


### PR DESCRIPTION
Update Interface.run as well to be able to specify local_scheduler
via kwargs.

Not sure but when I started learning luigi this documentation page
was super confusing as I constantly was getting some timeouts..