### PR TITLE
Makes assistants reasonably runnable

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -109,8 +109,10 @@ class core(task.ConfigWithoutSection):
     parallel_scheduling = parameter.BoolParameter(
         default=False,
         description='Use multiprocessing to do scheduling in parallel.',
-        config_path={'section': 'core', 'name': 'parallel-scheduling'},
-    )
+        config_path={'section': 'core', 'name': 'parallel-scheduling'})
+    assistant = parameter.BoolParameter(
+        default=False,
+        description='Run any task from the scheduler.')
 
 
 class WorkerSchedulerFactory(object):
@@ -121,10 +123,10 @@ class WorkerSchedulerFactory(object):
     def create_remote_scheduler(self, host, port):
         return rpc.RemoteScheduler(host=host, port=port)
 
-    def create_worker(self, scheduler, worker_processes):
+    def create_worker(self, scheduler, worker_processes, assistant=False):
         from luigi import worker
         return worker.Worker(
-            scheduler=scheduler, worker_processes=worker_processes)
+            scheduler=scheduler, worker_processes=worker_processes, assistant=assistant)
 
 
 class Interface(object):
@@ -171,7 +173,7 @@ class Interface(object):
                 port=env_params.scheduler_port)
 
         w = worker_scheduler_factory.create_worker(
-            scheduler=sch, worker_processes=env_params.workers)
+            scheduler=sch, worker_processes=env_params.workers, assistant=env_params.assistant)
 
         success = True
         for t in tasks:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -623,7 +623,6 @@ class CentralPlannerScheduler(Scheduler):
         # Return remaining tasks that have no FAILED descendents
         self.update(worker, {'host': host})
         best_task = None
-        best_task_id = None
         locally_pending_tasks = 0
         running_tasks = []
 
@@ -637,7 +636,8 @@ class CentralPlannerScheduler(Scheduler):
         tasks.sort(key=self._rank(), reverse=True)
 
         for task in tasks:
-            if task.status == 'RUNNING' and worker in task.workers:
+            in_workers = assistant or worker in task.workers
+            if task.status == 'RUNNING' and in_workers:
                 # Return a list of currently running tasks to the client,
                 # makes it easier to troubleshoot
                 other_worker = self._state.get_worker(task.worker_running)
@@ -646,22 +646,22 @@ class CentralPlannerScheduler(Scheduler):
                     more_info.update(other_worker.info)
                     running_tasks.append(more_info)
 
-            if task.status == PENDING and (worker in task.workers or assistant):
+            if task.status == PENDING and in_workers:
                 locally_pending_tasks += 1
-                if len(task.workers) == 1:
+                if len(task.workers) == 1 and not assistant:
                     n_unique_pending += 1
 
-            if task.status == RUNNING and (task.worker_running in greedy_workers or assistant):
+            if task.status == RUNNING and (task.worker_running in greedy_workers):
                 greedy_workers[task.worker_running] -= 1
                 for resource, amount in six.iteritems((task.resources or {})):
                     greedy_resources[resource] += amount
 
             if not best_task and self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
-                if (worker in task.workers or assistant) and self._has_resources(task.resources, used_resources):
+                if in_workers and self._has_resources(task.resources, used_resources):
                     best_task = task
-                    best_task_id = task.id
                 else:
-                    for task_worker in task.workers:
+                    workers = itertools.chain(task.workers, [worker]) if assistant else task.workers
+                    for task_worker in workers:
                         if greedy_workers.get(task_worker, 0) > 0:
                             # use up a worker
                             greedy_workers[task_worker] -= 1

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -323,6 +323,7 @@ class Worker(object):
 
         self._id = worker_id
         self._scheduler = scheduler
+        self._assistant = assistant
 
         self.host = socket.gethostname()
         self._scheduled_tasks = {}
@@ -333,8 +334,6 @@ class Worker(object):
         self.add_succeeded = True
         self.run_succeeded = True
         self.unfulfilled_counts = collections.defaultdict(int)
-
-        self.assistant = assistant
 
         class KeepAliveThread(threading.Thread):
             """
@@ -579,7 +578,7 @@ class Worker(object):
 
     def _get_work(self):
         logger.debug("Asking scheduler for work...")
-        r = self._scheduler.get_work(worker=self._id, host=self.host, assistant=self.assistant)
+        r = self._scheduler.get_work(worker=self._id, host=self.host, assistant=self._assistant)
         # Support old version of scheduler
         if isinstance(r, tuple) or isinstance(r, list):
             n_pending_tasks, task_id = r
@@ -720,13 +719,18 @@ class Worker(object):
         Returns true if a worker should stay alive given.
 
         If worker-keep-alive is not set, this will always return false.
+        For an assistant, it will always return the value of worker-keep-alive.
         Otherwise, it will return true for nonzero n_pending_tasks.
 
         If worker-count-uniques is true, it will also
         require that one of the tasks is unique to this worker.
         """
-        return (self.__keep_alive and n_pending_tasks and
-                (n_unique_pending or not self.__count_uniques))
+        if not self.__keep_alive:
+            return False
+        elif self._assistant:
+            return True
+        else:
+            return n_pending_tasks and (n_unique_pending or not self.__count_uniques)
 
     def run(self):
         """

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -97,7 +97,7 @@ class CustomizedWorkerSchedulerFactory(object):
     def create_remote_scheduler(self, host, port):
         return CustomizedRemoteScheduler(host=host, port=port)
 
-    def create_worker(self, scheduler, worker_processes=None):
+    def create_worker(self, scheduler, worker_processes=None, assistant=False):
         return self.worker
 
 


### PR DESCRIPTION
This contains commits that allow the assistant to be run on the command-line, stay alive while waiting for new jobs to be scheduled, and have the scheduler properly recognize that the assistant is running jobs rather than marking them as failed. This provides basic functionality to run the assistant, but it doesn't tend to last long for me before it gets a job type it doesn't know about.