### PR TITLE
Don't run `env` from tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ setenv =
 commands =
   cdh,hdp: {toxinidir}/scripts/ci/setup_hadoop_env.sh
   python --version
-  env
   coverage run test/runtests.py -v --ignore-files='(^\.|^_|^setup\.py$)' \
                                    --ignore-files=not_imported.py \
                                    {posargs:}


### PR DESCRIPTION
It was only temporarily added by @erikbern when he was debugging some
random failures (see #953). After this patch, we don't need to see this
anymore:

    WARNING:test command found but not installed in testenv
      cmd: /usr/bin/env
      env: /home/arash/spotify/repos/luigis/github_luigi/.tox/py27-nonhdfs
    Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.
    ...
    USER=arash
    LC_ALL=en_US.utf-8
    PATH=...
    COVERAGE_PROCESS_START=/home/arash/spotify/repos/luigis/github_luigi/.coveragerc