### PR TITLE
Hdfs support for python3

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -36,7 +36,6 @@ import luigi.file
 import luigi.format
 import luigi.target
 from luigi.format import FileWrapper
-from luigi import six
 
 
 class RemoteFileSystem(luigi.target.FileSystem):
@@ -189,7 +188,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
         os.rename(tmp_local_path, local_path)
 
 
-class AbstractAtomicFtpFile(object):
+class AtomicFtpFile(luigi.target.AtomicLocalFile):
     """
     Simple class that writes to a temp file and upload to ftp on close().
 
@@ -203,54 +202,15 @@ class AbstractAtomicFtpFile(object):
         :param path:
         :type path: str
         """
-        self.__tmp_path = '%s-luigi-tmp-%09d' % (path, random.randrange(0, 1e10))
         self._fs = fs
-        self.path = path
-        init_args = self.get_init_args(self.__tmp_path)
-        super(AbstractAtomicFtpFile, self).__init__(*init_args)
+        super(AtomicFtpFile, self).__init__(path)
 
-    def get_init_args(self, path):
-        return (io.FileIO(path, 'w'),)
-
-    def close(self):
-        # close and upload file to ftp
-        super(AbstractAtomicFtpFile, self).close()
-        self._fs.put(self.__tmp_path, self.path)
-        os.remove(self.__tmp_path)
-
-    def __del__(self):
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    @property
-    def tmp_path(self):
-        return self.__tmp_path
+    def move_to_final_destination(self):
+        self._fs.put(self.tmp_path, self.path)
 
     @property
     def fs(self):
         return self._fs
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception
-        Upload file to ftp
-        """
-        if exc_type:
-            return
-        return file.__exit__(self, exc_type, exc, traceback)
-
-
-class AtomicFtpTextFile(AbstractAtomicFtpFile, io.TextIOWrapper):
-    pass
-
-
-class AtomicFtpBinaryFile(AbstractAtomicFtpFile, io.BufferedWriter):
-    pass
-
-if six.PY2:
-    class AtomicFtpfile(AbstractAtomicFtpFile, file):
-        def get_init_args(self, path):
-            return (path, 'w')
 
 
 class RemoteTarget(luigi.target.FileSystemTarget):
@@ -260,7 +220,12 @@ class RemoteTarget(luigi.target.FileSystemTarget):
     The target is implemented using ssh commands streaming data over the network.
     """
 
-    def __init__(self, path, host, format=None, username=None, password=None, port=21, mtime=None, tls=False):
+    def __init__(
+        self, path, host, format=None, username=None,
+        password=None, port=21, mtime=None, tls=False
+    ):
+        if format is None:
+            format = luigi.format.get_default_format()
         self.path = path
         self.mtime = mtime
         self.format = format
