### PR TITLE
Remove is_global support

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -202,7 +202,7 @@ class Task(object):
         exc_desc = '%s[args=%s, kwargs=%s]' % (task_name, args, kwargs)
 
         # Fill in the positional arguments
-        positional_params = [(n, p) for n, p in params if not p.is_global and p.positional]
+        positional_params = [(n, p) for n, p in params if p.positional]
         for i, arg in enumerate(args):
             if i >= len(positional_params):
                 raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))


### PR DESCRIPTION
Note that we sill support global parameters in the sense that they are
globally assigned (The `--ClassName-param-name param_value` syntax).
However, they don't clutter up the namespace anymore since they are
prepended with the task_family.