### PR TITLE
Skip DbTaskHistory test when is not MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ before_script:
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   - ssh -o StrictHostKeyChecking=no localhost true
 
-  - mysql -e 'create database IF NOT EXISTS luigi_test;' -uroot
+  # Create mysql database if possible but fail silently if not available.
+  - mysql -e 'create database IF NOT EXISTS luigi_test;' -uroot || true
 
 script:
   - tox

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -88,7 +88,10 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
 
     @with_config(dict(task_history=dict(db_connection='mysql+mysqlconnector://travis@localhost/luigi_test')))
     def setUp(self):
-        self.history = DbTaskHistory()
+        try:
+            self.history = DbTaskHistory()
+        except Exception:
+            raise unittest.SkipTest('DBTaskHistory cannot be created: probably no MySQL available')
 
     def test_subsecond_timestamp(self):
         # Add 2 events in <1s


### PR DESCRIPTION
See #915. If DbTaskHistory() fails to initialise assume MySQL is unavailable and skip.  This will allow the tests to pass in a vanilla tox environment.
