### PR TITLE
Text format

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -257,7 +257,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
             self._fs.get(self.path, self.__tmp_path)
 
             return self.format.pipe_reader(
-                FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
+                FileWrapper(io.BufferedReader(io.FileIO(self.__tmp_path, 'r')))
             )
         else:
             raise Exception('mode must be r/w')

--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -36,7 +36,6 @@ import luigi.file
 import luigi.format
 import luigi.target
 from luigi.format import FileWrapper
-from luigi import six
 
 
 class RemoteFileSystem(luigi.target.FileSystem):
@@ -189,7 +188,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
         os.rename(tmp_local_path, local_path)
 
 
-class AbstractAtomicFtpFile(object):
+class AtomicFtpFile(luigi.target.AtomicLocalFile):
     """
     Simple class that writes to a temp file and upload to ftp on close().
 
@@ -203,54 +202,15 @@ class AbstractAtomicFtpFile(object):
         :param path:
         :type path: str
         """
-        self.__tmp_path = '%s-luigi-tmp-%09d' % (path, random.randrange(0, 1e10))
         self._fs = fs
-        self.path = path
-        init_args = self.get_init_args(self.__tmp_path)
-        super(AbstractAtomicFtpFile, self).__init__(*init_args)
+        super(AtomicFtpFile, self).__init__(path)
 
-    def get_init_args(self, path):
-        return (io.FileIO(path, 'w'),)
-
-    def close(self):
-        # close and upload file to ftp
-        super(AbstractAtomicFtpFile, self).close()
-        self._fs.put(self.__tmp_path, self.path)
-        os.remove(self.__tmp_path)
-
-    def __del__(self):
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    @property
-    def tmp_path(self):
-        return self.__tmp_path
+    def move_to_final_destination(self):
+        self._fs.put(self.tmp_path, self.path)
 
     @property
     def fs(self):
         return self._fs
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception
-        Upload file to ftp
-        """
-        if exc_type:
-            return
-        return file.__exit__(self, exc_type, exc, traceback)
-
-
-class AtomicFtpTextFile(AbstractAtomicFtpFile, io.TextIOWrapper):
-    pass
-
-
-class AtomicFtpBinaryFile(AbstractAtomicFtpFile, io.BufferedWriter):
-    pass
-
-if six.PY2:
-    class AtomicFtpfile(AbstractAtomicFtpFile, file):
-        def get_init_args(self, path):
-            return (path, 'w')
 
 
 class RemoteTarget(luigi.target.FileSystemTarget):
@@ -260,7 +220,12 @@ class RemoteTarget(luigi.target.FileSystemTarget):
     The target is implemented using ssh commands streaming data over the network.
     """
 
-    def __init__(self, path, host, format=None, username=None, password=None, port=21, mtime=None, tls=False):
+    def __init__(
+        self, path, host, format=None, username=None,
+        password=None, port=21, mtime=None, tls=False
+    ):
+        if format is None:
+            format = luigi.format.get_default_format()
         self.path = path
         self.mtime = mtime
         self.format = format
