### PR TITLE
History subsecond timestamp.  Fixes #905

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk: oraclejdk7
 
 services:
   - elasticsearch
+  - mysql
 
 env:
   global:
@@ -36,6 +37,8 @@ before_script:
   - ssh-keygen -t rsa -N '' -C '' -f ~/.ssh/id_rsa
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   - ssh -o StrictHostKeyChecking=no localhost true
+
+  - mysql -e 'create database luigi_test;'
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   - ssh -o StrictHostKeyChecking=no localhost true
 
-  - mysql -e 'create database luigi_test;'
+  - mysql -e 'create database IF NOT EXISTS luigi_test;' -uroot
 
 script:
   - tox

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -185,8 +185,6 @@ def compile_TIMESTAMP(element, compiler, **kw):
     """
     return 'TIMESTAMP(6)'
 
-
-
 class TaskParameter(Base):
     """
     Table to track luigi.Parameter()s of a Task.

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -49,6 +49,7 @@ import sqlalchemy
 import sqlalchemy.ext.declarative
 import sqlalchemy.orm
 import sqlalchemy.orm.collections
+from sqlalchemy.ext.compiler import compiles
 Base = sqlalchemy.ext.declarative.declarative_base()
 
 logger = logging.getLogger('luigi-interface')
@@ -175,6 +176,15 @@ class DbTaskHistory(task_history.TaskHistory):
         """
         with self._session(session) as session:
             return session.query(TaskRecord).get(id)
+
+
+@compiles(sqlalchemy.TIMESTAMP, 'mysql')
+def compile_TIMESTAMP(element, compiler, **kw):
+    """
+    Includes sub-second accuracy to MySQL TIMESTAMP type
+    """
+    return 'TIMESTAMP(6)'
+
 
 
 class TaskParameter(Base):

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -185,6 +185,7 @@ def compile_TIMESTAMP(element, compiler, **kw):
     """
     return 'TIMESTAMP(6)'
 
