### PR TITLE
Remove hdp from tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   matrix:
     - TOX_ENV=pep8
     - TOX_ENV=cdh
-    - TOX_ENV=hdp
     - TOX_ENV=nonhdfs
     - TOX_ENV=docs
 


### PR DESCRIPTION
Hadoop builds are super slow and Travis doesn't fully parallelize the builds. This should cut down build times by a third at least. CDH and HDP should be almost entirely correlated (in fact we don't have a single check in the code for it)