### PR TITLE
Task to upload a file to Salesforce

### DIFF
--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Example configuration section in client.cfg::
+
+    [salesforce]
+    username: ${SF_USERNAME}
+    password: ${SF_PASSWORD}
+    security_token: ${SF_SECURITY_TOKEN}
+"""
+
+
+import requests
+import time
+try:
+    from urlparse import urlsplit
+except ImportError:
+    from urllib.parse import urlsplit
+import xml.etree.ElementTree as ET
+
+from luigi import configuration
+from luigi import BoolParameter, Parameter
+from luigi import target_factory
+from luigi import Task
+from luigi.s3 import S3Target
+
+
+import logging
+logger = logging.getLogger('luigi-interface')
+
+
+class UploadToSalesforceTask(Task):
+    """
+    This task will upload a file to Salesforce.  It requires the following fields
+    to be set in the [salesforce] section of the client.cfg file:
+
+    * username: The username of the SF user that will be doing the uploading.
+    * password: The password of the SF user that will be doing the uploading.
+    * security_token: The security_token of the SF user that will be doing the uploading.
+
+    The data will be uploaded as an upsert job in order to ensure idempotency.  A token
+    file is written on job success to track whether the task has completed or not.
+    """
+
+    # The file path where token files will be written to track the start/finish
+    # start of this task by Luigi.
+    #
+    # This path should contain components for any custom task parameters that influence
+    # the output.  Ex. dates, environments, versions, etc.
+    token_path = Parameter()
+
+    # The SF name of the field that ties to a unique id in the original source of the data.
+    # This field is required by SF when doing an upsert operation.
+    #
+    # Must have the SF "__c" suffix if this is for a custom object.
+    sf_external_id_field_name = Parameter()
+
+    # The name of the object we're uploading.  Must have the SF "__c" suffix if it
+    # is a custom object.
+    sf_object_name = Parameter()
+
+    # True iff we should be uploading to a sandbox environment instead of the
+    # Production organization.
+    sf_use_sandbox = BoolParameter()
+
+    # Name of the sandbox environment being used.  None if using Production.
+    sf_sandbox_name = Parameter(default=None)
+
+    # This is the path to the file to be uploaded.  May be a local file or an S3 file.
+    sf_upload_file_path = Parameter()
+
+    def output(self):
+        """
+        Uses the success token as its output to avoid having to query Salesforce to
+        determine if the job has completed.
+        """
+        return [self.success_token()]
+
+    def run(self):
+        if self.sf_use_sandbox and not self.sf_sandbox_name:
+            raise Exception("Parameter sf_sandbox_name must be provided when uploading to a Salesforce Sandbox")
+
+        sf_username = configuration.get_config().get('salesforce', 'username')
+        sf_password = configuration.get_config().get('salesforce', 'password')
+        sf_security_token = configuration.get_config().get('salesforce', 'security_token')
+
+        sfa = SalesforceAPI(sf_username, sf_password, sf_security_token, self.sf_sandbox_name)
+        # Checks to make sure we have a valid target before creating the job in SF
+        upload_target = target_factory.get_target(self.sf_upload_file_path)
+
+        job_id = sfa.create_upsert_job(self.sf_object_name, self.sf_external_id_field_name)
+        logger.info("Started upsert job %s in salesforce for object %s" % (job_id, self.sf_object_name))
+
+        try:
+            batch_id = sfa.create_batch(job_id, upload_target)
+            logger.info("Creating new batch %s to upload file: %s for job: %s." % (batch_id, self.sf_upload_file_path, job_id))
+            sfa.block_on_batch(job_id, batch_id)
+        finally:
+            logger.info("Closing job %s" % job_id)
+            sfa.close_job(job_id)
+
+        target_factory.write_file(self.success_token(), job_id)
+
+    def success_token(self):
+        """
+        Writes a token file that indicates this task has finished successfully.
+        """
+        root_token_path = self.token_path[:-1] if self.token_path[-1] == "/" else self.token_path
+        sf_org_name = self.sf_sandbox_name if self.sf_use_sandbox else "production"
+
+        token_path = "%s/%s-%s-Success" % (root_token_path, sf_org_name, self.__class__.__name__)
+        logger.info("UploadToSalesforceTask token path: %s" % token_path)
+        return target_factory.get_target(token_path)
+
+
+class SalesforceAPI(object):
+    """
+    Class used to interact with the SalesforceAPI.  Currently provides only the
+    methods necessary for performing a bulk upload operation.
+    """
+    API_VERSION = 33.0
+    SOAP_NS = "{urn:partner.soap.sforce.com}"
+    API_NS = "{http://www.force.com/2009/06/asyncapi/dataload}"
+
+    def __init__(self, username, password, security_token, sandbox_name=None):
+        self.username = username
+        self.password = password
+        self.security_token = security_token
+        self.sandbox_name = sandbox_name
+
+        if self.sandbox_name:
+            self.username += ".%s" % self.sandbox_name
+
+        self.session_id = None
+        self.server_url = None
+        self.hostname = None
+
+    def start_session(self):
+        """
+        Starts a Salesforce session and determines which SF instance to use for future requests.
+        """
+        if self.has_active_session():
+            raise Exception("Session already in progress.")
+
+        response = requests.post(self._get_login_url(),
+                                 headers=self._get_login_headers(),
+                                 data=self._get_login_xml())
+        response.raise_for_status()
+
+        root = ET.fromstring(response.text)
+        for e in root.iter("%ssessionId" % self.SOAP_NS):
+            if self.session_id:
+                raise Exception("Invalid login attempt.  Multiple session ids found.")
+            self.session_id = e.text
+
+        for e in root.iter("%sserverUrl" % self.SOAP_NS):
+            if self.server_url:
+                raise Exception("Invalid login attempt.  Multiple server urls found.")
+            self.server_url = e.text
+
+        if not self.has_active_session():
+            raise Exception("Invalid login attempt resulted in null sessionId [%s] and/or serverUrl [%s]." %
+                            (self.session_id, self.server_url))
+        self.hostname = urlsplit(self.server_url).hostname
+
+    def create_upsert_job(self, obj, external_id_field_name, content_type='CSV'):
+        """
+        Creates a new SF job that for doing an upsert upload
+        """
+        if not self.has_active_session():
+            self.start_session()
+
+        response = requests.post(self._get_create_job_url(),
+                                 headers=self._get_create_job_headers(),
+                                 data=self._get_create_upsert_xml(obj, external_id_field_name, content_type))
+        response.raise_for_status()
+
+        root = ET.fromstring(response.text)
+        job_id = root.find('%sid' % self.API_NS).text
+        return job_id
+
+    def close_job(self, job_id):
+        """
+        Closes the SF job.
+        """
+        if not job_id or not self.has_active_session():
+            raise Exception("Can not close job without valid job_id and an active session.")
+
+        response = requests.post(self._get_close_job_url(job_id),
+                                 headers=self._get_close_job_headers(),
+                                 data=self._get_close_job_xml())
+        response.raise_for_status()
+
+    def create_batch(self, job_id, file_target):
+        """
+        Creates a batch for uploading.
+
+        This will pull the contents of the file_target into memory when running.
+        That shouldn't be a problem for any files that meet the Salesforce single batch upload
+        size limit (10MB) and is done to ensure compressed files can be uploaded properly.
+        """
+        if not job_id or not self.has_active_session():
+            raise Exception("Can not create a batch without a valid job_id and an active session.")
+
+        data = "".join([l for l in file_target.open('r')])
+        headers = self._get_create_batch_headers()
+        headers['Content-Length'] = len(data)
+
+        response = requests.post(self._get_create_batch_url(job_id),
+                                 headers=self._get_create_batch_headers(),
+                                 data=data)
+        response.raise_for_status()
+
+        root = ET.fromstring(response.text)
+        batch_id = root.find('%sid' % self.API_NS).text
+        return batch_id
+
+    def block_on_batch(self, job_id, batch_id, sleep_time_seconds=5, max_wait_time_seconds=-1):
+        """
+        Blocks until @batch_id is completed or failed.
+        """
+        if not job_id or not batch_id or not self.has_active_session():
+            raise Exception("Can not block on a batch without a valid batch_id, job_id and an active session.")
+
+        start_time = time.time()
+        status = {}
+        while max_wait_time_seconds < 0 or time.time() - start_time < max_wait_time_seconds:
+            status = self._get_batch_status(job_id, batch_id)
+            logger.info("Batch %s Job %s in state %s.  %s records processed.  %s records failed." %
+                        (batch_id, job_id, status['state'], status['num_processed'], status['num_failed']))
+            if status['state'].lower() in ["completed", "failed"]:
+                return status
+            time.sleep(sleep_time_seconds)
+
+        raise Exception("Batch did not complete in %s seconds.  Final status was: %s" % (sleep_time_seconds, status))
+
+    def _get_batch_status(self, job_id, batch_id):
+        response = requests.get(self._get_check_batch_status_url(job_id, batch_id),
+                                headers=self._get_check_batch_status_headers())
+        response.raise_for_status()
+
+        root = ET.fromstring(response.text)
+
+        result = {
+            "state": root.find('%sstate' % self.API_NS).text,
+            "num_processed": root.find('%snumberRecordsProcessed' % self.API_NS).text,
+            "num_failed": root.find('%snumberRecordsFailed' % self.API_NS).text,
+        }
+        return result
+
+    def has_active_session(self):
+        return self.session_id and self.server_url
+
+    def _get_login_url(self):
+        server = "login" if not self.sandbox_name else "test"
+        return "https://%s.salesforce.com/services/Soap/u/%s" % (server, self.API_VERSION)
+
+    def _get_create_job_url(self):
+        return "https://%s/services/async/%s/job" % (self.hostname, self.API_VERSION)
+
+    def _get_close_job_url(self, job_id):
+        return "https://%s/services/async/%s/job/%s" % (self.hostname, self.API_VERSION, job_id)
+
+    def _get_create_batch_url(self, job_id):
+        return "https://%s/services/async/%s/job/%s/batch" % (self.hostname, self.API_VERSION, job_id)
+
+    def _get_check_batch_status_url(self, job_id, batch_id):
+        return "https://%s/services/async/%s/job/%s/batch/%s" % (self.hostname, self.API_VERSION, job_id, batch_id)
+
+    def _get_login_headers(self):
+        headers = {
+            'Content-Type': "text/xml; charset=UTF-8",
+            'SOAPAction': 'login'
+        }
+        return headers
+
+    def _get_create_job_headers(self):
+        headers = {
+            'X-SFDC-Session': self.session_id,
+            'Content-Type': "application/xml; charset=UTF-8"
+        }
+        return headers
+
+    def _get_close_job_headers(self):
+        headers = {
+            'X-SFDC-Session': self.session_id,
+            'Content-Type': "application/xml; charset=UTF-8"
+        }
+        return headers
+
+    def _get_create_batch_headers(self):
+        headers = {
+            'X-SFDC-Session': self.session_id,
+            'Content-Type': "text/csv; charset=UTF-8"
+        }
+        return headers
+
+    def _get_check_batch_status_headers(self):
+        headers = {
+            'X-SFDC-Session': self.session_id,
+        }
+        return headers
+
+    def _get_login_xml(self):
+        xml = """<?xml version="1.0" encoding="utf-8" ?>
+            <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+              <env:Body>
+                <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+                  <n1:username>%s</n1:username>
+                  <n1:password>%s%s</n1:password>
+                </n1:login>
+              </env:Body>
+            </env:Envelope>
+        """ % (self.username, self.password, self.security_token)
+        return xml
+
+    def _get_create_upsert_xml(self, obj, external_id_field_name, content_type):
+        return self._get_create_job_xml('upsert', obj, content_type,
+                                        external_id_field_name=external_id_field_name)
+
+    def _get_create_job_xml(self, operation, obj, content_type, external_id_field_name=None):
+        external_id_field_name_element = "" if not external_id_field_name else \
+            "\n<externalIdFieldName>%s</externalIdFieldName>" % external_id_field_name
+
+        # Note: "Unable to parse job" error may be caused by reordering fields.
+        #       ExternalIdFieldName element must be before contentType element.
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+            <jobInfo xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+                <operation>%s</operation>
+                <object>%s</object>
+                %s
+                <contentType>%s</contentType>
+            </jobInfo>
+        """ % (operation, obj, external_id_field_name_element, content_type)
+        return xml
+
+    def _get_close_job_xml(self):
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+            <jobInfo xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+              <state>Closed</state>
+            </jobInfo>
+        """
+        return xml

--- a/luigi/target_factory.py
+++ b/luigi/target_factory.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import datetime
+from luigi.format import Gzip
+from luigi.s3 import S3Target
+from luigi.target import FileSystemTarget
+from luigi import LocalTarget
+
+
+def get_target(path):
+    """
+    Factory method to create a Luigi Target from a path string.
+    Supports the following Target types:
+    * S3Target: s3://my-bucket/my-path
+    * LocalTarget: /path/to/file or file:///path/to/file
+    :type path: str
+    :param path: s3 or file URL, or local path
+    :rtype: Target:
+    :returns: Target for path string
+    """
+    file_format = None
+    if path.endswith(".gz"):
+        file_format = Gzip
+
+    if path.startswith('s3:') or path.startswith('s3n:'):
+        return S3Target(path, format=file_format)
+    elif path.startswith('/'):
+        return LocalTarget(path, format=file_format)
+    elif path.startswith('file://'):
+        # remove the file portion
+        actual_path = path[7:]
+        return LocalTarget(actual_path, format=file_format)
+    else:
+        raise RuntimeError("Unknown scheme for path: %s" % path)
+
+
+def write_file(out_target, text=None):
+    """
+    Factory method to write a token file to a Luigi Target.
+    :type out_target: Target
+    :param out_target: Target where token file should be written
+    :type text: str
+    :param text: Optional text to write to token file. Default: write current UTC time.
+    """
+    with out_target.open('w') as token_file:
+        if text:
+            token_file.write('%s\n' % text)
+        else:
+            token_file.write('%s' % datetime.datetime.utcnow().isoformat())

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ install_requires = [
 if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.append('sqlalchemy')
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
+    install_requires.append('requests')
+    # So that we can build documentation for luigi.contrib.salesforce
 
 if sys.version_info[:2] < (2, 7):
     install_requires.extend(['argparse', 'ordereddict', 'importlib'])

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import with_config, unittest
+import luigi
+from luigi.contrib.salesforce import UploadToSalesforceTask, SalesforceAPI
+from mock import patch
+import os
+import requests
+import tempfile
+
+
+class UploadToSalesforceTaskTest(unittest.TestCase):
+    def setUp(self):
+        self.data = 'somedata'
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.write(self.data)
+        self.tmp.close()
+
+        self.unicode_data = u"aàçñ"
+        self.unicode_tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.unicode_tmp.write(self.unicode_data.encode('utf8'))
+        self.unicode_tmp.close()
+
+    def tearDown(self):
+        if self.tmp:
+            os.remove(self.tmp.name)
+            self.tmp = None
+
+    @with_config({'salesforce': {'username': 'user',
+                                 'password': "pw",
+                                 'security_token': 'st'}})
+    @patch('luigi.contrib.salesforce.SalesforceAPI')
+    def test_run__success(self, mock):
+        job_id = "123"
+        batch_id = "456"
+
+        sf_object_name = "object_name"
+        sf_external_id_field_name = "external_id_field_name"
+        token_path = tempfile.gettempdir()
+
+        mock.return_value.create_upsert_job = self._get_mock_create_job(sf_object_name, sf_external_id_field_name, job_id)
+        mock.return_value.create_batch = self._get_mock_create_batch(job_id, self.tmp.name, batch_id)
+        mock.return_value.block_on_batch = self._get_mock_block_on_batch(job_id, batch_id, True)
+        mock.return_value.close_job = self._get_mock_close_job(job_id)
+
+        job = UploadToSalesforceTask(token_path=token_path,
+                                     sf_object_name=sf_object_name,
+                                     sf_external_id_field_name=sf_external_id_field_name,
+                                     sf_use_sandbox=False,
+                                     sf_upload_file_path=self.tmp.name)
+
+        success_token = job.success_token()
+
+        if success_token.exists():
+            success_token.remove()
+
+        self.assertFalse(success_token.exists())
+        job.run()
+        self.assertTrue(success_token.exists())
+
+    @with_config({'salesforce': {'username': 'user-unicode',
+                                 'password': "pw-unicode",
+                                 'security_token': 'st-unicode'}})
+    @patch('luigi.contrib.salesforce.SalesforceAPI')
+    def test_run__unicode_success(self, mock):
+        job_id = "123"
+        batch_id = "456"
+
+        sf_object_name = "object_name"
+        sf_external_id_field_name = "external_id_field_name"
+        token_path = tempfile.gettempdir()
+
+        mock.return_value.create_upsert_job = self._get_mock_create_job(sf_object_name, sf_external_id_field_name, job_id)
+        mock.return_value.create_batch = self._get_mock_create_batch(job_id, self.unicode_tmp.name, batch_id)
+        mock.return_value.block_on_batch = self._get_mock_block_on_batch(job_id, batch_id, True)
+        mock.return_value.close_job = self._get_mock_close_job(job_id)
+
+        job = UploadToSalesforceTask(token_path=token_path,
+                                     sf_object_name=sf_object_name,
+                                     sf_external_id_field_name=sf_external_id_field_name,
+                                     sf_use_sandbox=False,
+                                     sf_upload_file_path=self.unicode_tmp.name)
+
+        success_token = job.success_token()
+
+        if success_token.exists():
+            success_token.remove()
+
+        self.assertFalse(success_token.exists())
+        job.run()
+        self.assertTrue(success_token.exists())
+
+    @with_config({'salesforce': {'username': 'user',
+                                 'password': "pw",
+                                 'security_token': 'st'}})
+    @patch('luigi.contrib.salesforce.SalesforceAPI')
+    def test_run_batch_fails(self, mock):
+        job_id = "23"
+        batch_id = "56"
+
+        sf_object_name = "object_name"
+        sf_external_id_field_name = "external_id_field_name"
+        token_path = tempfile.gettempdir()
+
+        mock.return_value.create_upsert_job = self._get_mock_create_job(sf_object_name, sf_external_id_field_name, job_id)
+        mock.return_value.create_batch = self._get_mock_create_batch(job_id, self.tmp.name, batch_id)
+        mock.return_value.block_on_batch = self._get_mock_block_on_batch(job_id, batch_id, False)
+        mock.return_value.close_job = self._get_mock_close_job(job_id)
+
+        job = UploadToSalesforceTask(token_path=token_path,
+                                     sf_object_name=sf_object_name,
+                                     sf_external_id_field_name=sf_external_id_field_name,
+                                     sf_use_sandbox=False,
+                                     sf_upload_file_path=self.tmp.name)
+
+        success_token = job.success_token()
+
+        if success_token.exists():
+            success_token.remove()
+
+        self.assertFalse(success_token.exists())
+        self.assertRaises(Exception, job.run)
+        self.assertFalse(success_token.exists())
+
+    def _get_mock_create_job(self, expected_object, expected_field_name, returned_job_id):
+        def _create_job(obj, field_name):
+            self.assertEqual(expected_object, obj)
+            self.assertEqual(expected_field_name, field_name)
+            return returned_job_id
+        return _create_job
+
+    def _get_mock_create_batch(self, expected_job_id, expected_path, returned_batch_id):
+        def _create_batch(job_id, upload_path_target):
+            self.assertEqual(expected_job_id, job_id)
+            self.assertEqual(expected_path, upload_path_target.path)
+            return returned_batch_id
+        return _create_batch
+
+    def _get_mock_block_on_batch(self, expected_job_id, expected_batch_id, should_return):
+        def _create_block_on_batch(job_id, batch_id):
+            self.assertEqual(expected_job_id, job_id)
+            self.assertEqual(expected_batch_id, batch_id)
+            if not should_return:
+                raise Exception("Timed out")
+            return {}
+        return _create_block_on_batch
+
+    def _get_mock_close_job(self, expected_job_id):
+        def _create_close_job(job_id):
+            self.assertEqual(expected_job_id, job_id)
+        return _create_close_job
+
+
+class SalesforceAPITest(unittest.TestCase):
+
+    def setUp(self):
+        self.sfa = SalesforceAPI('user', 'pw', 'eid')
+
+    @patch('requests.post')
+    def test_start_session(self, mock):
+        instance = "some-server-instance.salesforce.com"
+        server_url = "https://%s/services/Soap/m/33.0/" % instance
+        session_id = "some-session-id"
+
+        mock.return_value = MockResponse(self._get_login_xml(session_id, server_url))
+        self.sfa.start_session()
+        self.assertEquals(instance, self.sfa.hostname)
+        self.assertEquals(server_url, self.sfa.server_url)
+        self.assertEquals(session_id, self.sfa.session_id)
+
+    @patch('requests.post')
+    def test_create_upsert_job(self, mock):
+        self.sfa.session_id = "some-session-id"
+        self.sfa.server_url = "some-server-url"
+        job_id = "12345"
+
+        mock.return_value = MockResponse(self._get_upsert_xml(job_id))
+
+        result_job_id = self.sfa.create_upsert_job('obj', 'eid')
+        self.assertEquals(job_id, result_job_id)
+
+    @patch('requests.post')
+    def test_create_batch(self, mock):
+        self.sfa.session_id = "some-session-id"
+        self.sfa.server_url = "some-server-url"
+        batch_id = "abcdef"
+
+        mock.return_value = MockResponse(self._get_create_batch_xml(batch_id))
+
+        data = 'somedata'
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        tmp_file.write(data)
+        tmp_file.close()
+
+        result_batch_id = self.sfa.create_batch('job-id', luigi.target_factory.get_target(tmp_file.name))
+        self.assertEquals(batch_id, result_batch_id)
+
+        os.remove(tmp_file.name)
+
+    @patch('requests.get')
+    def test_block_on_batch(self, mock):
+        self.sfa.session_id = "some-session-id"
+        self.sfa.server_url = "some-server-url"
+
+        # Test Multiple Calls - success
+        mock.side_effect = [
+            MockResponse(self._get_batch_status_xml("Queued")),
+            MockResponse(self._get_batch_status_xml("Completed")),
+        ]
+        status = self.sfa.block_on_batch('job-id', 'batch-id', sleep_time_seconds=0, max_wait_time_seconds=2)
+        self.assertEquals('5', status['num_processed'])
+        self.assertEquals('Completed', status['state'])
+
+        # Test Multiple Calls - timeout
+        mock.return_value = MockResponse(self._get_batch_status_xml("Queued"))
+        self.assertRaises(Exception, self.sfa.block_on_batch, 'job-id', 'batch-id', sleep_time_seconds=0, max_wait_time_seconds=1)
+
+    def _get_login_xml(self, session_id="a-session-id", server_url="a-server-url"):
+        return """<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:partner.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <soapenv:Body>
+      <loginResponse>
+         <result>
+            <metadataServerUrl>%smeta</metadataServerUrl>
+            <passwordExpired>false</passwordExpired>
+            <sandbox>true</sandbox>
+            <serverUrl>%s</serverUrl>
+            <sessionId>%s</sessionId>
+            <userId>some-user-id</userId>
+         </result>
+      </loginResponse>
+   </soapenv:Body>
+</soapenv:Envelope>
+        """ % (server_url, server_url, session_id)
+
+    def _get_upsert_xml(self, job_id):
+        return """<?xml version="1.0" encoding="UTF-8"?>
+<jobInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+  <id>%s</id>
+  <operation>insert</operation>
+  <object>Contact</object>
+  <createdById>005x0000000wPWdAAM</createdById>
+  <createdDate>2009-09-01T16:42:46.000Z</createdDate>
+  <systemModstamp>2009-09-01T16:42:46.000Z</systemModstamp>
+  <state>Open</state>
+  <concurrencyMode>Parallel</concurrencyMode>
+  <contentType>CSV</contentType>
+  <numberBatchesQueued>0</numberBatchesQueued>
+  <numberBatchesInProgress>0</numberBatchesInProgress>
+  <numberBatchesCompleted>5</numberBatchesCompleted>
+  <numberBatchesFailed>0</numberBatchesFailed>
+  <numberBatchesTotal>0</numberBatchesTotal>
+  <numberRecordsProcessed>0</numberRecordsProcessed>
+  <numberRetries>0</numberRetries>
+  <apiVersion>33.0</apiVersion>
+</jobInfo>
+        """ % job_id
+
+    def _get_create_batch_xml(self, batch_id):
+        return """<?xml version="1.0" encoding="UTF-8"?>
+<batchInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+  <id>%s</id>
+  <jobId>750x0000000005LAAQ</jobId>
+  <state>Queued</state>
+  <createdDate>2009-09-01T17:44:45.000Z</createdDate>
+  <systemModstamp>2009-09-01T17:44:45.000Z</systemModstamp>
+  <numberRecordsProcessed>0</numberRecordsProcessed>
+</batchInfo>
+        """ % batch_id
+
+    def _get_batch_status_xml(self, state):
+        return """<?xml version="1.0" encoding="UTF-8"?><batchInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>some-id</id>
+ <jobId>some-job-id</jobId>
+ <state>%s</state>
+ <createdDate>2015-05-21T15:09:35.000Z</createdDate>
+ <systemModstamp>2015-05-21T15:09:35.000Z</systemModstamp>
+ <numberRecordsProcessed>5</numberRecordsProcessed>
+ <numberRecordsFailed>0</numberRecordsFailed>
+ <totalProcessingTime>0</totalProcessingTime>
+ <apiActiveProcessingTime>0</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</batchInfo>
+        """ % state
+
+
+class MockResponse(object):
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass

--- a/test/target_factory_test.py
+++ b/test/target_factory_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import gzip
+import mock
+import os
+import tempfile
+import unittest
+from luigi import target_factory
+
+
+class TestTargetFactory(unittest.TestCase):
+
+    def setUp(self):
+        self.data = 'someoutputdata'
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.write(self.data.encode('utf-8'))
+        self.tmp.close()
+
+        tmp_gz_file = tempfile.NamedTemporaryFile(delete=False, suffix=".gz")
+        tmp_gz_file.close()
+        self.tmp_gz = gzip.open(tmp_gz_file.name, 'wb')
+        self.tmp_gz.write(self.data.encode('utf-8'))
+        self.tmp_gz.close()
+
+    def tearDown(self):
+        if self.tmp:
+            os.remove(self.tmp.name)
+            self.tmp = None
+
+    @mock.patch('luigi.target_factory.S3Target')
+    def test_get_target_s3(self, mock_s3_target_cls):
+        mock_s3_target = mock.Mock()
+        mock_s3_target_cls.return_value = mock_s3_target
+        s3_target = target_factory.get_target('s3://mybucket/mypath')
+        self.assertEquals(mock_s3_target, s3_target)
+        s3n_target = target_factory.get_target('s3n://mybucket/mypath')
+        self.assertEquals(mock_s3_target, s3n_target)
+
+    def test_get_target_local(self):
+        local_target = target_factory.get_target(self.tmp.name)
+        reread_data = local_target.open().read()
+        self.assertEquals(self.data, reread_data)
+
+    def test_get_target_file(self):
+        file_target = target_factory.get_target('file://%s' % self.tmp.name)
+        reread_data = file_target.open().read()
+        self.assertEquals(self.data, reread_data)
+
+    def test_get_target_file_gz(self):
+        file_target = target_factory.get_target('file://%s' % self.tmp_gz.name)
+        reread_data = file_target.open().read()
+        self.assertEquals(self.data, reread_data)


### PR DESCRIPTION
This PR adds a task that can be used to upload a file to Salesforce.  It uses a helper file target_factory that takes a local/s3 file path and returns the appropriate target object.