### PR TITLE
Fix for #822

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -29,6 +29,11 @@ import logging
 import traceback
 import warnings
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 from luigi import six
 
 from luigi import parameter
@@ -160,10 +165,11 @@ class Register(abc.ABCMeta):
     def get_reg(cls, include_config_without_section=False):
         """Return all of the registery classes.
 
-        :return:  a ``dict`` of task_family -> class
+        :return:  an ``collections.OrderedDict`` of task_family -> class
         """
         # We have to do this on-demand in case task names have changed later
-        reg = {}
+        # We return this in a topologically sorted list of inheritance: this is useful in some cases (#822)
+        reg = OrderedDict()
         for cls in cls._reg:
             if cls.run == NotImplemented:
                 continue

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -140,6 +140,14 @@ class Banana(luigi.Task):
         self.output().open('w').close()
 
 
+class FooBaseClass(luigi.Task):
+    x = luigi.Parameter()
+
+
+class FooSubClass(FooBaseClass):
+    pass
+
+
 class MyConfig(luigi.Config):
     mc_p = luigi.IntParameter()
     mc_q = luigi.IntParameter(default=73)
@@ -351,6 +359,13 @@ class TestNewStyleGlobalParameters(unittest.TestCase):
     def test_y_arg_override_banana(self):
         luigi.run(['--local-scheduler', '--no-lock', 'Banana', '--y', 'bar', '--style', 'y-kwarg', '--BananaDep-x', 'xyz', '--Banana-x', 'baz'])
         self.expect_keys(['banana-baz-bar', 'banana-dep-xyz-bar'])
+
+    def test_multiple_subclasses(self):
+        # This should work
+        luigi.run(['--local-scheduler', '--no-lock', 'FooSubClass', '--x', 'xyz', '--FooBaseClass-x', 'xyz'])
+
+        # This won't work because --FooSubClass-x doesn't exist
+        self.assertRaises(BaseException, luigi.run, (['--local-scheduler', '--no-lock', 'FooBaseClass', '--x', 'xyz', '--FooSubClass-x', 'xyz'],))
 
 
 class TestRemoveGlobalParameters(unittest.TestCase):


### PR DESCRIPTION
The solution is to let `--MyClass-my-param` only be exposed for params set on the base class. If any class inherits from MyClass, the param name will not change (or be duplicated). Eg. if there will be no `--MySubClass-my-param` option if MySubClass inherits from MyClass