### PR TITLE
Escapes search queries for the jquery selector in the visualiser.

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -223,7 +223,7 @@ function visualiserApp(luigi) {
 
             // unhide columns that matches filter
             attrSelector = arr.map(function(a) {
-                return a ? '[data-task-id*=' + a + ']' : '';
+                return a ? '[data-task-id*=' + a.replace(/\W/g, "\\$&") + ']' : '';
             }).join("");
             selector = '.taskRow' + attrSelector;
             $(selector).removeClass('hidden');


### PR DESCRIPTION
Search queries in the visualiser have been passed into jquery selectors
unmodified, leading to errors when they include special characters. This
corrects the errors by escaping all special characters.