### PR TITLE
Fix bug with history page when connecting to a postgres DB

### DIFF
--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -151,7 +151,7 @@ class DbTaskHistory(task_history.TaskHistory):
             return session.query(TaskRecord).\
                 join(TaskEvent).\
                 filter(TaskEvent.ts >= yesterday).\
-                group_by(TaskRecord.id, TaskEvent.event_name).\
+                group_by(TaskRecord.id, TaskEvent.event_name, TaskEvent.ts).\
                 order_by(TaskEvent.ts.desc()).\
                 all()
 


### PR DESCRIPTION
The current DbTaskHistory class executes the following query when finding all of the latest runs:
```
SELECT tasks.id AS tasks_id, tasks.name AS tasks_name, tasks.host AS tasks_host 
FROM tasks JOIN task_events ON tasks.id = task_events.task_id 
WHERE task_events.ts >= %(ts_1)s 
GROUP BY tasks.id, task_events.event_name 
ORDER BY task_events.ts DESC' {'ts_1': datetime.datetime(2015, 4, 9, 10, 25, 58, 589578)}
```
This query is not valid in Postgres and gives the following error:
```
ProgrammingError: (ProgrammingError) column "task_events.ts" must appear in the GROUP BY clause or be used in an aggregate function
LINE 3: ...ROUP BY tasks.id, task_events.event_name ORDER BY task_event...
```
See http://dba.stackexchange.com/questions/88988/postgres-error-column-must-appear-in-the-group-by-clause-or-be-used-in-an-aggre

I created a simple fix to add the task_events.ts to the GROUP BY clause. This fixed my error and now the history page renders as expected.