@@ -283,37 +248,17 @@ class RemoteTarget(luigi.target.FileSystemTarget):
                      additional options.
         :type mode: str
         """
-        char_mode = luigi.target.get_char_mode(mode)
-        if 'w' in mode:
+        if mode == 'w':
+            return self.format.pipe_writer(AtomicFtpFile(self._fs, self.path))
 
-            if char_mode == 'b':
-                atomic_type = AtomicFtpBinaryFile
-            elif char_mode == 't':
-                atomic_type = AtomicFtpTextFile
-            else:
-                atomic_type = AtomicFtpfile
-
-            if self.format:
-                return self.format.pipe_writer(atomic_type(self._fs, self.path))
-            else:
-                return atomic_type(self._fs, self.path)
-
-        elif 'r' in mode:
+        elif mode == 'r':
             self.__tmp_path = self.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
             # download file to local
             self._fs.get(self.path, self.__tmp_path)
 
-            # manage tmp file
-            if char_mode == 't':
-                fileobj = FileWrapper(io.TextIOWrapper(io.FileIO(self.path, 'r')))
-            elif char_mode == 'b':
-                fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
-            else:
-                fileobj = FileWrapper(open(self.path, 'r'))
-
-            if self.format:
-                return self.format.pipe_reader(fileobj)
-            return fileobj
+            return self.format.pipe_reader(
+                FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
+            )
         else:
             raise Exception('mode must be r/w')
 

--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -230,6 +230,8 @@ class RemoteTarget(luigi.target.FileSystemTarget):
 
     def __init__(self, path, host, format=None, username=None, key_file=None):
         super(RemoteTarget, self).__init__(path)
+        if format is None:
+            format = luigi.format.get_default_format()
         self.format = format
         self._fs = RemoteFileSystem(host, username, key_file)
 

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -23,14 +23,12 @@ from __future__ import absolute_import
 
 import logging
 import os
-import random
-import tempfile
-import io
 
 from luigi import six
 
 from luigi import configuration
-from luigi.target import FileSystemTarget, get_char_mode
+from luigi.target import FileSystemTarget, AtomicLocalFile
+from luigi.format import get_default_format
 
 logger = logging.getLogger("luigi-interface")
 
@@ -44,47 +42,42 @@ except ImportError:
 class WebHdfsTarget(FileSystemTarget):
     fs = None
 
-    def __init__(self, path, client=None):
+    def __init__(self, path, client=None, format=None):
         super(WebHdfsTarget, self).__init__(path)
         path = self.path
         self.fs = client or WebHdfsClient()
+        if format is None:
+            format = get_default_format()
+        self.format = format
 
     def open(self, mode='r'):
-        if 'r' not in mode and 'w' not in mode:
+        if mode not in ('r', 'w'):
             raise ValueError("Unsupported open mode '%s'" % mode)
 
-        char_mode = get_char_mode(mode)
+        if mode == 'r':
+            return self.format.pipe_reader(
+                ReadableWebHdfsFile(path=self.path, client=self.fs)
+            )
 
-        if 'r' in mode:
-            return ReadableWebHdfsFile(path=self.path, client=self.fs, char_mode=char_mode)
-
-        if char_mode == 't':
-            atomic_type = AtomicWebHdfsFile
-        else:
-            atomic_type = AtomicBinaryWebHdfsFile
-
-        return atomic_type(path=self.path, client=self.fs)
+        return self.format.pipe_writer(
+            AtomicWebHdfsFile(path=self.path, client=self.fs)
+        )
 
 
 class ReadableWebHdfsFile(object):
 
-    def __init__(self, path, client, char_mode):
+    def __init__(self, path, client):
         self.path = path
         self.client = client
         self.generator = None
-        self.char_mode = char_mode
 
     def read(self):
         self.generator = self.client.read(self.path)
         res = list(self.generator)[0]
-        if 't' in self.char_mode:
-            return res.decode('utf8')
         return res
 
     def readlines(self, char='\n'):
         self.generator = self.client.read(self.path, buffer_char=char)
-        if 't' in self.char_mode:
-            return (x.decode('utf8') for x in self.generator)
         return self.generator
 
     def __enter__(self):
@@ -108,48 +101,18 @@ class ReadableWebHdfsFile(object):
         self.generator.close()
 
 
-class AbstractAtomicWebHdfsFile(object):
+class AtomicWebHdfsFile(AtomicLocalFile):
     """
     An Hdfs file that writes to a temp file and put to WebHdfs on close.
     """
 
     def __init__(self, path, client):
-        unique_name = 'luigi-webhdfs-tmp-%09d' % random.randrange(0, 1e10)
-        self.tmp_path = os.path.join(tempfile.gettempdir(), unique_name)
-        self.path = path
         self.client = client
-        super(AbstractAtomicWebHdfsFile, self).__init__(io.FileIO(self.tmp_path, 'w'))
+        super(AtomicWebHdfsFile, self).__init__(path)
 
-    def close(self):
-        super(AtomicWebHdfsFile, self).close()
+    def move_to_final_destination(self):
         if not self.client.exists(self.path):
             self.client.upload(self.path, self.tmp_path)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception.
-        """
-        if exc_type:
-            return
-        return super(AtomicWebHdfsFile, self).__exit__(exc_type, exc, traceback)
-
-    def __del__(self):
-        """
-        Remove the temporary directory.
-        """
-        if os.path.exists(self.tmp_path):
-            os.remove(self.tmp_path)
-
-
-class AtomicBinaryWebHdfsFile(AbstractAtomicWebHdfsFile, io.BufferedWriter):
-    pass
-
-
-class AtomicWebHdfsFile(AbstractAtomicWebHdfsFile, io.TextIOWrapper):
-    pass
 
 
 class WebHdfsClient(object):

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -21,64 +21,21 @@ import shutil
 import tempfile
 import io
 
-from luigi import six
-
 import luigi.util
-from luigi.format import FileWrapper
-from luigi.target import FileSystem, FileSystemTarget, get_char_mode
+from luigi.format import FileWrapper, get_default_format
+from luigi.target import FileSystem, FileSystemTarget, AtomicLocalFile
 
 
-if six.PY3:
-    unicode = str
+class atomic_file(AtomicLocalFile):
+    """Simple class that writes to a temp file and moves it on close
+    Also cleans up the temp file if close is not invoked
+    """
 
+    def move_to_final_destination(self):
+        os.rename(self.tmp_path, self.path)
 
-class abstract_atomic_file(object):
-    # Simple class that writes to a temp file and moves it on close()
-    # Also cleans up the temp file if close is not invoked
-    # This is an abstract class see atomic_file for text file,
-    # atomic_binary_file for binary file
-
-    def __init__(self, path):
-        self.__tmp_path = path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
-        self.path = path
-        init_args = self.get_init_args(self.__tmp_path)
-        super(abstract_atomic_file, self).__init__(*init_args)
-
-    def get_init_args(self, path):
-        return (io.FileIO(path, 'w'),)
-
-    def close(self):
-        super(abstract_atomic_file, self).close()
-        os.rename(self.__tmp_path, self.path)
-
-    def __del__(self):
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    @property
-    def tmp_path(self):
-        return self.__tmp_path
-
-    def __exit__(self, exc_type, exc, traceback):
-        " Close/commit the file if there are no exception "
-        if exc_type:
-            return
-        return super(abstract_atomic_file, self).__exit__(exc_type, exc, traceback)
-
-
-class atomic_binary_file(abstract_atomic_file, io.BufferedWriter):
-    pass
-
-
-class atomic_text_file(abstract_atomic_file, io.TextIOWrapper):
-    pass
-
-
-if six.PY2:
-    class atomic_file(abstract_atomic_file, file):
-        # for compatibility (bytes file with universal newline)
-        def get_init_args(self, path):
-            return (path, 'w')
+    def generate_tmp_path(self, path):
+        return path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
 
 
 class LocalFileSystem(FileSystem):
