### PR TITLE
Make sure to kill tornado process at the end of a test

### DIFF
--- a/test/server_test.py
+++ b/test/server_test.py
@@ -17,6 +17,7 @@
 import os
 import multiprocessing
 import random
+import signal
 import time
 
 from helpers import unittest, with_config
@@ -73,7 +74,9 @@ class ServerTestRun(unittest.TestCase):
 
     def stop_server(self):
         self._process.terminate()
-        self._process.join()
+        self._process.join(1)
+        if self._process.is_alive():
+            os.kill(self._process.pid, signal.SIGKILL)
 
     def setUp(self):
         self.remove_state()


### PR DESCRIPTION
I saw Travis hanging on bin_test.py. Hopefully that would make sure it doesn't happen again. Might need better way to kill the daemon, thou.