### PR TITLE
Adds assistant argument to RemoteScheduler.get_work

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -127,10 +127,10 @@ class RemoteScheduler(Scheduler):
             'params': params,
         })
 
-    def get_work(self, worker, host=None):
+    def get_work(self, worker, assistant=False, host=None):
         return self._request(
             '/api/get_work',
-            {'worker': worker, 'host': host},
+            {'worker': worker, 'host': host, 'assistant': assistant},
             log_exceptions=False,
             attempts=1)
 


### PR DESCRIPTION
Workers can't use the remote scheduler at all with the bug this fixes.