### PR TITLE
Reset global variables between runs

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -301,7 +301,6 @@ class Parameter(object):
             f = parser.add_argument
         f(flag,
           help=' '.join(description),
-          default=None,
           action=action,
           dest=dest)
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -319,6 +319,8 @@ class Parameter(object):
             value = getattr(args, dest, None)
             if value is not None:
                 self.set_global(self.parse_from_input(param_name, value))
+            else:
+                self.reset_global()
 
 
 class DateHourParameter(Parameter):

--- a/test/dynamic_import_test.py
+++ b/test/dynamic_import_test.py
@@ -44,4 +44,4 @@ class CmdlineTest(unittest.TestCase):
     def test_run(self):
         # TODO: this needs to run after the existing module, since by now foo_module is already imported
 
-        luigi.run(['--local-scheduler', '--module', 'foo_module', 'FooTask', '--x', '100'], use_dynamic_argparse=True)
+        luigi.run(['--local-scheduler', '--no-lock', '--module', 'foo_module', 'FooTask', '--x', '100'], use_dynamic_argparse=True)

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -69,7 +69,7 @@ class FibTest(FibTestBase):
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
 
     def test_cmdline(self):
-        luigi.run(['--local-scheduler', 'Fib', '--n', '100'])
+        luigi.run(['--local-scheduler', '--no-lock', 'Fib', '--n', '100'])
 
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')

--- a/test/optparse_test.py
+++ b/test/optparse_test.py
@@ -20,7 +20,7 @@ from fib_test import FibTestBase
 class OptParseTest(FibTestBase):
 
     def test_cmdline_optparse(self):
-        luigi.run(['--local-scheduler', '--task', 'Fib', '--n', '100'], use_optparse=True)
+        luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True)
 
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
@@ -30,7 +30,7 @@ class OptParseTest(FibTestBase):
         parser = optparse.OptionParser()
         parser.add_option('--blaha')
 
-        luigi.run(['--local-scheduler', '--task', 'Fib', '--n', '100'], use_optparse=True, existing_optparse=parser)
+        luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True, existing_optparse=parser)
 
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
         self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')

--- a/test/set_task_name_test.py
+++ b/test/set_task_name_test.py
@@ -37,7 +37,7 @@ class SetTaskNameTest(unittest.TestCase):
     to resolve the issue. '''
 
     def test_set_task_name(self):
-        luigi.run(['--local-scheduler', 'MyNewTask'])
+        luigi.run(['--local-scheduler', '--no-lock', 'MyNewTask'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Found a small issue where global state was leaked between tests