### PR TITLE
Remove various python 2.6 stuff

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends:	debhelper (>= 7),
 		python-unittest2,
 		snakebite
 Standards-Version: 3.7.3
-X-Python-Version: >= 2.6
+X-Python-Version: >= 2.7
 
 Package: luigi
 Architecture: all

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.append('sqlalchemy')
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
 
-if sys.version_info[:2] < (2, 7):
-    install_requires.extend(['argparse', 'ordereddict', 'importlib'])
-
 setup(
     name='luigi',
     version='1.2.2',
@@ -87,7 +84,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -23,14 +23,7 @@ import luigi
 import luigi.task_register
 from luigi import six
 
-# import unittest on python 2.6 for support of test skip
-if sys.version_info[:2] <= (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        import unittest
-else:
-    import unittest
+import unittest
 
 
 class with_config(object):

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -82,13 +82,6 @@ class FailingTask(luigi.Task):
 
 
 class SchedulerVisualisationTest(unittest.TestCase):
-    # The following 2 are required to retain compatibility with python 2.6
-
-    def assertGreaterEqual(self, a, b):
-        self.assertTrue(a >= b)
-
-    def assertLessEqual(self, a, b):
-        self.assertTrue(a <= b)
 
     def setUp(self):
         self.scheduler = luigi.scheduler.CentralPlannerScheduler()


### PR DESCRIPTION
Python 2.6 is not supported anymore, but these things were left
lingering around.