### PR TITLE
Set cmdline argument defaults via task_name / param_name

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -321,12 +321,18 @@ class Parameter(object):
             return
         flag = '--' + dest.replace('_', '-')
 
+        default = None
+        if self.has_task_value(task_name, param_name):
+            default = self.task_value(task_name, param_name)
+            if default is not None:
+                default = self.serialize(default)
+
         description = []
         description.append('%s.%s' % (task_name, param_name))
         if self.description:
             description.append(self.description)
-        if self.has_value:
-            description.append(" [default: %s]" % (self.value,))
+        if default is not None:
+            description.append(" [default: %s]" % (default,))
 
         if self.is_list:
             action = "append"
@@ -341,6 +347,7 @@ class Parameter(object):
         f(flag,
           help=' '.join(description),
           action=action,
+          default=default,
           dest=dest)
 
     def parse_from_args(self, param_name, task_name, args, params):


### PR DESCRIPTION
This avoids side-effects caused by luigi.interface.set_global_parameters
where parsed cmdline arguments are set to parameter default values
without checking the config file.

To test, create a simple config file:
```
[hdfs]
client: snakebite
snakebite_autoconfig: True
```
and a simple task w/ luigi.hdfs.HdfsTarget:
```
class Foobar(luigi.Task):
  def output(self):
    return luigi.hdfs.HdfsTarget('foobar')
```

Without this patch, snakebite_autoconfig will be initialized to the task-level default=False set in luigi.hdfs.hdfs instead of the config file value True.

The reason for this, I believe, is that luigi.interface initializes global param values to the cmdline parsed values (set_global_parameters), but does not pass config file defaults to the cmdline parser.  Once the global value for a parameter is set, the config file is never again consulted (perhaps only affecting non-None values).