### PR TITLE
Create an abstract hdfs client

### DIFF
--- a/luigi/contrib/hdfs/abstract_client.py
+++ b/luigi/contrib/hdfs/abstract_client.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Module containing abstract class about hdfs clients.
+"""
+
+import abc
+from luigi import six
+import luigi.target
+import warnings
+
+
+@six.add_metaclass(abc.ABCMeta)
+class HdfsFileSystem(luigi.target.FileSystem):
+    """
+    This client uses Apache 2.x syntax for file system commands, which also matched CDH4.
+    """
+
+    @abc.abstractmethod
+    def rename(self, path, dest):
+        """
+        Rename or move a file
+        """
+        pass
+
+    def rename_dont_move(self, path, dest):
+        """
+        Override this method with an implementation that uses rename2,
+        which is a rename operation that never moves.
+
+        For instance, `rename2 a b` never moves `a` into `b` folder.
+
+        Currently, the hadoop cli does not support this operation.
+
+        We keep the interface simple by just aliasing this to
+        normal rename and let individual implementations redefine the method.
+
+        rename2 -
+        https://github.com/apache/hadoop/blob/ae91b13/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
+        (lines 483-523)
+        """
+        warnings.warn("Configured HDFS client doesn't support rename_dont_move, using normal mv operation instead.")
+        if self.exists(dest):
+            return False
+        self.rename(path, dest)
+        return True
+
+    @abc.abstractmethod
+    def remove(self, path, recursive=True, skip_trash=False):
+        pass
+
+    @abc.abstractmethod
+    def chmod(self, path, permissions, recursive=False):
+        pass
+
+    @abc.abstractmethod
+    def chown(self, path, owner, group, recursive=False):
+        pass
+
+    @abc.abstractmethod
+    def count(self, path):
+        """
+        Count contents in a directory
+        """
+        pass
+
+    @abc.abstractmethod
+    def copy(self, path, destination):
+        pass
+
+    @abc.abstractmethod
+    def put(self, local_path, destination):
+        pass
+
+    @abc.abstractmethod
+    def get(self, path, local_destination):
+        pass
+
+    @abc.abstractmethod
+    def mkdir(self, path, parents=True, raise_if_exists=False):
+        pass
+
+    @abc.abstractmethod
+    def listdir(self, path, ignore_directories=False, ignore_files=False,
+                include_size=False, include_type=False, include_time=False, recursive=False):
+        pass
+
+    @abc.abstractmethod
+    def touchz(self, path):
+        pass

--- a/luigi/contrib/hdfs/snakebite_client.py
+++ b/luigi/contrib/hdfs/snakebite_client.py
@@ -24,7 +24,7 @@ Originally written by Alan Brenner <alan@magnetic.com> github.com/alanbbr
 
 from luigi.contrib.hdfs import config as hdfs_config
 from luigi.contrib.hdfs import error as hdfs_error
-from luigi.contrib.hdfs import hadoopcli_clients as hdfs_hadoopcli_clients
+from luigi.contrib.hdfs import abstract_client as hdfs_abstract_client
 from luigi import six
 import luigi.contrib.target
 import logging
@@ -34,7 +34,7 @@ import os
 logger = logging.getLogger('luigi-interface')
 
 
-class SnakebiteHdfsClient(hdfs_hadoopcli_clients.HdfsClient):
+class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
     """
     A hdfs client using snakebite. Since Snakebite has a python API, it'll be
     about 100 times faster than the hadoop cli client, which does shell out to
@@ -200,6 +200,18 @@ class SnakebiteHdfsClient(hdfs_hadoopcli_clients.HdfsClient):
         return {'content_size': content_size, 'dir_count': dir_count,
                 'file_count': file_count}
 
+    def copy(self, path):
+        """
+        Raise a NotImplementedError exception.
+        """
+        return NotImplementedError("SnakebiteClient in luigi doesn't implement copy")
+
+    def put(self, local_path, destination):
+        """
+        Raise a NotImplementedError exception.
+        """
+        return NotImplementedError("Snakebite doesn't implement put")
+
     def get(self, path, local_destination):
         """
         Use snakebite.copyToLocal, if available.
@@ -272,3 +284,9 @@ class SnakebiteHdfsClient(hdfs_hadoopcli_clients.HdfsClient):
                 yield tuple(rval)
             else:
                 yield rval[0]
+
+    def touchz(self, path):
+        """
+        Raise a NotImplementedError exception.
+        """
+        return NotImplementedError("SnakebiteClient in luigi doesn't implement touchz")


### PR DESCRIPTION
Now clearer what client implements what. And we finally get rid of this weird
behaviour that the snakebite client inherits from HdfsClient.

This change kind of pushses for snakebite uses to start using the
snakebite_with_hadoopcli_fallback option, a many important file system
operations have not been ported to snakebite as of yet. But that's good, as that
configuration name better reflects what they actually use.