### PR TITLE
PySparkTask & SparkSubmitTask improvements

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -446,10 +446,10 @@ worker-disconnect-delay
 [spark]
 -------
 
-Parameters controlling the default execution of ``SparkSubmitTask``:
+Parameters controlling the default execution of ``SparkSubmitTask`` and ``PySparkTask``:
 
 .. deprecated:: 1.1.1
-   ``SparkJob``, ``Spark1xJob`` and ``PySpark1xJob`` are deprecated. Please use ``SparkSubmitTask``.
+   ``SparkJob``, ``Spark1xJob`` and ``PySpark1xJob`` are deprecated. Please use ``SparkSubmitTask`` or ``PySparkTask``.
 
 spark-submit
   Command to run in order to submit spark jobs. Default: spark-submit
@@ -517,16 +517,21 @@ num-executors
 archives
     Comma separated list of archives to be extracted into the working directory of each executor. Default: Spark default
 
+hadoop-conf-dir
+  Location of the hadoop conf dir. Sets HADOOP_CONF_DIR environment variable
+  when running spark. Example: /etc/hadoop/conf
+
+*Extra configuration for PySparkTask jobs:*
+
+py-packages
+    Comma-separated list of local packages (in your python path) to be distributed to the cluster.
+
 *Parameters controlling the execution of SparkJob jobs (deprecated):*
 
 spark-jar
   Location of the spark jar. Sets SPARK_JAR environment variable when
   running spark. Example:
   /usr/share/spark/jars/spark-assembly-0.8.1-incubating-hadoop2.2.0.jar
-
-hadoop-conf-dir
-  Location of hadoop conf dir. Sets HADOOP_CONF_DIR environment variable
-  when running spark. Example: /etc/hadoop/conf
 
 spark-class
   Location of script to invoke. Example: /usr/share/spark/spark-class

--- a/luigi/contrib/pyspark_runner.py
+++ b/luigi/contrib/pyspark_runner.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+The pyspark program.
+
+This module will be run by spark-submit for PySparkTask jobs.
+
+The first argument is a path to the pickled instance of the PySparkTask,
+other arguments are the ones returned by PySparkTask.app_options()
+
+"""
+
+from __future__ import print_function
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+import logging
+import sys
+
+
+class PySparkRunner(object):
+
+    def __init__(self, job):
+        self.job = pickle.load(open(job, "rb"))
+
+    def run(self, sc, *args):
+        self.job.setup_remote(sc)
+        self.job.main(sc, *args)
+
+
+def main(run_pickle, *args):
+    logging.basicConfig(level=logging.WARN)
+    from pyspark import SparkContext
+    with SparkContext() as sc:
+        PySparkRunner(run_pickle).run(sc, *args)
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -25,7 +25,15 @@ import subprocess
 import sys
 import tempfile
 import time
+import shutil
+import importlib
+import tarfile
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import warnings
+
 from luigi import six
 import luigi
 import luigi.format
@@ -37,33 +45,24 @@ logger = logging.getLogger('luigi-interface')
 
 class SparkRunContext(object):
 
-    def __init__(self):
-        self.app_id = None
+    def __init__(self, proc):
+        self.proc = proc
 
     def __enter__(self):
         self.__old_signal = signal.getsignal(signal.SIGTERM)
         signal.signal(signal.SIGTERM, self.kill_job)
         return self
 
-    def kill_job(self, captured_signal=None, stack_frame=None):
-        if self.app_id:
-            done = False
-            while not done:
-                try:
-                    logger.info('Job interrupted, killing application %s', self.app_id)
-                    subprocess.call(['yarn', 'application', '-kill', self.app_id])
-                    done = True
-                except KeyboardInterrupt:
-                    continue
-
-        if captured_signal is not None:
-            # adding 128 gives the exit code corresponding to a signal
-            sys.exit(128 + captured_signal)
-
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is KeyboardInterrupt:
             self.kill_job()
         signal.signal(signal.SIGTERM, self.__old_signal)
+
+    def kill_job(self, captured_signal=None, stack_frame=None):
+        self.proc.kill()
+        if captured_signal is not None:
+            # adding 128 gives the exit code corresponding to a signal
+            sys.exit(128 + captured_signal)
 
 
 class SparkJobError(RuntimeError):
@@ -101,7 +100,7 @@ class SparkSubmitTask(luigi.Task):
 
     def app_options(self):
         """
