### PR TITLE
Fix spark configuration property setup via client.cfg file

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -269,7 +269,7 @@ class SparkSubmitTask(luigi.Task):
         command = []
         if value and isinstance(value, dict):
             for prop, value in value.items():
-                command += [name, '"{0}={1}"'.format(prop, value)]
+                command += [name, '{0}={1}'.format(prop, value)]
         return command
 
     def _flag_arg(self, name, value):

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -149,7 +149,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
         self.assertEqual(proc.call_args[0][0],
                          ['ss-stub', '--master', 'yarn-client', '--deploy-mode', 'client', '--name', 'AppName',
                           '--class', 'org.test.MyClass', '--jars', 'jars/my.jar', '--py-files', 'file1.py,file2.py',
-                          '--files', 'file1,file2', '--archives', 'archive1,archive2', '--conf', '"Prop=Value"',
+                          '--files', 'file1,file2', '--archives', 'archive1,archive2', '--conf', 'Prop=Value',
                           '--properties-file', 'conf/spark-defaults.conf', '--driver-memory', '4G', '--driver-java-options', '-Xopt',
                           '--driver-library-path', 'library/path', '--driver-class-path', 'class/path', '--executor-memory', '8G',
                           '--driver-cores', '8', '--supervise', '--total-executor-cores', '150', '--executor-cores', '10',
@@ -165,7 +165,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
         self.assertEqual(proc.call_args[0][0],
                          ['ss-stub', '--master', 'spark://host:7077', '--jars', 'jar1.jar,jar2.jar',
                           '--py-files', 'file1.py,file2.py', '--files', 'file1,file2', '--archives', 'archive1',
-                          '--conf', '"prop1=val1"', 'test.py'])
+                          '--conf', 'prop1=val1', 'test.py'])
 
     @patch('luigi.contrib.spark.tempfile.TemporaryFile')
     @patch('luigi.contrib.spark.subprocess.Popen')


### PR DESCRIPTION
Removing the extra quotes when setting the spark configuration via client.cfg.

With the extra quotes the final flag for the spark-submit command might be:
`--conf '"spark.cores.max=2"'`
which is interpreted as 
`key: "spark.cores.max`
`value: 2"`
when it should be 
`--conf 'spark.cores.max=2'`

Since spark only accepts properties that start with the "spark." prefix, the property is ignored altogether.