### PR TITLE
Support running a remote hadoop jar command

### DIFF
--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -83,7 +83,9 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
             arglist.append('{}@{}'.format(username, host))
         else:
             arglist = []
-            if not job.jar() or not os.path.exists(job.jar()):
+            if not job.jar():
+                raise HadoopJarJobError("Jar not defined")
+            if not os.path.exists(job.jar()):
                 logger.error("Can't find jar: %s, full path %s", job.jar(), os.path.abspath(job.jar()))
                 raise HadoopJarJobError("job jar does not exist")
 

--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -64,23 +64,40 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
         pass
 
     def run_job(self, job):
+        ssh_config = job.ssh()
+        if ssh_config:
+            host = ssh_config.get("host", None)
+            key_file = ssh_config.get("key_file", None)
+            username = ssh_config.get("username", None)
+            if not host or not key_file or not username or not job.jar():
+                raise Exception("missing some config for HadoopRemoteJarJobRunner")
+            arglist = ['ssh', '-i', key_file,
+                       '-o', 'BatchMode=yes']  # no password prompts etc
+            if ssh_config.get("no_host_key_check", False):
+                arglist += ['-o', 'UserKnownHostsFile=/dev/null',
+                            '-o', 'StrictHostKeyChecking=no']
+            arglist.append('%s@%s' % (username, host))
+        else:
+            arglist = []
+            if not job.jar() or not os.path.exists(job.jar()):
+                logger.error("Can't find jar: %s, full path %s", job.jar(), os.path.abspath(job.jar()))
+                raise Exception("job jar does not exist")
+
         # TODO(jcrobak): libjars, files, etc. Can refactor out of
         # hadoop.HadoopJobRunner
-        if not job.jar() or not os.path.exists(job.jar()):
-            logger.error("Can't find jar: %s, full path %s", job.jar(), os.path.abspath(job.jar()))
-            raise Exception("job jar does not exist")
-        arglist = luigi.contrib.hdfs.load_hadoop_cmd() + ['jar', job.jar()]
+        hadoop_arglist = luigi.contrib.hdfs.load_hadoop_cmd() + ['jar', job.jar()]
         if job.main():
-            arglist.append(job.main())
+            hadoop_arglist.append(job.main())
 
         jobconfs = job.jobconfs()
 
         for jc in jobconfs:
-            arglist += ['-D' + jc]
+            hadoop_arglist += ['-D' + jc]
 
         (tmp_files, job_args) = fix_paths(job)
 
-        arglist += job_args
+        hadoop_arglist += job_args
+        arglist.extend(hadoop_arglist)
 
         luigi.contrib.hadoop.run_and_track_hadoop_job(arglist)
 
@@ -115,6 +132,13 @@ class HadoopJarJobTask(luigi.contrib.hadoop.BaseHadoopJobTask):
         atomically move them into place after the job finishes.
         """
         return True
+
+    def ssh(self):
+        """
+        Set this to run hadoop command remotely via ssh. It needs to be a dict that looks like
+        {"host": "myhost", "key_file": None, "username": None, ["no_host_key_check": False]}
+        """
+        return None
 
     def args(self):
         """

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import luigi
+import tempfile
+from helpers import unittest
+from luigi.contrib.hadoop_jar import HadoopJarJobError, HadoopJarJobTask
+from mock import patch, MagicMock
+
+
+class TestHadoopJarJob(HadoopJarJobTask):
+    path = luigi.Parameter()
+
+    def jar(self):
+        return self.path
+
+
+class TestMissingJarJob(HadoopJarJobTask):
+    pass
+
+
+class TestRemoteHadoopJarJob(TestHadoopJarJob):
+    def ssh(self):
+        return {"host": "myhost", "key_file": "file", "username": "user"}
+
+
+class TestRemoteMissingJarJob(TestHadoopJarJob):
+    def ssh(self):
+        return {"host": "myhost", "key_file": "file"}
+
+
+class HadoopJarJobTaskTest(unittest.TestCase):
+    @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_good(self, mock_job):
+        mock_job.return_value = None
+        with tempfile.NamedTemporaryFile() as temp_file:
+            task = TestHadoopJarJob(temp_file.name)
+            task.run()
+
+    @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_missing_jar(self, mock_job):
+        mock_job.return_value = None
+        task = TestMissingJarJob()
+        self.assertRaises(HadoopJarJobError, task.run)
+
+    @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_remote_job(self, mock_job):
+        mock_job.return_value = None
+        with tempfile.NamedTemporaryFile() as temp_file:
+            task = TestRemoteHadoopJarJob(temp_file.name)
+            task.run()
+
+    @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_remote_job_missing_config(self, mock_job):
+        mock_job.return_value = None
+        with tempfile.NamedTemporaryFile() as temp_file:
+            task = TestRemoteMissingJarJob(temp_file.name)
+            self.assertRaises(HadoopJarJobError, task.run)


### PR DESCRIPTION
I am not sure if you guys would like this or whether this could be useful for other people. We have some requirements that needs to submit a hadoop job to a remote server so I added HadoopRemoteJarJobRunner and HadoopRemoteJarJobTask.