@@ -108,6 +65,8 @@ class File(FileSystemTarget):
     fs = LocalFileSystem()
 
     def __init__(self, path=None, format=None, is_tmp=False):
+        if format is None:
+            format = get_default_format()
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')
@@ -126,34 +85,14 @@ class File(FileSystemTarget):
             os.makedirs(parentfolder)
 
     def open(self, mode='r'):
-        char_mode = get_char_mode(mode)
-        if 'w' in mode:
+        if mode == 'w':
             self.makedirs()
+            return self.format.pipe_writer(atomic_file(self.path))
 
-            if char_mode == 'b':
-                atomic_type = atomic_binary_file
-            elif char_mode == 't':
-                atomic_type = atomic_text_file
-            else:
-                atomic_type = atomic_file
+        elif mode == 'r':
+            fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
+            return self.format.pipe_reader(fileobj)
 
-            if self.format:
-                return self.format.pipe_writer(atomic_type(self.path))
-            else:
-                return atomic_type(self.path)
-
-        elif 'r' in mode:
-            if char_mode == 't':
-                fileobj = FileWrapper(io.TextIOWrapper(io.FileIO(self.path, 'r')))
-            elif char_mode == 'b':
-                fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
-            else:
-                fileobj = FileWrapper(open(self.path, 'r'))
-
-            if self.format:
-                return self.format.pipe_reader(fileobj)
-
-            return fileobj
         else:
             raise Exception('mode must be r/w')
 

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -20,7 +20,6 @@ import subprocess
 import io
 import os
 import re
-import locale
 import tempfile
 
 from luigi import six
@@ -307,22 +306,6 @@ class NewlineWrapper(BaseWrapper):
         self._stream.write(re.sub(b'(\n|\r\n|\r)', newline, b))
 
 
-class MixedUnicodeBytesWrapper(BaseWrapper):
-    """
-    """
-
-    def write(self, b):
-        if isinstance(b, unicode):
-            b = b.encode(locale.getpreferredencoding())
-        self._stream.write(b)
-
-    def writelines(self, lines):
-        for x in range(len(lines)):
-            if isinstance(lines[x]):
-                lines[x] = lines[x].encode(locale.getpreferredencoding())
-        self._stream.writelines(lines)
-
-
 class Format(object):
     """
     Interface for format specifications.
@@ -457,8 +440,6 @@ Text = TextFormat()
 UTF8 = TextFormat(encoding='utf8')
 Nop = NopFormat()
 SysNewLine = WrappedFormat(NewlineWrapper)
-#: format to reproduce the default behavior of python2 (accept both unicode and bytes)
-MixedUnicodeBytes = WrappedFormat(MixedUnicodeBytesWrapper)
 Gzip = GzipFormat()
 Bzip2 = Bzip2Format()
 
@@ -467,6 +448,6 @@ def get_default_format():
     if six.PY3:
         return Text
     elif os.linesep == '\n':
-        return MixedUnicodeBytes
+        return Nop
     else:
-        return MixedUnicodeBytes >> SysNewLine
+        return SysNewLine

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -18,6 +18,14 @@
 import signal
 import subprocess
 import io
+import os
+import re
+import locale
+
+from luigi import six
+
+if six.PY3:
+    unicode = str
 
 
 class FileWrapper(object):
@@ -211,6 +219,86 @@ class OutputPipeProcessWrapper(object):
         return False
 
 
+class BaseWrapper(object):
+
+    def __init__(self, stream, *args, **kwargs):
+        self._stream = stream
+        try:
+            super(BaseWrapper, self).__init__(stream, *args, **kwargs)
+        except TypeError:
+            pass
+
+    def __getattr__(self, name):
+        if name == '_stream':
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+    def __enter__(self):
+        self._stream.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self._stream.__exit__(*args)
+
+
+class NewlineWrapper(BaseWrapper):
+
+    def __init__(self, stream, newline=None):
+        if newline is None:
+            self.newline = newline
+        else:
+            self.newline = newline.encode('ascii')
+
+        if self.newline not in (b'', b'\r\n', b'\n', b'\r', None):
+            raise ValueError("newline need to be one of {b'', b'\r\n', b'\n', b'\r', None}")
+        super(NewlineWrapper, self).__init__(stream)
+
+    def read(self, n=-1):
+        b = self._stream.read(n)
+
+        if self.newline == b'':
+            return b
+
+        if self.newline is None:
+            newline = b'\n'
+
+        return re.sub(b'(\n|\r\n|\r)', newline, b)
+
+    def writelines(self, lines):
+        if self.newline is None or self.newline == '':
+            newline = os.linesep.encode('ascii')
+        else:
+            newline = self.newline
+
+        self._stream.writelines(
+            [re.sub(b'(\n|\r\n|\r)', newline, line) for line in lines]
+        )
+
+    def write(self, b):
+        if self.newline is None or self.newline == '':
+            newline = os.linesep.encode('ascii')
+        else:
+            newline = self.newline
+
+        self._stream.write(re.sub(b'(\n|\r\n|\r)', newline, b))
+
+
+class MixedUnicodeBytesWrapper(BaseWrapper):
+    """
+    """
+
+    def write(self, b):
+        if isinstance(b, unicode):
+            b = b.encode(locale.getpreferredencoding())
+        self._stream.write(b)
+
+    def writelines(self, lines):
+        for x in range(len(lines)):
+            if isinstance(lines[x]):
+                lines[x] = lines[x].encode(locale.getpreferredencoding())
+        self._stream.writelines(lines)
+
+
 class Format(object):
     """
     Interface for format specifications.
