### PR TITLE
Standardize the directory interface on FileSystem

### DIFF
--- a/luigi/contrib/target.py
+++ b/luigi/contrib/target.py
@@ -35,7 +35,7 @@ class CascadingClient(object):
     # methods here. If you want full control of which methods that should be
     # created, pass the kwarg to the constructor.
     ALL_METHOD_NAMES = ['exists', 'rename', 'remove', 'chmod', 'chown',
-                        'count', 'copy', 'get', 'put', 'mkdir', 'listdir',
+                        'count', 'copy', 'get', 'put', 'mkdir', 'list', 'listdir',
                         'getmerge',
                         'isdir',
                         'rename_dont_move',

--- a/luigi/date_interval.py
+++ b/luigi/date_interval.py
@@ -264,7 +264,7 @@ class Custom(DateInterval):
 
     @classmethod
     def parse(cls, s):
-        if re.match('\d\d\d\d\-\d\d\-\d\d\-\d\d\d\d\-\d\d\-\d\d$', s):
+        if re.match(r'\d\d\d\d\-\d\d\-\d\d\-\d\d\d\d\-\d\d\-\d\d$', s):
             x = list(map(int, s.split('-')))
             date_a = datetime.date(*x[:3])
             date_b = datetime.date(*x[3:])

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -74,6 +74,14 @@ class MissingParentDirectory(FileSystemException):
     pass
 
 
+class NotADirectory(FileSystemException):
+    """
+    Raised when a file system operation can't be performed because
+    an expected directory is actually a file.
+    """
+    pass
+
+
 @six.add_metaclass(abc.ABCMeta)
 class FileSystem(object):
     """
@@ -136,6 +144,18 @@ class FileSystem(object):
         *Note*: This method is optional, not all FileSystem subclasses implements it.
         """
         raise NotImplementedError("isdir() not implemented on {0}".format(self.__class__.__name__))
+
+    def listdir(self, path):
+        """Return a list of files rooted in path.
+
+        This returns an iterable of the files rooted at ``path``. This is intended to be a
+        recursive listing.
+
+        :param str path: a path within the FileSystem to list.
+
+        *Note*: This method is optional, not all FileSystem subclasses implements it.
+        """
+        raise NotImplementedError("listdir() not implemented on {0}".format(self.__class__.__name__))
 
 
 class FileSystemTarget(Target):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -68,9 +68,9 @@ class BulkCompleteNotImplementedError(NotImplementedError):
     """This is here to trick pylint.
 
     pylint thinks anything raising NotImplementedError needs to be implemented
-    in any subclass. bulk_complete does not. This tricks pylint into thinking
-    that the default implementation is a valid implementation and not an
-    abstract method."""
+    in any subclass. bulk_complete isn't like that. This tricks pylint into
+    thinking that the default implementation is a valid implementation and no
+    an abstract method."""
     pass
 
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -64,6 +64,16 @@ def id_to_name_and_params(task_id):
     return luigi.tools.parse_task.id_to_name_and_params(task_id)
 
 
+class BulkCompleteNotImplementedError(NotImplementedError):
+    """This is here to trick pylint.
+
+    pylint thinks anything raising NotImplementedError needs to be implemented
+    in any subclass. bulk_complete does not. This tricks pylint into thinking
+    that the default implementation is a valid implementation and not an
+    abstract method."""
+    pass
+
+
 @six.add_metaclass(Register)
 class Task(object):
     """
@@ -358,7 +368,7 @@ class Task(object):
         Override (with an efficient implementation) for efficient scheduling
         with range tools. Keep the logic consistent with that of complete().
         """
-        raise NotImplementedError
+        raise BulkCompleteNotImplementedError()
 
     def output(self):
         """


### PR DESCRIPTION
This is the first step in bringing Google Cloud Storage support. While technically not necessary, I thought that it would be a nice refactoring.

 - is_dir vs isdir -> prefer the latter
 - list vs listdir -> prefer the latter
 - add listdir() to the base FileSystem interface, and implement it in a bunch of places
