### PR TITLE
Remove coverage and coveralls for now

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,6 @@ skipsdist = True
 usedevelop = True
 deps=
   -r{toxinidir}/test/requirements.txt
-  coverage>=3.6,<3.999
-  coveralls
 setenv =
   cdh: HADOOP_DISTRO=cdh
   cdh: HADOOP_HOME=/tmp/hadoop-cdh
@@ -18,8 +16,7 @@ setenv =
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client.cfg
 commands =
   cdh,hdp: {toxinidir}/scripts/ci/setup_hadoop_env.sh
-  coverage run test/runtests.py -v {posargs:}
-  coveralls
+  python test/runtests.py -v {posargs:}
 
 [testenv:pep8]
 deps = pep8


### PR DESCRIPTION
This is about fixing the SUPER-SCARY false positives we get from Travis
CI service. See #759. I see this as urgent, so if the tests fail for
this PR, that's good.

While we haven't had any incident yet, we were about to have two on
Spotify's side and apparently @daveFNbuck have had one already (#752).

Just now, I got some 2.6 error which is still green.
https://travis-ci.org/spotify/luigi/jobs/51362963