### PR TITLE
Activate py3k test that are now fixed

### DIFF
--- a/luigi/hdfs.py
+++ b/luigi/hdfs.py
@@ -622,7 +622,11 @@ def get_configured_hdfs_client(show_warnings=True):
     """
     config = hdfs()
     custom = config.client
-    if six.PY3 and (custom == "snakebite" or config.use_snakebite):
+    conf_usinf_snakebite = [
+        "snakebite_with_hadoopcli_fallback",
+        "snakebite",
+    ]
+    if six.PY3 and (custom in conf_usinf_snakebite or config.use_snakebite):
         if show_warnings:
             warnings.warn(
                 "snakebite client not compatible with python3 at the moment"

--- a/test/minicluster.py
+++ b/test/minicluster.py
@@ -18,21 +18,12 @@
 import getpass
 import os
 
-from luigi import hadoop, hdfs, six
+from luigi import hadoop, hdfs
 from nose.plugins.attrib import attr
 
 import unittest
 
-# Doesn't use helpers.unittest because it makes fail some test
-# see: https://github.com/spotify/luigi/pull/796#issuecomment-76617218
-try:
-    from unittest import skipIf
-except ImportError:
-    from unittest2 import skipIf
-
-
-if six.PY2:
-    from snakebite.minicluster import MiniCluster
+from snakebite.minicluster import MiniCluster
 
 
 @attr('minicluster')
@@ -45,7 +36,6 @@ class MiniClusterTestCase(unittest.TestCase):
     https://github.com/spotify/snakebite"""
     cluster = None
 
-    @skipIf(six.PY3, 'Minicluster is not supported on python3')
     @classmethod
     def setupClass(cls):
         if not cls.cluster:

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -29,7 +29,7 @@ from boto.s3.key import Key
 from luigi.s3 import S3Client
 
 
-if sys.version_info[:2] == (3, 4):
+if (3, 4, 0) <= sys.version_info[:3] < (3, 4, 3):
     # spulec/moto#308
     mock_s3 = unittest.skip('moto mock doesn\'t work with python3.4')
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,3 +7,4 @@ unittest2
 boto
 sqlalchemy
 elasticsearch
+snakebite>=2.5.2

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -16,23 +16,20 @@
 #
 from __future__ import print_function
 
-import gc
 import os
 import sys
 import tempfile
 
-from luigi import six
 from target_test import FileSystemTargetTestMixin
 from helpers import with_config, unittest
 
-import luigi.format
 from boto.exception import S3ResponseError
 from boto.s3 import key
 from moto import mock_s3
 from luigi import configuration
 from luigi.s3 import FileNotFoundException, InvalidDeleteException, S3Client, S3Target
 
-if sys.version_info[:2] == (3, 4):
+if (3, 4, 0) <= sys.version_info[:3] < (3, 4, 3):
     # spulec/moto#308
     raise unittest.SkipTest('moto mock doesn\'t work with python3.4')
 


### PR DESCRIPTION
Those succeed now beacuse:
 - release of python 3.4.3
 - snakebite 2.5.2
 - new way of testing webserver