### PR TITLE
remove deps in _serialize_task() when unnecessary

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -751,7 +751,6 @@ class CentralPlannerScheduler(Scheduler):
     def _serialize_task(self, task_id, include_deps=True):
         task = self._state.get_task(task_id)
         ret = {
-            'deps': list(task.deps),
             'status': task.status,
             'workers': list(task.workers),
             'worker_running': task.worker_running,

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -668,6 +668,12 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(WORKER, 'F', deps=['A', 'B'])
         self.check_task_order('DCABEF')
 
+    def test_task_list_no_deps(self):
+        self.sch.add_task(WORKER, 'B', deps=('A',))
+        self.sch.add_task(WORKER, 'A')
+        task_list = self.sch.task_list('PENDING', '')
+        self.assertFalse('deps' in task_list['A'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added this a while back in https://github.com/spotify/luigi/pull/484

Then I saw this got reverted in https://github.com/spotify/luigi/commit/4bcb2ca8623f807037db8e012950fef867b30357#diff-ec5c8f6c192cef5a08a5e22aa6273604L405

I put that change back in again. The goal is that when we call task_list() from dashboard, we don't need to load the entire deps for each task.

I also added a test in case we revert that again.