### PR TITLE
Support DataInterchange with json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,11 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
+my_dir
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,4 @@ after_failure:
 branches:
   only:
     - master
+    - support_json_deserialization

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -28,7 +28,6 @@ import abc
 import binascii
 import datetime
 import glob
-import json
 import logging
 import os
 import pickle
@@ -58,6 +57,12 @@ from luigi import mrrunner
 
 if six.PY2:
     from itertools import imap as map
+
+try:
+    # See benchmark at https://gist.github.com/mvj3/02dca2bcc8b0ef1bbfb5
+    import ujson as json
+except:
+    import json
 
 logger = logging.getLogger('luigi-interface')
 
@@ -677,6 +682,7 @@ class BaseHadoopJobTask(luigi.Task):
       """.format(message=exception.message, stdout=exception.out, stderr=exception.err)
         else:
             return super(BaseHadoopJobTask, self).on_failure(exception)
+
 
 DataInterchange = {
     "python": {"serialize": str,

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -22,6 +22,5 @@ luigi.hadoop has moved to :py:mod:`luigi.contrib.hadoop`
 import warnings
 
 from luigi.contrib.hadoop import *
-
 warnings.warn("luigi.hadoop module has been moved to luigi.contrib.hadoop",
               DeprecationWarning)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
+    'cached_property',
     'pyparsing',
     'tornado',
     'python-daemon',

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -207,9 +207,13 @@ class CommonTests(object):
             c.append(line)
         # Make sure unicode('test') isnt grouped with str('test')
         # Since this is what happens when running on cluster
-        test_case.assertEqual(len(c), 2)
-        test_case.assertEqual(c[0], "test\t2\n")
-        test_case.assertEqual(c[0], "test\t2\n")
+        if sys.version_info.major == 3:
+            test_case.assertEqual(len(c), 2)
+            test_case.assertEqual(c[0], "test\t2\n")
+        # str and unicode can be equal in Python 2
+        if sys.version_info.major == 2:
+            test_case.assertEqual(len(c), 1)
+            test_case.assertEqual(c[0], "test\t4\n")
 
     @staticmethod
     def test_failing_job(test_case):

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import json
 import unittest
 
 import luigi
@@ -147,6 +148,24 @@ class UnicodeJob(HadoopJobTask):
         return self.get_output('luigitest-4')
 
 
+class UseJsonAsDataInteterchangeFormatJob(HadoopJobTask):
+
+    data_interchange_format = "json"
+
+    def mapper(self, line):
+        yield "json", {"data type": "json"}
+
+    def reducer(self, _, vals):
+        yield "", json.dumps(list(vals)[0])
+
+    def requires(self):
+        """ Two lines from Word.task will cause two `mapper` call. """
+        return Words(self.use_hdfs)
+
+    def output(self):
+        return self.get_output('luigitest-5')
+
+
 class FailingJobException(Exception):
     pass
 
@@ -207,13 +226,17 @@ class CommonTests(object):
             c.append(line)
         # Make sure unicode('test') isnt grouped with str('test')
         # Since this is what happens when running on cluster
-        if sys.version_info.major == 3:
-            test_case.assertEqual(len(c), 2)
-            test_case.assertEqual(c[0], "test\t2\n")
-        # str and unicode can be equal in Python 2
-        if sys.version_info.major == 2:
-            test_case.assertEqual(len(c), 1)
-            test_case.assertEqual(c[0], "test\t4\n")
+        test_case.assertEqual(len(c), 2)
+        test_case.assertEqual(c[0], "test\t2\n")
+
+    @staticmethod
+    def test_use_json_as_data_interchange_format_job(test_case):
+        job = UseJsonAsDataInteterchangeFormatJob(use_hdfs=test_case.use_hdfs)
+        luigi.build([job], local_scheduler=True)
+        c = []
+        for line in job.output().open('r'):
+            c.append(line)
+        test_case.assertEqual(c, ['{"data type": "json"}\n'])
 
     @staticmethod
     def test_failing_job(test_case):
@@ -237,6 +260,9 @@ class MapreduceLocalTest(unittest.TestCase):
 
     def test_unicode_job(self):
         CommonTests.test_unicode_job(self)
+
+    def test_use_json_as_data_interchange_format_job(self):
+        CommonTests.test_use_json_as_data_interchange_format_job(self)
 
     def test_failing_job(self):
         CommonTests.test_failing_job(self)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,3 +9,4 @@ sqlalchemy
 elasticsearch
 snakebite>=2.5.2
 mysql-connector-python
+cached_property


### PR DESCRIPTION
Our team use JSON format as data warehouse basic data format. We found that luigi use Python's builtin `eval` function to load data from `mapper` into `reducer`, it's slower than `json.loads` function.

Here provides a solution that adding a `data_interchange_format` attribute to Task class,  default value is "python", and another one is "json". The limitations are `set` data structure is not supported.

P.S. This patch treat `str` and `unicode` as the same type, see it at `test_unicode_job` test case.