### PR TITLE
Allow for workflows in which the assistant is the only long-term worker

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -170,7 +170,8 @@ class Interface(object):
             success &= w.add(t, env_params.parallel_scheduling)
         logger = logging.getLogger('luigi-interface')
         logger.info('Done scheduling tasks')
-        success &= w.run()
+        if env_params.workers != 0:
+            success &= w.run()
         w.stop()
         return success
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -774,6 +774,11 @@ class MultipleWorkersTest(unittest.TestCase):
         luigi.build([MyDynamicTask(i) for i in range(100)], workers=100, local_scheduler=True)
         self.assertTrue(time.time() < t0 + 5.0)  # should ideally take exactly 0.1s, but definitely less than 10.0
 
+    def test_zero_workers(self):
+        d = DummyTask()
+        luigi.build([d], workers=0, local_scheduler=True)
+        self.assertFalse(d.complete())
+
     def test_system_exit(self):
         # This would hang indefinitely before this fix:
         # https://github.com/spotify/luigi/pull/439


### PR DESCRIPTION
This encompasses two changes. First, it allows scheduling with --workers 0 so that after scheduling the worker will immediately die. Second, it keeps runnable jobs (and DONE jobs they depend on) from being pruned if there is an assistant. By combining these, we can create a workflows in which scheduling and running jobs are handled completely separately.