### PR TITLE
Fix Mock dependency error

### DIFF
--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -199,7 +199,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
             job.run()
         except KeyboardInterrupt:
             pass
-        proc.return_value.kill.assert_called()
+        proc.return_value.kill.check_called()
 
 
 class PySparkTaskTest(unittest.TestCase):

--- a/test/worker_parallel_scheduling_test.py
+++ b/test/worker_parallel_scheduling_test.py
@@ -104,7 +104,7 @@ class ParallelSchedulingTest(unittest.TestCase):
     @mock.patch('luigi.notifications.send_error_email')
     def test_raise_exception_in_complete(self, send):
         self.w.add(ExceptionCompleteTask(), multiprocess=True)
-        send.assert_called_once()
+        send.check_called_once()
         self.assertEqual(0, self.sch.add_task.call_count)
         self.assertTrue('assert False' in send.call_args[0][1])
 
@@ -120,14 +120,14 @@ class ParallelSchedulingTest(unittest.TestCase):
 
         # verify this can run async
         self.w.add(UnpicklableExceptionTask(), multiprocess=True)
-        send.assert_called_once()
+        send.check_called_once()
         self.assertEqual(0, self.sch.add_task.call_count)
         self.assertTrue('raise UnpicklableException()' in send.call_args[0][1])
 
     @mock.patch('luigi.notifications.send_error_email')
     def test_raise_exception_in_requires(self, send):
         self.w.add(ExceptionRequiresTask(), multiprocess=True)
-        send.assert_called_once()
+        send.check_called_once()
         self.assertEqual(0, self.sch.add_task.call_count)
 
 


### PR DESCRIPTION
From version 1.1.1 of Mock, 'AttributeError' is reaised in case of attribute starting with 'assert' or 'assret'