-        Subclass this method to map your task parameters to the driver app's arguments
+        Subclass this method to map your task parameters to the app's arguments
 
         """
         return []
@@ -120,19 +119,19 @@ class SparkSubmitTask(luigi.Task):
 
     @property
     def jars(self):
-        return configuration.get_config().get("spark", "jars", None)
+        return self._list_config(configuration.get_config().get("spark", "jars", None))
 
     @property
     def py_files(self):
-        return configuration.get_config().get("spark", "py-files", None)
+        return self._list_config(configuration.get_config().get("spark", "py-files", None))
 
     @property
     def files(self):
-        return configuration.get_config().get("spark", "files", None)
+        return self._list_config(configuration.get_config().get("spark", "files", None))
 
     @property
     def conf(self):
-        return configuration.get_config().get("spark", "conf", None)
+        return self._dict_config(configuration.get_config().get("spark", "conf", None))
 
     @property
     def properties_file(self):
@@ -184,74 +183,42 @@ class SparkSubmitTask(luigi.Task):
 
     @property
     def archives(self):
-        return configuration.get_config().get("spark", "archives", None)
+        return self._list_config(configuration.get_config().get("spark", "archives", None))
 
-    def spark_heartbeat(self, line, spark_run_context):
-        pass
+    @property
+    def hadoop_conf_dir(self):
+        return configuration.get_config().get("spark", "hadoop-conf-dir", None)
+
+    def get_environment(self):
+        env = os.environ.copy()
+        hadoop_conf_dir = self.hadoop_conf_dir
+        if hadoop_conf_dir:
+            env['HADOOP_CONF_DIR'] = hadoop_conf_dir
+        return env
 
     def spark_command(self):
         command = [self.spark_submit]
-        if self.master:
-            command += ['--master', self.master]
-        if self.deploy_mode:
-            command += ['--deploy-mode', self.deploy_mode]
-        if self.name:
-            command += ['--name', self.name]
-        if self.entry_class:
-            command += ['--class', self.entry_class]
-        if self.jars:
-            if isinstance(self.jars, (list, tuple)):
-                command += ['--jars', ','.join(self.jars)]
-            elif isinstance(self.jars, six.string_types):
-                command += ['--jars', self.jars]
-        if self.py_files:
-            if isinstance(self.py_files, (list, tuple)):
-                command += ['--py-files', ','.join(self.py_files)]
-            elif isinstance(self.py_files, six.string_types):
-                command += ['--py-files', self.py_files]
-        if self.files:
-            if isinstance(self.files, (list, tuple)):
-                command += ['--files', ','.join(self.files)]
-            elif isinstance(self.files, six.string_types):
-                command += ['--files', self.files]
-        if self.archives:
-            if isinstance(self.archives, (list, tuple)):
-                command += ['--archives', ','.join(self.archives)]
-            elif isinstance(self.archives, six.string_types):
-                command += ['--archives', self.archives]
-        if self.conf:
-            conf = None
-            if isinstance(self.conf, six.string_types):
-                conf = dict(map(lambda i: i.split('='), self.conf.split('|')))
-            if isinstance(self.conf, dict):
-                conf = self.conf
-            if conf:
-                for prop, value in conf.items():
-                    command += ['--conf', '{0}="{1}"'.format(prop, value)]
-        if self.properties_file:
-            command += ['--properties-file', self.properties_file]
-        if self.driver_memory:
-            command += ['--driver-memory', self.driver_memory]
-        if self.driver_java_options:
-            command += ['--driver-java-options', self.driver_java_options]
-        if self.driver_library_path:
-            command += ['--driver-library-path', self.driver_library_path]
-        if self.driver_class_path:
-            command += ['--driver-class-path', self.driver_class_path]
-        if self.executor_memory:
-            command += ['--executor-memory', self.executor_memory]
-        if self.driver_cores:
-            command += ['--driver-cores', self.driver_cores]
-        if self.supervise:
-            command += ['--supervise']
-        if self.total_executor_cores:
-            command += ['--total-executor-cores', self.total_executor_cores]
-        if self.executor_cores:
-            command += ['--executor-cores', self.executor_cores]
-        if self.queue:
-            command += ['--queue', self.queue]
-        if self.num_executors:
-            command += ['--num-executors', self.num_executors]
+        command += self._text_arg('--master', self.master)
+        command += self._text_arg('--deploy-mode', self.deploy_mode)
+        command += self._text_arg('--name', self.name)
+        command += self._text_arg('--class', self.entry_class)
+        command += self._list_arg('--jars', self.jars)
+        command += self._list_arg('--py-files', self.py_files)
+        command += self._list_arg('--files', self.files)
+        command += self._list_arg('--archives', self.archives)
+        command += self._dict_arg('--conf', self.conf)
+        command += self._text_arg('--properties-file', self.properties_file)
+        command += self._text_arg('--driver-memory', self.driver_memory)
+        command += self._text_arg('--driver-java-options', self.driver_java_options)
+        command += self._text_arg('--driver-library-path', self.driver_library_path)
+        command += self._text_arg('--driver-class-path', self.driver_class_path)
+        command += self._text_arg('--executor-memory', self.executor_memory)
+        command += self._text_arg('--driver-cores', self.driver_cores)
+        command += self._flag_arg('--supervise', self.supervise)
+        command += self._text_arg('--total-executor-cores', self.total_executor_cores)
+        command += self._text_arg('--executor-cores', self.executor_cores)
+        command += self._text_arg('--queue', self.queue)
+        command += self._text_arg('--num-executors', self.num_executors)
         return command
 
     def app_command(self):
@@ -260,68 +227,143 @@ class SparkSubmitTask(luigi.Task):
         return [self.app] + self.app_options()
 
     def run(self):
-        args = map(str, self.spark_command() + self.app_command())
-        env = os.environ.copy()
-        temp_stderr = tempfile.TemporaryFile()
+        args = list(map(str, self.spark_command() + self.app_command()))
         logger.info('Running: %s', repr(args))
-        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=temp_stderr, env=env, close_fds=True)
-        return_code, final_state, app_id = self.track_progress(proc)
-        if final_state == 'FAILED':
-            raise SparkJobError("Spark job failed: see your master's logs for {0}".format(app_id))
-        elif return_code != 0:
-            temp_stderr.seek(0)
-            errors = "".join((x.decode('utf8') for x in temp_stderr.readlines()))
-            logger.error(errors)
-            raise SparkJobError('Spark job failed', err=errors)
+        tmp_stdout, tmp_stderr = tempfile.TemporaryFile(), tempfile.TemporaryFile()
+        proc = subprocess.Popen(args, stdout=tmp_stdout, stderr=tmp_stderr,
+                                env=self.get_environment(), close_fds=True,
+                                universal_newlines=True)
+        try:
+            with SparkRunContext(proc):
+                while proc.poll() is None:
+                    pass
+            logger.info(proc.communicate()[0])
+            if proc.returncode != 0:
+                tmp_stdout.seek(0)
+                stdout = "".join(map(lambda s: s.decode('utf-8'), tmp_stdout.readlines()))
+                tmp_stderr.seek(0)
+                stderr = "".join(map(lambda s: s.decode('utf-8'), tmp_stderr.readlines()))
+                raise SparkJobError('Spark job failed {0}'.format(repr(args)), out=stdout, err=stderr)
+        finally:
+            tmp_stderr.close()
+            tmp_stdout.close()
 
-    def track_progress(self, proc):
-        """
-        The Spark client currently outputs a multiline status to stdout every second while the application is running.
+    def _list_config(self, config):
+        if config and isinstance(config, six.string_types):
+            return list(map(lambda x: x.strip(), config.split(',')))
 