@@ -283,37 +248,17 @@ class RemoteTarget(luigi.target.FileSystemTarget):
                      additional options.
         :type mode: str
         """
-        char_mode = luigi.target.get_char_mode(mode)
-        if 'w' in mode:
+        if mode == 'w':
+            return self.format.pipe_writer(AtomicFtpFile(self._fs, self.path))
 
-            if char_mode == 'b':
-                atomic_type = AtomicFtpBinaryFile
-            elif char_mode == 't':
-                atomic_type = AtomicFtpTextFile
-            else:
-                atomic_type = AtomicFtpfile
-
-            if self.format:
-                return self.format.pipe_writer(atomic_type(self._fs, self.path))
-            else:
-                return atomic_type(self._fs, self.path)
-
-        elif 'r' in mode:
+        elif mode == 'r':
             self.__tmp_path = self.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
             # download file to local
             self._fs.get(self.path, self.__tmp_path)
 
-            # manage tmp file
-            if char_mode == 't':
-                fileobj = FileWrapper(io.TextIOWrapper(io.FileIO(self.path, 'r')))
-            elif char_mode == 'b':
-                fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
-            else:
-                fileobj = FileWrapper(open(self.path, 'r'))
-
-            if self.format:
-                return self.format.pipe_reader(fileobj)
-            return fileobj
+            return self.format.pipe_reader(
+                FileWrapper(io.BufferedReader(io.FileIO(self.__tmp_path, 'r')))
+            )
         else:
             raise Exception('mode must be r/w')
 

--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -230,6 +230,8 @@ class RemoteTarget(luigi.target.FileSystemTarget):
 
     def __init__(self, path, host, format=None, username=None, key_file=None):
         super(RemoteTarget, self).__init__(path)
+        if format is None:
+            format = luigi.format.get_default_format()
         self.format = format
         self._fs = RemoteFileSystem(host, username, key_file)
 

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -23,14 +23,12 @@ from __future__ import absolute_import
 
 import logging
 import os
-import random
-import tempfile
-import io
 
 from luigi import six
 
 from luigi import configuration
-from luigi.target import FileSystemTarget, get_char_mode
+from luigi.target import FileSystemTarget, AtomicLocalFile
+from luigi.format import get_default_format
 
 logger = logging.getLogger("luigi-interface")
 
@@ -44,47 +42,42 @@ except ImportError:
 class WebHdfsTarget(FileSystemTarget):
     fs = None
 
-    def __init__(self, path, client=None):
+    def __init__(self, path, client=None, format=None):
         super(WebHdfsTarget, self).__init__(path)
         path = self.path
         self.fs = client or WebHdfsClient()
+        if format is None:
+            format = get_default_format()
+        self.format = format
 
     def open(self, mode='r'):
-        if 'r' not in mode and 'w' not in mode:
+        if mode not in ('r', 'w'):
             raise ValueError("Unsupported open mode '%s'" % mode)
 
-        char_mode = get_char_mode(mode)
+        if mode == 'r':
+            return self.format.pipe_reader(
+                ReadableWebHdfsFile(path=self.path, client=self.fs)
+            )
 
-        if 'r' in mode:
-            return ReadableWebHdfsFile(path=self.path, client=self.fs, char_mode=char_mode)
-
-        if char_mode == 't':
-            atomic_type = AtomicWebHdfsFile
-        else:
-            atomic_type = AtomicBinaryWebHdfsFile
-
-        return atomic_type(path=self.path, client=self.fs)
+        return self.format.pipe_writer(
+            AtomicWebHdfsFile(path=self.path, client=self.fs)
+        )
 
 
 class ReadableWebHdfsFile(object):
 
-    def __init__(self, path, client, char_mode):
+    def __init__(self, path, client):
         self.path = path
         self.client = client
         self.generator = None
-        self.char_mode = char_mode
 
     def read(self):
         self.generator = self.client.read(self.path)
         res = list(self.generator)[0]
-        if 't' in self.char_mode:
-            return res.decode('utf8')
         return res
 
     def readlines(self, char='\n'):
         self.generator = self.client.read(self.path, buffer_char=char)
-        if 't' in self.char_mode:
-            return (x.decode('utf8') for x in self.generator)
         return self.generator
 
     def __enter__(self):
@@ -108,48 +101,18 @@ class ReadableWebHdfsFile(object):
         self.generator.close()
 
 
-class AbstractAtomicWebHdfsFile(object):
+class AtomicWebHdfsFile(AtomicLocalFile):
     """
     An Hdfs file that writes to a temp file and put to WebHdfs on close.
     """
 
     def __init__(self, path, client):
-        unique_name = 'luigi-webhdfs-tmp-%09d' % random.randrange(0, 1e10)
-        self.tmp_path = os.path.join(tempfile.gettempdir(), unique_name)
-        self.path = path
         self.client = client
-        super(AbstractAtomicWebHdfsFile, self).__init__(io.FileIO(self.tmp_path, 'w'))
+        super(AtomicWebHdfsFile, self).__init__(path)
 
-    def close(self):
-        super(AtomicWebHdfsFile, self).close()
+    def move_to_final_destination(self):
         if not self.client.exists(self.path):
             self.client.upload(self.path, self.tmp_path)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception.
-        """
-        if exc_type:
-            return
-        return super(AtomicWebHdfsFile, self).__exit__(exc_type, exc, traceback)
-
-    def __del__(self):
-        """
-        Remove the temporary directory.
-        """
-        if os.path.exists(self.tmp_path):
-            os.remove(self.tmp_path)
-
-
-class AtomicBinaryWebHdfsFile(AbstractAtomicWebHdfsFile, io.BufferedWriter):
-    pass
-
-
-class AtomicWebHdfsFile(AbstractAtomicWebHdfsFile, io.TextIOWrapper):
-    pass
 
 
 class WebHdfsClient(object):

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -25,66 +25,21 @@ import shutil
 import tempfile
 import io
 
