### PR TITLE
Adding SequenceFileAsBinaryInputFormat iterator for hadoop mappers

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -39,6 +39,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+import struct
 import subprocess
 import sys
 import tempfile
@@ -479,6 +480,7 @@ class HadoopJobRunner(JobRunner):
         if self.output_format:
             arglist += ['-outputformat', self.output_format]
         if self.input_format:
+            job._input_format = self.input_format
             arglist += ['-inputformat', self.input_format]
 
         for target in luigi.task.flatten(job.input_hadoop()):
@@ -881,13 +883,40 @@ class JobTask(BaseHadoopJobTask):
                 yield output
         self._flush_batch_incr_counter()
 
+    def _binseqfile_iter(self, stream):
+        """
+        Turn a typedbytes SequenceFile into (key, val) pairs.
+        """
+        while True:
+            keyheader = stream.read(4)
+            if not keyheader:
+                break
+            keylen = struct.unpack("!i", keyheader)[0]
+            key = stream.read(keylen)
+            tab = stream.read(1)
+            if tab != "\t":
+                raise IOError("Expected a %r separating key and value. Found %r instead." % 
+                    ("\t", tab))
+            valheader = stream.read(4)
+            if not valheader:
+                raise IOError("No value header found.")
+            vallen = struct.unpack("!i", valheader)[0]
+            val = stream.read(vallen)
+            eoln = stream.read(1)
+            if eoln != "\n":
+                raise IOError("Expected binary-tab-binary-eoln, we encountered %r-%r-%r-(%d bytes)-%r..." % (keyheader, key, tab, length, eoln))
+            yield key, val
+
     def run_mapper(self, stdin=sys.stdin, stdout=sys.stdout):
         """
         Run the mapper on the hadoop node.
         """
         self.init_hadoop()
         self.init_mapper()
-        outputs = self._map_input((line[:-1] for line in stdin))
+        if "SequenceFileAsBinaryInputFormat" in self._input_format:
+            outputs = self._map_input(self._binseqfile_iter(stdin))
+        else:
+            outputs = self._map_input((line[:-1] for line in stdin))
         if self.reducer == NotImplemented:
             self.writer(outputs, stdout)
         else:


### PR DESCRIPTION
I'm currently running some Hadoop jobs on image data. They are `typedbytes` in a SequenceFile. 

I set the job's `-inputformat` to `org.apache.hadoop.mapred.SequenceFileAsBinaryInputFormat`, which worked great to pass in `typedbytes` to the mapper. 

However, I found that `JobTask._map_input` always splits on newlines. However, newlines occur in the middle of my image files, which causes failures.

Here's a janky fix that reads in the keys and values and their lengths, and splits the input stream based on that. I have a few questions before I would consider this worthy of merging, but since I'm already working on it I figured it should probably go in a PR.

1. The method by which I access (and check) the input_format is really janky. Is there a better way to set this up? Maybe when `job_runner().run_job(job)` is called, we can set `job.jobopts` to be a dict of all the options passed in to `job_runner`.

2. How would you suggest testing this? It looks like `test/hadoop_test.py` seems to be mostly tests of the "run jobs, then check the output" flavor. Would it be sufficient to just have a "`_binseqfile_iter(stdin)` takes binary input and outputs key-value pairs properly" test?