### PR TITLE
Prevents non-runnable tasks from going to assistants

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -653,7 +653,7 @@ class CentralPlannerScheduler(Scheduler):
         tasks.sort(key=self._rank(), reverse=True)
 
         for task in tasks:
-            in_workers = assistant or worker in task.workers
+            in_workers = (assistant and task.workers) or worker in task.workers
             if task.status == 'RUNNING' and in_workers:
                 # Return a list of currently running tasks to the client,
                 # makes it easier to troubleshoot

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -188,6 +188,10 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(list(running_tasks.keys()), ['A'])
         self.assertEqual(running_tasks['A']['worker_running'], 'Y')
 
+    def test_assistant_get_work_external_task(self):
+        self.sch.add_task('X', task_id='A', runnable=False)
+        self.assertTrue(self.sch.get_work('Y', assistant=True)['task_id'] is None)
+
     def test_task_fails_when_assistant_dies(self):
         self.setTime(0)
         self.sch.add_task(worker='X', task_id='A')


### PR DESCRIPTION
I was seeing a lot of errors from assistants trying to run external tasks and
being unable to even find and load the class. It turns out assistants were
being treated as potential workers even by tasks with no workers. As a partial
fix, assistants can now only work on tasks that some worker is capable of.

This fix is great for workflows where external tasks only exist to check that
non-luigi jobs are complete, but won't work for tasks that are external to the
assistant but not to all workers.