### PR TITLE
Add @attr('sqlalchemy') to sqlalchemy tests

### DIFF
--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -28,6 +28,7 @@ import luigi
 import sqlalchemy
 from luigi.contrib import sqla
 from luigi.mock import MockFile
+from nose.plugins.attrib import attr
 
 #################################
 # Globals part of the test case #
@@ -63,6 +64,7 @@ class SQLATask(sqla.CopyToTable):
         return BaseTask()
 
 
+@attr('sqlalchemy')
 class TestSQLA(unittest.TestCase):
     NUM_WORKERS = 1
 
@@ -364,6 +366,7 @@ class TestSQLA(unittest.TestCase):
         self._check_entries(self.engine)
 
 
+@attr('sqlalchemy')
 class TestSQLA2(TestSQLA):
     """ 2 workers version
     """


### PR DESCRIPTION
In case you want to filter away tests that rely on sqlalchemy being
installed.

I get something like this currently:

    Traceback (most recent call last):
      File "/usr/lib/python2.6/unittest.py", line 279, in run
        testMethod()
      File "/«PKGBUILDDIR»/test/contrib/sqla_test.py", line 249, in test_row_overload
        self._check_entries(self.engine)
      File "/«PKGBUILDDIR»/test/contrib/sqla_test.py", line 130, in _check_entries
        with engine.begin() as conn:
    AttributeError: 'Engine' object has no attribute 'begin'