@@ -235,10 +323,10 @@ class Format(object):
         raise NotImplementedError()
 
     def __rshift__(a, b):
-        return Chain(a, b)
+        return ChainFormat(a, b)
 
 
-class Chain(Format):
+class ChainFormat(Format):
 
     def __init__(self, *args):
         self.args = args
@@ -254,20 +342,55 @@ class Chain(Format):
         return output_pipe
 
 
-class TextWrapper(Format):
+class TextWrapper(BaseWrapper, io.TextIOWrapper):
 
-    def __init__(self, *args, **kwargs):
+    def __exit__(self, *args):
+        # io.TextIOWrapper close the file on __exit__, let the underlying file decide
+        if not self.closed:
+            super(TextWrapper, self).flush()
+
+        self._stream.__exit__(*args)
+
+    def __del__(self, *args):
+        # io.TextIOWrapper close the file on __del__, let the underlying file decide
+        if not self.closed:
+            super(TextWrapper, self).flush()
+
+        try:
+            self._stream.__del__(*args)
+        except AttributeError:
+            pass
+
+
+class NopFormat(Format):
+    def pipe_reader(self, input_pipe):
+        return input_pipe
+
+    def pipe_writer(self, output_pipe):
+        return output_pipe
+
+
+class WrappedFormat(Format):
+
+    def __init__(self, wrapper_cls, *args, **kwargs):
+        self.wrapper_cls = wrapper_cls
         self.args = args
         self.kwargs = kwargs
 
     def pipe_reader(self, input_pipe):
-        return io.TextIOWrapper(input_pipe, *self.args, **self.kwargs)
+        return self.wrapper_cls(input_pipe, *self.args, **self.kwargs)
 
     def pipe_writer(self, output_pipe):
-        return io.TextIOWrapper(output_pipe, *self.args, **self.kwargs)
+        return self.wrapper_cls(output_pipe, *self.args, **self.kwargs)
 
 
-class GzipWrapper(Format):
+class TextFormat(WrappedFormat):
+
+    def __init__(self, *args, **kwargs):
+        super(TextFormat, self).__init__(TextWrapper, *args, **kwargs)
+
+
+class GzipFormat(Format):
 
     def __init__(self, compression_level=None):
         self.compression_level = compression_level
@@ -282,7 +405,7 @@ class GzipWrapper(Format):
         return OutputPipeProcessWrapper(args, output_pipe)
 
 
-class Bzip2Wrapper(Format):
+class Bzip2Format(Format):
 
     def pipe_reader(self, input_pipe):
         return InputPipeProcessWrapper(['bzcat'], input_pipe)
@@ -290,7 +413,20 @@ class Bzip2Wrapper(Format):
     def pipe_writer(self, output_pipe):
         return OutputPipeProcessWrapper(['bzip2'], output_pipe)
 
-Text = TextWrapper()
-UTF8 = TextWrapper(encoding='utf8')
-Gzip = GzipWrapper()
-Bzip2 = Bzip2Wrapper()
+Text = TextFormat()
+UTF8 = TextFormat(encoding='utf8')
+Nop = NopFormat()
+SysNewLine = WrappedFormat(NewlineWrapper)
+#: format to reproduce the default behavior of python2 (accept both unicode and bytes)
+MixedUnicodeBytes = WrappedFormat(MixedUnicodeBytesWrapper)
+Gzip = GzipFormat()
+Bzip2 = Bzip2Format()
+
+
+def get_default_format():
+    if six.PY3:
+        return Text
+    elif os.linesep == '\n':
+        return MixedUnicodeBytes
+    else:
+        return MixedUnicodeBytes >> SysNewLine

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -21,6 +21,7 @@ import io
 import os
 import re
 import locale
+import tempfile
 
 from luigi import six
 