-from luigi import six
-
 import luigi.util
-from luigi.format import FileWrapper
-from luigi.target import FileSystem, FileSystemTarget, get_char_mode
+from luigi.format import FileWrapper, get_default_format
+from luigi.target import FileSystem, FileSystemTarget, AtomicLocalFile
 
 
-if six.PY3:
-    unicode = str
-
-
-class abstract_atomic_file(object):
-    """
-    Simple class that writes to a temp file and moves it on close()
+class atomic_file(AtomicLocalFile):
+    """Simple class that writes to a temp file and moves it on close()
     Also cleans up the temp file if close is not invoked
-    This is an abstract class see atomic_file for text file,
-    atomic_binary_file for binary file
     """
 
-    def __init__(self, path):
-        self.__tmp_path = path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
-        self.path = path
-        init_args = self.get_init_args(self.__tmp_path)
-        super(abstract_atomic_file, self).__init__(*init_args)
+    def move_to_final_destination(self):
+        os.rename(self.tmp_path, self.path)
 
-    def get_init_args(self, path):
-        return (io.FileIO(path, 'w'),)
-
-    def close(self):
-        super(abstract_atomic_file, self).close()
-        os.rename(self.__tmp_path, self.path)
-
-    def __del__(self):
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    @property
-    def tmp_path(self):
-        return self.__tmp_path
-
-    def __exit__(self, exc_type, exc, traceback):
-        " Close/commit the file if there are no exception "
-        if exc_type:
-            return
-        return super(abstract_atomic_file, self).__exit__(exc_type, exc, traceback)
-
-
-class atomic_binary_file(abstract_atomic_file, io.BufferedWriter):
-    pass
-
-
-class atomic_text_file(abstract_atomic_file, io.TextIOWrapper):
-    pass
-
-
-if six.PY2:
-    class atomic_file(abstract_atomic_file, file):
-        # for compatibility (bytes file with universal newline)
-        def get_init_args(self, path):
-            return (path, 'w')
+    def generate_tmp_path(self, path):
+        return path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
 
 
 class LocalFileSystem(FileSystem):
@@ -114,6 +69,8 @@ class File(FileSystemTarget):
     fs = LocalFileSystem()
 
     def __init__(self, path=None, format=None, is_tmp=False):
+        if format is None:
+            format = get_default_format()
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')
@@ -132,34 +89,14 @@ class File(FileSystemTarget):
             os.makedirs(parentfolder)
 
     def open(self, mode='r'):
-        char_mode = get_char_mode(mode)
-        if 'w' in mode:
+        if mode == 'w':
             self.makedirs()
+            return self.format.pipe_writer(atomic_file(self.path))
 
-            if char_mode == 'b':
-                atomic_type = atomic_binary_file
-            elif char_mode == 't':
-                atomic_type = atomic_text_file
-            else:
-                atomic_type = atomic_file
+        elif mode == 'r':
+            fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
+            return self.format.pipe_reader(fileobj)
 
-            if self.format:
-                return self.format.pipe_writer(atomic_type(self.path))
-            else:
-                return atomic_type(self.path)
-
-        elif 'r' in mode:
-            if char_mode == 't':
-                fileobj = FileWrapper(io.TextIOWrapper(io.FileIO(self.path, 'r')))
-            elif char_mode == 'b':
-                fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
-            else:
-                fileobj = FileWrapper(open(self.path, 'r'))
-
-            if self.format:
-                return self.format.pipe_reader(fileobj)
-
-            return fileobj
         else:
             raise Exception('mode must be r/w')
 

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -20,7 +20,6 @@ import subprocess
 import io
 import os
 import re
-import locale
 import tempfile
 
 from luigi import six
@@ -306,22 +305,6 @@ class NewlineWrapper(BaseWrapper):
         self._stream.write(re.sub(b'(\n|\r\n|\r)', newline, b))
 
 
-class MixedUnicodeBytesWrapper(BaseWrapper):
-    """
-    """
-
-    def write(self, b):
-        if isinstance(b, unicode):
-            b = b.encode(locale.getpreferredencoding())
-        self._stream.write(b)
-
-    def writelines(self, lines):
-        for x in range(len(lines)):
-            if isinstance(lines[x]):
-                lines[x] = lines[x].encode(locale.getpreferredencoding())
-        self._stream.writelines(lines)
-
-
 class Format(object):
     """
     Interface for format specifications.
