### PR TITLE
tox: Don't fail travis on linkchecks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,9 +68,6 @@ commands =
     sed -i.orig '/.. image::/d' README.rst
     sed -i.orig '/:target:/d' README.rst
 
-    # check URLs in docs
-    sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc doc/_build/linkcheck
-
     # build HTML docs
     sphinx-build -W -b html -d {envtmpdir}/doctrees doc doc/_build/html
 


### PR DESCRIPTION
This is yet another intermittent failure causing pain for a luigi maintainer. We can't make sure that external websites are up and responding.

From what I saw from the docs[1]. There's no feature to do retries or accept intermittent failures. Hence, let us just ignore failures. This commit was inspired by [2].

[1]: http://sphinx-doc.org/builders.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder
[2]: https://travis-ci.org/spotify/luigi/jobs/69595616