### PR TITLE
Remove global parameters

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -26,6 +26,7 @@ Event = event.Event
 
 Task = task.Task
 Config = task.Config
+ConfigWithoutSection = task.ConfigWithoutSection
 ExternalTask = task.ExternalTask
 WrapperTask = task.WrapperTask
 Target = target.Target

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -25,6 +25,7 @@ import event
 Event = event.Event
 
 Task = task.Task
+Config = task.Config
 ExternalTask = task.ExternalTask
 WrapperTask = task.WrapperTask
 Target = target.Target

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -51,7 +51,7 @@ def setup_interface_logging(conf_file=None):
     setup_interface_logging.has_run = True
 
 
-class EnvironmentParamsContainer(task.Config):
+class EnvironmentParamsContainer(task.ConfigWithoutSection):
 
     ''' Keeps track of a bunch of environment params.
 
@@ -199,11 +199,11 @@ def add_task_parameters(parser, task_cls, optparse=False):
 
 def add_global_parameters(parser, optparse=False):
     seen_params = set()
-    for task_name, is_config, param_name, param in Register.get_all_params():
+    for task_name, is_without_section, param_name, param in Register.get_all_params():
         if param in seen_params:
             continue
         seen_params.add(param)
-        param.add_to_cmdline_parser(parser, param_name, task_name, optparse=optparse, glob=True, is_config=is_config)
+        param.add_to_cmdline_parser(parser, param_name, task_name, optparse=optparse, glob=True, is_without_section=is_without_section)
 
 
 def get_task_parameters(task_cls, args):
@@ -216,8 +216,8 @@ def get_task_parameters(task_cls, args):
 
 def set_global_parameters(args):
     # Note that this is not side effect free
-    for task_name, is_config, param_name, param in Register.get_all_params():
-        param.set_global_from_args(param_name, task_name, args, is_config=is_config)
+    for task_name, is_without_section, param_name, param in Register.get_all_params():
+        param.set_global_from_args(param_name, task_name, args, is_without_section=is_without_section)
 
 
 class ArgParseInterface(Interface):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -275,8 +275,8 @@ class Parameter(object):
         else:
             return self.serialize(x)
 
-    def parser_dest(self, param_name, task_name, glob=False):
-        if self.is_global:
+    def parser_dest(self, param_name, task_name, glob=False, is_config=False):
+        if self.is_global or is_config:
             if glob:
                 return param_name
             else:
@@ -287,8 +287,8 @@ class Parameter(object):
             else:
                 return param_name
 
-    def add_to_cmdline_parser(self, parser, param_name, task_name, optparse=False, glob=False):
-        dest = self.parser_dest(param_name, task_name, glob)
+    def add_to_cmdline_parser(self, parser, param_name, task_name, optparse=False, glob=False, is_config=False):
+        dest = self.parser_dest(param_name, task_name, glob, is_config=is_config)
         if not dest:
             return
         flag = '--' + dest.replace('_', '-')
@@ -322,9 +322,9 @@ class Parameter(object):
             value = getattr(args, dest, None)
             params[param_name] = self.parse_from_input(param_name, value)
 
-    def set_global_from_args(self, param_name, task_name, args):
+    def set_global_from_args(self, param_name, task_name, args, is_config=False):
         # Note: side effects
-        dest = self.parser_dest(param_name, task_name, glob=True)
+        dest = self.parser_dest(param_name, task_name, glob=True, is_config=is_config)
         if dest is not None:
             value = getattr(args, dest, None)
             if value is not None:

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -101,7 +101,7 @@ class Parameter(object):
         :param bool is_bool: specify ``True`` if the parameter is a bool value. Default:
                                 ``False``. Bool's have an implicit default value of ``False``.
         :param bool is_global: specify ``True`` if the parameter is global (i.e. used by multiple
-                               Tasks). Default: ``False``.
+                               Tasks). Default: ``False``. DEPRECATED.
         :param bool significant: specify ``False`` if the parameter should not be treated as part of
                                  the unique identifier for a Task. An insignificant Parameter might
                                  also be used to specify a password or other sensitive information
@@ -123,6 +123,14 @@ class Parameter(object):
         self.is_bool = is_boolean and not is_list  # Only BoolParameter should ever use this. TODO(erikbern): should we raise some kind of exception?
         self.is_global = is_global  # It just means that the default value is exposed and you can override it
         self.significant = significant  # Whether different values for this parameter will differentiate otherwise equal tasks
+
+        if is_global:
+            warnings.warn(
+                'is_global is deprecated and will be removed. Please use either '
+                ' (a) class level config (eg. --MyTask-my-param 42)'
+                ' (b) a separate Config class with global settings on it',
+                DeprecationWarning,
+                stacklevel=2)
 
         if is_global and default == _no_value and config_path is None:
             raise ParameterException('Global parameters need default values')

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -283,8 +283,8 @@ class Parameter(object):
         else:
             return self.serialize(x)
 
-    def parser_dest(self, param_name, task_name, glob=False, is_config=False):
-        if self.is_global or is_config:
+    def parser_dest(self, param_name, task_name, glob=False, is_without_section=False):
+        if self.is_global or is_without_section:
             if glob:
                 return param_name
             else:
@@ -295,8 +295,8 @@ class Parameter(object):
             else:
                 return param_name
 
-    def add_to_cmdline_parser(self, parser, param_name, task_name, optparse=False, glob=False, is_config=False):
-        dest = self.parser_dest(param_name, task_name, glob, is_config=is_config)
+    def add_to_cmdline_parser(self, parser, param_name, task_name, optparse=False, glob=False, is_without_section=False):
+        dest = self.parser_dest(param_name, task_name, glob, is_without_section=is_without_section)
         if not dest:
             return
         flag = '--' + dest.replace('_', '-')
@@ -330,9 +330,9 @@ class Parameter(object):
             value = getattr(args, dest, None)
             params[param_name] = self.parse_from_input(param_name, value)
 
-    def set_global_from_args(self, param_name, task_name, args, is_config=False):
+    def set_global_from_args(self, param_name, task_name, args, is_without_section=False):
         # Note: side effects
-        dest = self.parser_dest(param_name, task_name, glob=True, is_config=is_config)
+        dest = self.parser_dest(param_name, task_name, glob=True, is_without_section=is_without_section)
         if dest is not None:
             value = getattr(args, dest, None)
             if value is not None:

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -134,26 +134,29 @@ class Register(abc.ABCMeta):
             return "%s.%s" % (cls.task_namespace, cls.__name__)
 
     @classmethod
-    def get_reg(cls):
-        """
-        Return all of the registery classes.
+    def get_reg(cls, include_config=False):
+        """Return all of the registery classes.
 
         :return:  a ``dict`` of task_family -> class
         """
         # We have to do this on-demand in case task names have changed later
         reg = {}
         for cls in cls._reg:
-            if cls.run != NotImplemented:
-                name = cls.task_family
-                if name in reg and reg[name] != cls and \
-                        reg[name] != cls.AMBIGUOUS_CLASS and \
-                        not issubclass(cls, reg[name]):
-                    # Registering two different classes - this means we can't instantiate them by name
-                    # The only exception is if one class is a subclass of the other. In that case, we
-                    # instantiate the most-derived class (this fixes some issues with decorator wrappers).
-                    reg[name] = cls.AMBIGUOUS_CLASS
-                else:
-                    reg[name] = cls
+            if cls.run == NotImplemented:
+                continue
+            if issubclass(cls, Config) and not include_config:
+                continue
+            name = cls.task_family
+
+            if name in reg and reg[name] != cls and \
+                    reg[name] != cls.AMBIGUOUS_CLASS and \
+                    not issubclass(cls, reg[name]):
+                # Registering two different classes - this means we can't instantiate them by name
+                # The only exception is if one class is a subclass of the other. In that case, we
+                # instantiate the most-derived class (this fixes some issues with decorator wrappers).
+                reg[name] = cls.AMBIGUOUS_CLASS
+            else:
+                reg[name] = cls
 
         return reg
 
@@ -183,11 +186,11 @@ class Register(abc.ABCMeta):
 
         :return: a ``dict`` of parameter name -> parameter.
         """
-        for task_name, task_cls in cls.get_reg().iteritems():
+        for task_name, task_cls in cls.get_reg(include_config=True).iteritems():
             if task_cls == cls.AMBIGUOUS_CLASS:
                 continue
             for param_name, param_obj in task_cls.get_params():
-                yield task_name, param_name, param_obj
+                yield task_name, issubclass(task_cls, Config), param_name, param_obj
 
 
 class Task(object):
@@ -602,6 +605,13 @@ class WrapperTask(Task):
 
     def complete(self):
         return all(r.complete() for r in flatten(self.requires()))
+
+
+class Config(Task):
+
+    """Used for global config that's not specific to a certain task
+    """
+    pass
 
 
 def getpaths(struct):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -134,7 +134,7 @@ class Register(abc.ABCMeta):
             return "%s.%s" % (cls.task_namespace, cls.__name__)
 
     @classmethod
-    def get_reg(cls, include_config=False):
+    def get_reg(cls, include_config_without_section=False):
         """Return all of the registery classes.
 
         :return:  a ``dict`` of task_family -> class
@@ -144,7 +144,7 @@ class Register(abc.ABCMeta):
         for cls in cls._reg:
             if cls.run == NotImplemented:
                 continue
-            if issubclass(cls, Config) and not include_config:
+            if issubclass(cls, ConfigWithoutSection) and not include_config_without_section:
                 continue
             name = cls.task_family
 
@@ -186,11 +186,11 @@ class Register(abc.ABCMeta):
 
         :return: a ``dict`` of parameter name -> parameter.
         """
-        for task_name, task_cls in cls.get_reg(include_config=True).iteritems():
+        for task_name, task_cls in cls.get_reg(include_config_without_section=True).iteritems():
             if task_cls == cls.AMBIGUOUS_CLASS:
                 continue
             for param_name, param_obj in task_cls.get_params():
-                yield task_name, issubclass(task_cls, Config), param_name, param_obj
+                yield task_name, issubclass(task_cls, ConfigWithoutSection), param_name, param_obj
 
 
 class Task(object):
@@ -609,7 +609,19 @@ class WrapperTask(Task):
 
 class Config(Task):
 
-    """Used for global config that's not specific to a certain task
+    """Used for configuration that's not specific to a certain task
+
+    TODO: let's refactor Task & Config so that it inherits from a common
+    ParamContainer base class
+    """
+    pass
+
+
+class ConfigWithoutSection(Task):
+
+    """Used for configuration that doesn't have a particular section
+
+    (eg. --n-workers)
     """
     pass
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -119,7 +119,7 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch("warnings.warn")
     @mock.patch("luigi.interface.setup_interface_logging")
     def test_cmdline_logger(self, setup_mock, warn):
-        with mock.patch("luigi.interface.EnvironmentParamsContainer.env_params") as env_params:
+        with mock.patch("luigi.interface.EnvironmentParamsContainer") as env_params:
             env_params.return_value.logging_conf_file = None
             luigi.run(['SomeTask', '--n', '7', '--local-scheduler', '--no-lock'])
             self.assertEqual([mock.call(None)], setup_mock.call_args_list)

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -485,7 +485,7 @@ class OverrideEnvStuff(unittest.TestCase):
 
     @with_config({"core": {"default-scheduler-port": '6543'}})
     def testOverrideSchedulerPort(self):
-        env_params = luigi.interface.EnvironmentParamsContainer.env_params()
+        env_params = luigi.interface.EnvironmentParamsContainer()
         self.assertEqual(env_params.scheduler_port, 6543)
 
 

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -137,6 +137,20 @@ class Banana(luigi.Task):
         self.output().open('w').close()
 
 
+class MyConfig(luigi.Config):
+    mc_p = luigi.IntParameter()
+    mc_q = luigi.IntParameter(default=73)
+
+
+class MyConfigWithoutSection(luigi.ConfigWithoutSection):
+    mc_r = luigi.IntParameter()
+    mc_s = luigi.IntParameter(default=99)
+
+
+class NoopTask(luigi.Task):
+    pass
+
+
 class ParameterTest(EmailTest):
 
     def setUp(self):
@@ -308,6 +322,68 @@ class TestNewStyleGlobalParameters(EmailTest):
     def test_y_arg_override_banana(self):
         luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--y', 'bar', '--style', 'y-kwarg', '--BananaDep-x', 'xyz', '--Banana-x', 'baz'])
         self.expect_keys(['banana-baz-bar', 'banana-dep-xyz-bar'])
+
+
+class TestRemoveGlobalParameters(EmailTest):
+
+    def setUp(self):
+        super(TestRemoveGlobalParameters, self).setUp()
+        MyConfig.mc_p.reset_global()
+        MyConfig.mc_q.reset_global()
+        MyConfigWithoutSection.mc_r.reset_global()
+        MyConfigWithoutSection.mc_s.reset_global()
+
+    def test_use_config_class_1(self):
+        luigi.run(['--local-scheduler', '--no-lock', '--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask'])
+        self.assertEqual(MyConfig().mc_p, 99)
+        self.assertEqual(MyConfig().mc_q, 73)
+        self.assertEqual(MyConfigWithoutSection().mc_r, 55)
+        self.assertEqual(MyConfigWithoutSection().mc_s, 99)
+
+    def test_use_config_class_2(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'NoopTask', '--MyConfig-mc-p', '99', '--mc-r', '55'])
+        self.assertEqual(MyConfig().mc_p, 99)
+        self.assertEqual(MyConfig().mc_q, 73)
+        self.assertEqual(MyConfigWithoutSection().mc_r, 55)
+        self.assertEqual(MyConfigWithoutSection().mc_s, 99)
+
+    def test_use_config_class_more_args(self):
+        luigi.run(['--local-scheduler', '--no-lock', '--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask', '--mc-s', '123', '--MyConfig-mc-q', '42'])
+        self.assertEqual(MyConfig().mc_p, 99)
+        self.assertEqual(MyConfig().mc_q, 42)
+        self.assertEqual(MyConfigWithoutSection().mc_r, 55)
+        self.assertEqual(MyConfigWithoutSection().mc_s, 123)
+
+    @with_config({"MyConfig": {"mc_p": "666", "mc_q": "777"}})
+    def test_use_config_class_with_configuration(self):
+        luigi.run(['--local-scheduler', '--no-lock', '--mc-r', '555', 'NoopTask'])
+        self.assertEqual(MyConfig().mc_p, 666)
+        self.assertEqual(MyConfig().mc_q, 777)
+        self.assertEqual(MyConfigWithoutSection().mc_r, 555)
+        self.assertEqual(MyConfigWithoutSection().mc_s, 99)
+
+    @with_config({"MyConfigWithoutSection": {"mc_r": "999", "mc_s": "888"}})
+    def test_use_config_class_with_configuration_2(self):
+        luigi.run(['--local-scheduler', '--no-lock', 'NoopTask', '--MyConfig-mc-p', '222', '--mc-r', '555'])
+        self.assertEqual(MyConfig().mc_p, 222)
+        self.assertEqual(MyConfig().mc_q, 73)
+        self.assertEqual(MyConfigWithoutSection().mc_r, 555)
+        self.assertEqual(MyConfigWithoutSection().mc_s, 888)
+
+    def test_misc_1(self):
+        class Dogs(luigi.Config):
+            n_dogs = luigi.IntParameter()
+
+        class CatsWithoutSection(luigi.ConfigWithoutSection):
+            n_cats = luigi.IntParameter()
+
+        luigi.run(['--local-scheduler', '--no-lock', '--n-cats', '123', '--Dogs-n-dogs', '456', 'WithDefault'])
+        self.assertEqual(Dogs().n_dogs, 456)
+        self.assertEqual(CatsWithoutSection().n_cats, 123)
+
+        luigi.run(['--local-scheduler', '--no-lock', 'WithDefault', '--n-cats', '321', '--Dogs-n-dogs', '654'])
+        self.assertEqual(Dogs().n_dogs, 654)
+        self.assertEqual(CatsWithoutSection().n_cats, 321)
 
 
 class TestParamWithDefaultFromConfig(unittest.TestCase):


### PR DESCRIPTION
This is one attempt at removing `is_global=True`. The idea is to support "taskless" parameters by putting them on a separate `luigi.Config` class (that happens to be a Task, but that's another story).

See `luigi.interface` for an example of this, where `EnvironmentParamsContainer` uses `luigi.Config`

This needs some more tests and some cleanup in `luigi.parameter` to be perfect, but let me know what you think of the overall idea!