-        This instead captures status data and updates a single line of output until the application finishes.
+    def _dict_config(self, config):
+        if config and isinstance(config, six.string_types):
+            return dict(map(lambda i: i.split('='), config.split('|')))
+
+    def _text_arg(self, name, value):
+        if value:
+            return [name, value]
+        return []
+
+    def _list_arg(self, name, value):
+        if value and isinstance(value, (list, tuple)):
+            return [name, ','.join(value)]
+        return []
+
+    def _dict_arg(self, name, value):
+        command = []
+        if value and isinstance(value, dict):
+            for prop, value in value.items():
+                command += [name, '"{0}={1}"'.format(prop, value)]
+        return command
+
+    def _flag_arg(self, name, value):
+        if value:
+            return [name]
+        return []
+
+
+class PySparkTask(SparkSubmitTask):
+    """
+    Template task for running an inline PySpark job
+
+    Simply implement the ``main`` method in your subclass
+
+    You can optionally define package names to be distributed to the cluster
+    with ``py_packages`` (uses luigi's global py-packages configuration by default)
+
+    """
+
+    # Path to the pyspark program passed to spark-submit
+    app = os.path.join(os.path.dirname(__file__), 'pyspark_runner.py')
+    # Python only supports the client deploy mode, force it
+    deploy_mode = "client"
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    @property
+    def py_packages(self):
+        packages = configuration.get_config().get('spark', 'py-packages', None)
+        if packages:
+            return map(lambda s: s.strip(), packages.split(','))
+
+    def setup_remote(self, sc):
+        self._setup_packages(sc)
+
+    def main(self, sc, *args):
         """
-        app_id = None
-        app_status = 'N/A'
-        url = 'N/A'
-        final_state = None
-        start = time.time()
-        re_app_id = re.compile('application identifier: (\w+)')
-        re_app_status = re.compile('yarnAppState: (\w+)')
-        re_url = re.compile('appTrackingUrl: (.+)')
-        re_final_state = re.compile('distributedFinalState: (\w+)')
-        with SparkRunContext() as context:
-            while proc.poll() is None:
-                s = proc.stdout.readline()
-                app_id_s = re_app_id.search(s)
-                if app_id_s:
-                    app_id = app_id_s.group(1)
-                    context.app_id = app_id
-                app_status_s = re_app_status.search(s)
-                if app_status_s:
-                    app_status = app_status_s.group(1)
-                url_s = re_url.search(s)
-                if url_s:
-                    url = url_s.group(1)
-                final_state_s = re_final_state.search(s)
-                if final_state_s:
-                    final_state = final_state_s.group(1)
-                if not app_id:
-                    logger.info(s.strip())
-                else:
-                    t_diff = time.time() - start
-                    elapsed_mins, elapsed_secs = divmod(t_diff, 60)
-                    status = ('[%0d:%02d] Status: %s Tracking: %s' % (elapsed_mins, elapsed_secs, app_status, url))
-                    sys.stdout.write("\r\x1b[K" + status)
-                    sys.stdout.flush()
-                self.spark_heartbeat(s, context)
-        logger.info(proc.communicate()[0])
-        return proc.returncode, final_state, app_id
+        Called by the pyspark_runner, passing a SparkContext and any arguments returned by ``app_options()``
+
+        :param sc: SparkContext
+        :param args: arguments list
+        """
+        raise NotImplementedError("subclass should define a main method")
+
+    def app_command(self):
+        return [self.app, self.run_pickle] + self.app_options()
+
+    def run(self):
+        self.run_path = tempfile.mkdtemp(prefix=self.name)
+        self.run_pickle = os.path.join(self.run_path, '.'.join([self.name.replace(' ', '_'), 'pickle']))
+        with open(self.run_pickle, 'wb') as fd:
+            self._dump(fd)
+        try:
+            super(PySparkTask, self).run()
+        finally:
+            shutil.rmtree(self.run_path)
+
+    def _dump(self, fd):
+        if self.__module__ == '__main__':
+            d = pickle.dumps(self)
+            module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
+            d = d.replace(b'(c__main__', "(c" + module_name)
+            fd.write(d)
+        else:
+            pickle.dump(self, fd)
+
+    def _setup_packages(self, sc):
+        """
+        This method compresses and uploads packages to the cluster
+
+        """
+        packages = self.py_packages
+        if not packages:
+            return
+        for package in packages:
+            mod = importlib.import_module(package)
+            try:
+                mod_path = mod.__path__[0]
+            except AttributeError:
+                mod_path = mod.__file__
+            tar_path = os.path.join(self.run_path, package + '.tar.gz')
+            tar = tarfile.open(tar_path, "w:gz")
+            tar.add(mod_path, os.path.basename(mod_path))
+            tar.close()
+            sc.addPyFile(tar_path)
 
 
 class SparkJob(luigi.Task):
     """
     .. deprecated:: 1.1.1
-       Use ``SparkSubmitTask`` instead.
+       Use ``SparkSubmitTask`` or ``PySparkTask`` instead.
 
     """
     spark_workers = None
