### PR TITLE
Improve best case complexity for get_work

### DIFF
--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -741,6 +741,22 @@ class CentralPlannerTest(unittest.TestCase):
         test_task.failures.first_failure_time = fake_failure_time
         self.assertTrue(test_task.has_excessive_failures())
 
+    def test_quadratic_behavior(self):
+        """ Test that get_work is not taking linear amount of time.
+
+        This is of course impossible to test, however, doing reasonable
+        assumptions about hardware. This time should finish in a timely
+        manner.
+        """
+        # For 10000 it takes almost 1 second on my laptop.  Prior to these
+        # changes it was being slow already at NUM_TASKS=300
+        NUM_TASKS = 10000
+        for i in range(NUM_TASKS):
+            self.sch.add_task(worker=str(i), task_id=str(i), resources={})
+
+        for i in range(NUM_TASKS):
+            self.assertEqual(self.sch.get_work(worker=str(i))['task_id'], str(i))
+            self.sch.add_task(worker=str(i), task_id=str(i), status=DONE)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -56,6 +56,9 @@ class RPCTest(central_planner_test.CentralPlannerTest, ServerTestBase):
     def test_task_has_excessive_failures(self):
         pass
 
+    def test_quadratic_behavior(self):
+        """ This would be too slow to run through network """
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -23,7 +23,9 @@ from helpers import unittest
 
 import luigi.scheduler
 from helpers import with_config
+import logging
 
+logging.config.fileConfig('test/testconfig/logging.cfg', disable_existing_loggers=False)
 luigi.notifications.DEBUG = True
 
 
@@ -73,6 +75,28 @@ class SchedulerTest(unittest.TestCase):
         cps = luigi.scheduler.CentralPlannerScheduler()
         self.assertEqual({'a': 100, 'b': 200}, cps._resources)
 
+    def test_load_recovers_tasks_index(self):
+        cps = luigi.scheduler.CentralPlannerScheduler()
+        cps.add_task(worker='A', task_id='1')
+        cps.add_task(worker='B', task_id='2')
+        cps.add_task(worker='C', task_id='3')
+        cps.add_task(worker='D', task_id='4')
+        self.assertEqual(cps.get_work(worker='A')['task_id'], '1')
+
+        with tempfile.NamedTemporaryFile(delete=True) as fn:
+            def reload_from_disk(cps):
+                cps._state._state_path = fn.name
+                cps.dump()
+                cps = luigi.scheduler.CentralPlannerScheduler()
+                cps._state._state_path = fn.name
+                cps.load()
+                return cps
+            del cps._state.get_worker('B').tasks  # If you upgrade from old server
+            cps = reload_from_disk(cps=cps)  # tihii, cps == continuation passing style ;)
+            self.assertEqual(cps.get_work(worker='B')['task_id'], '2')
+            self.assertEqual(cps.get_work(worker='C')['task_id'], '3')
+            cps = reload_from_disk(cps=cps)  # This time without deleting
+            self.assertEqual(cps.get_work(worker='D')['task_id'], '4')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Yes, we only improve the best case complexity, not the worst case.
In summary, you'll get sublinear in aomunt of tasks if your worker
doesn't do any tasks that use global resources.

get_work has gotten way to complex once we added global resource
constraints, as the resource constraints interaction with priorities is
a hairy beast requiring a global perspective, not allowing for
worker-local optimization. See these related tickets which added the
expressiveness/complicated stuff:

  * spotify/luigi#445
  * spotify/luigi#462
  * spotify/luigi#496
  * spotify/luigi#513

Note that the optimization once done in spotify/luigi#584 which helped
@daveFNbuck's company a lot doesn't help Spotify's setup. Most of
Spotify's tasks lingering in the scheduler are pending tasks and not
done tasks.

The proposed hacky solution here, which I mostly see as a temporary
solution until we do a bigger rewrite and rethink of the central
scheduler is the following:

Categorize the get_work scenario in two different buckets, "trivial" and
"nontrivial". Trivial is when none of the tasks of the worker require
global resources, in that scenario, just loop over the tasks the worker
have registered for instead of all the tasks. For the non-trivial case,
we do what we've always done previously.

So in that sense this commit contains two parts:

 * Add an "index" so you can quickly retrieve the tasks for a worker
 * Do the special-casing of trivial and nontrivial in get_work

At Spotify, we don't use the resources feature that much, so we're
hoping for tremendous speed improvements, no more 30-second get-work
calls! :)