### PR TITLE
Passes module information in get_work response for assistants

### DIFF
--- a/dummy_test_module/not_imported.py
+++ b/dummy_test_module/not_imported.py
@@ -1,0 +1,6 @@
+import luigi
+
+
+class UnimportedTask(luigi.Task):
+    def complete(self):
+        return False

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -111,7 +111,7 @@ class RemoteScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None, priority=0,
-                 family='', params=None):
+                 family='', module=None, params=None):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -123,6 +123,7 @@ class RemoteScheduler(Scheduler):
             'resources': resources,
             'priority': priority,
             'family': family,
+            'module': module,
             'params': params,
         })
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -543,7 +543,8 @@ class Worker(object):
                                  deps=deps, runnable=runnable, priority=task.priority,
                                  resources=task.process_resources(),
                                  params=task.to_str_params(),
-                                 family=task.task_family)
+                                 family=task.task_family,
+                                 module=task.task_module)
 
         logger.info('Scheduled %s (%s)', task.task_id, status)
 
@@ -598,7 +599,7 @@ class Worker(object):
             try:
                 # TODO: we should obtain the module name from the server!
                 self._scheduled_tasks[task_id] = \
-                    load_task(module=None,
+                    load_task(module=r.get('task_module'),
                               task_name=r['task_family'],
                               params_str=r['task_params'])
             except TaskClassException as ex:
@@ -696,6 +697,7 @@ class Worker(object):
                                      runnable=None,
                                      params=task.to_str_params(),
                                      family=task.task_family,
+                                     module=task.task_module,
                                      new_deps=new_deps)
 
             if status == RUNNING:


### PR DESCRIPTION
This allows assistants to run jobs that they have the code for but have not
imported the module. This will unfortunately not work with jobs that were in
the __main__ module of the worker that first added them.