### PR TITLE
Adding support for schemas in checks for redshift table names.

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -216,12 +216,18 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         Determine whether the table already exists.
         """
-        query = ("select 1 as table_exists "
-                 "from pg_table_def "
-                 "where tablename = %s limit 1")
+
+        if '.' in self.table:
+            query = ("select 1 as table_exists "
+                     "from information_schema.tables "
+                     "where table_schema = %s and table_name = %s limit 1")
+        else:
+            query = ("select 1 as table_exists "
+                     "from pg_table_def "
+                     "where tablename = %s limit 1")
         cursor = connection.cursor()
         try:
-            cursor.execute(query, (self.table,))
+            cursor.execute(query, tuple(self.table.split('.')))
             result = cursor.fetchone()
             return bool(result)
         finally:


### PR DESCRIPTION
The does_table_exist method doesn't work for table names that include a specific schema.  This patch adds support for redshift tables that specify a schema, without changing behavior for tables that do not specify a schema.

All other methods (create table, truncate) work fine with an explicit schema.

The big benefit of specifying a schema as a table name is that, when luigi creates a table, it can be created in an explicit, non-default schema.