### PR TITLE
CascadingClient: Avoid scary stack trace

### DIFF
--- a/luigi/contrib/target.py
+++ b/luigi/contrib/target.py
@@ -71,5 +71,5 @@ class CascadingClient(object):
                 if is_last_iteration:
                     raise
                 else:
-                    logger.exception('The %s failed to %s, using fallback class %s',
-                                     client.__class__.__name__, method_name, self.clients[i + 1].__class__.__name__)
+                    logger.warning('The %s failed to %s, using fallback class %s',
+                                   client.__class__.__name__, method_name, self.clients[i + 1].__class__.__name__)


### PR DESCRIPTION
The idea is that most users react to stack traces. The very common
scenario for the CascadingClient is that it's totally fine for the
non-last clients in the cascading chain to fail. So when there's an
error, they are likely to get blind by this actually harmless stack
trace.