### PR TITLE
Typo. warnings.ImportWarning -> ImportWarning

### DIFF
--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -148,7 +148,7 @@ try:
     import sqlalchemy
 except ImportError:
     # Don't fail on import because we want the documentation to be generated
-    warnings.warn("sqlalchemy could not be imported, db_task_history will not work", warnings.ImportWarning, stacklevel=3)
+    warnings.warn("sqlalchemy could not be imported, db_task_history will not work", ImportWarning, stacklevel=3)
 
 
 class SQLAlchemyTarget(luigi.Target):

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -40,7 +40,7 @@ try:
     Base = sqlalchemy.ext.declarative.declarative_base()
 except ImportError:
     # Don't fail on import because we want the documentation to be generated
-    warnings.warn("sqlalchemy could not be imported, db_task_history will not work", warnings.ImportWarning, stacklevel=3)
+    warnings.warn("sqlalchemy could not be imported, db_task_history will not work", ImportWarning, stacklevel=3)
 
 logger = logging.getLogger('luigi-interface')
 


### PR DESCRIPTION
On a slightly separate note, why isn't this displayed on stdout/stderr? Seems to defeat the purpose of having warnings