### PR TITLE
Fix get_work() slowdown introduced in #986

### DIFF
--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -761,5 +761,26 @@ class CentralPlannerTest(unittest.TestCase):
             self.assertEqual(self.sch.get_work(worker=str(i))['task_id'], str(i))
             self.sch.add_task(worker=str(i), task_id=str(i), status=DONE)
 
+    def test_get_work_speed(self):
+        """ Test that get_work is fast for few workers and many DONEs.
+
+        In #986, @daveFNbuck reported that he got a slowdown.
+        """
+        # This took almost 4 minutes without optimization.
+        # Now it takes 10 seconds on my machine.
+        NUM_PENDING = 1000
+        NUM_DONE = 200000
+        assert NUM_DONE >= NUM_PENDING
+        for i in range(NUM_PENDING):
+            self.sch.add_task(worker=WORKER, task_id=str(i), resources={})
+
+        for i in range(NUM_PENDING, NUM_DONE):
+            self.sch.add_task(worker=WORKER, task_id=str(i), status=DONE)
+
+        for i in range(NUM_PENDING):
+            res = int(self.sch.get_work(worker=WORKER)['task_id'])
+            self.assertTrue(0 <= res < NUM_PENDING)
+            self.sch.add_task(worker=WORKER, task_id=str(res), status=DONE)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -60,5 +60,9 @@ class RPCTest(central_planner_test.CentralPlannerTest, ServerTestBase):
         """ This would be too slow to run through network """
         pass
 
+    def test_get_work_speed(self):
+        """ This would be too slow to run through network """
+        pass
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As daveFNbuck said in that PR. The patch in #986 slowed down his
get_work() calls. My theory is that I actually worsened the worst case
complexity in that patch because I assumed that tasks-per-worker is less
than total-pending-tasks. While that's definetly is the case at Spotify.
That is not the case at Houzz.

This patch tries to get the fastest speed in both settings. The setting
that will get a speed-up from this patch is when you have a very few
workers and most of your tasks are in the DONE state.

ping @daveFNbuck 