### PR TITLE
Sets task counts properly when not visible

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -228,7 +228,7 @@ function visualiserApp(luigi) {
             groupCount = 0;
 
             // update each task family
-            taskFamilies = $(taskGroups[i]).find('.taskFamily:visible');
+            taskFamilies = $(taskGroups[i]).find('.taskFamily');
             for (j=0; j<taskFamilies.length; j++) {
                 cnt = $(taskFamilies[j]).find('.taskRow:not(.hidden)').length;
                 groupCount += cnt;


### PR DESCRIPTION
This fixes a bug in which loading a dependency graph or visualiser page would
lead to all counts being zero. The count updates were being unnecessarily
limited to only visible groups, so this lifts that restriction. Count update
correctness is maintained because the lines computing the counts are not
affected.