### PR TITLE
Add coveralls badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,11 @@
 About Luigi
 -----------
 
-.. image:: https://travis-ci.org/spotify/luigi.svg?branch=master
+.. image:: https://img.shields.io/travis/spotify/luigi/master.svg?style=flat
     :target: https://travis-ci.org/spotify/luigi
+
+.. image:: https://img.shields.io/coveralls/spotify/luigi/master.svg?style=flat
+    :target: https://coveralls.io/r/spotify/luigi?branch=master
 
 Luigi is a Python package that helps you build complex pipelines of
 batch jobs. It handles dependency resolution, workflow management,


### PR DESCRIPTION
* Add coveralls badge to README
* Shielded both badges via http://shields.io to keep the same style

This gives and instant hint to a user where to find the coverage information.