### PR TITLE
Doc fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ data processing, like `Hive <http://hive.apache.org/>`__,
 replace these. Instead it helps you stitch many tasks together, where
 each task can be a `Hive query <http://luigi.readthedocs.org/en/latest/api/luigi.contrib.hive.html>`__,
 a `Hadoop job in Java <http://luigi.readthedocs.org/en/latest/api/luigi.hadoop_jar.html>`_,
+a  `Spark job in Scala or Python <http://luigi.readthedocs.org/en/latest/api/luigi.contrib.spark.html>`_
 a Python snippet,
 `dumping a table <http://luigi.readthedocs.org/en/latest/api/luigi.contrib.sqla.html>`_
 from a database, or anything else. It's easy to build up

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -446,16 +446,17 @@ worker-disconnect-delay
 [spark]
 -------
 
-Parameters controlling the default execution of ``SparkSubmitTask`` and ``PySparkTask``:
+Parameters controlling the default execution of :py:class:`~luigi.contrib.spark.SparkSubmitTask` and :py:class:`~luigi.contrib.spark.PySparkTask`:
 
 .. deprecated:: 1.1.1
-   ``SparkJob``, ``Spark1xJob`` and ``PySpark1xJob`` are deprecated. Please use ``SparkSubmitTask`` or ``PySparkTask``.
+   :py:class:`~luigi.contrib.spark.SparkJob`, :py:class:`~luigi.contrib.spark.Spark1xJob` and :py:class:`~luigi.contrib.spark.PySpark1xJob`
+    are deprecated. Please use :py:class:`~luigi.contrib.spark.SparkSubmitTask` or :py:class:`~luigi.contrib.spark.PySparkTask`.
 
 spark-submit
   Command to run in order to submit spark jobs. Default: spark-submit
 
 master
-  Master url to use for spark-submit. Example: local[*]. Default: Spark default (Prior to 1.1.0: yarn-client)
+  Master url to use for spark-submit. Example: local[*], spark://masterhost:7077. Default: Spark default (Prior to 1.1.1: yarn-client)
 
 deploy-mode
     Whether to launch the driver programs locally ("client") or on one of the worker machines inside the cluster ("cluster"). Default: Spark default


### PR DESCRIPTION
Added class links to doc as suggested in previous PR and thought it'd be good to add Spark support as a selling point to the main readme.

Since PySparkTask and SparkSubmitTask are new features, should I update the version on the deprecation directives to 1.2.0 to follow semver?