### PR TITLE
Adds pypy scheduler tests to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - TOXENV=py27-cdh
     - TOXENV=py33-cdh
     - TOXENV=py34-cdh
+    - TOXENV=pypy-scheduler
 
 sudo: false
 

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -19,6 +19,8 @@ import time
 import datetime
 from helpers import unittest
 
+from nose.plugins.attrib import attr
+
 import luigi.notifications
 from luigi.scheduler import DISABLED, DONE, FAILED, CentralPlannerScheduler
 
@@ -26,6 +28,7 @@ luigi.notifications.DEBUG = True
 WORKER = 'myworker'
 
 
+@attr('scheduler')
 class CentralPlannerTest(unittest.TestCase):
 
     def setUp(self):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,6 @@ mock
 moto
 HTTPretty>=0.8.8
 nose
-psycopg2
 unittest2
 boto
 sqlalchemy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-{cdh,hdp,nonhdfs}, docs, pep8
+envlist = py{27,33,34}-{cdh,hdp,nonhdfs}, pypy-scheduler, docs, pep8
 skipsdist = True
 
 [testenv]
@@ -7,6 +7,7 @@ usedevelop = True
 install_command = pip install {opts} --allow-external mysql-connector-python {packages}
 deps=
   -r{toxinidir}/test/requirements.txt
+  py{27,33,34}: psycopg2
   coverage>=3.6,<3.999
   coveralls
 passenv = USER JAVA_HOME
@@ -16,6 +17,7 @@ setenv =
   cdh: HADOOP_HOME={toxinidir}/.tox/hadoop-cdh
   hdp: HADOOP_DISTRO=hdp
   hdp: HADOOP_HOME={toxinidir}/.tox/hadoop-hdp
+  scheduler: NOSE_ATTR=scheduler
   cdh,hdp: NOSE_ATTR=minicluster
   nonhdfs: NOSE_ATTR=!minicluster
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/client.cfg


### PR DESCRIPTION
I just started running my scheduler with PyPy, and it's reducing latency so I'd like to stick with it. I've added tests to tox.ini to ensure that this functionality is not lost with future updates. Psycopg2 isn't
compatible with PyPy, so I moved it out of requirements.txt and into tox.ini for compatible interpreters. If we wanted to make it work, psycopg2cffi is compatible with all versions but would require some code changes.