### PR TITLE
add configurable per-invocation task-limit

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -173,6 +173,14 @@ worker-ping-interval
   Number of seconds to wait between pinging scheduler to let it know
   that the worker is still alive. Defaults to 1.0.
 
+worker-task-limit
+  .. versionadded:: 1.0.25
+
+  Maximum number of tasks to schedule per invocation. Upon exceeding it,
+  the worker will issue a warning and proceed with the workflow obtained
+  thus far. Prevents incidents due to spamming of the scheduler, usually
+  accidental. Default: no limit.
+
 worker-timeout
   .. versionadded:: 1.0.20
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -140,7 +140,7 @@ class CmdlineTest(unittest.TestCase):
 
         with mock.patch("luigi.configuration.get_config") as getconf:
             getconf.return_value.get.side_effect = ConfigParser.NoOptionError(section='foo', option='bar')
-            getconf.return_value.get_boolean.return_value = True
+            getconf.return_value.getint.return_value = 0
 
             luigi.interface.setup_interface_logging.call_args_list = []
             luigi.run(['SomeTask', '--n', '42', '--local-scheduler', '--no-lock'])


### PR DESCRIPTION
Prevents incidents due to spamming of the central scheduler, usually accidental.

The default limit is None, so nothing existing should be affected.