### PR TITLE
do not normalize remote path in RemoteFileSystem

### DIFF
--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -40,6 +40,7 @@ import contextlib
 import os
 import random
 import subprocess
+import posixpath
 
 import luigi
 import luigi.format
@@ -173,7 +174,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
 
     def put(self, local_path, path):
         # create parent folder if not exists
-        normpath = os.path.normpath(path)
+        normpath = posixpath.normpath(path)
         folder = os.path.dirname(normpath)
         if folder and not self.exists(folder):
             self.remote_context.check_output(['mkdir', '-p', folder])


### PR DESCRIPTION
fixes #891
This patch means people should/can not use a remote path like "path/.." because that would end up in a "mkdir .."