### PR TITLE
Fix for task history save problem on scheduler

### DIFF
--- a/luigi/tools/parse_task.py
+++ b/luigi/tools/parse_task.py
@@ -32,7 +32,7 @@ def id_to_name_and_params(task_id):
         DeprecationWarning,
         stacklevel=2)
 
-    name_chars = pp.alphanums + '_'
+    name_chars = pp.alphanums + '_.'
     # modified version of pp.printables. Removed '[]', '()', ','
     value_chars = pp.alphanums + '\'!"#$%&*+-./:;<=>?@\\^_`{|}~'
     parameter = (


### PR DESCRIPTION
So today we were testing the task history (we wanted to enhance it) and found a problem related to the refactory of luigi's source code in many points. As we understand now with the new NameSpaces on the luigi clasess, this is part of the Luigis Task Names (hence id)... so there was a bug on the  luigi/tools/parse_task.py that was preventing from saving luigi's history in the enabled db. This mas mainly because of the introduction of a new character to the class namespace the period ".". 

To reproduce the bug just schedule any luigi task, with a period while having enabled the task_history feature. This will cause the scheduler to fail when it tries persist it in the db. To fix this we simply added the dot character to the valid chars parsed by pyparsing in parse_task utility class.

I can open a bug request also if needed.