### PR TITLE
feature at LocalTarget: support for directories in open('w') call

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -26,7 +26,7 @@ import tempfile
 import io
 import warnings
 
-from luigi.format import FileWrapper, get_default_format
+from luigi.format import FileWrapper, get_default_format, Directory
 from luigi.target import FileAlreadyExists, MissingParentDirectory, NotADirectory, FileSystem, FileSystemTarget, AtomicLocalFile
 
 
@@ -90,7 +90,8 @@ class LocalTarget(FileSystemTarget):
     def __init__(self, path=None, format=None, is_tmp=False, is_dir=False):
         if format is None:
             format = get_default_format()
-
+            if is_dir:
+                format = format >> Directory
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -112,9 +112,13 @@ class LocalTarget(FileSystemTarget):
     def open(self, mode='r'):
         if mode == 'w':
             self.makedirs()
+            if self.is_dir:
+                return self.format.pipe_writer(self.path)
             return self.format.pipe_writer(atomic_file(self.path, is_dir=self.is_dir))
 
         elif mode == 'r':
+            if self.is_dir:
+                return self.format.pipe_reader(self.path)
             fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
             return self.format.pipe_reader(fileobj)
 

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -87,7 +87,7 @@ class LocalFileSystem(FileSystem):
 class LocalTarget(FileSystemTarget):
     fs = LocalFileSystem()
 
-    def __init__(self, path=None, format=None, is_tmp=False):
+    def __init__(self, path=None, format=None, is_tmp=False, is_dir=False):
         if format is None:
             format = get_default_format()
 
@@ -98,6 +98,7 @@ class LocalTarget(FileSystemTarget):
         super(LocalTarget, self).__init__(path)
         self.format = format
         self.is_tmp = is_tmp
+        self.is_dir = is_dir
 
     def makedirs(self):
         """
@@ -111,7 +112,7 @@ class LocalTarget(FileSystemTarget):
     def open(self, mode='r'):
         if mode == 'w':
             self.makedirs()
-            return self.format.pipe_writer(atomic_file(self.path))
+            return self.format.pipe_writer(atomic_file(self.path, is_dir=self.is_dir))
 
         elif mode == 'r':
             fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -540,7 +540,7 @@ class DirectoryFormat(Format):
             raise FileAlreadyExists(output_pipe)
 
         # the file does not exists and no write privileges are given
-        if not os.access(os.path.dirname(output_pipe), os.W_OK):
+        if not os.access(os.path.dirname(os.path.abspath(output_pipe)), os.W_OK):
             raise FileSystemException("Can not write into %s" % output_pipe)
 
         if not self.max_size:

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -169,13 +169,13 @@ class InputPipeProcessWrapper(object):
 class OutputPipeProcessWrapper(object):
     WRITES_BEFORE_FLUSH = 10000
 
-    def __init__(self, command, output_pipe=None):
+    def __init__(self, command, output_pipe=None, use_stdout_as_output=True):
         self.closed = False
         self._command = command
         self._output_pipe = output_pipe
         self._process = subprocess.Popen(command,
                                          stdin=subprocess.PIPE,
-                                         stdout=output_pipe,
+                                         stdout=output_pipe if use_stdout_as_output else None,
                                          close_fds=True)
         self._flushcount = 0
 

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -512,7 +512,7 @@ class DirectoryFormat(Format):
     gnu_split = 'split'  # gnu split required (gsplit on OSX)
     gnu_cat = 'cat'
 
-    def __init__(self, prefix='part-',  max_part_size=None, suffix=None, writes_before_flash=None):
+    def __init__(self, prefix='part-', max_part_size=None, suffix=None, writes_before_flash=None):
         super(DirectoryFormat, self).__init__()
         self.max_size = max_part_size
         self.prefix = prefix

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -169,7 +169,7 @@ class InputPipeProcessWrapper(object):
 class OutputPipeProcessWrapper(object):
     WRITES_BEFORE_FLUSH = 10000
 
-    def __init__(self, command, output_pipe=None, use_stdout_as_output=True):
+    def __init__(self, command, output_pipe=None, use_stdout_as_output=True, writes_before_flash=None):
         self.closed = False
         self._command = command
         self._output_pipe = output_pipe
@@ -178,6 +178,8 @@ class OutputPipeProcessWrapper(object):
                                          stdout=output_pipe if use_stdout_as_output else None,
                                          close_fds=True)
         self._flushcount = 0
+        if writes_before_flash is not None:
+            self.WRITES_BEFORE_FLUSH = writes_before_flash
 
     def write(self, *args, **kwargs):
         self._process.stdin.write(*args, **kwargs)

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -222,7 +222,8 @@ class OutputPipeProcessWrapper(object):
             if self._output_pipe is not None:
                 self._output_pipe.close()
         else:
-            raise RuntimeError('Error when executing command %s' % self._command)
+            raise RuntimeError('Error when executing command %s. Error code="%s"' % (self._command,
+                                                                                     self._process.returncode))
 
     def abort(self):
         self._finish()

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -529,7 +529,7 @@ class DirectoryFormat(Format):
             return FileWrapper(io.BufferedReader(io.FileIO(input_pipe, 'r')))
 
         pattern = "%s*%s" % (self.prefix, self.suffix if self.suffix else "")
-        input_files = glob.glob(os.path.join(input_pipe, pattern))
+        input_files = sorted(glob.glob(os.path.join(input_pipe, pattern)))
         cmd = [self.gnu_cat] + input_files
         return InputPipeProcessWrapper(cmd, None)
 

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -23,8 +23,16 @@ import abc
 import io
 import os
 import random
+import shutil
 import tempfile
 import logging
+
+#support for python2.7/python3
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 from luigi import six
 
 logger = logging.getLogger('luigi-interface')
@@ -220,6 +228,14 @@ class FileSystemTarget(Target):
         self.fs.remove(self.path)
 
 
+class _NonWritableStream(StringIO):
+    def write(self, b):
+        raise NotImplementedError("You can not write to this stream.")
+
+    def writable(self):
+        return not self.closed
+
+
 class AtomicLocalFile(io.BufferedWriter):
     """Abstract class to create Target that create
     a tempoprary file in the local filesystem before
