### PR TITLE
Fix parameter passing

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -331,7 +331,7 @@ class Task(object):
         exc_desc = '%s[args=%s, kwargs=%s]' % (task_name, args, kwargs)
 
         # Fill in the positional arguments
-        positional_params = [(n, p) for n, p in params if p.significant]
+        positional_params = [(n, p) for n, p in params if not p.is_global]
         for i, arg in enumerate(args):
             if i >= len(positional_params):
                 raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -341,22 +341,28 @@ class TestRemoveGlobalParameters(unittest.TestCase):
         MyConfigWithoutSection.mc_r.reset_global()
         MyConfigWithoutSection.mc_s.reset_global()
 
+    def run_and_check(self, args):
+        run_exit_status = luigi.run(['--local-scheduler', '--no-lock'] + args)
+        self.assertTrue(run_exit_status)
+        return run_exit_status
+
+
     def test_use_config_class_1(self):
-        luigi.run(['--local-scheduler', '--no-lock', '--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask'])
+        self.run_and_check(['--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask'])
         self.assertEqual(MyConfig().mc_p, 99)
         self.assertEqual(MyConfig().mc_q, 73)
         self.assertEqual(MyConfigWithoutSection().mc_r, 55)
         self.assertEqual(MyConfigWithoutSection().mc_s, 99)
 
     def test_use_config_class_2(self):
-        luigi.run(['--local-scheduler', '--no-lock', 'NoopTask', '--MyConfig-mc-p', '99', '--mc-r', '55'])
+        self.run_and_check(['NoopTask', '--MyConfig-mc-p', '99', '--mc-r', '55'])
         self.assertEqual(MyConfig().mc_p, 99)
         self.assertEqual(MyConfig().mc_q, 73)
         self.assertEqual(MyConfigWithoutSection().mc_r, 55)
         self.assertEqual(MyConfigWithoutSection().mc_s, 99)
 
     def test_use_config_class_more_args(self):
-        luigi.run(['--local-scheduler', '--no-lock', '--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask', '--mc-s', '123', '--MyConfig-mc-q', '42'])
+        self.run_and_check(['--MyConfig-mc-p', '99', '--mc-r', '55', 'NoopTask', '--mc-s', '123', '--MyConfig-mc-q', '42'])
         self.assertEqual(MyConfig().mc_p, 99)
         self.assertEqual(MyConfig().mc_q, 42)
         self.assertEqual(MyConfigWithoutSection().mc_r, 55)
@@ -364,7 +370,7 @@ class TestRemoveGlobalParameters(unittest.TestCase):
 
     @with_config({"MyConfig": {"mc_p": "666", "mc_q": "777"}})
     def test_use_config_class_with_configuration(self):
-        luigi.run(['--local-scheduler', '--no-lock', '--mc-r', '555', 'NoopTask'])
+        self.run_and_check(['--mc-r', '555', 'NoopTask'])
         self.assertEqual(MyConfig().mc_p, 666)
         self.assertEqual(MyConfig().mc_q, 777)
         self.assertEqual(MyConfigWithoutSection().mc_r, 555)
@@ -372,7 +378,7 @@ class TestRemoveGlobalParameters(unittest.TestCase):
 
     @with_config({"MyConfigWithoutSection": {"mc_r": "999", "mc_s": "888"}})
     def test_use_config_class_with_configuration_2(self):
-        luigi.run(['--local-scheduler', '--no-lock', 'NoopTask', '--MyConfig-mc-p', '222', '--mc-r', '555'])
+        self.run_and_check(['NoopTask', '--MyConfig-mc-p', '222', '--mc-r', '555'])
         self.assertEqual(MyConfig().mc_p, 222)
         self.assertEqual(MyConfig().mc_q, 73)
         self.assertEqual(MyConfigWithoutSection().mc_r, 555)
@@ -385,11 +391,11 @@ class TestRemoveGlobalParameters(unittest.TestCase):
         class CatsWithoutSection(luigi.ConfigWithoutSection):
             n_cats = luigi.IntParameter()
 
-        luigi.run(['--local-scheduler', '--no-lock', '--n-cats', '123', '--Dogs-n-dogs', '456', 'WithDefault'])
+        self.run_and_check(['--n-cats', '123', '--Dogs-n-dogs', '456', 'WithDefault'])
         self.assertEqual(Dogs().n_dogs, 456)
         self.assertEqual(CatsWithoutSection().n_cats, 123)
 
-        luigi.run(['--local-scheduler', '--no-lock', 'WithDefault', '--n-cats', '321', '--Dogs-n-dogs', '654'])
+        self.run_and_check(['WithDefault', '--n-cats', '321', '--Dogs-n-dogs', '654'])
         self.assertEqual(Dogs().n_dogs, 654)
         self.assertEqual(CatsWithoutSection().n_cats, 321)
 


### PR DESCRIPTION
Copy pasting the commit message from the second commit, as that is what's essential here:

-----

At the moment, we think the behavioral change introduced in a78338c was
a mistake. There were no test cases that covered the behavior of passing
global parameters positionally, so this commits adds that.

The major issue was partially solved in f5c3316, but I think that was
kind of an arbitrary fix that still breaks backward compatibility.
Please see the discussion in spotify/luigi#738.  Hopefully, nobody
started to rely on this intermediete behavior that would have existed
for about 2 weeks.

Eventually, we'll have to change the condition

        positional_params = [(n, p) for n, p in params if not p.is_global]

to just

        positional_params = [(n, p) for n, p in params]

just like we did in a78338c. Though that should be done after global
parameters have been deprecated for half a year or something at least.
People need time to change their cron lines from `--pool development` to
`--BaseHadoopJobTask-pool development`.  Then we can change it to

        positional_params = [(n, p) for n, p in params]

AND remove is_global (you can't just do one of them like we did in
a78338c)

----