@@ -65,7 +66,23 @@ class InputPipeProcessWrapper(object):
                         Alternatively, just its args argument as a convenience.
         """
         self._command = command
+
         self._input_pipe = input_pipe
+        self._original_input = True
+
+        if input_pipe is not None:
+            try:
+                input_pipe.fileno()
+            except AttributeError:
+                # subprocess require a fileno to work, if not reprsent we copy to disk first
+                self._original_input = False
+                f = tempfile.NamedTemporaryFile('wb', prefix='luigi-process_tmp', delete=False)
+                self._tmp_file = f.name
+                f.write(input_pipe.read())
+                input_pipe.close()
+                f.close()
+                self._input_pipe = FileWrapper(io.BufferedReader(io.FileIO(self._tmp_file, 'r')))
+
         self._process = command if isinstance(command, subprocess.Popen) else self.create_subprocess(command)
         # we want to keep a circular reference to avoid garbage collection
         # when the object is used in, e.g., pipe.read()
@@ -90,6 +107,8 @@ class InputPipeProcessWrapper(object):
     def _finish(self):
         # Need to close this before input_pipe to get all SIGPIPE messages correctly
         self._process.stdout.close()
+        if not self._original_input and os.path.exists(self._tmp_file):
+            os.remove(self._tmp_file)
 
         if self._input_pipe is not None:
             self._input_pipe.close()
@@ -239,6 +258,11 @@ class BaseWrapper(object):
 
     def __exit__(self, *args):
         self._stream.__exit__(*args)
+
+    def __iter__(self):
+        for line in self._stream:
+            yield line
+        self.close()
 
 
 class NewlineWrapper(BaseWrapper):

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -366,7 +366,7 @@ class ChainFormat(Format):
         return output_pipe
 
 
-class TextWrapper(BaseWrapper, io.TextIOWrapper):
+class TextWrapper(io.TextIOWrapper):
 
     def __exit__(self, *args):
         # io.TextIOWrapper close the file on __exit__, let the underlying file decide
@@ -384,6 +384,22 @@ class TextWrapper(BaseWrapper, io.TextIOWrapper):
             self._stream.__del__(*args)
         except AttributeError:
             pass
+
+    def __init__(self, stream, *args, **kwargs):
+        self._stream = stream
+        try:
+            super(TextWrapper, self).__init__(stream, *args, **kwargs)
+        except TypeError:
+            pass
+
+    def __getattr__(self, name):
+        if name == '_stream':
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+    def __enter__(self):
+        self._stream.__enter__()
+        return self
 
 
 class NopFormat(Format):

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -16,17 +16,13 @@
 #
 
 import multiprocessing
-import os
 from io import BytesIO
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-import sys
 
+import sys
 
 import luigi.util
 from luigi import target
+from luigi.format import get_default_format
 
 
 class MockFileSystem(target.FileSystem):
@@ -81,9 +77,12 @@ class MockFileSystem(target.FileSystem):
 class MockFile(target.FileSystemTarget):
     fs = MockFileSystem()
 
-    def __init__(self, fn, is_tmp=None, mirror_on_stderr=False):
+    def __init__(self, fn, is_tmp=None, mirror_on_stderr=False, format=None):
         self._mirror_on_stderr = mirror_on_stderr
         self._fn = fn
+        if format is None:
+            format = get_default_format()
+        self.format = format
 
     def exists(self,):
         return self._fn in self.fs.get_all_data()
@@ -102,10 +101,13 @@ class MockFile(target.FileSystemTarget):
     def open(self, mode):
         fn = self._fn
 
-        class StringBuffer(StringIO):
+        class Buffer(BytesIO):
             # Just to be able to do writing + reading from the same buffer
 
             _write_line = True
+
+            def set_wrapper(self, wrapper):
+                self.wrapper = wrapper
 
             def write(self2, data):
                 if self._mirror_on_stderr:
@@ -116,12 +118,16 @@ class MockFile(target.FileSystemTarget):
                         self2._write_line = True
                     else:
                         self2._write_line = False
-                StringIO.write(self2, data)
+                super(Buffer, self2).write(data)
 
             def close(self2):
-                if 'w' in mode:
+                if mode == 'w':
+                    try:
+                        self.wrapper.flush()
+                    except AttributeError:
+                        pass
                     self.fs.get_all_data()[fn] = self2.getvalue()
-                StringIO.close(self2)
+                super(Buffer, self2).close()
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 if not exc_type:
@@ -130,36 +136,9 @@ class MockFile(target.FileSystemTarget):
             def __enter__(self):
                 return self
 
-        class BinaryBuffer(BytesIO):
-            # Just to be able to do writing + reading from the same buffer
-
-            def write(self2, data):
-                if self._mirror_on_stderr:
-                    self2.seek(-1, os.SEEK_END)
-                    if self2.tell() <= 0 or self2.read(1) == '\n':
-                        sys.stderr.write(fn + ": ")
-                    sys.stderr.write(data)
-                BytesIO.write(self2, data)
-
-            def close(self2):
-                if 'w' in mode:
-                    self.fs.get_all_data()[fn] = self2.getvalue()
-                BytesIO.close(self2)
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                if not exc_type:
-                    self.close()
-
-            def __enter__(self):
-                return self
-
-        char_mode = target.get_char_mode(mode)
-        if char_mode == 't':
-            atomic_type = StringBuffer
+        if mode == 'w':
+            wrapper = self.format.pipe_writer(Buffer())
+            wrapper.set_wrapper(wrapper)
+            return wrapper
         else:
-            atomic_type = BinaryBuffer
-
-        if 'w' in mode:
-            return atomic_type()
-        else:
-            return atomic_type(self.fs.get_all_data()[fn])
+            return Buffer(self.fs.get_all_data()[fn])

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -20,6 +20,7 @@ from io import BytesIO
 
 import sys
 
+from luigi import six
 import luigi.util
 from luigi import target
 from luigi.format import get_default_format
@@ -110,10 +111,14 @@ class MockFile(target.FileSystemTarget):
                 self.wrapper = wrapper
 
             def write(self2, data):
+                if six.PY3:
+                    stderrbytes = sys.stderr.buffer
+                else:
+                    stderrbytes = sys.stderr
                 if self._mirror_on_stderr:
                     if self2._write_line:
                         sys.stderr.write(fn + ": ")
-                    sys.stderr.write(data)
+                    stderrbytes.write(data)
                     if (data[-1]) == '\n':
                         self2._write_line = True
                     else:
@@ -133,12 +138,21 @@ class MockFile(target.FileSystemTarget):
                 if not exc_type:
                     self.close()
 
-            def __enter__(self):
-                return self
+            def __enter__(self2):
+                return self2
+
+            def readable(self2):
+                return mode == 'r'
+
+            def writeable(self2):
+                return mode == 'w'
+
+            def seekable(self2):
+                return False
 
         if mode == 'w':
             wrapper = self.format.pipe_writer(Buffer())
             wrapper.set_wrapper(wrapper)
             return wrapper
         else:
-            return Buffer(self.fs.get_all_data()[fn])
+            return self.format.pipe_reader(Buffer(self.fs.get_all_data()[fn]))

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -19,9 +19,7 @@ import itertools
 import logging
 import os
 import os.path
-import random
 import tempfile
-import io
 try:
     from urlparse import urlsplit
 except ImportError:
@@ -35,9 +33,9 @@ except ImportError:
 from luigi import six
 
 from luigi import configuration
-from luigi.format import FileWrapper
+from luigi.format import FileWrapper, get_default_format
 from luigi.parameter import Parameter
-from luigi.target import FileSystem, FileSystemException, FileSystemTarget
+from luigi.target import FileSystem, FileSystemException, FileSystemTarget, AtomicLocalFile
 from luigi.task import ExternalTask
 
 logger = logging.getLogger('luigi-interface')
@@ -335,40 +333,17 @@ class S3Client(FileSystem):
         return key if key[-1:] == '/' else key + '/'
 
 
-class AtomicS3File(io.BufferedWriter):
+class AtomicS3File(AtomicLocalFile):
     """
     An S3 file that writes to a temp file and put to S3 on close.
     """
 
     def __init__(self, path, s3_client):
-        self.__tmp_path = \
-            os.path.join(tempfile.gettempdir(),
-                         'luigi-s3-tmp-%09d' % random.randrange(0, 1e10))
-        self.path = path
         self.s3_client = s3_client
-        super(AtomicS3File, self).__init__(io.FileIO(self.__tmp_path, 'wb'))
+        super(AtomicS3File, self).__init__(path)
 
-    def close(self):
-        """
-        Close the file.
-        """
-        super(AtomicS3File, self).close()
-
-        # store the contents in S3
-        self.s3_client.put_multipart(self.__tmp_path, self.path)
-
-    def __del__(self):
-        # remove the temporary directory
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception.
-        """
-        if exc_type:
-            return
-        return super(AtomicS3File, self).__exit__(exc_type, exc, traceback)
+    def move_to_final_destination(self):
+        self.s3_client.put_multipart(self.tmp_path, self.path)
 
 
 class ReadableS3File(object):
