### PR TITLE
Fix external dynamic deps

### DIFF
--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -135,8 +135,6 @@ class Register(abc.ABCMeta):
         # We return this in a topologically sorted list of inheritance: this is useful in some cases (#822)
         reg = OrderedDict()
         for cls in cls._reg:
-            if cls.run == NotImplemented:
-                continue
             name = cls.task_family
 
             if name in reg and reg[name] != cls and \

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 
 import luigi
 import luigi.task
+from luigi.task_register import load_task
 
 
 class DummyTask(luigi.Task):
@@ -54,6 +55,10 @@ class TaskTest(unittest.TestCase):
         original = DummyTask(**params)
         other = DummyTask.from_str_params(original.to_str_params())
         self.assertEqual(original, other)
+
+    def test_external_tasks_loadable(self):
+        task = load_task("luigi", "ExternalTask", {})
+        assert(isinstance(task, luigi.ExternalTask))
 
     def test_id_to_name_and_params(self):
         task_id = "InputText(date=2014-12-29)"


### PR DESCRIPTION
Since running tasks communicate with worker via a queue, all dynamic dependencies that they yield must be serialized and then deserialized back. This doesn't work if a task has `run = NotImplemented`, since there was a specific check for that in Register for unclear reason.

This PR adds a test case to reproduce the issue and fixes it by removing the check.