### PR TITLE
Remove last is global usage

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -375,7 +375,7 @@ class SparkJob(luigi.Task):
     spark_workers = None
     spark_master_memory = None
     spark_worker_memory = None
-    queue = luigi.Parameter(is_global=True, default=None, significant=False)
+    queue = luigi.Parameter(default=None, significant=False, positional=False)
     temp_hadoop_output_file = None
 
     def requires_local(self):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -103,7 +103,7 @@ class Parameter(object):
 
     @deprecate_kwarg('is_boolean', 'is_bool', False)
     def __init__(self, default=_no_value, is_list=False, is_boolean=False, is_global=False, significant=True, description=None,
-                 config_path=None):
+                 config_path=None, positional=True):
         """
         :param default: the default value for this parameter. This should match the type of the
                         Parameter, i.e. ``datetime.date`` for ``DateParameter`` or ``int`` for
@@ -128,6 +128,10 @@ class Parameter(object):
                                  specifying a config file entry from which to read the
                                  default value for this parameter. DEPRECATED.
                                  Default: ``None``.
+        :param bool positional: If true, you can set the argument as a
+                                positional argument. Generally we recommend ``positional=False``
+                                as positional arguments become very tricky when
+                                you have inheritance and whatnot.
         """
         # The default default is no default
         self.__default = default
@@ -137,6 +141,7 @@ class Parameter(object):
         self.is_bool = is_boolean and not is_list  # Only BoolParameter should ever use this. TODO(erikbern): should we raise some kind of exception?
         self.is_global = is_global  # It just means that the default value is exposed and you can override it
         self.significant = significant  # Whether different values for this parameter will differentiate otherwise equal tasks
+        self.positional = positional
 
         if is_global:
             warnings.warn(

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -202,7 +202,7 @@ class Task(object):
         exc_desc = '%s[args=%s, kwargs=%s]' % (task_name, args, kwargs)
 
         # Fill in the positional arguments
-        positional_params = [(n, p) for n, p in params if not p.is_global]
+        positional_params = [(n, p) for n, p in params if not p.is_global and p.positional]
         for i, arg in enumerate(args):
             if i >= len(positional_params):
                 raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))

--- a/test/clone_test.py
+++ b/test/clone_test.py
@@ -51,10 +51,6 @@ class PowerSum(LinearSum):
         return x ** self.p
 
 
-class PowerSum2(PowerSum):
-    q = luigi.IntParameter(is_global=True, default=7)
-
-
 class CloneTest(unittest.TestCase):
 
     def test_args(self):
@@ -69,10 +65,5 @@ class CloneTest(unittest.TestCase):
 
     def test_inheritance(self):
         t = PowerSum(lo=42, hi=45, p=2)
-        luigi.build([t], local_scheduler=True)
-        self.assertEqual(t.s, 42 ** 2 + 43 ** 2 + 44 ** 2)
-
-    def test_inheritance_and_global(self):
-        t = PowerSum2(lo=42, hi=45, p=2)
         luigi.build([t], local_scheduler=True)
         self.assertEqual(t.s, 42 ** 2 + 43 ** 2 + 44 ** 2)

--- a/test/dynamic_import_test.py
+++ b/test/dynamic_import_test.py
@@ -22,17 +22,17 @@ import luigi.interface
 
 
 class ExtraArgs(luigi.Task):
-    blah = luigi.Parameter(is_global=True, default=444)
+    blah = luigi.Parameter(default=444)
 
 
 class CmdlineTest(unittest.TestCase):
 
     def test_dynamic_loading(self):
         interface = luigi.interface.ArgParseInterface()
-        self.assertRaises(SystemExit, interface.parse, (['FooTask', '--blah', 'xyz', '--x', '123'],))  # should raise since it's not imported
+        self.assertRaises(SystemExit, interface.parse, (['FooTask', '--ExtraArgs-blah', 'xyz', '--x', '123'],))  # should raise since it's not imported
 
         interface = luigi.interface.DynamicArgParseInterface()
-        tasks = interface.parse(['--module', 'foo_module', 'FooTask', '--blah', 'xyz', '--x', '123'])
+        tasks = interface.parse(['--module', 'foo_module', 'FooTask', '--ExtraArgs-blah', 'xyz', '--x', '123'])
 
         self.assertEqual(ExtraArgs().blah, 'xyz')
 

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -306,6 +306,16 @@ class ParameterTest(unittest.TestCase):
         self.assertRaises(luigi.parameter.MissingParameterException,
                           lambda: MyTask())
 
+    def test_nonpositional_param(self):
+        """ Ensure we have the same behavior as in before a78338c  """
+        class MyTask(luigi.Task):
+            # This could typically be "--num-threads=True"
+            x = luigi.Parameter(significant=False, positional=False)
+
+        MyTask(x='arg')
+        self.assertRaises(luigi.parameter.UnknownParameterException,
+                          lambda: MyTask('arg'))
+
 
 class TestNewStyleGlobalParameters(unittest.TestCase):
 


### PR DESCRIPTION
See individual commits.

After this is merged, there's no code using is_global within spotify/luigi. So then we can finally delete this annoying is_global logic that massively complicates things.