### PR TITLE
fix failure when ftp._rm_recursive() is called on a file

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -93,8 +93,17 @@ class RemoteFileSystem(luigi.target.FileSystem):
         """
         wd = ftp.pwd()
 
+        # check if it is a file first, because some FTP servers don't return
+        # correctly on ftp.nlst(file)
         try:
-            names = ftp.nlst(path)
+            ftp.cwd(path)
+        except ftplib.all_errors:
+            # this is a file, we will just delete the file
+            ftp.delete(path)
+            return
+
+        try:
+            names = ftp.nlst()
         except ftplib.all_errors as e:
             # some FTP servers complain when you try and list non-existent paths
             return


### PR DESCRIPTION
Let's say if the ftp folder is like this:
```
- dirA
  |- fileB
```

`_rm_recursive()` fails on `/dirA/fileB` because `ftplib.nlst("/dirA/fileB")` returns "/dirA/fileB/fileB" in our environment.

It is a problem because `ftp._rm_recursive()` is called in `ftp.RemoteTarget().remove()`