@@ -333,6 +375,7 @@ class SparkJob(luigi.Task):
     def requires_local(self):
         """
         Default impl - override this method if you need any local input to be accessible in init().
+
         """
         return []
 
@@ -362,7 +405,7 @@ class SparkJob(luigi.Task):
         raise NotImplementedError("subclass should define HDFS output path")
 
     def run(self):
-        warnings.warn("The use of SparkJob is deprecated. Please use SparkSubmitTask.", stacklevel=2)
+        warnings.warn("The use of SparkJob is deprecated. Please use SparkSubmitTask or PySparkTask.", stacklevel=2)
         original_output_path = self.output().path
         path_no_slash = original_output_path[:-2] if original_output_path.endswith('/*') else original_output_path
         path_no_slash = original_output_path[:-1] if original_output_path[-1] == '/' else path_no_slash
@@ -424,9 +467,9 @@ class SparkJob(luigi.Task):
         url = 'N/A'
         final_state = None
         start = time.time()
-        with SparkRunContext() as context:
+        with SparkRunContext(proc) as context:
             while proc.poll() is None:
-                s = proc.stdout.readline()
+                s = proc.stdout.readline().decode('utf8')
                 app_id_s = re.compile('application identifier: (\w+)').search(s)
                 if app_id_s:
                     app_id = app_id_s.group(1)
