### PR TITLE
Preserve the overrided method's signature.

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -56,7 +56,7 @@ class LocalFileSystem(FileSystem):
     def exists(self, path):
         return os.path.exists(path)
 
-    def mkdir(self, path):
+    def mkdir(self, path, parents=True, raise_if_exists=False):
         os.makedirs(path)
 
     def isdir(self, path):


### PR DESCRIPTION
FileSystem (parent class) has mkdir defined as:

def mkdir(self, path, parents=True, raise_if_exists=False):
   ...