@@ -456,8 +439,6 @@ Text = TextFormat()
 UTF8 = TextFormat(encoding='utf8')
 Nop = NopFormat()
 SysNewLine = WrappedFormat(NewlineWrapper)
-#: format to reproduce the default behavior of python2 (accept both unicode and bytes)
-MixedUnicodeBytes = WrappedFormat(MixedUnicodeBytesWrapper)
 Gzip = GzipFormat()
 Bzip2 = Bzip2Format()
 
@@ -466,6 +447,6 @@ def get_default_format():
     if six.PY3:
         return Text
     elif os.linesep == '\n':
-        return MixedUnicodeBytes
+        return Nop
     else:
-        return MixedUnicodeBytes >> SysNewLine
+        return SysNewLine

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -365,7 +365,7 @@ class ChainFormat(Format):
         return output_pipe
 
 
-class TextWrapper(BaseWrapper, io.TextIOWrapper):
+class TextWrapper(io.TextIOWrapper):
 
     def __exit__(self, *args):
         # io.TextIOWrapper close the file on __exit__, let the underlying file decide
@@ -383,6 +383,22 @@ class TextWrapper(BaseWrapper, io.TextIOWrapper):
             self._stream.__del__(*args)
         except AttributeError:
             pass
+
+    def __init__(self, stream, *args, **kwargs):
+        self._stream = stream
+        try:
+            super(TextWrapper, self).__init__(stream, *args, **kwargs)
+        except TypeError:
+            pass
+
+    def __getattr__(self, name):
+        if name == '_stream':
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+    def __enter__(self):
+        self._stream.__enter__()
+        return self
 
 
 class NopFormat(Format):

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -257,8 +257,8 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
 
     def track_process(arglist, tracking_url_callback, env=None):
         # Dump stdout to a temp file, poll stderr and log it
-        temp_stdout = tempfile.TemporaryFile()
-        proc = subprocess.Popen(arglist, stdout=temp_stdout, stderr=subprocess.PIPE, env=env, close_fds=True)
+        temp_stdout = tempfile.TemporaryFile('w+t')
+        proc = subprocess.Popen(arglist, stdout=temp_stdout, stderr=subprocess.PIPE, env=env, close_fds=True, universal_newlines=True)
 
         # We parse the output to try to find the tracking URL.
         # This URL is useful for fetching the logs of the job.
@@ -846,11 +846,11 @@ class JobTask(BaseHadoopJobTask):
         if self.__module__ == '__main__':
             d = pickle.dumps(self)
             module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-            d = d.replace('(c__main__', "(c" + module_name)
-            open(file_name, "w").write(d)
+            d = d.replace(b'(c__main__', "(c" + module_name)
+            open(file_name, "wb").write(d)
 
         else:
