### PR TITLE
More detailed error emails.

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -72,10 +72,24 @@ def generate_email(sender, subject, message, recipients, image_png):
 
 
 def wrap_traceback(traceback):
-    # TODO: Detect presence of Pygments and use if possible
     if email_type() == 'html':
-        return '<pre>%s</pre>' % traceback
-    return traceback
+        try:
+            from pygments import highlight
+            from pygments.lexers import PythonTracebackLexer
+            from pygments.formatters import HtmlFormatter
+            with_pygments = True
+        except ImportError:
+            with_pygments = False
+
+        if with_pygments:
+            formatter = HtmlFormatter(noclasses=True)
+            wrapped = highlight(traceback, PythonTracebackLexer(), formatter)
+        else:
+            wrapped = '<pre>%s</pre>' % traceback
+    else:
+        wrapped = traceback
+
+    return wrapped
 
 
 def send_email_smtp(config, sender, subject, message, recipients, image_png):
@@ -205,24 +219,55 @@ def format_task_error(headline, task, formatted_exception=None):
     :return: message body
 
     """
-    msg_template = textwrap.dedent('''\
-    {headline}
 
-    Task name: {name}
-
-    Task parameters:
-    {params}
-
-    {traceback}
-    ''')
-
+    typ = email_type()
     if formatted_exception:
         formatted_exception = wrap_traceback(formatted_exception)
     else:
         formatted_exception = ""
 
-    str_params = task.to_str_params()
-    max_width = max([0] + [len(x) for x in str_params.keys()])
-    params = '\n'.join('  {:{width}}: {}'.format(*items, width=max_width) for items in str_params.items())
+    if typ == 'html':
+        msg_template = textwrap.dedent('''
+        <html>
+        <body>
+        <h2>{headline}</h2>
 
-    return msg_template.format(headline=headline, name=task.task_family, params=params, traceback=formatted_exception)
+        <table style="border-top: 1px solid black; border-bottom: 1px solid black">
+        <thead>
+        <tr><th>name</th><td>{name}</td></tr>
+        </thead>
+        <tbody>
+        {param_rows}
+        </tbody>
+        </table>
+        </pre>
+
+        <h2>Traceback</h2>
+        {traceback}
+        </body>
+        </html>
+        ''')
+
+        str_params = task.to_str_params()
+        params = '\n'.join('<tr><th>{}</th><td>{}</td></tr>'.format(*items) for items in str_params.items())
+        body = msg_template.format(headline=headline, name=task.task_family, param_rows=params,
+                                   traceback=formatted_exception)
+    else:
+        msg_template = textwrap.dedent('''\
+        {headline}
+
+        Name: {name}
+
+        Parameters:
+        {params}
+
+        {traceback}
+        ''')
+
+        str_params = task.to_str_params()
+        max_width = max([0] + [len(x) for x in str_params.keys()])
+        params = '\n'.join('  {:{width}}: {}'.format(*items, width=max_width) for items in str_params.items())
+        body = msg_template.format(headline=headline, name=task.task_family, params=params,
+                                   traceback=formatted_exception)
+
+    return body

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -153,9 +153,11 @@ class TaskProcess(multiprocessing.Process):
         except BaseException as ex:
             status = FAILED
             logger.exception("[pid %s] Worker %s failed    %s", os.getpid(), self.worker_id, self.task)
-            error_message = notifications.wrap_traceback(self.task.on_failure(ex))
             self.task.trigger_event(Event.FAILURE, self.task, ex)
             subject = "Luigi: %s FAILED" % self.task
+
+            error_message = notifications.format_task_error(subject, self.task,
+                                                            formatted_exception=traceback.format_exc())
             notifications.send_error_email(subject, error_message)
         finally:
             self.result_queue.put(
@@ -374,15 +376,17 @@ class Worker(object):
 
     def _email_complete_error(self, task, formatted_traceback):
         # like logger.exception but with WARNING level
-        formatted_traceback = notifications.wrap_traceback(formatted_traceback)
         subject = "Luigi: {task} failed scheduling. Host: {host}".format(task=task, host=self.host)
-        message = "Will not schedule {task} or any dependencies due to error in complete() method:\n{traceback}".format(task=task, traceback=formatted_traceback)
+        headline = "Will not schedule task or any dependencies due to error in complete() method"
+
+        message = notifications.format_task_error(headline, task, formatted_traceback)
         notifications.send_error_email(subject, message)
 
     def _email_unexpected_error(self, task, formatted_traceback):
-        formatted_traceback = notifications.wrap_traceback(formatted_traceback)
         subject = "Luigi: Framework error while scheduling {task}. Host: {host}".format(task=task, host=self.host)
-        message = "Luigi framework error:\n{traceback}".format(traceback=formatted_traceback)
+        headline = "Luigi framework error"
+
+        message = notifications.format_task_error(headline, task, formatted_traceback)
         notifications.send_error_email(subject, message)
 
     def add(self, task, multiprocess=False):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -156,9 +156,10 @@ class TaskProcess(multiprocessing.Process):
             self.task.trigger_event(Event.FAILURE, self.task, ex)
             subject = "Luigi: %s FAILED" % self.task
 
-            error_message = notifications.format_task_error(subject, self.task,
-                                                            formatted_exception=traceback.format_exc())
-            notifications.send_error_email(subject, error_message)
+            error_message = notifications.wrap_traceback(self.task.on_failure(ex))
+            formatted_error_message = notifications.format_task_error(subject, self.task,
+                                                                      formatted_exception=error_message)
+            notifications.send_error_email(subject, formatted_error_message)
         finally:
             self.result_queue.put(
                 (self.task.task_id, status, error_message, missing, new_deps))

--- a/test/email_test.py
+++ b/test/email_test.py
@@ -16,9 +16,13 @@
 #
 
 from helpers import unittest
+import mock
 
 from helpers import with_config
 from luigi import notifications
+from luigi.scheduler import CentralPlannerScheduler
+from luigi.worker import Worker
+import luigi
 
 
 class TestEmail(unittest.TestCase):
@@ -29,3 +33,73 @@ class TestEmail(unittest.TestCase):
     @with_config({"core": {"email-prefix": "[prefix]"}})
     def testEmailPrefix(self):
         self.assertEqual("[prefix] subject", notifications._prefix('subject'))
+
+
+class TestException(Exception):
+    pass
+
+
+class TestTask(luigi.Task):
+    foo = luigi.Parameter()
+    bar = luigi.Parameter()
+
+
+class FailSchedulingTask(TestTask):
+    def requires(self):
+        raise TestException('Oops!')
+
+    def run(self):
+        pass
+
+    def complete(self):
+        return False
+
+
+class FailRunTask(TestTask):
+    def run(self):
+        raise TestException('Oops!')
+
+    def complete(self):
+        return False
+
+
+class ExceptionFormatTest(unittest.TestCase):
+
+    def setUp(self):
+        self.sch = CentralPlannerScheduler()
+        self.w = Worker(scheduler=self.sch)
+
+    def tear_down(self):
+        self.w.stop()
+
+    def test_fail_run(self):
+        task = FailRunTask(foo='foo', bar='bar')
+        self._run_task(task)
+
+    def test_fail_schedule(self):
+        task = FailSchedulingTask(foo='foo', bar='bar')
+        self._run_task(task)
+
+    @with_config({'core': {'error-email': 'nowhere@example.com',
+                           'error-prefix': '[TEST] '}})
+    @mock.patch('luigi.notifications.send_error_email')
+    def _run_task(self, task, mock_send):
+        self.w.add(task)
+        self.w.run()
+
+        self.assertEqual(mock_send.call_count, 1)
+        args, kwargs = mock_send.call_args
+        self._check_subject(args[0], task)
+        self._check_body(args[1], task, html=False)
+
+    def _check_subject(self, subject, task):
+        self.assertIn(task.task_id, subject)
+
+    def _check_body(self, body, task, html=False):
+        self.assertIn('Task name: {}\n'.format(task.task_family), body)
+        self.assertIn('Task parameters:\n', body)
+
+        for param, value in task.param_kwargs.items():
+            self.assertIn('{}: {}\n'.format(param, value), body)
+
+        self.assertIn('TestException: Oops!', body)

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps=
   coveralls<1.0
   unixsockets: requests<3.0
   unixsockets: requests-unixsocket<1.0
+  pygments
 passenv =
   USER JAVA_HOME GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID TRAVIS
 setenv =


### PR DESCRIPTION
We find that error emails are difficult to act upon because the task parameters are buried at the end of a long subject line.  This PR lists the task name and parameters clearly at the top of the email with each parameter on a separate line.