### PR TITLE
get_work optimizations

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -747,12 +747,15 @@ class CentralPlannerScheduler(Scheduler):
                 if len(task.workers) == 1 and not assistant:
                     n_unique_pending += 1
 
+            if best_task:
+                continue
+
             if task.status == RUNNING and (task.worker_running in greedy_workers):
                 greedy_workers[task.worker_running] -= 1
                 for resource, amount in six.iteritems((task.resources or {})):
                     greedy_resources[resource] += amount
 
-            if not best_task and self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
+            if self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
                 if in_workers and self._has_resources(task.resources, used_resources):
                     best_task = task
                 else:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -800,6 +800,8 @@ class CentralPlannerScheduler(Scheduler):
                 dep_id = task_stack.pop()
                 if self._state.has_task(dep_id):
                     dep = self._state.get_task(dep_id)
+                    if dep.status == DONE:
+                        continue
                     if dep_id not in upstream_status_table:
                         if dep.status == PENDING and dep.deps:
                             task_stack = task_stack + [dep_id] + list(dep.deps)

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -670,33 +670,6 @@ class CentralPlannerTest(unittest.TestCase):
         self.assertEqual(2, response['n_pending_tasks'])
         self.assertEqual(2, response['n_unique_pending'])
 
-    def test_prefer_more_dependents(self):
-        self.sch.add_task(worker=WORKER, task_id='A')
-        self.sch.add_task(worker=WORKER, task_id='B')
-        self.sch.add_task(worker=WORKER, task_id='C', deps=['B'])
-        self.sch.add_task(worker=WORKER, task_id='D', deps=['B'])
-        self.sch.add_task(worker=WORKER, task_id='E', deps=['A'])
-        self.check_task_order('BACDE')
-
-    def test_prefer_readier_dependents(self):
-        self.sch.add_task(worker=WORKER, task_id='A')
-        self.sch.add_task(worker=WORKER, task_id='B')
-        self.sch.add_task(worker=WORKER, task_id='C')
-        self.sch.add_task(worker=WORKER, task_id='D')
-        self.sch.add_task(worker=WORKER, task_id='F', deps=['A', 'B', 'C'])
-        self.sch.add_task(worker=WORKER, task_id='G', deps=['A', 'B', 'C'])
-        self.sch.add_task(worker=WORKER, task_id='E', deps=['D'])
-        self.check_task_order('DABCFGE')
-
-    def test_ignore_done_dependents(self):
-        self.sch.add_task(worker=WORKER, task_id='A')
-        self.sch.add_task(worker=WORKER, task_id='B')
-        self.sch.add_task(worker=WORKER, task_id='C')
-        self.sch.add_task(worker=WORKER, task_id='D', priority=1)
-        self.sch.add_task(worker=WORKER, task_id='E', deps=['C', 'D'])
-        self.sch.add_task(worker=WORKER, task_id='F', deps=['A', 'B'])
-        self.check_task_order('DCABEF')
-
     def test_task_list_no_deps(self):
         self.sch.add_task(worker=WORKER, task_id='B', deps=('A',))
         self.sch.add_task(worker=WORKER, task_id='A')


### PR DESCRIPTION
This combines three optimizations for get_work. The first one removes the number of dependencies computation from ranking, as I noticed that this was a large component of get_work time and I no longer think it makes much of a difference overall. Next, I limit upstream_status computation to not look past DONE tasks, giving a decent performance boost when many tasks are DONE. Finally, I remove unnecessary computation in get_work that occurs after finding a best_task.