### PR TITLE
Text formatter

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -223,8 +223,8 @@ class Chain(Format):
         self.args = args
 
     def pipe_reader(self, input_pipe):
-        for x in self.args:
-            input_pipe = x.pipereader(input_pipe)
+        for x in reversed(self.args):
+            input_pipe = x.pipe_reader(input_pipe)
         return input_pipe
 
     def pipe_writer(self, output_pipe):

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -167,7 +167,7 @@ class FileTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.copy))
 
     def test_text(self):
-        t = File(self.path, luigi.format.Text(encoding='utf8'))
+        t = File(self.path, luigi.format.UTF8)
         a = u'我éçф'
         with t.open('wb') as f:
             f.write(a)
@@ -176,11 +176,8 @@ class FileTest(unittest.TestCase):
         self.assertEqual(a, b)
 
     def test_format_chain(self):
-        chain = luigi.format.Chain(
-            luigi.format.Text(encoding='utf8', newline='\r\n'),
-            luigi.format.Gzip,
-        )
-        t = File(self.path, chain)
+        UTF8WIN = luigi.format.TextWrapper(encoding='utf8', newline='\r\n')
+        t = File(self.path, UTF8WIN >> luigi.format.Gzip)
         a = u'我é\nçф'
 
         with t.open('wb') as f:
@@ -192,11 +189,7 @@ class FileTest(unittest.TestCase):
         self.assertEqual(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84', b)
 
     def test_format_chain_reverse(self):
-        chain = luigi.format.Chain(
-            luigi.format.Text(encoding='utf8'),
-            luigi.format.Gzip,
-        )
-        t = File(self.path, chain)
+        t = File(self.path, luigi.format.UTF8 >> luigi.format.Gzip)
 
         with gzip.open(self.path, 'wb') as f:
             f.write(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84')

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -166,16 +166,45 @@ class FileTest(unittest.TestCase):
         self.assertFalse(os.path.exists(self.path))
         self.assertTrue(os.path.exists(self.copy))
 
-    @mock.patch("locale.getpreferredencoding", return_value="utf8")
-    def test_unicode(self, mock_encoding):
-        t = File(self.path)
+    def test_text(self):
+        t = File(self.path, luigi.format.Text(encoding='utf8'))
         a = u'我éçф'
-        f = t.open('wt')
-        f.write(a)
-        f.close()
-        f = t.open('rt')
-        b = f.read()
+        with t.open('wb') as f:
+            f.write(a)
+        with t.open('rb') as f:
+            b = f.read()
         self.assertEqual(a, b)
+
+    def test_format_chain(self):
+        chain = luigi.format.Chain(
+            luigi.format.Text(encoding='utf8', newline='\r\n'),
+            luigi.format.Gzip,
+        )
+        t = File(self.path, chain)
+        a = u'我é\nçф'
+
+        with t.open('wb') as f:
+            f.write(a)
+
+        with gzip.open(self.path, 'rb') as f:
+            b = f.read()
+
+        self.assertEqual(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84', b)
+
+    def test_format_chain_reverse(self):
+        chain = luigi.format.Chain(
+            luigi.format.Text(encoding='utf8'),
+            luigi.format.Gzip,
+        )
+        t = File(self.path, chain)
+
+        with gzip.open(self.path, 'wb') as f:
+            f.write(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84')
+
+        with t.open('rb') as f:
+            b = f.read()
+
+        self.assertEqual(u'我é\nçф', b)
 
 
 class FileCreateDirectoriesTest(FileTest):


### PR DESCRIPTION
This PR create two new formaters for targets:
  - A text formater for to write text with different encoding and newline
  - A Chain formater that combine other formatter

usage example (create file target writting utf8 with windows newline in a gzip file)
```python
chain = luigi.format.Chain(
    luigi.format.Text(encoding='utf8', newline='\r\n'),
    luigi.format.Gzip,
)
t = File(text.gz, chain)
```

If this get accepted I would remove the text mode that I added to the file target.