### PR TITLE
Add task to kill open Redshift sessions

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -311,7 +311,7 @@ class KillOpenRedshiftSessions(luigi.Task):
     """
     An task for killing any open Redshift sessions
     in a given database. This is necessary to prevent open user sessions
-    with transactions against the table from blocking drop or truncate 
+    with transactions against the table from blocking drop or truncate
     table commands.
 
     Usage:


### PR DESCRIPTION
Open user Redshift sessions can prevent truncate or drop operations from completing. This task kills any open Redshift tasks (except the current one) and handles any perturbation in connectivity following the operation.