### PR TITLE
Handle UnicodeDecodeError on write to Postgres.

### DIFF
--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -315,7 +315,10 @@ class CopyToTable(rdbms.CopyToTable):
                 logger.info("Wrote %d lines", n)
             rowstr = self.column_separator.join(self.map_column(val) for val in row)
             rowstr += "\n"
-            tmp_file.write(rowstr.encode('utf-8'))
+            try:
+                tmp_file.write(rowstr.encode('utf-8'))
+            except UnicodeDecodeError:
+                tmp_file.write(rowstr)
 
         logger.info("Done writing, importing at %s", datetime.datetime.now())
         tmp_file.seek(0)


### PR DESCRIPTION
Unfortunately, I don't have a good automated test to show this, but the following simple example returns a UnicodeDecodeError with the current `postgres.py` in master when it attempts to write the third row (or any text with extended Unicode characters).

```
#coding: utf-8

import luigi
import luigi.postgres
import logging

logger = logging.getLogger("luigi-interface")

testdata = ([99, 'My fake plants died because I did not pretend to water them.'],
       [100, 'I always arrive late at the office, but I make up for it by leaving early.'],
       [101, 'ஸ்றீனிவாஸ ராமானுஜன் ஐயங்கார்'])

class TrivialPgLoad(luigi.postgres.CopyToTable):
    host = 'localhost'
    database = 'spotify'
    user = 'spotify'
    password = 'guest'
    table = 'trivium'
    columns = [("trival_id", "INT"),
               ("description", "TEXT")]

    def rows(self):
        for row in testdata:
            yield row

if __name__ == '__main__':
    luigi.run(main_task_cls=TrivialPgLoad)
```

The traceback looks like:

```
Traceback (most recent call last):
  File "/Users/thomas/Dropbox/envs/luigi-pg-unicode/lib/python2.7/site-packages/luigi/worker.py", line 137, in run
    new_deps = self._run_get_new_deps()
  File "/Users/thomas/Dropbox/envs/luigi-pg-unicode/lib/python2.7/site-packages/luigi/worker.py", line 88, in _run_get_new_deps
    task_gen = self.task.run()
  File "/Users/thomas/Dropbox/envs/luigi-pg-unicode/lib/python2.7/site-packages/luigi/postgres.py", line 318, in run
    tmp_file.write(rowstr.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 4: ordinal not in range(128)
```

The load to Postgres succeeds with my fix.