### PR TITLE
Fails assistant when it can't determine the task type

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -197,9 +197,10 @@ class Register(abc.ABCMeta):
         """
         task_cls = Register.get_reg().get(name)
         if not task_cls:
-            raise Exception('Task %r not found. Candidates are: %s' % (name, Register.tasks_str()))
+            raise TaskClassException('Task %r not found. Candidates are: %s' % (name, Register.tasks_str()))
+
         if task_cls == Register.AMBIGUOUS_CLASS:
-            raise Exception('Task %r is ambiguous' % name)
+            raise TaskClassException('Task %r is ambiguous' % name)
         return task_cls
 
     @classmethod
@@ -214,6 +215,10 @@ class Register(abc.ABCMeta):
                 continue
             for param_name, param_obj in task_cls.get_params():
                 yield task_name, issubclass(task_cls, ConfigWithoutSection), param_name, param_obj
+
+
+class TaskClassException(Exception):
+    pass
 
 
 @six.add_metaclass(Register)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -860,6 +860,18 @@ class AssistantTest(unittest.TestCase):
         self.assistant.run()
         self.assertTrue(d.complete())
 
+    def test_bad_job_type(self):
+        class Dummy3Task(Dummy2Task):
+            task_family = 'UnknownTaskFamily'
+
+        d = Dummy3Task('123')
+        self.w.add(d)
+
+        self.assertFalse(d.complete())
+        self.assertFalse(self.assistant.run())
+        self.assertFalse(d.complete())
+        self.assertEqual(list(self.sch.task_list('FAILED', '').keys()), [str(d)])
+
 
 class ForkBombTask(luigi.Task):
     depth = luigi.IntParameter()


### PR DESCRIPTION
When the assistant can't create a task for a given family, it should not just
die. This catches the errors caused by unknown task families and logs messaeges
rather than just dying. The scheduler is informed of the failure and the
assistant can continue requesting other jobs.

As a future improvement, the scheduler could also use the failure report to
avoid giving the assistant these types of jobs.