@@ -396,7 +371,7 @@ class ReadableS3File(object):
         self.buffer.append(line)
 
     def _flush_buffer(self):
-        output = ''.join(self.buffer)
+        output = b''.join(self.buffer)
         self.buffer = []
         return output
 
@@ -439,6 +414,8 @@ class S3Target(FileSystemTarget):
 
     def __init__(self, path, format=None, client=None):
         super(S3Target, self).__init__(path)
+        if format is None:
+            format = get_default_format()
         self.format = format
         self.fs = client or S3Client()
 
@@ -450,28 +427,13 @@ class S3Target(FileSystemTarget):
 
         if mode == 'r':
             s3_key = self.fs.get_key(self.path)
-            if s3_key:
-                fileobj = ReadableS3File(s3_key)
-                if self.format:
-                    self._tmp_extract_path = tempfile.mktemp(
-                        prefix='luigi_s3_')
-                    with open(self._tmp_extract_path, 'w') as f:
-                        f.write(fileobj.read())
-                    try:
-                        with open(self._tmp_extract_path) as f:
-                            return self.format.pipe_reader(FileWrapper(f))
-                    finally:
-                        os.remove(self._tmp_extract_path)
-                return fileobj
-            else:
-                raise FileNotFoundException(
-                    "Could not find file at %s" % self.path)
+            if not s3_key:
+                raise FileNotFoundException("Could not find file at %s" % self.path)
+
+            fileobj = ReadableS3File(s3_key)
+            return self.format.pipe_reader(fileobj)
         else:
-            if self.format:
-                return self.format.pipe_writer(
-                    AtomicS3File(self.path, self.fs))
-            else:
-                return AtomicS3File(self.path, self.fs)
+            return self.format.pipe_writer(AtomicS3File(self.path, self.fs))
 
 
 class S3FlagTarget(S3Target):
