### PR TITLE
Documentation: Fixing PyPI Link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Getting Luigi
 -------------
 
 Run ``pip install luigi`` to install the latest stable version from
-`PyPI <pypi.python.org/pypi/luigi>`_.
+`PyPI <https://pypi.python.org/pypi/luigi>`_.
 
 For bleeding edge code,
 ``git clone https://github.com/spotify/luigi`` and


### PR DESCRIPTION
PyPI Luigi link was a local reference that went relative to where the documentation was hosted, not to the PyPI page.