@@ -488,7 +531,7 @@ class Spark1xBackwardCompat(SparkSubmitTask):
 class Spark1xJob(Spark1xBackwardCompat):
     """
     .. deprecated:: 1.1.1
-       Use ``SparkSubmitTask`` instead.
+       Use ``SparkSubmitTask`` or ``PySparkTask`` instead.
 
     """
     # Old interface
@@ -508,7 +551,7 @@ class Spark1xJob(Spark1xBackwardCompat):
         return self.jar()
 
     def run(self):
-        warnings.warn("The use of Spark1xJob is deprecated. Please use SparkSubmitTask.", stacklevel=2)
+        warnings.warn("The use of Spark1xJob is deprecated. Please use SparkSubmitTask or PySparkTask.", stacklevel=2)
         return super(Spark1xJob, self).run()
 
 
@@ -516,7 +559,7 @@ class PySpark1xJob(Spark1xBackwardCompat):
     """
 
     .. deprecated:: 1.1.1
-       Use ``SparkSubmitTask`` instead.
+       Use ``SparkSubmitTask`` or ``PySparkTask`` instead.
 
     """
 
@@ -530,5 +573,5 @@ class PySpark1xJob(Spark1xBackwardCompat):
         return self.program()
 
     def run(self):
-        warnings.warn("The use of PySpark1xJob is deprecated. Please use SparkSubmitTask.", stacklevel=2)
+        warnings.warn("The use of PySpark1xJob is deprecated. Please use SparkSubmitTask or PySparkTask.", stacklevel=2)
         return super(PySpark1xJob, self).run()

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
 
 if sys.version_info[:2] < (2, 7):
-    install_requires.extend(['argparse', 'ordereddict'])
+    install_requires.extend(['argparse', 'ordereddict', 'importlib'])
 
 setup(
     name='luigi',


### PR DESCRIPTION
Adds ability to create luigi tasks with an inline pyspark job (depends on https://github.com/spotify/luigi/pull/812):

* PySparkTask submits pyspark_runner.py along with a pickled task and calls main on the task with a SparkContext instance
* PySparkTask can upload listed packages to the spark cluster (global config available)
* Refactors SparkSubmitTask command creation (shorter & more readable method)
* SparkRunContext calls proc.kill() to kill the spark-submit process instead of calling yarn

Need to add unit tests for PySparkTask (and refactor existing spark unit tests, SparkSubmitTask 100% tested so far)