+
 class TaskParameter(Base):
     """
     Table to track luigi.Parameter()s of a Task.
@@ -206,7 +207,7 @@ class TaskEvent(Base):
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
     task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'))
     event_name = sqlalchemy.Column(sqlalchemy.String(20))
-    ts = sqlalchemy.Column(sqlalchemy.TIMESTAMP, index=True)
+    ts = sqlalchemy.Column(sqlalchemy.TIMESTAMP, index=True, nullable=False)
 
     def __repr__(self):
         return "TaskEvent(task_id=%s, event_name=%s, ts=%s" % (self.task_id, self.event_name, self.ts)

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -146,6 +146,7 @@ class SelectedRunHandler(BaseTaskHistoryHandler):
         self.render('history.html', name=name, statusResults=statusResults, taskResults=taskResults)
 
 
+#!FIXME: Will fail if sent a timestamp without sub-second precision, E.g. in MySQL
 def from_utc(utcTime, fmt="%Y-%m-%d %H:%M:%S.%f"):
     """convert UTC time string to time.struct_time: change datetime.datetime to time, return time.struct_time type"""
     time_struct = datetime.datetime.strptime(utcTime, fmt)

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -146,12 +146,23 @@ class SelectedRunHandler(BaseTaskHistoryHandler):
         self.render('history.html', name=name, statusResults=statusResults, taskResults=taskResults)
 
 
-#!FIXME: Will fail if sent a timestamp without sub-second precision, E.g. in MySQL
-def from_utc(utcTime, fmt="%Y-%m-%d %H:%M:%S.%f"):
+def from_utc(utcTime, fmt=None):
     """convert UTC time string to time.struct_time: change datetime.datetime to time, return time.struct_time type"""
-    time_struct = datetime.datetime.strptime(utcTime, fmt)
-    date = int(time.mktime(time_struct.timetuple()))
-    return date
+    if fmt is None:
+        try_formats = ["%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"]
+    else:
+        try_formats = [fmt]
+
+    for fmt in try_formats:
+        try:
+            time_struct = datetime.datetime.strptime(utcTime, fmt)
+        except ValueError:
+            pass
+        else:
+            date = int(time.mktime(time_struct.timetuple()))
+            return date
+    else:
+        raise ValueError("No UTC format matches {}".format(utcTime))
 
 
 class RecentRunHandler(BaseTaskHistoryHandler):

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -96,7 +96,7 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
         self.run_task(task)
 
         task_record = self.history.find_all_by_name('DummyTask').next()
-        print task_record.events
+        print (task_record.events)
         self.assertEqual(task_record.events[0].event_name, DONE)
 
     def run_task(self, task):

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -82,3 +82,24 @@ class DbTaskHistoryTest(unittest.TestCase):
         self.history.task_scheduled(task.task_id)
         self.history.task_started(task.task_id, 'hostname')
         self.history.task_finished(task.task_id, successful=True)
+
+
+class MySQLDbTaskHistoryTest(unittest.TestCase):
+
+    @with_config(dict(task_history=dict(db_connection='mysql://@localhost/luigi_test')))
+    def setUp(self):
+        self.history = DbTaskHistory()
+
+    def test_subsecond_timestamp(self):
+        # Add 2 events in <1s
+        task = DummyTask()
+        self.run_task(task)
+
+        task_record = self.history.find_all_by_name('DummyTask').next()
+        print task_record.events
+        self.assertEqual(task_record.events[0].event_name, DONE)
+
+    def run_task(self, task):
+        self.history.task_scheduled(task.task_id)
+        self.history.task_started(task.task_id, 'hostname')
+        self.history.task_finished(task.task_id, successful=True)

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -86,7 +86,7 @@ class DbTaskHistoryTest(unittest.TestCase):
 
 class MySQLDbTaskHistoryTest(unittest.TestCase):
 
-    @with_config(dict(task_history=dict(db_connection='mysql+pymysql://travis@localhost/luigi_test')))
+    @with_config(dict(task_history=dict(db_connection='mysql+mysqlconnector://travis@localhost/luigi_test')))
     def setUp(self):
         self.history = DbTaskHistory()
 

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -95,7 +95,7 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
         task = DummyTask()
         self.run_task(task)
 
-        task_record = self.history.find_all_by_name('DummyTask').next()
+        task_record = six.advance_iterator(self.history.find_all_by_name('DummyTask'))
         print (task_record.events)
         self.assertEqual(task_record.events[0].event_name, DONE)
 
@@ -105,7 +105,7 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
         task = DummyTask()
         self.run_task(task)
 
-        task_record = self.history.find_all_by_name('DummyTask').next()
+        task_record = six.advance_iterator(self.history.find_all_by_name('DummyTask'))
         last_event = task_record.events[0]
         try:
             print (from_utc(str(last_event.ts)))

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -86,7 +86,7 @@ class DbTaskHistoryTest(unittest.TestCase):
 
 class MySQLDbTaskHistoryTest(unittest.TestCase):
 
-    @with_config(dict(task_history=dict(db_connection='mysql://@localhost/luigi_test')))
+    @with_config(dict(task_history=dict(db_connection='mysql://travis@localhost/luigi_test')))
     def setUp(self):
         self.history = DbTaskHistory()
 

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -86,7 +86,7 @@ class DbTaskHistoryTest(unittest.TestCase):
 
 class MySQLDbTaskHistoryTest(unittest.TestCase):
 
-    @with_config(dict(task_history=dict(db_connection='mysql://travis@localhost/luigi_test')))
+    @with_config(dict(task_history=dict(db_connection='mysql+pymysql://travis@localhost/luigi_test')))
     def setUp(self):
         self.history = DbTaskHistory()
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,4 +8,4 @@ boto
 sqlalchemy
 elasticsearch
 snakebite>=2.5.2
-pymysql
+mysql-connector-python

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,4 +8,4 @@ boto
 sqlalchemy
 elasticsearch
 snakebite>=2.5.2
-MySQL-python
+pymysql

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,3 +8,4 @@ boto
 sqlalchemy
 elasticsearch
 snakebite>=2.5.2
+MySQL-python

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py{26,27,33,34}-{cdh,hdp,nonhdfs}, docs, pep8
 skipsdist = True
+install_command = pip install {opts} --allow-external mysql-connector-python {packages}
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist = py{26,27,33,34}-{cdh,hdp,nonhdfs}, docs, pep8
 skipsdist = True
-install_command = pip install {opts} --allow-external mysql-connector-python {packages}
 
 [testenv]
 usedevelop = True
+install_command = pip install {opts} --allow-external mysql-connector-python {packages}
 deps=
   -r{toxinidir}/test/requirements.txt
   coverage>=3.6,<3.999


### PR DESCRIPTION
Ensure MySQL TIMESTAMP columns are sub-second accurate.

SQLAlchemy has hooks to adapt column types to the dialect using the compiler extension.
Test included, which assumes a running MySQL.  Not sure how this fits with your test framework but it has demonstrated the fix works here.