### PR TITLE
Mkae python-daemon a core requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'pyparsing',
     'tornado',
     'snakebite>=2.5.0',
+    'python-daemon',
 ]
 
 if sys.version_info[:2] < (2, 7):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,5 +4,4 @@ nose
 psycopg2
 boto
 sqlalchemy
-python-daemon
 ipdb


### PR DESCRIPTION
Previously, it was only required to run the tests. Though given that
luigi is useless without it, I move it as a requirement for the whole
package (like it it in debian).