### PR TITLE
Eliminate busy wait, fixing 100% CPU usage.

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -235,9 +235,7 @@ class SparkSubmitTask(luigi.Task):
                                 universal_newlines=True)
         try:
             with SparkRunContext(proc):
-                while proc.poll() is None:
-                    pass
-            logger.info(proc.communicate()[0])
+                proc.wait()
             tmp_stdout.seek(0)
             stdout = "".join(map(lambda s: s.decode('utf-8'), tmp_stdout.readlines()))
             logger.info("Spark job stdout:\n{0}".format(stdout))

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -193,7 +193,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
         def interrupt():
             raise KeyboardInterrupt()
 
-        proc.return_value.poll = interrupt
+        proc.return_value.wait = interrupt
         try:
             job = TestSparkSubmitTask()
             job.run()


### PR DESCRIPTION
Also remove unecessary communicate() call. It just prints "None" to the
log.