### PR TITLE
Add support for custom local-tmp-dir in LocalTarget

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -27,10 +27,16 @@ import io
 import sys
 import warnings
 
+import luigi
 import luigi.util
 import luigi.configuration
 from luigi.format import FileWrapper, get_default_format, MixedUnicodeBytes
 from luigi.target import FileSystem, FileSystemTarget, AtomicLocalFile
+
+
+class localfile(luigi.Config):
+    tmp_dir = luigi.Parameter(default=tempfile.gettempdir(),
+                              config_path=dict(section='core', name='local-tmp-dir'))
 
 
 class atomic_file(AtomicLocalFile):
@@ -75,9 +81,6 @@ class LocalTarget(FileSystemTarget):
         if format is None:
             format = get_default_format()
 
-        tmp_dir = luigi.configuration.get_config().get("core", "local-tmp-dir", None)
-        if not tmp_dir:
-            tmp_dir = tempfile.gettempdir()
         # Allow to write unicode in file for retrocompatibility
         if sys.version_info[:2] <= (2, 6):
             format = format >> MixedUnicodeBytes
@@ -85,7 +88,7 @@ class LocalTarget(FileSystemTarget):
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')
-            path = os.path.join(tmp_dir, 'luigi-tmp-%09d' % random.randint(0, 999999999))
+            path = os.path.join(localfile().tmp_dir, 'luigi-tmp-%09d' % random.randint(0, 999999999))
         super(LocalTarget, self).__init__(path)
         self.format = format
         self.is_tmp = is_tmp

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -28,6 +28,7 @@ import sys
 import warnings
 
 import luigi.util
+import luigi.configuration
 from luigi.format import FileWrapper, get_default_format, MixedUnicodeBytes
 from luigi.target import FileSystem, FileSystemTarget, AtomicLocalFile
 
@@ -74,6 +75,9 @@ class LocalTarget(FileSystemTarget):
         if format is None:
             format = get_default_format()
 
+        tmp_dir = luigi.configuration.get_config().get("core", "local-tmp-dir", None)
+        if not tmp_dir:
+            tmp_dir = tempfile.gettempdir()
         # Allow to write unicode in file for retrocompatibility
         if sys.version_info[:2] <= (2, 6):
             format = format >> MixedUnicodeBytes
@@ -81,7 +85,7 @@ class LocalTarget(FileSystemTarget):
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')
-            path = os.path.join(tempfile.gettempdir(), 'luigi-tmp-%09d' % random.randint(0, 999999999))
+            path = os.path.join(tmp_dir, 'luigi-tmp-%09d' % random.randint(0, 999999999))
         super(LocalTarget, self).__init__(path)
         self.format = format
         self.is_tmp = is_tmp

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -27,9 +27,8 @@ import io
 import sys
 import warnings
 
-import luigi
+import luigi.Config
 import luigi.util
-import luigi.configuration
 from luigi.format import FileWrapper, get_default_format, MixedUnicodeBytes
 from luigi.target import FileSystem, FileSystemTarget, AtomicLocalFile
 

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -21,8 +21,11 @@ import gzip
 import os
 import random
 import shutil
+
 from helpers import unittest
 import mock
+
+import helpers
 
 import luigi.format
 from luigi import LocalTarget
@@ -51,6 +54,11 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
     def assertCleanUp(self, tmp_path=''):
         self.assertFalse(os.path.exists(tmp_path))
+
+    @helpers.with_config({"localfile": {"tmp_dir": "/tmp/bar"}})
+    def test_localfile(self):
+        t = LocalTarget()
+        self.assertTrue(t.path.startswith("/tmp/bar"))
 
     def test_exists(self):
         t = self.create_target()


### PR DESCRIPTION
This requires setting a client.cfg option:
[core]
local-tmp-dir: /media/ephemeral