### PR TITLE
Don't use socket.getfqdn

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -36,7 +36,7 @@ from luigi import configuration
 logger = logging.getLogger("luigi-interface")
 
 
-DEFAULT_CLIENT_EMAIL = 'luigi-client@%s' % socket.getfqdn()
+DEFAULT_CLIENT_EMAIL = 'luigi-client@%s' % socket.gethostname()
 DEBUG = False
 
 


### PR DESCRIPTION
It's deadly slow and makes importing luigi...painful.

Before
```shell
$ time python -c 'import luigi'

real	0m5.172s
user	0m0.080s
sys	0m0.075s
```

After
```
$ time python -c 'import luigi'

real	0m0.172s
user	0m0.092s
sys	0m0.078s
```

This is on an OSX machine, which by default doesn't associate the local hostname with it's own ip in /etc/hosts.

I haven't heard anybody ever actually needing getfqdn (most times they just want the output of `hostname`). However if you do depend on it, let me know, and I'll just make this lazily-evaluated.