@@ -229,10 +245,20 @@ class AtomicLocalFile(io.BufferedWriter):
     :class:`luigi.file.LocalTarget` for example
     """
 
-    def __init__(self, path):
+    def __init__(self, path, is_dir=False):
         self.__tmp_path = self.generate_tmp_path(path)
         self.path = path
-        super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, 'w'))
+        self.is_dir = is_dir
+
+        if not self.is_dir:
+            file_io = io.FileIO(self.__tmp_path, 'w')
+        else:
+            file_io = _NonWritableStream()
+            if os.path.exists(self.__tmp_path):
+                raise FileAlreadyExists(self.__tmp_path)
+            os.makedirs(self.__tmp_path)
+
+        super(AtomicLocalFile, self).__init__(file_io)
 
     def close(self):
         super(AtomicLocalFile, self).close()
@@ -246,7 +272,10 @@ class AtomicLocalFile(io.BufferedWriter):
 
     def __del__(self):
         if os.path.exists(self.tmp_path):
-            os.remove(self.tmp_path)
+            if self.is_dir:
+                shutil.rmtree(self.tmp_path)
+            else:
+                os.remove(self.tmp_path)
 
     @property
     def tmp_path(self):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -27,7 +27,7 @@ import shutil
 import tempfile
 import logging
 
-#support for python2.7/python3
+# support for python2.7/python3
 try:
     from StringIO import StringIO
 except ImportError:

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -25,6 +25,7 @@ import shutil
 import mock
 
 
+
 # python 3 support
 try:
     from StringIO import StringIO
@@ -213,7 +214,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
         # Verifying our own directory reader
         f = LocalTarget(self.path, is_dir=True, format=directory_format).open('r')
-        self.assertTrue(test_data == f.read())
+        self.assertEqual(test_data, f.read())
         f.close()
 
         # Verifying using gzip

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -185,7 +185,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertTrue(os.path.exists(self.path))
 
         # Validate split
-        self.assertEquals(sorted(os.listdir(self.path)), ['part-00', 'part-01'])
+        self.assertEquals(sorted(os.listdir(self.path)), ['part-aa', 'part-ab'])
 
         # Verifying our own directory reader
         f = LocalTarget(self.path, is_dir=True, format=directory_format).open('r')
@@ -193,7 +193,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         f.close()
 
     def test_directory_with_gzip_split(self):
-        directory_format = luigi.format.Gzip >> luigi.format.DirectoryFormat(max_part_size=10, suffix=".gz")
+        directory_format = luigi.format.Gzip >> luigi.format.DirectoryFormat(max_part_size=10)
         t = LocalTarget(self.path, is_dir=True, format=directory_format)
         p = t.open('w')
         test_data = b'test'
@@ -204,7 +204,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertTrue(os.path.exists(self.path))
 
         # Validate split
-        self.assertEquals(sorted(os.listdir(self.path)), ['part-00.gz', 'part-01.gz', 'part-02.gz'])
+        self.assertEquals(sorted(os.listdir(self.path)), ['part-aa', 'part-ab', 'part-ac'])
 
         # Verifying our own directory reader
         f = LocalTarget(self.path, is_dir=True, format=directory_format).open('r')
@@ -212,7 +212,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         f.close()
 
         # Verifying using gzip
-        with LocalTarget(self.path, is_dir=True, format=luigi.format.DirectoryFormat(suffix=".gz")).open('r') as fp:
+        with LocalTarget(self.path, is_dir=True, format=luigi.format.DirectoryFormat()).open('r') as fp:
             v = BytesIO(fp.read())
             with gzip.GzipFile(fileobj=v, mode='rb') as gp:
                 self.assertEqual(test_data, gp.read())

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -24,13 +24,7 @@ import shutil
 
 import mock
 
-
-
-# python 3 support
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 from helpers import unittest
 import luigi.format
@@ -219,12 +213,12 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
         # Verifying using gzip
         with LocalTarget(self.path, is_dir=True, format=luigi.format.DirectoryFormat(suffix=".gz")).open('r') as fp:
-            v = StringIO(fp.read())
+            v = BytesIO(fp.read())
             with gzip.GzipFile(fileobj=v, mode='rb') as gp:
                 self.assertEqual(test_data, gp.read())
 
     def test_atomicity_dir_simple(self):
-        test_data = 'test'
+        test_data = b'test'
         target = LocalTarget(self.path, is_dir=True, format=luigi.format.DirectoryFormat(max_part_size=3))
         with target.open("w") as f:
             self.assertFalse(target.exists())
@@ -233,7 +227,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertTrue(target.open().read(), test_data)
 
     def test_atomicity_dir_with_error(self):
-        test_data = 'test'
+        test_data = b'test'
         target = LocalTarget(self.path, is_dir=True, format=luigi.format.DirectoryFormat(max_part_size=3))
 
         def raises_error():

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -24,6 +24,7 @@ import shutil
 
 import mock
 
+
 # python 3 support
 try:
     from StringIO import StringIO
@@ -189,7 +190,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertTrue(os.path.exists(self.path))
 
         # Validate split
-        self.assertEquals(os.listdir(self.path), ['part-00', 'part-01'])
+        self.assertEquals(sorted(os.listdir(self.path)), ['part-00', 'part-01'])
 
         # Verifying our own directory reader
         f = LocalTarget(self.path, is_dir=True, format=directory_format).open('r')
@@ -208,7 +209,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertTrue(os.path.exists(self.path))
 
         # Validate split
-        self.assertEquals(os.listdir(self.path), ['part-00.gz', 'part-01.gz', 'part-02.gz'])
+        self.assertEquals(sorted(os.listdir(self.path)), ['part-00.gz', 'part-01.gz', 'part-02.gz'])
 
         # Verifying our own directory reader
         f = LocalTarget(self.path, is_dir=True, format=directory_format).open('r')

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -24,7 +24,7 @@ import shutil
 
 import mock
 
-#python 3 support
+# python 3 support
 try:
     from StringIO import StringIO
 except ImportError:


### PR DESCRIPTION
based on https://groups.google.com/d/msg/luigi-user/oGy5Tyz7LAw/WNDzbJLIlf4J

Currently atomic_file/AtomicS3File objects works great if user want to write one file. However, if we could use .tmp_path of the return object and use it as it is, that would solve the problem. Currently that can not be done, as at the moment AtomicLocalFile is created,the file on disk is created as well. Thus we can not treat it as Directory. 
 
This PR fixes that by:  
  * is_dir flag at  LocalTarget object constractor, propagates it to atomic_file on write.
  * added is_dir parameter to AtomicFile constractor. If set, does not create IOFile, but fakes it with NonWritableFile object (raise exception on write). This way we can get object that has .tmp_path. That is the target directory.

Example
```
t = LocalTarget(path, is_dir=True):
with open(t,'w') as dp:
     write_something_to_the_dir(dp.tmp_path)
```
