### PR TITLE
Don't be oververbose in send_email()

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -121,14 +121,6 @@ def send_email(subject, message, sender, recipients, image_png=None):
     config = configuration.get_config()
 
     subject = _prefix(subject)
-    logger.debug("Emailing:\n"
-                 "-------------\n"
-                 "To: %s\n"
-                 "From: %s\n"
-                 "Subject: %s\n"
-                 "Message:\n"
-                 "%s\n"
-                 "-------------", recipients, sender, subject, message)
     if not recipients or recipients == (None,):
         return
     if (sys.stdout.isatty() or DEBUG) and (not config.getboolean('email', 'force-send', False)):


### PR DESCRIPTION
    ERROR: [pid 20172] Worker Worker(salt=640365789, workers=1, host=myhost.spotify.com, username=arash, pid=20172) failed    AppleIAPDailyCohortsLuigiQa(test=False)
    Traceback (most recent call last):
      File "/usr/lib/python2.6/dist-packages/luigi/worker.py", line 87, in run
        task_gen = self.task.run()
      File "/tmp/tmp9vkWs9/python/imported_luigi_tasks/in_app_purchases.py", line 123, in run
        raise Exception()
    Exception
    INFO: Sending warning email to 'dataex-squad+notifications@spotify.com'
    DEBUG: Emailing:
    -------------
    To: ('myhost@spotify.com',)
    From: luigi-client@myhost.spotify.com
    Subject: Luigi: MyTask() FAILED
    Message:
    Runtime error:
    Traceback (most recent call last):
      File "/usr/lib/python2.6/dist-packages/luigi/worker.py", line 87, in run
        task_gen = self.task.run()
      File "/tmp/tmp9vkWs9/python/imported_luigi_tasks/in_app_purchases.py", line 123, in run
        raise Exception()
    Exception
    
    -------------

This is TOTALLY superflous information. Instead, I think we can just keep the
INFO line. The DEBUG line isn't useful even when debugging, because all of the
information is trivially retrieved anyway. Here's what I propose:


    ERROR: [pid 20172] Worker Worker(salt=640365789, workers=1, host=myhost.spotify.com, username=arash, pid=20172) failed    AppleIAPDailyCohortsLuigiQa(test=False)
    Traceback (most recent call last):
      File "/usr/lib/python2.6/dist-packages/luigi/worker.py", line 87, in run
        task_gen = self.task.run()
      File "/tmp/tmp9vkWs9/python/imported_luigi_tasks/in_app_purchases.py", line 123, in run
        raise Exception()
    Exception
    INFO: Sending warning email to 'dataex-squad+notifications@spotify.com'

This should be easier to read.