@@ -507,6 +469,9 @@ class S3FlagTarget(S3Target):
         :param flag:
         :type flag: str
         """
+        if format is None:
+            format = get_default_format()
+
         if path[-1] != "/":
             raise ValueError("S3FlagTarget requires the path to be to a "
                              "directory.  It must end with a slash ( / ).")

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -16,24 +16,14 @@
 #
 
 import abc
+import io
+import os
+import random
+import tempfile
 import logging
 from luigi import six
 
 logger = logging.getLogger('luigi-interface')
-
-
-def get_char_mode(mode):
-    """determine if a target should be open in text or binary mode
-    """
-    if 'b' in mode:
-        return 'b'
-    if 't' in mode:
-        return 't'
-    if six.PY2:
-        # support mixed mode (binary but \n is converted to platform newline)
-        # retrocompatibility with python2 on windows
-        return 'm'
-    return 't'
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -204,3 +194,42 @@ class FileSystemTarget(Target):
         This method is implemented by using :py:meth:`fs`.
         """
         self.fs.remove(self.path)
+
+
+class AtomicLocalFile(io.BufferedWriter):
+    """Abstract class to create Target that create
+    a tempoprary file in the local filesystem before
+    moving it to there final destination
+
+    This class is just for the writing part of the Target. See
+    luigi.file.File for example
+    """
+
+    def __init__(self, path):
+        self.__tmp_path = self.generate_tmp_path(path)
+        self.path = path
+        super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, 'w'))
+
+    def close(self):
+        super(AtomicLocalFile, self).close()
+        self.move_to_final_destination()
+
+    def generate_tmp_path(self, path):
+        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-%09d' % random.randrange(0, 1e10))
+
+    def move_to_final_destination(self):
+        raise NotImplementedError()
+
+    def __del__(self):
+        if os.path.exists(self.tmp_path):
+            os.remove(self.tmp_path)
+
+    @property
+    def tmp_path(self):
+        return self.__tmp_path
+
+    def __exit__(self, exc_type, exc, traceback):
+        " Close/commit the file if there are no exception "
+        if exc_type:
+            return
+        return super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)

--- a/test/_s3_test.py
+++ b/test/_s3_test.py
@@ -168,7 +168,6 @@ class TestS3Target(unittest.TestCase):
             result = f.read()
 
         self.assertEqual(test_data, result)
-        self.assertFalse(os.path.exists(t._tmp_extract_path))
 
 
 class TestS3Client(unittest.TestCase):

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -98,12 +98,12 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch("logging.getLogger")
     def test_cmdline_main_task_cls(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', '--n', '100'], main_task_cls=SomeTask)
-        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_100': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_100': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_other_task(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', 'SomeTask', '--n', '1000'])
-        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_1000': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_1000': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_ambiguous_class(self, logger):

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -310,8 +310,8 @@ class CopyTest(unittest.TestCase):
 
     def test_copy(self):
         luigi.build([PCopy(date=datetime.date(2012, 1, 1))], local_scheduler=True)
-        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), 'hello, world\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2012-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), b'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2012-01-01.txt'), b'hello, world\n')
 
 
 class PickleTest(unittest.TestCase):
@@ -323,8 +323,8 @@ class PickleTest(unittest.TestCase):
         p = pickle.loads(p_pickled)
 
         luigi.build([p], local_scheduler=True)
-        self.assertEqual(MockFile.fs.get_data('/tmp/data-2013-01-01.txt'), 'hello, world\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2013-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2013-01-01.txt'), b'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2013-01-01.txt'), b'hello, world\n')
 
 
 class Subtask(luigi.Task):

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -69,20 +69,20 @@ class FibTest(FibTestBase):
         w.add(Fib(100))
         w.run()
         w.stop()
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_cmdline(self):
         luigi.run(['--local-scheduler', '--no-lock', 'Fib', '--n', '100'])
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_build_internal(self):
         luigi.build([Fib(100)], local_scheduler=True)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
 if __name__ == '__main__':
     luigi.run()

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -94,7 +94,7 @@ class FileTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.path))
 
         # Using gzip module as validation
-        f = gzip.open(self.path, 'rb')
+        f = gzip.open(self.path, 'r')
         self.assertTrue(test_data == f.read())
         f.close()
 
@@ -114,7 +114,7 @@ class FileTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.path))
 
         # Using bzip module as validation
-        f = bz2.BZ2File(self.path, 'rb')
+        f = bz2.BZ2File(self.path, 'r')
         self.assertTrue(test_data == f.read())
         f.close()
 
@@ -169,21 +169,21 @@ class FileTest(unittest.TestCase):
     def test_text(self):
         t = File(self.path, luigi.format.UTF8)
         a = u'我éçф'
-        with t.open('wb') as f:
+        with t.open('w') as f:
             f.write(a)
-        with t.open('rb') as f:
+        with t.open('r') as f:
             b = f.read()
         self.assertEqual(a, b)
 
     def test_format_chain(self):
-        UTF8WIN = luigi.format.TextWrapper(encoding='utf8', newline='\r\n')
+        UTF8WIN = luigi.format.TextFormat(encoding='utf8', newline='\r\n')
         t = File(self.path, UTF8WIN >> luigi.format.Gzip)
         a = u'我é\nçф'
 
-        with t.open('wb') as f:
+        with t.open('w') as f:
             f.write(a)
 
