### PR TITLE
Enables searching within groups too large to display in the visualiser

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -137,8 +137,12 @@ class RemoteScheduler(Scheduler):
     def inverse_dep_graph(self, task_id):
         return self._request('/api/inverse_dep_graph', {'task_id': task_id})
 
-    def task_list(self, status, upstream_status):
-        return self._request('/api/task_list', {'status': status, 'upstream_status': upstream_status})
+    def task_list(self, status, upstream_status, search=None):
+        return self._request('/api/task_list', {
+            'search': search,
+            'status': status,
+            'upstream_status': upstream_status,
+        })
 
     def worker_list(self):
         return self._request('/api/worker_list', {})

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -84,7 +84,7 @@
             {{/tasks}}
         </script>
         <script type="text/template" name="rowCountTemplate">
-            <h4>Too many tasks to display: {{num_tasks}}</h4>
+            <h4 class="tooManyTasks">Too many tasks to display: {{num_tasks}}</h4>
         </script>
         <script type="text/template" name="errorTemplate">
             <div class="modal-header">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -35,6 +35,10 @@ var LuigiAPI = (function() {
         });
     }
 
+    function searchTerm() {
+        return $('#filter-input').val();
+    }
+
     LuigiAPI.prototype.getDependencyGraph = function (taskId, callback) {
         jsonRPC(this.urlRoot + "/dep_graph", {task_id: taskId}, function(response) {
             callback(flatten(response.response, taskId));
@@ -48,19 +52,20 @@ var LuigiAPI = (function() {
     }
 
     LuigiAPI.prototype.getFailedTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "FAILED", upstream_status: ""}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "FAILED", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
 
     LuigiAPI.prototype.getUpstreamFailedTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "UPSTREAM_FAILED"}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "UPSTREAM_FAILED", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
 
     LuigiAPI.prototype.getDoneTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "DONE", upstream_status: ""}, function(response) {
+        console.log('search ' + searchTerm());
+        jsonRPC(this.urlRoot + "/task_list", {status: "DONE", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
@@ -78,25 +83,25 @@ var LuigiAPI = (function() {
     };
 
     LuigiAPI.prototype.getRunningTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "RUNNING", upstream_status: ""}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "RUNNING", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
 
     LuigiAPI.prototype.getPendingTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: ""}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
 
     LuigiAPI.prototype.getDisabledTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "DISABLED", upstream_status: ""}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "DISABLED", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };
 
     LuigiAPI.prototype.getUpstreamDisabledTaskList = function(callback) {
-        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "UPSTREAM_DISABLED"}, function(response) {
+        jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "UPSTREAM_DISABLED", search: searchTerm()}, function(response) {
             callback(flatten(response.response));
         });
     };

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -2,6 +2,7 @@ function visualiserApp(luigi) {
     var templates = {};
     var invertDependencies = false;
     var typingTimer = 0;
+    var expandTasks = ['runningTasks'];
 
     function loadTemplates() {
         $("script[type='text/template']").each(function(i, element) {
@@ -207,13 +208,37 @@ function visualiserApp(luigi) {
             var length = tasks.length;
             var rendered = renderTasks(tasks);
         }
+        $(id).empty();
         $(id).append(rendered);
-        $(id).prev("h3").append(" (" + length + ")");
+        var header = $(id).prev("h3");
+        var countIndex = header.text().indexOf(" (");
+        if (countIndex != -1) {
+            header.text(header.text().slice(0, countIndex))
+        }
+        header.append(" (" + length + ")");
         bindTaskEvents(id, expand);
-        filterTasks();
+        filterTasks(false);
     }
 
-    function filterTasks() {
+    var lastSearchLoads = {};
+
+    function reloadTasksForFilter() {
+        $('.emptyTaskGroup').children('.taskList').each (function (i, task) {
+            var lastLoad = lastSearchLoads[task.id] || '';
+            var currentLoad = $('#filter-input').val();
+            var hasTooMany = $('#' + task.id + ' .tooManyTasks').length > 0;
+            if (hasTooMany || !currentLoad.startsWith(lastLoad)) {
+                loadTasks(task.id);
+                lastSearchLoads[task.id] = currentLoad;
+            }
+        });
+        updateCount();
+    }
+
+    function filterTasks(reload) {
+        if (reload === undefined || reload) {
+            reloadTasksForFilter();
+        }
         inputVal = $('#filter-input').val();
         if (inputVal) {
             arr = inputVal.split(" ");
@@ -237,8 +262,11 @@ function visualiserApp(luigi) {
     }
 
     function updateCount() {
-        taskGroups = $('#taskList .taskGroup:not(.emptyTaskGroup)');
+        taskGroups = $('#taskList .taskGroup');
         for (i=0; i<taskGroups.length; i++) {
+            if ($(taskGroups[i]).find('.tooManyTasks').length > 0) {
+                continue;
+            }
             groupCount = 0;
 
             // update each task family
@@ -256,6 +284,12 @@ function visualiserApp(luigi) {
         }
     }
 
+    function loadTasks(groupName) {
+        expand = $.inArray(groupName, expandTasks) != -1;
+        getFunc = "get" + groupName[0].toUpperCase() + groupName.slice(1, -1) + "List";
+        luigi[getFunc](function(tasks) { getTaskList("#" + groupName, tasks, expand); });
+    }
+
     $(document).ready(function() {
         loadTemplates();
 
@@ -270,33 +304,15 @@ function visualiserApp(luigi) {
             $("#workerList").append(renderWorkers(workers));
         });
 
-        luigi.getRunningTaskList(function(runningTasks) {
-            getTaskList("#runningTasks", runningTasks, true);
-        });
-
-        luigi.getFailedTaskList(function(failedTasks) {
-            getTaskList("#failedTasks", failedTasks);
-        });
-
-        luigi.getUpstreamFailedTaskList(function(upstreamFailedTasks) {
-            getTaskList("#upstreamFailedTasks", upstreamFailedTasks);
-        });
-
-        luigi.getDisabledTaskList(function(disabledTasks) {
-            getTaskList("#disabledTasks", disabledTasks);
-        });
-
-        luigi.getUpstreamDisabledTaskList(function(upstreamDisabledTasks) {
-            getTaskList("#upstreamDisabledTasks", upstreamDisabledTasks);
-        });
-
-        luigi.getPendingTaskList(function(pendingTasks) {
-            getTaskList("#pendingTasks", pendingTasks);
-        });
-
-        luigi.getDoneTaskList(function(doneTasks) {
-            getTaskList("#doneTasks", doneTasks);
-        });
+        [
+            "runningTasks",
+            "failedTasks",
+            "upstreamFailedTasks",
+            "disabledTasks",
+            "upstreamDisabledTasks",
+            "pendingTasks",
+            "doneTasks",
+        ].forEach(loadTasks);
 
         bindListEvents();
 

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -597,6 +597,30 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(set('EFG'), set(sch.task_list('PENDING', '').keys()))
         self.assertEqual({'num_tasks': 4}, sch.task_list('DONE', ''))
 
+    def test_task_list_filter_by_search(self):
+        self.sch.add_task(WORKER, 'test_match_task')
+        self.sch.add_task(WORKER, 'test_filter_task')
+        matches = self.sch.task_list('PENDING', '', search='match')
+        self.assertEqual(['test_match_task'], list(matches.keys()))
+
+    def test_task_list_filter_by_multiple_search_terms(self):
+        self.sch.add_task(WORKER, 'abcd')
+        self.sch.add_task(WORKER, 'abd')
+        self.sch.add_task(WORKER, 'acd')
+        self.sch.add_task(WORKER, 'ad')
+        self.sch.add_task(WORKER, 'bc')
+        matches = self.sch.task_list('PENDING', '', search='b c')
+        self.assertEqual(set(['abcd', 'bc']), set(matches.keys()))
+
+    def test_search_results_beyond_limit(self):
+        sch = CentralPlannerScheduler(max_shown_tasks=3)
+        sch.add_task(WORKER, 'task_a')
+        sch.add_task(WORKER, 'task_b')
+        sch.add_task(WORKER, 'task_c')
+        sch.add_task(WORKER, 'task_d')
+        self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', '', search='a'))
+        self.assertEqual(['task_a'], list(sch.task_list('PENDING', '', search='_a').keys()))
+
     def test_priority_update_dependency_chain(self):
         self.sch.add_task(WORKER, 'A', priority=10, deps=['B'])
         self.sch.add_task(WORKER, 'B', priority=5, deps=['C'])


### PR DESCRIPTION
This adds to the task_list api to allow search queries to be sent to the scheduler in order to retrieve a filtered list of tasks when the entire list is too large for the visualiser. This enables search results to be displayed for tasks in these groups, making the visualiser more useful when a lot of tasks are scheduled.