### PR TITLE
Renames inverse_dependencies to inverse_dep_graph to match the api call

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -809,7 +809,7 @@ class CentralPlannerScheduler(Scheduler):
                 worker['running'] = tasks
         return workers
 
-    def inverse_dependencies(self, task_id, **kwargs):
+    def inverse_dep_graph(self, task_id, **kwargs):
         self.prune()
         serialized = {}
         if self._state.has_task(task_id):

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -354,7 +354,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
                 return [Z(1), Z(2)]
 
         self._build([ZZ()])
-        dep_graph = self._remote().inverse_dependencies('X()')
+        dep_graph = self._remote().inverse_dep_graph('X()')
 
         def assert_has_deps(task_id, deps):
             self.assertTrue(task_id in dep_graph, '%s not in dep_graph %s' % (task_id, dep_graph))


### PR DESCRIPTION
This api call was broken by the recent rpc refactoring.