### PR TITLE
Does not consider upstream disabled jobs as pending for worker keep-aliv...

### DIFF
--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -585,6 +585,26 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(3, response['n_pending_tasks'])
         self.assertEqual(2, response['n_unique_pending'])
 
+    def test_pending_downstream_disable(self):
+        self.sch.add_task(WORKER, 'A', status=DISABLED)
+        self.sch.add_task(WORKER, 'B', deps=('A',))
+        self.sch.add_task(WORKER, 'C', deps=('B',))
+
+        response = self.sch.get_work(WORKER)
+        self.assertTrue(response['task_id'] is None)
+        self.assertEqual(0, response['n_pending_tasks'])
+        self.assertEqual(0, response['n_unique_pending'])
+
+    def test_pending_downstream_failure(self):
+        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(WORKER, 'B', deps=('A',))
+        self.sch.add_task(WORKER, 'C', deps=('B',))
+
+        response = self.sch.get_work(WORKER)
+        self.assertTrue(response['task_id'] is None)
+        self.assertEqual(2, response['n_pending_tasks'])
+        self.assertEqual(2, response['n_unique_pending'])
+
     def test_prefer_more_dependents(self):
         self.sch.add_task(WORKER, 'A')
         self.sch.add_task(WORKER, 'B')


### PR DESCRIPTION
This is a simplified version of #686 which achieves the same goal without altering the status of any jobs.

If you schedule a worker with a pending task that depends on a disabled task and
have worker-keep-alive set to true, the worker will stay alive forever waiting
for a pending task that can never be scheduled. This updates the get_work
response not consider upstream disabled jobs as pending so that workers can die
once all potentially runnable jobs are complete.