### PR TITLE
Various param cleanup

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -31,7 +31,6 @@ Event = event.Event
 
 Task = task.Task
 Config = task.Config
-ConfigWithoutSection = task.ConfigWithoutSection
 ExternalTask = task.ExternalTask
 WrapperTask = task.WrapperTask
 Target = target.Target

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -58,7 +58,7 @@ def setup_interface_logging(conf_file=None):
     setup_interface_logging.has_run = True
 
 
-class core(task.ConfigWithoutSection):
+class core(task.Config):
 
     ''' Keeps track of a bunch of environment params.
 
@@ -67,6 +67,7 @@ class core(task.ConfigWithoutSection):
     and get an object with all the environment variables set.
     This is arguably a bit of a hack.
     '''
+    use_cmdline_section = False
 
     local_scheduler = parameter.BoolParameter(
         default=False,

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -99,8 +99,7 @@ class core(task.ConfigWithoutSection):
         description='Used for dynamic loading of modules')  # see DynamicArgParseInterface
     parallel_scheduling = parameter.BoolParameter(
         default=False,
-        description='Use multiprocessing to do scheduling in parallel.',
-        config_path={'section': 'core', 'name': 'parallel-scheduling'})
+        description='Use multiprocessing to do scheduling in parallel.')
     assistant = parameter.BoolParameter(
         default=False,
         description='Run any task from the scheduler.')

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -180,11 +180,17 @@ class Parameter(object):
             v = self._get_value_from_config(task_name, param_name)
             if v != _no_value:
                 return v
+            v = self._get_value_from_config(task_name, param_name.replace('_', '-'))
+            if v != _no_value:
+                warnings.warn(
+                    'The use of the configuration [%s] %s (with dashes) should be avoided. Please use underscores.' %
+                    (task_name, param_name), DeprecationWarning, stacklevel=2)
+                return v
         if self.__config:
             v = self._get_value_from_config(self.__config['section'], self.__config['name'])
             if v != _no_value and task_name and param_name:
                 warnings.warn(
-                    'The use of the configuration %s>%s is deprecated. Please use %s>%s' %
+                    'The use of the configuration [%s] %s is deprecated. Please use [%s] %s' %
                     (self.__config['section'], self.__config['name'], task_name, param_name),
                     DeprecationWarning, stacklevel=2)
             if v != _no_value:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -79,14 +79,10 @@ STATUS_TO_UPSTREAM_MAP = {
 class scheduler(Config):
     # TODO(erikbern): the config_path is needed for backwards compatilibity. We should drop the compatibility
     # at some point (in particular this would force users to replace all dashes with underscores in the config)
-    retry_delay = parameter.FloatParameter(default=900.0,
-                                           config_path=dict(section='scheduler', name='retry-delay'))
-    remove_delay = parameter.FloatParameter(default=600.0,
-                                            config_path=dict(section='scheduler', name='remove-delay'))
-    worker_disconnect_delay = parameter.FloatParameter(default=60.0,
-                                                       config_path=dict(section='scheduler', name='worker-disconnect-delay'))
-    state_path = parameter.Parameter(default='/var/lib/luigi-server/state.pickle',
-                                     config_path=dict(section='scheduler', name='state-path'))
+    retry_delay = parameter.FloatParameter(default=900.0)
+    remove_delay = parameter.FloatParameter(default=600.0)
+    worker_disconnect_delay = parameter.FloatParameter(default=60.0)
+    state_path = parameter.Parameter(default='/var/lib/luigi-server/state.pickle')
 
     # Jobs are disabled if we see more than disable_failures failures in disable_window seconds.
     # These disables last for disable_persist seconds.
@@ -96,11 +92,9 @@ class scheduler(Config):
                                               config_path=dict(section='scheduler', name='disable-num-failures'))
     disable_persist = parameter.IntParameter(default=86400,
                                              config_path=dict(section='scheduler', name='disable-persist-seconds'))
-    max_shown_tasks = parameter.IntParameter(default=100000,
-                                             config_path=dict(section='scheduler', name='max-shown-task'))
+    max_shown_tasks = parameter.IntParameter(default=100000)
 
-    record_task_history = parameter.BoolParameter(default=False,
-                                                  config_path=dict(section='scheduler', name='record_task_history'))
+    record_task_history = parameter.BoolParameter(default=False)
 
 
 def fix_time(x):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -118,8 +118,11 @@ class Task(object):
     #: Defaults to 0 or value in client.cfg
     worker_timeout = None
 
