### PR TITLE
A Fix the TypeError whenever prune is called before update has been e…

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -224,7 +224,7 @@ class Worker(object):
     Structure for tracking worker activity and keeping their references.
     """
 
-    def __init__(self, worker_id, last_active=None):
+    def __init__(self, worker_id, last_active=time.time()):
         self.id = worker_id
         self.reference = None  # reference to the worker in the real world. (Currently a dict containing just the host)
         self.last_active = last_active  # seconds since epoch

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -98,5 +98,14 @@ class SchedulerTest(unittest.TestCase):
             cps = reload_from_disk(cps=cps)  # This time without deleting
             self.assertEqual(cps.get_work(worker='D')['task_id'], '4')
 
+    def test_worker_prune_after_init(self):
+        worker = luigi.scheduler.Worker(123)
+
+        class TmpCfg:
+            def __init__(self):
+                self.worker_disconnect_delay = 10
+
+        worker.prune(TmpCfg())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 Fix the TypeError whenever prune is called before update has been executed.

 Before worker.update has been called, self.last_active is None; and if
 worker.prune is called at this time, TypeError: unsupported operand type(s)
 for +: 'NoneType' and 'float' will be raised in worker.prune.

