### PR TITLE
Read record_task_history parameter in scheduler.scheduler

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -99,7 +99,8 @@ class scheduler(Config):
     max_shown_tasks = parameter.IntParameter(default=100000,
                                              config_path=dict(section='scheduler', name='max-shown-task'))
 
-    record_task_history = parameter.BoolParameter(default=False)
+    record_task_history = parameter.BoolParameter(default=False,
+                                                  config_path=dict(section='scheduler', name='record_task_history'))
 
 
 def fix_time(x):


### PR DESCRIPTION
We're trying to do something like this:
```
class MyJob(luigi.task):
    def complete(self):
        scheduler = luigi.scheduler.CentralPlannerScheduler()

        history = scheduler.task_history
        if isinstance(history, luigi.task_history.NopHistory):
            return False

        params = {k: str(getattr(self, k)) for k, _ in self.get_params()}
        tasks = history.find_all_by_parameters(self.task_family, **params)
        return any(any(e.event_name == "DONE" for e in t.events) for t in tasks)
```

When we run `luigi.scheduler.CentralPlannerScheduler()` from ipython, it uses `DbTaskHistory` however when complete() is invoked via the worker, it uses `NopHistory`.

Perhaps there's a nice way to build in this sort of functionality too.