### PR TITLE
Remove snakebite dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ with open('README.rst') as fobj:
 install_requires = [
     'pyparsing',
     'tornado',
-    'snakebite>=2.5.0',
     'python-daemon',
 ]
 


### PR DESCRIPTION
I'm trying to package luigi for conda py34 (and push it to my [binstar](https://binstar.org/gpoulin)) and this is currently causing me issues. Since Luigi works perfectly without snakebite, I thought that was the best way to solve my issue.