### PR TITLE
Keeps assistants from becoming stakeholders

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -105,7 +105,7 @@ class RemoteScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None, priority=0,
-                 family='', module=None, params=None):
+                 family='', module=None, params=None, assistant=False):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -119,6 +119,7 @@ class RemoteScheduler(Scheduler):
             'family': family,
             'module': module,
             'params': params,
+            'assistant': assistant,
         })
 
     def get_work(self, worker, host=None, assistant=False):

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -502,7 +502,8 @@ class CentralPlannerScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
-                 priority=0, family='', module=None, params=None, **kwargs):
+                 priority=0, family='', module=None, params=None,
+                 assistant=False, **kwargs):
         """
         * add task identified by task_id if it doesn't exist
         * if deps is not None, update dependency list
@@ -547,8 +548,7 @@ class CentralPlannerScheduler(Scheduler):
         if resources is not None:
             task.resources = resources
 
-        # only assistants should normally schedule tasks as FAILED and not runnable
-        if runnable or status != FAILED:
+        if not assistant:
             task.stakeholders.add(worker)
 
             # Task dependencies might not exist yet. Let's create dummy tasks for them for now.

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -607,7 +607,8 @@ class Worker(object):
                 subject = 'Luigi: %s' % msg
                 error_message = notifications.wrap_traceback(ex)
                 notifications.send_error_email(subject, error_message)
-                self._scheduler.add_task(self._id, task_id, status=FAILED, runnable=False)
+                self._scheduler.add_task(self._id, task_id, status=FAILED, runnable=False,
+                                         assistant=self._assistant)
                 task_id = None
                 self.run_succeeded = False
 
@@ -697,7 +698,8 @@ class Worker(object):
                                      params=task.to_str_params(),
                                      family=task.task_family,
                                      module=task.task_module,
-                                     new_deps=new_deps)
+                                     new_deps=new_deps,
+                                     assistant=self._assistant)
 
             if status == RUNNING:
                 continue

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -201,6 +201,22 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.ping('X')
         self.assertEqual(list(self.sch.task_list('FAILED', '').keys()), ['A'])
 
+    def test_prune_with_live_assistant(self):
+        self.setTime(0)
+        self.sch.add_task(worker='X', task_id='A')
+        self.sch.get_work('Y', assistant=True)
+        self.sch.add_task(worker='Y', task_id='A', status=DONE, assistant=True)
+
+        # worker X stops communicating, A should be marked for removal
+        self.setTime(600)
+        self.sch.ping('Y')
+        self.sch.prune()
+
+        # A will now be pruned
+        self.setTime(2000)
+        self.sch.prune()
+        self.assertFalse(list(self.sch.task_list('', '')))
+
     def test_scheduler_resources_none_allow_one(self):
         self.sch.add_task(worker='X', task_id='A', resources={'R1': 1})
         self.assertEqual(self.sch.get_work(worker='X')['task_id'], 'A')


### PR DESCRIPTION
If assistants live longer than other workers, we don't want them to keep tasks
alive unnecessarily. By preventing assistants from becoming stakeholders of
tasks they're working on, pruning of tasks done by the assistant is allowed when
the workers that actually scheduled them go away.