### PR TITLE
Remove the temporary README.rst

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,9 @@ commands =
     # build HTML docs
     sphinx-build -W -b html -d {envtmpdir}/doctrees doc doc/_build/html
 
+    # remove temporary README.rst
+    rm doc/README.rst
+
 whitelist_externals =
     cp
     sed


### PR DESCRIPTION
During docs generation we copy README.rst to doc/ and clean it up
a bit. Lets delete afterwards.