### PR TITLE
Fix upload progress indicator in Google Cloud Storage target

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -139,9 +139,9 @@ class GCSClient(luigi.target.FileSystem):
         while response is None:
             error = None
             try:
-                progress, response = request.next_chunk()
-                if progress:
-                    logger.debug('Upload progress: %.2f%%', 100 * progress.progress())
+                status, response = request.next_chunk()
+                if status:
+                    logger.debug('Upload progress: %.2f%%', 100 * status.progress())
             except errors.HttpError as err:
                 error = err
                 if err.resp.status < 500:

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -140,8 +140,8 @@ class GCSClient(luigi.target.FileSystem):
             error = None
             try:
                 progress, response = request.next_chunk()
-                if progress is not None:
-                    logger.debug('Upload progress: %.2f%%', 100 * progress)
+                if progress:
+                    logger.debug('Upload progress: %.2f%%', 100 * progress.progress())
             except errors.HttpError as err:
                 error = err
                 if err.resp.status < 500:

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -144,12 +144,15 @@ class GCSClientTest(_GCSBaseTestCase):
 
     def test_put_file(self):
         with tempfile.NamedTemporaryFile() as fp:
-            fp.write(b'hi')
+            lorem = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt\n'
+            # Larger file than chunk size, fails with incorrect progress set up
+            big = lorem * 41943
+            fp.write(big)
             fp.flush()
 
             self.client.put(fp.name, bucket_url('test_put_file'))
             self.assertTrue(self.client.exists(bucket_url('test_put_file')))
-            self.assertEquals(b'hi', self.client.download(bucket_url('test_put_file')).read())
+            self.assertEquals(big, self.client.download(bucket_url('test_put_file')).read())
 
 
 @attr('gcloud')


### PR DESCRIPTION
Line 144 of luigi/contrib/gcs.py in master tries to multiply 100 * a MediaUploadProgress object, resulting in TypeError. A little hard to detect, unless uploading a file that takes several chunks to upload. This sample code:

```
# coding: utf-8

import luigi
from luigi.contrib import gcs
import os

bucket_name = os.getenv('GSCBUCKET', 'warehouse-hadoop')

class GCSUpload(luigi.Task):

    def output(self):
        target = 'gs://%s/tmp/big' % bucket_name
        return luigi.contrib.gcs.GCSTarget(target)

    def run(self):
        f = self.output().open(mode='w')
        f.write("\0" * 10000000)
        f.close()
```
Results in the following error:
```
  File "/Users/thomas/Dropbox/envs/etl-luigi/lib/python2.7/site-packages/luigi/contrib/gcs.py", line 145, in _do_put
    logger.debug('Upload progress: %.2f%%', 100 * progress)
TypeError: unsupported operand type(s) for *: 'int' and 'MediaUploadProgress'
```
While patched gcs.py in my branch logs progess as expected.