### PR TITLE
Improve most common memory footprint

### DIFF
--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -28,6 +28,7 @@ from luigi.target import FileSystemTarget
 from luigi.task import Register, flatten_output
 import re
 import time
+import operator
 
 logger = logging.getLogger('luigi-interface')
 
@@ -214,7 +215,7 @@ def most_common(items):
     for i in items:
         counts.setdefault(i, 0)
         counts[i] += 1
-    return sorted(counts.items(), key=lambda x: x[1])[-1]
+    return max(counts.iteritems(), key=operator.itemgetter(1))
 
 
 def _get_per_location_glob(tasks, outputs, regexes):

--- a/test/most_common_test.py
+++ b/test/most_common_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from luigi.tools.range import most_common
+
+
+class MostCommonTest(unittest.TestCase):
+    def setUp(self):
+        self.runs = [
+            ([1], (1, 1)),
+            ([1, 1], (1, 2)),
+            ([1, 1, 2], (1, 2)),
+            ([1, 1, 2, 2, 2], (2, 3))
+        ]
+
+    def test_runs(self):
+        for args, result in self.runs:
+            actual = most_common(args)
+            expected = result
+            self.assertEqual(expected, actual)


### PR DESCRIPTION
No need neither to create a list in items() nor to sort the whole
sequence. We need only the max one, right?

If we have two values with the same frequence than we still have
undefined result as before as dict.items() & dict.iteritems()
return values in an undefined order.

Yeah, I just read random code in luigi and see if I can improve
it.