### PR TITLE
add double quote on mapred.job.name

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -613,7 +613,7 @@ class BaseHadoopJobTask(luigi.Task):
 
     def jobconfs(self):
         jcs = []
-        jcs.append('mapred.job.name=%s' % self.task_id)
+        jcs.append('mapred.job.name="%s"' % self.task_id)
         if self.mr_priority != NotImplemented:
             jcs.append('mapred.job.priority=%s' % self.mr_priority())
         pool = self.pool


### PR DESCRIPTION
so it won't break when there is space in self.task_id sometimes