### PR TITLE
Use sphinx-build as it is more Windows friendly.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,8 @@ deps = autopep8
 commands = autopep8 --ignore E309,E501 -a -i -r luigi test examples bin
 
 [testenv:docs]
-# to call this use `tox -e docs -- html`
 deps =
   sqlalchemy
   Sphinx
   sphinx_rtd_theme
-changedir = doc
-commands = /usr/bin/make {posargs}
+commands = sphinx-build -b html -d {envtmpdir}/doctrees doc doc/_build/html


### PR DESCRIPTION
* Use sphinx-build
* User should not read tox.ini in order to understand how to use it,
  so use html as default output format.
* Kept same output dir for html just in case.