### PR TITLE
Let tox handle the python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: python
 
-python:
-  - "2.7"
-  - "2.6"
-  - "3.3"
-  - "3.4"
-
 jdk: oraclejdk7
 
 services:
@@ -16,10 +10,16 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - POSTGRES_USER=postgres
   matrix:
-    - TOX_ENV=pep8
-    - TOX_ENV=cdh
-    - TOX_ENV=nonhdfs
-    - TOX_ENV=docs
+    - TOXENV=pep8
+    - TOXENV=docs
+    - TOXENV=py26-nonhdfs
+    - TOXENV=py27-nonhdfs
+    - TOXENV=py33-nonhdfs
+    - TOXENV=py34-nonhdfs
+    - TOXENV=py26-cdh
+    - TOXENV=py27-cdh
+    - TOXENV=py33-cdh
+    - TOXENV=py34-cdh
 
 sudo: false
 
@@ -27,7 +27,6 @@ cache:
   - $HOME/.pip-cache
 
 install:
-  - pip install .
   - pip install tox
 
 before_script:
@@ -39,7 +38,7 @@ before_script:
   - ssh -o StrictHostKeyChecking=no localhost true
 
 script:
-  - tox -e $TOX_ENV
+  - tox
 
 after_failure:
   - cat /home/travis/build/spotify/luigi/.tox/cdh/log/cdh-1.log

--- a/scripts/ci/setup_hadoop_env.sh
+++ b/scripts/ci/setup_hadoop_env.sh
@@ -42,8 +42,6 @@ while test $# -gt 0; do
     esac
 done
 
-HADOOP_HOME=/tmp/hadoop-${HADOOP_DISTRO}
-
 if $ONLY_DOWNLOAD && $ONLY_EXTRACT; then
     echo "Both only-download and only-extract specified - abort" >&2
     exit 1
@@ -60,7 +58,7 @@ else
     exit 1
 fi
 
-if ! $ONLY_EXTRACT; then
+if ! $ONLY_EXTRACT && [ ! -e ${HADOOP_HOME}/hadoop.tar.gz ] ; then
     echo "Downloading Hadoop from $URL to ${HADOOP_HOME}/hadoop.tar.gz"
     curl -z ${HADOOP_HOME}/hadoop.tar.gz -o ${HADOOP_HOME}/hadoop.tar.gz -L $URL
 

--- a/test/import_test.py
+++ b/test/import_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+from helpers import unittest
+
+
+class ImportTest(unittest.TestCase):
+
+    def import_test(self):
+        """Test that all module can be imported
+        """
+
+        luigidir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..'
+        )
+
+        packagedir = os.path.join(luigidir, 'luigi')
+
+        for root, subdirs, files in os.walk(packagedir):
+            package = os.path.relpath(root, luigidir).replace('/', '.')
+
+            if '__init__.py' in files:
+                __import__(package)
+
+            for f in files:
+                if f.endswith('.py') and not f.startswith('_'):
+                    __import__(package + '.' + f[:-3])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {pep8,cdh,hdp,nonhdfs}
+envlist = py{26,27,33,34}-{cdh,hdp,nonhdfs}, docs, pep8
 skipsdist = True
 
 [testenv]
@@ -10,9 +10,9 @@ deps=
   coveralls
 setenv =
   cdh: HADOOP_DISTRO=cdh
-  cdh: HADOOP_HOME=/tmp/hadoop-cdh
+  cdh: HADOOP_HOME={toxinidir}/.tox/hadoop-cdh
   hdp: HADOOP_DISTRO=hdp
-  hdp: HADOOP_HOME=/tmp/hadoop-hdp
+  hdp: HADOOP_HOME={toxinidir}/.tox/hadoop-hdp
   cdh,hdp: NOSE_ATTR=minicluster
   nonhdfs: NOSE_ATTR=!minicluster
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client.cfg
@@ -20,6 +20,7 @@ setenv =
   FULL_COVERAGE=true
 commands =
   cdh,hdp: {toxinidir}/scripts/ci/setup_hadoop_env.sh
+  python --version
   coverage run test/runtests.py -v {posargs:}
   coverage combine
   coveralls


### PR DESCRIPTION
Also cache the hadoop distribution
Allow easier switching between python version
Benifit from the tox cache

Before
```bash
export EPYTHON=python2.7 # Gentoo way to set python version
tox -e cdh # install deps and download hadoop
export EPYTHON=python3.4
tox -e cdh # install deps and download hadoop
export EPYTHON=python2.7
tox -e cdh # install deps and download hadoop
```

After
```bash
tox -e py27-cdh # install deps and download hadoop
tox -e py34-cdh # install deps
tox -e py27-cdh # just run the tests
```

In addition, I think that coveralls is currently a little confused when producing the coverage diff, hopefully that will help. The main inconvenient is that it makes the travis conf a little verbos.