-            pickle.dump(self, open(file_name, "w"))
+            pickle.dump(self, open(file_name, "wb"))
 
     def _map_input(self, input_stream):
         """

--- a/luigi/mrrunner.py
+++ b/luigi/mrrunner.py
@@ -43,7 +43,7 @@ class Runner(object):
 
     def __init__(self, job=None):
         self.extract_packages_archive()
-        self.job = job or pickle.load(open("job-instance.pickle"))
+        self.job = job or pickle.load(open("job-instance.pickle", "rb"))
         self.job._setup_remote()
 
     def run(self, kind, stdin=sys.stdin, stdout=sys.stdout):
@@ -69,7 +69,7 @@ class Runner(object):
 
 
 def print_exception(exc):
-    tb = traceback.format_exc(exc)
+    tb = traceback.format_exc()
     print('luigi-exc-hex=%s' % tb.encode('hex'), file=sys.stderr)
 
 

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -23,9 +23,7 @@ import itertools
 import logging
 import os
 import os.path
-import random
 import tempfile
-import io
 try:
     from urlparse import urlsplit
 except ImportError:
@@ -39,9 +37,9 @@ except ImportError:
 from luigi import six
 
 from luigi import configuration
-from luigi.format import FileWrapper
+from luigi.format import FileWrapper, get_default_format
 from luigi.parameter import Parameter
-from luigi.target import FileSystem, FileSystemException, FileSystemTarget
+from luigi.target import FileSystem, FileSystemException, FileSystemTarget, AtomicLocalFile
 from luigi.task import ExternalTask
 
 logger = logging.getLogger('luigi-interface')
@@ -339,40 +337,17 @@ class S3Client(FileSystem):
         return key if key[-1:] == '/' else key + '/'
 
 
-class AtomicS3File(io.BufferedWriter):
+class AtomicS3File(AtomicLocalFile):
     """
     An S3 file that writes to a temp file and put to S3 on close.
     """
 
     def __init__(self, path, s3_client):
-        self.__tmp_path = \
-            os.path.join(tempfile.gettempdir(),
-                         'luigi-s3-tmp-%09d' % random.randrange(0, 1e10))
-        self.path = path
         self.s3_client = s3_client
-        super(AtomicS3File, self).__init__(io.FileIO(self.__tmp_path, 'wb'))
+        super(AtomicS3File, self).__init__(path)
 
-    def close(self):
-        """
-        Close the file.
-        """
-        super(AtomicS3File, self).close()
-
-        # store the contents in S3
-        self.s3_client.put_multipart(self.__tmp_path, self.path)
-
-    def __del__(self):
-        # remove the temporary directory
-        if os.path.exists(self.__tmp_path):
-            os.remove(self.__tmp_path)
-
-    def __exit__(self, exc_type, exc, traceback):
-        """
-        Close/commit the file if there are no exception.
-        """
-        if exc_type:
-            return
-        return super(AtomicS3File, self).__exit__(exc_type, exc, traceback)
+    def move_to_final_destination(self):
+        self.s3_client.put_multipart(self.tmp_path, self.path)
 
 
 class ReadableS3File(object):
@@ -400,7 +375,7 @@ class ReadableS3File(object):
         self.buffer.append(line)
 
     def _flush_buffer(self):
-        output = ''.join(self.buffer)
+        output = b''.join(self.buffer)
         self.buffer = []
         return output
 
@@ -443,6 +418,8 @@ class S3Target(FileSystemTarget):
 
     def __init__(self, path, format=None, client=None):
         super(S3Target, self).__init__(path)
+        if format is None:
+            format = get_default_format()
         self.format = format
         self.fs = client or S3Client()
 
@@ -454,28 +431,13 @@ class S3Target(FileSystemTarget):
 
         if mode == 'r':
             s3_key = self.fs.get_key(self.path)
-            if s3_key:
-                fileobj = ReadableS3File(s3_key)
-                if self.format:
-                    self._tmp_extract_path = tempfile.mktemp(
-                        prefix='luigi_s3_')
-                    with open(self._tmp_extract_path, 'w') as f:
-                        f.write(fileobj.read())
-                    try:
-                        with open(self._tmp_extract_path) as f:
-                            return self.format.pipe_reader(FileWrapper(f))
-                    finally:
-                        os.remove(self._tmp_extract_path)
-                return fileobj
-            else:
-                raise FileNotFoundException(
-                    "Could not find file at %s" % self.path)
+            if not s3_key:
+                raise FileNotFoundException("Could not find file at %s" % self.path)
+
+            fileobj = ReadableS3File(s3_key)
+            return self.format.pipe_reader(fileobj)
         else:
-            if self.format:
-                return self.format.pipe_writer(
-                    AtomicS3File(self.path, self.fs))
-            else:
-                return AtomicS3File(self.path, self.fs)
+            return self.format.pipe_writer(AtomicS3File(self.path, self.fs))
 
 
 class S3FlagTarget(S3Target):
@@ -511,6 +473,9 @@ class S3FlagTarget(S3Target):
         :param flag:
         :type flag: str
         """