-    #: See :class:`~ConfigWithoutSection`
-    _config_without_section = False
+    @property
+    def use_cmdline_section(self):
+        ''' Property used by core config such as `--workers` etc.
+        These will be exposed without the class as prefix.'''
+        return True
 
     @classmethod
     def event_handler(cls, event):
@@ -513,15 +516,6 @@ class Config(Task):
     ParamContainer base class
     """
     pass
-
-
-class ConfigWithoutSection(Task):
-
-    """Used for configuration that doesn't have a particular section
-
-    (eg. --n-workers)
-    """
-    _config_without_section = True
 
 
 def getpaths(struct):

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -126,7 +126,7 @@ class Register(abc.ABCMeta):
             return "%s.%s" % (cls.task_namespace, cls.__name__)
 
     @classmethod
-    def __get_reg(cls, include_config_without_section=False):
+    def __get_reg(cls):
         """Return all of the registered classes.
 
         :return:  an ``collections.OrderedDict`` of task_family -> class
@@ -136,8 +136,6 @@ class Register(abc.ABCMeta):
         reg = OrderedDict()
         for cls in cls._reg:
             if cls.run == NotImplemented:
-                continue
-            if cls._config_without_section and not include_config_without_section:
                 continue
             name = cls.task_family
 
@@ -187,7 +185,7 @@ class Register(abc.ABCMeta):
 
         :return: a ``dict`` of parameter name -> parameter.
         """
-        for task_name, task_cls in six.iteritems(cls.__get_reg(include_config_without_section=True)):
+        for task_name, task_cls in six.iteritems(cls.__get_reg()):
             if task_cls == cls.AMBIGUOUS_CLASS:
                 continue
             for param_name, param_obj in task_cls.get_params():

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -183,13 +183,13 @@ class Register(abc.ABCMeta):
         """
         Compiles and returns all parameters for all :py:class:`Task`.
 
-        :return: a ``dict`` of parameter name -> parameter.
+        :return: a generator of tuples (TODO: we should make this more elegant)
         """
         for task_name, task_cls in six.iteritems(cls.__get_reg()):
             if task_cls == cls.AMBIGUOUS_CLASS:
                 continue
             for param_name, param_obj in task_cls.get_params():
-                yield task_name, task_cls._config_without_section, param_name, param_obj
+                yield task_name, (not task_cls.use_cmdline_section), param_name, param_obj
 
 
 def load_task(module, task_name, params_str):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -648,6 +648,16 @@ class OverrideEnvStuff(unittest.TestCase):
         env_params = luigi.interface.core()
         self.assertEqual(env_params.scheduler_port, 6543)
 
+    @with_config({"core": {"scheduler-port": '6544'}})
+    def testOverrideSchedulerPort2(self):
+        env_params = luigi.interface.core()
+        self.assertEqual(env_params.scheduler_port, 6544)
+
+    @with_config({"core": {"scheduler_port": '6545'}})
+    def testOverrideSchedulerPort3(self):
+        env_params = luigi.interface.core()
+        self.assertEqual(env_params.scheduler_port, 6545)
+
 
 if __name__ == '__main__':
     luigi.run(use_optparse=True)

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -145,7 +145,8 @@ class MyConfig(luigi.Config):
     mc_q = luigi.IntParameter(default=73)
 
 
-class MyConfigWithoutSection(luigi.ConfigWithoutSection):
+class MyConfigWithoutSection(luigi.Config):
+    use_cmdline_section = False
     mc_r = luigi.IntParameter()
     mc_s = luigi.IntParameter(default=99)
 
@@ -408,7 +409,8 @@ class TestRemoveGlobalParameters(unittest.TestCase):
         class Dogs(luigi.Config):
             n_dogs = luigi.IntParameter()
 
-        class CatsWithoutSection(luigi.ConfigWithoutSection):
+        class CatsWithoutSection(luigi.Config):
+            use_cmdline_section = False
             n_cats = luigi.IntParameter()
 
         self.run_and_check(['--n-cats', '123', '--Dogs-n-dogs', '456', 'WithDefault'])


### PR DESCRIPTION
Allow the use of dashes in the config names

(but throw a warning saying you should use underscores)