### PR TITLE
Avoid intermediate variables in luigi/__init__.py for improved IDE-friendliness

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -19,42 +19,29 @@ Package containing core luigi functionality.
 """
 
 from luigi import task
-from luigi import file  # wtf @ naming
-from luigi import rpc
-from luigi import parameter
-from luigi import configuration
-from luigi import interface
+from luigi.task import Task, Config, ExternalTask, WrapperTask, namespace
+
 from luigi import target
+from luigi.target import Target
+
+from luigi import file  # wtf @ naming
+from luigi.file import File, LocalTarget
+
+from luigi import rpc
+from luigi.rpc import RemoteScheduler, RPCError
+
+from luigi import parameter
+from luigi.parameter import Parameter, \
+    DateParameter, DateHourParameter, DateMinuteParameter, \
+    DateIntervalParameter, TimeDeltaParameter, \
+    IntParameter, FloatParameter, BooleanParameter, BoolParameter
+
+from luigi import configuration
+
+from luigi import interface
+from luigi.interface import run, build
+
 from luigi import event
-
-Event = event.Event
-
-Task = task.Task
-Config = task.Config
-ExternalTask = task.ExternalTask
-WrapperTask = task.WrapperTask
-Target = target.Target
-
-File = file.File  # TODO: remove, should be LocalTarget
-LocalTarget = file.LocalTarget
-Parameter = parameter.Parameter
-RemoteScheduler = rpc.RemoteScheduler
-RPCError = rpc.RPCError
-
-run = interface.run
-build = interface.build
-
-# TODO: how can we get rid of these?
-DateHourParameter = parameter.DateHourParameter
-DateMinuteParameter = parameter.DateMinuteParameter
-DateParameter = parameter.DateParameter
-IntParameter = parameter.IntParameter
-FloatParameter = parameter.FloatParameter
-BooleanParameter = parameter.BooleanParameter  # backward compatibility
-BoolParameter = parameter.BoolParameter
-DateIntervalParameter = parameter.DateIntervalParameter
-TimeDeltaParameter = parameter.TimeDeltaParameter
-
-namespace = task.namespace
+from luigi.event import Event
 
 from .tools import range  # just makes the tool classes available from command line

--- a/test/import_test.py
+++ b/test/import_test.py
@@ -42,3 +42,27 @@ class ImportTest(unittest.TestCase):
             for f in files:
                 if f.endswith('.py') and not f.startswith('_'):
                     __import__(package + '.' + f[:-3])
+
+    def import_luigi_test(self):
+        """
+        Test that the top luigi package can be imported and contains the usual suspects.
+        """
+        import luigi
+
+        # These should exist (if not, this will cause AttributeErrors)
+        expected = [
+            luigi.Event,
+            luigi.Config,
+            luigi.Task, luigi.ExternalTask, luigi.WrapperTask,
+            luigi.Target, luigi.LocalTarget, luigi.File,
+            luigi.namespace,
+            luigi.RemoteScheduler,
+            luigi.RPCError,
+            luigi.run, luigi.build,
+            luigi.Parameter,
+            luigi.DateHourParameter, luigi.DateMinuteParameter, luigi.DateParameter,
+            luigi.DateIntervalParameter, luigi.TimeDeltaParameter,
+            luigi.IntParameter, luigi.FloatParameter,
+            luigi.BooleanParameter, luigi.BoolParameter,
+        ]
+        self.assertGreater(len(expected), 0)


### PR DESCRIPTION
When I use luigi like this:
```python
import luigi.task
class MyTask(luigi.task.Task):
    def complete(self):
        ...
```
my IDE (PyCharm) provides "code intelligence" tricks like flagging the `complete` method as an override of the parent class' method, I can "go to declaration", etc

When I import luigi like this however:
```python
import luigi
class MyTask(luigi.Task):
    ...
```
all this fancy "code intelligence" does not work.


This pull request fixes that by avoiding intermediate variables in `luigi/__init__.py`