+        if format is None:
+            format = get_default_format()
+
         if path[-1] != "/":
             raise ValueError("S3FlagTarget requires the path to be to a "
                              "directory.  It must end with a slash ( / ).")

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -21,24 +21,14 @@ See `/api_overview` for an overview.
 """
 
 import abc
+import io
+import os
+import random
+import tempfile
 import logging
 from luigi import six
 
 logger = logging.getLogger('luigi-interface')
-
-
-def get_char_mode(mode):
-    """determine if a target should be open in text or binary mode
-    """
-    if 'b' in mode:
-        return 'b'
-    if 't' in mode:
-        return 't'
-    if six.PY2:
-        # support mixed mode (binary but \n is converted to platform newline)
-        # retrocompatibility with python2 on windows
-        return 'm'
-    return 't'
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -209,3 +199,42 @@ class FileSystemTarget(Target):
         This method is implemented by using :py:meth:`fs`.
         """
         self.fs.remove(self.path)
+
+
+class AtomicLocalFile(io.BufferedWriter):
+    """Abstract class to create Target that create
+    a tempoprary file in the local filesystem before
+    moving it to there final destination
+
+    This class is just for the writing part of the Target. See
+    luigi.file.File for example
+    """
+
+    def __init__(self, path):
+        self.__tmp_path = self.generate_tmp_path(path)
+        self.path = path
+        super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, 'w'))
+
+    def close(self):
+        super(AtomicLocalFile, self).close()
+        self.move_to_final_destination()
+
+    def generate_tmp_path(self, path):
+        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-%09d' % random.randrange(0, 1e10))
+
+    def move_to_final_destination(self):
+        raise NotImplementedError()
+
+    def __del__(self):
+        if os.path.exists(self.tmp_path):
+            os.remove(self.tmp_path)
+
+    @property
+    def tmp_path(self):
+        return self.__tmp_path
+
+    def __exit__(self, exc_type, exc, traceback):
+        " Close/commit the file if there are no exception "
+        if exc_type:
+            return
+        return super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)

--- a/test/_s3_test.py
+++ b/test/_s3_test.py
@@ -168,7 +168,6 @@ class TestS3Target(unittest.TestCase):
             result = f.read()
 
         self.assertEqual(test_data, result)
-        self.assertFalse(os.path.exists(t._tmp_extract_path))
 
 
 class TestS3Client(unittest.TestCase):

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -98,12 +98,12 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch("logging.getLogger")
     def test_cmdline_main_task_cls(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', '--n', '100'], main_task_cls=SomeTask)
-        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_100': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_100': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_other_task(self, logger):
         luigi.run(['--local-scheduler', '--no-lock', 'SomeTask', '--n', '1000'])
-        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_1000': 'done'})
+        self.assertEqual(dict(MockFile.fs.get_all_data()), {'/tmp/test_1000': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_ambiguous_class(self, logger):

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -310,8 +310,8 @@ class CopyTest(unittest.TestCase):
 
     def test_copy(self):
         luigi.build([PCopy(date=datetime.date(2012, 1, 1))], local_scheduler=True)
-        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), 'hello, world\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2012-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2012-01-01.txt'), b'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2012-01-01.txt'), b'hello, world\n')
 
 
 class PickleTest(unittest.TestCase):
@@ -323,8 +323,8 @@ class PickleTest(unittest.TestCase):
         p = pickle.loads(p_pickled)
 
         luigi.build([p], local_scheduler=True)
-        self.assertEqual(MockFile.fs.get_data('/tmp/data-2013-01-01.txt'), 'hello, world\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2013-01-01.txt'), 'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/data-2013-01-01.txt'), b'hello, world\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/copy-data-2013-01-01.txt'), b'hello, world\n')
 
 
 class Subtask(luigi.Task):

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -69,20 +69,20 @@ class FibTest(FibTestBase):
         w.add(Fib(100))
         w.run()
         w.stop()
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_cmdline(self):
         luigi.run(['--local-scheduler', '--no-lock', 'Fib', '--n', '100'])
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_build_internal(self):
         luigi.build([Fib(100)], local_scheduler=True)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
 if __name__ == '__main__':
     luigi.run()

