### PR TITLE
Add a re-enable button on the dashboard

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -750,6 +750,8 @@ class CentralPlannerScheduler(Scheduler):
             'priority': task.priority,
             'resources': task.resources,
         }
+        if task.status == DISABLED:
+            ret['re_enable_able'] = task.scheduler_disable_time is not None
         if include_deps:
             ret['deps'] = list(task.deps)
         return ret

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -75,6 +75,7 @@
                         <div class="span2">
                             <a href="#{{taskId}}" class="btn btn-info btn-small" data-action="drawGraph">Dependency Graph</a>
                             {{#error}}<a class="btn btn-primary btn-small error-trace-button" data-task-id="{{taskId}}">Show Error Trace</a>{{/error}}
+                            {{#re_enable}}<a class="btn btn-warning btn-small re-enable-button" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
                         </div>
                     </div>
                     {{/value}}
@@ -114,6 +115,7 @@
                     <div class="span2">
                         <a href="#{{taskId}}" class="btn btn-info btn-small" data-action="drawGraph">Dependency Graph</a>
                         {{#error}}<a class="btn btn-primary btn-small error-trace-button" data-task-id="{{taskId}}">Show Error Trace</a>{{/error}}
+                        {{#re_enable}}<a class="btn btn-warning btn-small re-enable-button" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
                     </div>
                 </div>
                 {{/tasks}}

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -65,6 +65,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.reEnable = function(taskId, callback) {
+        jsonRPC(this.urlRoot + "/re_enable_task", {task_id: taskId}, function(response) {
+            callback(response.response);
+        });
+    };
+
     LuigiAPI.prototype.getErrorTrace = function(taskId, callback) {
         jsonRPC(this.urlRoot + "/fetch_error", {task_id: taskId}, function(response) {
             callback(response.response);

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -44,7 +44,8 @@ function visualiserApp(luigi) {
             trackingUrl: task.trackingUrl,
             status: task.status,
             graph: (task.status == "PENDING" || task.status == "RUNNING" || task.status == "DONE"),
-            error: task.status == "FAILED"
+            error: task.status == "FAILED",
+            re_enable: task.status == "DISABLED" && task.re_enable_able
         };
     }
 
@@ -180,6 +181,19 @@ function visualiserApp(luigi) {
         $(id + " .error-trace-button").click(function() {
             luigi.getErrorTrace($(this).attr("data-task-id"), function(error) {
                showErrorTrace(error);
+            });
+        });
+        $(id + " .re-enable-button").click(function() {
+            var that = $(this);
+            $(this).attr('disabled', true);
+            luigi.reEnable($(this).attr("data-task-id"), function(data) {
+                if (data.name) {
+                  node = that.closest(".taskFamily").find(".badge-important");
+                  cnt = parseInt(node.text());
+                  cnt --;
+                  node.text(cnt);
+                  that.parent().parent().remove();
+                }
             });
         });
     }


### PR DESCRIPTION
So one can easily re-enable a task when it is disabled by scheduler (when too many failures).
![re_enable](https://cloud.githubusercontent.com/assets/50040/6612863/086db86e-c841-11e4-9e68-71f4ad80e6a8.png)
