### PR TITLE
Use keyword arguments for Schedulers

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -480,7 +480,7 @@ class Worker(object):
             deps = [d.task_id for d in deps]
 
         self._scheduled_tasks[task.task_id] = task
-        self._scheduler.add_task(self._id, task.task_id, status=status,
+        self._scheduler.add_task(worker=self._id, task_id=task.task_id, status=status,
                                  deps=deps, runnable=runnable, priority=task.priority,
                                  resources=task.process_resources(),
                                  params=task.to_str_params(),
@@ -539,7 +539,7 @@ class Worker(object):
                 subject = 'Luigi: %s' % msg
                 error_message = notifications.wrap_traceback(ex)
                 notifications.send_error_email(subject, error_message)
-                self._scheduler.add_task(self._id, task_id, status=FAILED, runnable=False,
+                self._scheduler.add_task(worker=self._id, task_id=task_id, status=FAILED, runnable=False,
                                          assistant=self._assistant)
                 task_id = None
                 self.run_succeeded = False
@@ -612,8 +612,8 @@ class Worker(object):
                     self.add(t)
                 new_deps = [t.task_id for t in new_req]
 
-            self._scheduler.add_task(self._id,
-                                     task_id,
+            self._scheduler.add_task(worker=self._id,
+                                     task_id=task_id,
                                      status=status,
                                      expl=error_message,
                                      resources=task.process_resources(),

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -54,36 +54,36 @@ class CentralPlannerTest(unittest.TestCase):
         time.time = lambda: t
 
     def test_dep(self):
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
-        self.sch.add_task(WORKER, 'A', status=DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'B')
-        self.sch.add_task(WORKER, 'B', status=DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'B')
+        self.sch.add_task(worker=WORKER, task_id='B', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_failed_dep(self):
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='A')
 
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)  # can still wait and retry: TODO: do we want this?
-        self.sch.add_task(WORKER, 'A', DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'B')
-        self.sch.add_task(WORKER, 'B', DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)  # can still wait and retry: TODO: do we want this?
+        self.sch.add_task(worker=WORKER, task_id='A', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'B')
+        self.sch.add_task(worker=WORKER, task_id='B', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_broken_dep(self):
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'A', runnable=False)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='A', runnable=False)
 
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)  # can still wait and retry: TODO: do we want this?
-        self.sch.add_task(WORKER, 'A', DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'B')
-        self.sch.add_task(WORKER, 'B', DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)  # can still wait and retry: TODO: do we want this?
+        self.sch.add_task(worker=WORKER, task_id='A', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'B')
+        self.sch.add_task(worker=WORKER, task_id='B', status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_two_workers(self):
         # Worker X wants to build A -> B
@@ -102,19 +102,19 @@ class CentralPlannerTest(unittest.TestCase):
     def test_retry(self):
         # Try to build A but fails, will retry after 100s
         self.setTime(0)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
-        self.sch.add_task(WORKER, 'A', FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
         for t in range(100):
             self.setTime(t)
-            self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
-            self.sch.ping(WORKER)
+            self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
+            self.sch.ping(worker=WORKER)
             if t % 10 == 0:
                 self.sch.prune()
 
         self.setTime(101)
         self.sch.prune()
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_disconnect_running(self):
         # X and Y wants to run A.
@@ -182,7 +182,7 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(worker='X', task_id='A')
         self.sch.add_worker('Y', [])
 
-        self.assertEqual(self.sch.get_work('Y', assistant=True)['task_id'], 'A')
+        self.assertEqual(self.sch.get_work(worker='Y', assistant=True)['task_id'], 'A')
 
         # check that the scheduler recognizes tasks as running
         running_tasks = self.sch.task_list('RUNNING', '')
@@ -191,31 +191,31 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(running_tasks['A']['worker_running'], 'Y')
 
     def test_assistant_get_work_external_task(self):
-        self.sch.add_task('X', task_id='A', runnable=False)
-        self.assertTrue(self.sch.get_work('Y', assistant=True)['task_id'] is None)
+        self.sch.add_task(worker='X', task_id='A', runnable=False)
+        self.assertTrue(self.sch.get_work(worker='Y', assistant=True)['task_id'] is None)
 
     def test_task_fails_when_assistant_dies(self):
         self.setTime(0)
         self.sch.add_task(worker='X', task_id='A')
         self.sch.add_worker('Y', [])
 
-        self.assertEqual(self.sch.get_work('Y', assistant=True)['task_id'], 'A')
+        self.assertEqual(self.sch.get_work(worker='Y', assistant=True)['task_id'], 'A')
         self.assertEqual(list(self.sch.task_list('RUNNING', '').keys()), ['A'])
 
         # Y dies for 50 seconds, X stays alive
         self.setTime(50)
-        self.sch.ping('X')
+        self.sch.ping(worker='X')
         self.assertEqual(list(self.sch.task_list('FAILED', '').keys()), ['A'])
 
     def test_prune_with_live_assistant(self):
         self.setTime(0)
         self.sch.add_task(worker='X', task_id='A')
-        self.sch.get_work('Y', assistant=True)
+        self.sch.get_work(worker='Y', assistant=True)
         self.sch.add_task(worker='Y', task_id='A', status=DONE, assistant=True)
 
         # worker X stops communicating, A should be marked for removal
         self.setTime(600)
-        self.sch.ping('Y')
+        self.sch.ping(worker='Y')
         self.sch.prune()
 
         # A will now be pruned
@@ -225,38 +225,38 @@ class CentralPlannerTest(unittest.TestCase):
 
     def test_prune_done_tasks(self, expected=None):
         self.setTime(0)
-        self.sch.add_task(WORKER, task_id='A', status=DONE)
-        self.sch.add_task(WORKER, task_id='B', deps=['A'], status=DONE)
-        self.sch.add_task(WORKER, task_id='C', deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='A', status=DONE)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=['A'], status=DONE)
+        self.sch.add_task(worker=WORKER, task_id='C', deps=['B'])
 
         self.setTime(600)
-        self.sch.ping('ASSISTANT')
+        self.sch.ping(worker='ASSISTANT')
         self.sch.prune()
         self.setTime(2000)
-        self.sch.ping('ASSISTANT')
+        self.sch.ping(worker='ASSISTANT')
         self.sch.prune()
 
         self.assertEqual(set(expected or ()), set(self.sch.task_list('', '').keys()))
 
     def test_keep_tasks_for_assistant(self):
-        self.sch.get_work('ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
+        self.sch.get_work(worker='ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
         self.test_prune_done_tasks(['B', 'C'])
 
     def test_keep_scheduler_disabled_tasks_for_assistant(self):
-        self.sch.get_work('ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
+        self.sch.get_work(worker='ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
 
         # create a scheduler disabled task and a worker disabled task
         for i in range(10):
-            self.sch.add_task(WORKER, 'D', status=FAILED)
-        self.sch.add_task(WORKER, 'E', status=DISABLED)
+            self.sch.add_task(worker=WORKER, task_id='D', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='E', status=DISABLED)
 
         # scheduler prunes the worker disabled task
         self.assertEqual(set(['D', 'E']), set(self.sch.task_list(DISABLED, '')))
         self.test_prune_done_tasks(['B', 'C', 'D'])
 
     def test_keep_failed_tasks_for_assistant(self):
-        self.sch.get_work('ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
-        self.sch.add_task(WORKER, 'D', status=FAILED, deps='A')
+        self.sch.get_work(worker='ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
+        self.sch.add_task(worker=WORKER, task_id='D', status=FAILED, deps='A')
         self.test_prune_done_tasks(['A', 'B', 'C', 'D'])
 
     def test_scheduler_resources_none_allow_one(self):
@@ -324,7 +324,7 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.update_resources(R=1)
         self.sch.add_worker('X', [('workers', 2)])
         self.sch.add_worker('Y', [])
-        self.assertFalse(self.sch.get_work('Y')['task_id'])
+        self.assertFalse(self.sch.get_work(worker='Y')['task_id'])
 
     def test_do_not_lock_resources_while_running_higher_priority(self):
         """ Test to make sure that resources won't go unused waiting on workers """
@@ -334,19 +334,19 @@ class CentralPlannerTest(unittest.TestCase):
 
         self.sch.update_resources(R=1)
         self.sch.add_worker('X', [('workers', 1)])
-        self.assertEqual('A', self.sch.get_work('X')['task_id'])
-        self.assertEqual('C', self.sch.get_work('Y')['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
+        self.assertEqual('C', self.sch.get_work(worker='Y')['task_id'])
 
     def test_lock_resources_while_running_lower_priority(self):
         """ Make sure resources will be made available while working on lower priority tasks """
         self.sch.add_task(worker='X', task_id='A', priority=4)
-        self.assertEqual('A', self.sch.get_work('X')['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
         self.sch.add_task(worker='X', task_id='B', resources={'R': 1}, priority=5)
         self.sch.add_task(worker='Y', task_id='C', resources={'R': 1}, priority=1)
 
         self.sch.update_resources(R=1)
         self.sch.add_worker('X', [('workers', 1)])
-        self.assertFalse(self.sch.get_work('Y')['task_id'])
+        self.assertFalse(self.sch.get_work(worker='Y')['task_id'])
 
     def test_lock_resources_for_second_worker(self):
         self.sch.add_task(worker='X', task_id='A', resources={'R': 1})
@@ -357,18 +357,18 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_worker('Y', {'workers': 1})
         self.sch.update_resources(R=2)
 
-        self.assertEqual('A', self.sch.get_work('X')['task_id'])
-        self.assertFalse(self.sch.get_work('X')['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
+        self.assertFalse(self.sch.get_work(worker='X')['task_id'])
 
     def test_can_work_on_lower_priority_while_waiting_for_resources(self):
         self.sch.add_task(worker='X', task_id='A', resources={'R': 1}, priority=0)
-        self.assertEqual('A', self.sch.get_work('X')['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
 
         self.sch.add_task(worker='Y', task_id='B', resources={'R': 1}, priority=10)
         self.sch.add_task(worker='Y', task_id='C', priority=0)
         self.sch.update_resources(R=1)
 
-        self.assertEqual('C', self.sch.get_work('Y')['task_id'])
+        self.assertEqual('C', self.sch.get_work(worker='Y')['task_id'])
 
     def test_priority_update_with_pruning(self):
         self.setTime(0)
@@ -382,124 +382,124 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.prune()
 
         # Here task A that B depends on is missing
-        self.sch.add_task(WORKER, task_id='C', deps=['B'], priority=100)
-        self.sch.add_task(WORKER, task_id='B', deps=['A'])
-        self.sch.add_task(WORKER, task_id='A')
-        self.sch.add_task(WORKER, task_id='D', priority=10)
+        self.sch.add_task(worker=WORKER, task_id='C', deps=['B'], priority=100)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=['A'])
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='D', priority=10)
 
         self.check_task_order('ABCD')
 
     def test_update_resources(self):
-        self.sch.add_task(WORKER, task_id='A', deps=['B'])
-        self.sch.add_task(WORKER, task_id='B', resources={'r': 2})
+        self.sch.add_task(worker=WORKER, task_id='A', deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r': 2})
         self.sch.update_resources(r=1)
 
         # B requires too many resources, we can't schedule
         self.check_task_order([])
 
-        self.sch.add_task(WORKER, task_id='B', resources={'r': 1})
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r': 1})
 
         # now we have enough resources
         self.check_task_order(['B', 'A'])
 
     def test_hendle_multiple_resources(self):
-        self.sch.add_task(WORKER, task_id='A', resources={'r1': 1, 'r2': 1})
-        self.sch.add_task(WORKER, task_id='B', resources={'r1': 1, 'r2': 1})
-        self.sch.add_task(WORKER, task_id='C', resources={'r1': 1})
+        self.sch.add_task(worker=WORKER, task_id='A', resources={'r1': 1, 'r2': 1})
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r1': 1, 'r2': 1})
+        self.sch.add_task(worker=WORKER, task_id='C', resources={'r1': 1})
         self.sch.update_resources(r1=2, r2=1)
 
-        self.assertEqual('A', self.sch.get_work(WORKER)['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker=WORKER)['task_id'])
         self.check_task_order('C')
 
     def test_single_resource_lock(self):
-        self.sch.add_task('X', task_id='A', resources={'r': 1})
-        self.assertEqual('A', self.sch.get_work('X')['task_id'])
+        self.sch.add_task(worker='X', task_id='A', resources={'r': 1})
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
 
-        self.sch.add_task(WORKER, task_id='B', resources={'r': 2}, priority=10)
-        self.sch.add_task(WORKER, task_id='C', resources={'r': 1})
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r': 2}, priority=10)
+        self.sch.add_task(worker=WORKER, task_id='C', resources={'r': 1})
         self.sch.update_resources(r=2)
 
         # Should wait for 2 units of r to be available for B before scheduling C
         self.check_task_order([])
 
     def test_no_lock_if_too_many_resources_required(self):
-        self.sch.add_task(WORKER, task_id='A', resources={'r': 2}, priority=10)
-        self.sch.add_task(WORKER, task_id='B', resources={'r': 1})
+        self.sch.add_task(worker=WORKER, task_id='A', resources={'r': 2}, priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r': 1})
         self.sch.update_resources(r=1)
         self.check_task_order('B')
 
     def test_multiple_resources_lock(self):
-        self.sch.add_task('X', task_id='A', resources={'r1': 1, 'r2': 1}, priority=10)
-        self.sch.add_task(WORKER, task_id='B', resources={'r2': 1})
-        self.sch.add_task(WORKER, task_id='C', resources={'r1': 1})
+        self.sch.add_task(worker='X', task_id='A', resources={'r1': 1, 'r2': 1}, priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r2': 1})
+        self.sch.add_task(worker=WORKER, task_id='C', resources={'r1': 1})
         self.sch.update_resources(r1=1, r2=1)
 
         # should preserve both resources for worker 'X'
         self.check_task_order([])
 
     def test_multiple_resources_no_lock(self):
-        self.sch.add_task(WORKER, task_id='A', resources={'r1': 1}, priority=10)
-        self.sch.add_task(WORKER, task_id='B', resources={'r1': 1, 'r2': 1}, priority=10)
-        self.sch.add_task(WORKER, task_id='C', resources={'r2': 1})
+        self.sch.add_task(worker=WORKER, task_id='A', resources={'r1': 1}, priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B', resources={'r1': 1, 'r2': 1}, priority=10)
+        self.sch.add_task(worker=WORKER, task_id='C', resources={'r2': 1})
         self.sch.update_resources(r1=1, r2=2)
 
-        self.assertEqual('A', self.sch.get_work(WORKER)['task_id'])
+        self.assertEqual('A', self.sch.get_work(worker=WORKER)['task_id'])
         # C doesn't block B, so it can go first
         self.check_task_order('C')
 
     def check_task_order(self, order):
         for expected_id in order:
-            self.assertEqual(self.sch.get_work(WORKER)['task_id'], expected_id)
-            self.sch.add_task(WORKER, expected_id, status=DONE)
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+            self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], expected_id)
+            self.sch.add_task(worker=WORKER, task_id=expected_id, status=DONE)
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_priorities(self):
-        self.sch.add_task(WORKER, 'A', priority=10)
-        self.sch.add_task(WORKER, 'B', priority=5)
-        self.sch.add_task(WORKER, 'C', priority=15)
-        self.sch.add_task(WORKER, 'D', priority=9)
+        self.sch.add_task(worker=WORKER, task_id='A', priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B', priority=5)
+        self.sch.add_task(worker=WORKER, task_id='C', priority=15)
+        self.sch.add_task(worker=WORKER, task_id='D', priority=9)
         self.check_task_order(['C', 'A', 'D', 'B'])
 
     def test_priorities_default_and_negative(self):
-        self.sch.add_task(WORKER, 'A', priority=10)
-        self.sch.add_task(WORKER, 'B')
-        self.sch.add_task(WORKER, 'C', priority=15)
-        self.sch.add_task(WORKER, 'D', priority=-20)
-        self.sch.add_task(WORKER, 'E', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='A', priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B')
+        self.sch.add_task(worker=WORKER, task_id='C', priority=15)
+        self.sch.add_task(worker=WORKER, task_id='D', priority=-20)
+        self.sch.add_task(worker=WORKER, task_id='E', priority=1)
         self.check_task_order(['C', 'A', 'E', 'B', 'D'])
 
     def test_priorities_and_dependencies(self):
-        self.sch.add_task(WORKER, 'A', deps=['Z'], priority=10)
-        self.sch.add_task(WORKER, 'B', priority=5)
-        self.sch.add_task(WORKER, 'C', deps=['Z'], priority=3)
-        self.sch.add_task(WORKER, 'D', priority=2)
-        self.sch.add_task(WORKER, 'Z', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='A', deps=['Z'], priority=10)
+        self.sch.add_task(worker=WORKER, task_id='B', priority=5)
+        self.sch.add_task(worker=WORKER, task_id='C', deps=['Z'], priority=3)
+        self.sch.add_task(worker=WORKER, task_id='D', priority=2)
+        self.sch.add_task(worker=WORKER, task_id='Z', priority=1)
         self.check_task_order(['Z', 'A', 'B', 'C', 'D'])
 
     def test_priority_update_dependency_after_scheduling(self):
-        self.sch.add_task(WORKER, 'A', priority=1)
-        self.sch.add_task(WORKER, 'B', priority=5, deps=['A'])
-        self.sch.add_task(WORKER, 'C', priority=10, deps=['B'])
-        self.sch.add_task(WORKER, 'D', priority=6)
+        self.sch.add_task(worker=WORKER, task_id='A', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='B', priority=5, deps=['A'])
+        self.sch.add_task(worker=WORKER, task_id='C', priority=10, deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='D', priority=6)
         self.check_task_order(['A', 'B', 'C', 'D'])
 
     def test_disable(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be disabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 0)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_disable_and_reenable(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be disabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
@@ -510,14 +510,14 @@ class CentralPlannerTest(unittest.TestCase):
         # should be enabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 0)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 1)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_disable_and_reenable_and_disable_again(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be disabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
@@ -528,180 +528,180 @@ class CentralPlannerTest(unittest.TestCase):
         # should be enabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 0)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 1)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be still enabled
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 0)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 1)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be disabled now
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 0)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], None)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], None)
 
     def test_disable_and_done(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
         # should be disabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
         self.assertEqual(len(self.sch.task_list('FAILED', '')), 0)
 
-        self.sch.add_task(WORKER, 'A', status=DONE)
+        self.sch.add_task(worker=WORKER, task_id='A', status=DONE)
 
         # should be enabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 0)
         self.assertEqual(len(self.sch.task_list('DONE', '')), 1)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_disable_by_worker(self):
-        self.sch.add_task(WORKER, 'A', status=DISABLED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=DISABLED)
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)
 
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
 
         # should be enabled at this point
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 0)
-        self.sch.add_task(WORKER, 'A')
-        self.assertEqual(self.sch.get_work(WORKER)['task_id'], 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_task_list_beyond_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=3)
         for c in 'ABCD':
-            sch.add_task(WORKER, c)
+            sch.add_task(worker=WORKER, task_id=c)
         self.assertEqual(set('ABCD'), set(sch.task_list('PENDING', '', False).keys()))
         self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', ''))
 
     def test_task_list_within_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=4)
         for c in 'ABCD':
-            sch.add_task(WORKER, c)
+            sch.add_task(worker=WORKER, task_id=c)
         self.assertEqual(set('ABCD'), set(sch.task_list('PENDING', '').keys()))
 
     def test_task_lists_some_beyond_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=3)
         for c in 'ABCD':
-            sch.add_task(WORKER, c, 'DONE')
+            sch.add_task(worker=WORKER, task_id=c, status=DONE)
         for c in 'EFG':
-            sch.add_task(WORKER, c)
+            sch.add_task(worker=WORKER, task_id=c)
         self.assertEqual(set('EFG'), set(sch.task_list('PENDING', '').keys()))
         self.assertEqual({'num_tasks': 4}, sch.task_list('DONE', ''))
 
     def test_task_list_filter_by_search(self):
-        self.sch.add_task(WORKER, 'test_match_task')
-        self.sch.add_task(WORKER, 'test_filter_task')
+        self.sch.add_task(worker=WORKER, task_id='test_match_task')
+        self.sch.add_task(worker=WORKER, task_id='test_filter_task')
         matches = self.sch.task_list('PENDING', '', search='match')
         self.assertEqual(['test_match_task'], list(matches.keys()))
 
     def test_task_list_filter_by_multiple_search_terms(self):
-        self.sch.add_task(WORKER, 'abcd')
-        self.sch.add_task(WORKER, 'abd')
-        self.sch.add_task(WORKER, 'acd')
-        self.sch.add_task(WORKER, 'ad')
-        self.sch.add_task(WORKER, 'bc')
+        self.sch.add_task(worker=WORKER, task_id='abcd')
+        self.sch.add_task(worker=WORKER, task_id='abd')
+        self.sch.add_task(worker=WORKER, task_id='acd')
+        self.sch.add_task(worker=WORKER, task_id='ad')
+        self.sch.add_task(worker=WORKER, task_id='bc')
         matches = self.sch.task_list('PENDING', '', search='b c')
         self.assertEqual(set(['abcd', 'bc']), set(matches.keys()))
 
     def test_search_results_beyond_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=3)
-        sch.add_task(WORKER, 'task_a')
-        sch.add_task(WORKER, 'task_b')
-        sch.add_task(WORKER, 'task_c')
-        sch.add_task(WORKER, 'task_d')
+        sch.add_task(worker=WORKER, task_id='task_a')
+        sch.add_task(worker=WORKER, task_id='task_b')
+        sch.add_task(worker=WORKER, task_id='task_c')
+        sch.add_task(worker=WORKER, task_id='task_d')
         self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', '', search='a'))
         self.assertEqual(['task_a'], list(sch.task_list('PENDING', '', search='_a').keys()))
 
     def test_priority_update_dependency_chain(self):
-        self.sch.add_task(WORKER, 'A', priority=10, deps=['B'])
-        self.sch.add_task(WORKER, 'B', priority=5, deps=['C'])
-        self.sch.add_task(WORKER, 'C', priority=1)
-        self.sch.add_task(WORKER, 'D', priority=6)
+        self.sch.add_task(worker=WORKER, task_id='A', priority=10, deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='B', priority=5, deps=['C'])
+        self.sch.add_task(worker=WORKER, task_id='C', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='D', priority=6)
         self.check_task_order(['C', 'B', 'A', 'D'])
 
     def test_priority_no_decrease_with_multiple_updates(self):
-        self.sch.add_task(WORKER, 'A', priority=1)
-        self.sch.add_task(WORKER, 'B', priority=10, deps=['A'])
-        self.sch.add_task(WORKER, 'C', priority=5, deps=['A'])
-        self.sch.add_task(WORKER, 'D', priority=6)
+        self.sch.add_task(worker=WORKER, task_id='A', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='B', priority=10, deps=['A'])
+        self.sch.add_task(worker=WORKER, task_id='C', priority=5, deps=['A'])
+        self.sch.add_task(worker=WORKER, task_id='D', priority=6)
         self.check_task_order(['A', 'B', 'D', 'C'])
 
     def test_unique_tasks(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'B')
-        self.sch.add_task(WORKER, 'C')
-        self.sch.add_task(WORKER + "_2", 'B')
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='B')
+        self.sch.add_task(worker=WORKER, task_id='C')
+        self.sch.add_task(worker=WORKER + "_2", task_id='B')
 
-        response = self.sch.get_work(WORKER)
+        response = self.sch.get_work(worker=WORKER)
         self.assertEqual(3, response['n_pending_tasks'])
         self.assertEqual(2, response['n_unique_pending'])
 
     def test_pending_downstream_disable(self):
-        self.sch.add_task(WORKER, 'A', status=DISABLED)
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'C', deps=('B',))
+        self.sch.add_task(worker=WORKER, task_id='A', status=DISABLED)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='C', deps=('B',))
 
-        response = self.sch.get_work(WORKER)
+        response = self.sch.get_work(worker=WORKER)
         self.assertTrue(response['task_id'] is None)
         self.assertEqual(0, response['n_pending_tasks'])
         self.assertEqual(0, response['n_unique_pending'])
 
     def test_pending_downstream_failure(self):
-        self.sch.add_task(WORKER, 'A', status=FAILED)
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'C', deps=('B',))
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='C', deps=('B',))
 
-        response = self.sch.get_work(WORKER)
+        response = self.sch.get_work(worker=WORKER)
         self.assertTrue(response['task_id'] is None)
         self.assertEqual(2, response['n_pending_tasks'])
         self.assertEqual(2, response['n_unique_pending'])
 
     def test_prefer_more_dependents(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'B')
-        self.sch.add_task(WORKER, 'C', deps=['B'])
-        self.sch.add_task(WORKER, 'D', deps=['B'])
-        self.sch.add_task(WORKER, 'E', deps=['A'])
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='B')
+        self.sch.add_task(worker=WORKER, task_id='C', deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='D', deps=['B'])
+        self.sch.add_task(worker=WORKER, task_id='E', deps=['A'])
         self.check_task_order('BACDE')
 
     def test_prefer_readier_dependents(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'B')
-        self.sch.add_task(WORKER, 'C')
-        self.sch.add_task(WORKER, 'D')
-        self.sch.add_task(WORKER, 'F', deps=['A', 'B', 'C'])
-        self.sch.add_task(WORKER, 'G', deps=['A', 'B', 'C'])
-        self.sch.add_task(WORKER, 'E', deps=['D'])
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='B')
+        self.sch.add_task(worker=WORKER, task_id='C')
+        self.sch.add_task(worker=WORKER, task_id='D')
+        self.sch.add_task(worker=WORKER, task_id='F', deps=['A', 'B', 'C'])
+        self.sch.add_task(worker=WORKER, task_id='G', deps=['A', 'B', 'C'])
+        self.sch.add_task(worker=WORKER, task_id='E', deps=['D'])
         self.check_task_order('DABCFGE')
 
     def test_ignore_done_dependents(self):
-        self.sch.add_task(WORKER, 'A')
-        self.sch.add_task(WORKER, 'B')
-        self.sch.add_task(WORKER, 'C')
-        self.sch.add_task(WORKER, 'D', priority=1)
-        self.sch.add_task(WORKER, 'E', deps=['C', 'D'])
-        self.sch.add_task(WORKER, 'F', deps=['A', 'B'])
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker=WORKER, task_id='B')
+        self.sch.add_task(worker=WORKER, task_id='C')
+        self.sch.add_task(worker=WORKER, task_id='D', priority=1)
+        self.sch.add_task(worker=WORKER, task_id='E', deps=['C', 'D'])
+        self.sch.add_task(worker=WORKER, task_id='F', deps=['A', 'B'])
         self.check_task_order('DCABEF')
 
     def test_task_list_no_deps(self):
-        self.sch.add_task(WORKER, 'B', deps=('A',))
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
+        self.sch.add_task(worker=WORKER, task_id='A')
         task_list = self.sch.task_list('PENDING', '')
         self.assertFalse('deps' in task_list['A'])
 
     def test_task_first_failure_time(self):
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
         test_task = self.sch._state.get_task('A')
         self.assertIsNone(test_task.failures.first_failure_time)
 
@@ -715,7 +715,7 @@ class CentralPlannerTest(unittest.TestCase):
                                 test_task.failures.first_failure_time)
 
     def test_task_first_failure_time_remains_constant(self):
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
         test_task = self.sch._state.get_task('A')
         self.assertIsNone(test_task.failures.first_failure_time)
 
@@ -726,7 +726,7 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(first_failure_time, test_task.failures.first_failure_time)
 
     def test_task_has_excessive_failures(self):
-        self.sch.add_task(WORKER, 'A')
+        self.sch.add_task(worker=WORKER, task_id='A')
         test_task = self.sch._state.get_task('A')
         self.assertIsNone(test_task.failures.first_failure_time)
 

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -48,7 +48,7 @@ class CustomizedLocalScheduler(luigi.scheduler.CentralPlannerScheduler):
         self.has_run = False
 
     def get_work(self, worker, host=None, **kwargs):
-        r = super(CustomizedLocalScheduler, self).get_work(worker, host)
+        r = super(CustomizedLocalScheduler, self).get_work(worker=worker, host=host)
         self.has_run = True
         return r
 
@@ -63,7 +63,7 @@ class CustomizedRemoteScheduler(luigi.rpc.RemoteScheduler):
         self.has_run = False
 
     def get_work(self, worker, host=None):
-        r = super(CustomizedRemoteScheduler, self).get_work(worker, host)
+        r = super(CustomizedRemoteScheduler, self).get_work(worker=worker, host=host)
         self.has_run = True
         return r
 

--- a/test/worker_parallel_scheduling_test.py
+++ b/test/worker_parallel_scheduling_test.py
@@ -76,7 +76,7 @@ class ParallelSchedulingTest(unittest.TestCase):
         self.w = Worker(scheduler=self.sch, worker_id='x')
 
     def added_tasks(self, status):
-        return [args[1] for args, kw in self.sch.add_task.call_args_list if kw['status'] == status]
+        return [kw['task_id'] for args, kw in self.sch.add_task.call_args_list if kw['status'] == status]
 
     def test_multiprocess_scheduling_with_overlapping_dependencies(self):
         self.w.add(OverlappingSelfDependenciesTask(5, 2), True)


### PR DESCRIPTION
My main motivation for doing this was to rename 'worker' to 'worker_id',
increasing readability.

The other reason is that the test cases and the code in worker.py
becomes easier to follow when we're passing keyword arguments.