-        with gzip.open(self.path, 'rb') as f:
+        with gzip.open(self.path, 'r') as f:
             b = f.read()
 
         self.assertEqual(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84', b)
@@ -191,13 +191,39 @@ class FileTest(unittest.TestCase):
     def test_format_chain_reverse(self):
         t = File(self.path, luigi.format.UTF8 >> luigi.format.Gzip)
 
-        with gzip.open(self.path, 'wb') as f:
+        with gzip.open(self.path, 'w') as f:
             f.write(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84')
 
-        with t.open('rb') as f:
+        with t.open('r') as f:
             b = f.read()
 
         self.assertEqual(u'我é\nçф', b)
+
+    @mock.patch('os.linesep', '\r\n')
+    def test_format_newline(self):
+        t = File(self.path, luigi.format.SysNewLine)
+
+        with t.open('w') as f:
+            f.write(b'a\rb\nc\r\nd')
+
+        with t.open('r') as f:
+            b = f.read()
+
+        with open(self.path, 'rb') as f:
+            c = f.read()
+
+        self.assertEqual(b'a\nb\nc\nd', b)
+        self.assertEqual(b'a\r\nb\r\nc\r\nd', c)
+
+    def test_del_with_Text(self):
+        t = File(self.path, luigi.format.UTF8)
+        p = t.open('w')
+        print(u'test', file=p)
+        tp = p.tmp_path
+        del p
+
+        self.assertFalse(os.path.exists(tp))
+        self.assertFalse(os.path.exists(self.path))
 
 
 class FileCreateDirectoriesTest(FileTest):

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -183,16 +183,18 @@ class FileTest(unittest.TestCase):
         with t.open('w') as f:
             f.write(a)
 
-        with gzip.open(self.path, 'r') as f:
-            b = f.read()
+        f = gzip.open(self.path, 'r')
+        b = f.read()
+        f.close()
 
         self.assertEqual(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84', b)
 
     def test_format_chain_reverse(self):
         t = File(self.path, luigi.format.UTF8 >> luigi.format.Gzip)
 
-        with gzip.open(self.path, 'w') as f:
-            f.write(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84')
+        f = gzip.open(self.path, 'w')
+        f.write(b'\xe6\x88\x91\xc3\xa9\r\n\xc3\xa7\xd1\x84')
+        f.close()
 
         with t.open('r') as f:
             b = f.read()

--- a/test/optparse_test.py
+++ b/test/optparse_test.py
@@ -25,8 +25,8 @@ class OptParseTest(FibTestBase):
     def test_cmdline_optparse(self):
         luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_cmdline_optparse_existing(self):
         import optparse
@@ -35,5 +35,5 @@ class OptParseTest(FibTestBase):
 
         luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True, existing_optparse=parser)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -47,7 +47,7 @@ class Popularity(luigi.Task):
 class RecursionTest(unittest.TestCase):
 
     def setUp(self):
-        MockFile.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = '0\n'
+        MockFile.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = b'0\n'
 
     def test_invoke(self):
         w = luigi.worker.Worker()
@@ -55,4 +55,4 @@ class RecursionTest(unittest.TestCase):
         w.run()
         w.stop()
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), b'365\n')

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -76,7 +76,7 @@ class TestRedshiftManifestTask(unittest.TestCase):
 
         output = t.output().open('r').read()
         expected_manifest_output = json.dumps(generate_manifest_json(folder_paths, FILES))
-        self.assertEqual(output.decode('utf8'), expected_manifest_output)
+        self.assertEqual(output, expected_manifest_output)
 
     @mock_s3
     def test_run_multiple_paths(self):
@@ -98,4 +98,4 @@ class TestRedshiftManifestTask(unittest.TestCase):
 
         output = t.output().open('r').read()
         expected_manifest_output = json.dumps(generate_manifest_json(folder_paths, FILES))
-        self.assertEqual(output.decode('utf8'), expected_manifest_output)
+        self.assertEqual(output, expected_manifest_output)

--- a/test/wrap_test.py
+++ b/test/wrap_test.py
@@ -93,11 +93,11 @@ class WrapperTest(unittest.TestCase):
 
     def test_a(self):
         luigi.build([AXML()], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile.fs.get_data('/tmp/a.xml'), '<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/a.xml'), b'<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
 
     def test_b(self):
         luigi.build([BXML(datetime.date(2012, 1, 1))], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile.fs.get_data('/tmp/b-2012-01-01.xml'), '<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/b-2012-01-01.xml'), b'<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
 
 
 class WrapperWithMultipleWorkersTest(WrapperTest):


### PR DESCRIPTION
Remove text vs binary mode (`rt` vs `rb`) for the target in favor of Format.

In detail:
  - Remove binary and text mode for target that was introduce by #745 (functionality replaced by Nop and Text format)
  - Add a default format to give expected behavior on py3k and retro compatibility on system not using `\n` as newline (https://github.com/gpoulin/luigi/blob/text_format/luigi/format.py#L447)
  - Create a base AtomicLocalFile to be use by target that first write to the local filesystem before moving to the final destination (https://github.com/gpoulin/luigi/blob/text_format/luigi/target.py#L199)
  - Modify the targets to take advantage of those changes
  - small changes to the tests to compensate for the difference between bytes and string (only affect py3k which is not fully supported yet)