--- a/test/hadoop_test.py
+++ b/test/hadoop_test.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 
 import luigi
+import luigi.format
 import luigi.hadoop
 import luigi.hdfs
 import luigi.mrrunner
@@ -40,7 +41,7 @@ class OutputMixin(luigi.Task):
 
     def get_output(self, fn):
         if self.use_hdfs:
-            return luigi.hdfs.HdfsTarget('/tmp/' + fn, format=luigi.hdfs.PlainDir)
+            return luigi.hdfs.HdfsTarget('/tmp/' + fn, format=luigi.format.get_default_format() >> luigi.hdfs.PlainDir)
         else:
             return File(fn)
 

--- a/test/optparse_test.py
+++ b/test/optparse_test.py
@@ -25,8 +25,8 @@ class OptParseTest(FibTestBase):
     def test_cmdline_optparse(self):
         luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_cmdline_optparse_existing(self):
         import optparse
@@ -35,5 +35,5 @@ class OptParseTest(FibTestBase):
 
         luigi.run(['--local-scheduler', '--no-lock', '--task', 'Fib', '--n', '100'], use_optparse=True, existing_optparse=parser)
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), '55\n')
-        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), '354224848179261915075\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_10'), b'55\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -47,7 +47,7 @@ class Popularity(luigi.Task):
 class RecursionTest(unittest.TestCase):
 
     def setUp(self):
-        MockFile.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = '0\n'
+        MockFile.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = b'0\n'
 
     def test_invoke(self):
         w = luigi.worker.Worker()
@@ -55,4 +55,4 @@ class RecursionTest(unittest.TestCase):
         w.run()
         w.stop()
 
-        self.assertEqual(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), '365\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/popularity/2010-01-01.txt'), b'365\n')

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -76,7 +76,7 @@ class TestRedshiftManifestTask(unittest.TestCase):
 
         output = t.output().open('r').read()
         expected_manifest_output = json.dumps(generate_manifest_json(folder_paths, FILES))
-        self.assertEqual(output.decode('utf8'), expected_manifest_output)
+        self.assertEqual(output, expected_manifest_output)
 
     @mock_s3
     def test_run_multiple_paths(self):
@@ -98,4 +98,4 @@ class TestRedshiftManifestTask(unittest.TestCase):
 
         output = t.output().open('r').read()
         expected_manifest_output = json.dumps(generate_manifest_json(folder_paths, FILES))
-        self.assertEqual(output.decode('utf8'), expected_manifest_output)
+        self.assertEqual(output, expected_manifest_output)

--- a/test/wrap_test.py
+++ b/test/wrap_test.py
@@ -93,11 +93,11 @@ class WrapperTest(unittest.TestCase):
 
     def test_a(self):
         luigi.build([AXML()], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile.fs.get_data('/tmp/a.xml'), '<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/a.xml'), b'<?xml version="1.0" ?>\n<dummy-xml>hello, world</dummy-xml>\n')
 
     def test_b(self):
         luigi.build([BXML(datetime.date(2012, 1, 1))], local_scheduler=True, no_lock=True, workers=self.workers)
-        self.assertEqual(MockFile.fs.get_data('/tmp/b-2012-01-01.xml'), '<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
+        self.assertEqual(MockFile.fs.get_data('/tmp/b-2012-01-01.xml'), b'<?xml version="1.0" ?>\n<dummy-xml>goodbye, space</dummy-xml>\n')
 
 
 class WrapperWithMultipleWorkersTest(WrapperTest):


### PR DESCRIPTION
This PR add a way for the format to explicitly declare the type of there input and output. The chaining of Format do a basic to ensure that the chaining is correct based on the types.

This PR also deprecate `luigi.format.Format.hdfs_reader` and `luigi.format.Format.hdfs_writer` in favor of Format chaining and explicit declaration of output type. `HdfsTarget` still verify for `hdfs_reader` and `hdfs_writer` and use them but would raise a deprecation warning.

This PR also include other minor fixes for python3.

This PR is based on #767 only the 2 last commits are different.

With this PR and spotify/snakebite#138, all hdfs test that doesn't necessitate SnakebiteClient are passing on python3.