### PR TITLE
Add GrowthIntel and slides to company users on README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ Several companies have written blog posts or presentation about Luigi:
 * `Buffer <https://overflow.bufferapp.com/2014/10/31/buffers-new-data-architecture/>`_
 * `SeatGeek <http://chairnerd.seatgeek.com/building-out-the-seatgeek-data-pipeline/>`_
 * `Treasure Data <http://blog.treasuredata.com/blog/2015/02/25/managing-the-data-pipeline-with-git-luigi/>`_
+* `Growth Intelligence <http://www.slideshare.net/growthintel/a-beginners-guide-to-building-data-pipelines-with-luigi>`_
 
 Please let us know if your company wants to be featured on this list!
 


### PR DESCRIPTION
@colemast and I gave a talk last weekend at PyData London on Luigi and would love to share the slides and be included in the list of companies currently using luigi. 