### PR TITLE
Add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.coverage.*
+doc/api/*.rst
+
 .nicesetup
 
 client.cfg


### PR DESCRIPTION
When running `tox docs`, a lot of documentation files are created and
not cleaned up.