### PR TITLE
Improve `flatten` method to handle TypeErrors in generators

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -576,13 +576,13 @@ def flatten(struct):
 
     try:
         # if iterable
-        for result in struct:
-            flat += flatten(result)
-        return flat
+        iterator = iter(struct)
     except TypeError:
-        pass
+        return [struct]
 
-    return [struct]
+    for result in iterator:
+        flat += flatten(result)
+    return flat
 
 
 def flatten_output(task):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -85,6 +85,7 @@ class TaskTest(unittest.TestCase):
         self.assertEquals(flatten('foo'), ['foo'])
         self.assertEquals(flatten(42), [42])
         self.assertEquals(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+        self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
 
 
 if __name__ == '__main__':

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -78,5 +78,14 @@ class TaskTest(unittest.TestCase):
         self.assertEquals(name, "InputText")
         self.assertEquals(params, dict(date="2014-12-29", foo=["bar", "baz-foo"]))
 
+    def test_flatten(self):
+        flatten = luigi.task.flatten
+        self.assertEquals(sorted(flatten({'a': 'foo', 'b': 'bar'})), ['bar', 'foo'])
+        self.assertEquals(sorted(flatten(['foo', ['bar', 'troll']])), ['bar', 'foo', 'troll'])
+        self.assertEquals(flatten('foo'), ['foo'])
+        self.assertEquals(flatten(42), [42])
+        self.assertEquals(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`luigi.task.flatten` method flattens all iterables, also including generators, e.g.:
```
>>> flatten(('foo-' + i for i in ['bar1', 'bar2']))
['foo-bar1', 'foo-bar2']
```
However, if there's any `TypeError` within the generator, `flatten` method will just output the generator object:
```
>>> flatten((('foo-',) + i for i in ['bar1', 'bar2']))
[<generator object <genexpr> at 0x1c35aa0>]
```
It is a common pattern to have a task's `require()` method implemented as a generator (dynamically yield dependencies). If there's any `TypeError` inside the generator, a user ends up seeing the misleading stack trace:
```
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 211, in check_complete
    is_complete = task.complete()
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 518, in complete
    return all(r.complete() for r in flatten(self.requires()))
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 518, in <genexpr>
    return all(r.complete() for r in flatten(self.requires()))
AttributeError: 'generator' object has no attribute 'complete'
```

The reason for this is that the `flatten` method assumes the `struct` object is iterable when:
* it is iterable 
AND
* there's no `TypeError` while iterating through it. 

If it is changed as proposed, only the former condition will be checked and any `TypeError` that occurs while iterating through a generator will be explicitly thrown.
E.g.:
```
>>> flatten((('foo-',) + i for i in ['bar1', 'bar2']))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/luigi/task.py", line 583, in flatten
    for result in iterator:
  File "<stdin>", line 1, in <genexpr>
TypeError: can only concatenate tuple (not "str") to tuple
```
