### PR TITLE
Add support for pseudo-tty allocation.

### DIFF
--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -57,6 +57,7 @@ class RemoteContext(object):
         self.port = kwargs.get('port', None)
         self.no_host_key_check = kwargs.get('no_host_key_check', False)
         self.sshpass = kwargs.get('sshpass', False)
+        self.tty = kwargs.get('tty', False)
 
     def __repr__(self):
         return '%s(%r, %r, %r, %r, %r)' % (
@@ -94,6 +95,9 @@ class RemoteContext(object):
 
         if self.key_file:
             connection_cmd.extend(["-i", self.key_file])
+
+        if self.tty:
+            connection_cmd.append('-t')
         return connection_cmd + cmd
 
     def Popen(self, cmd, **kwargs):


### PR DESCRIPTION
This is required to be able run sudo command.

From man ssh

```
     -t      Force pseudo-tty allocation.  This can be used to execute arbitrary screen-based programs on a remote machine, which can be very useful, e.g. when
             implementing menu services.  Multiple -t options force tty allocation, even if ssh has no local tty.
```