### PR TITLE
Removes unnecessary quotes from around mapred.job.name

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -634,7 +634,7 @@ class BaseHadoopJobTask(luigi.Task):
 
     def jobconfs(self):
         jcs = []
-        jcs.append('mapred.job.name="%s"' % self.task_id)
+        jcs.append('mapred.job.name=%s' % self.task_id)
         if self.mr_priority != NotImplemented:
             jcs.append('mapred.job.priority=%s' % self.mr_priority())
         pool = self._get_pool()


### PR DESCRIPTION
In setting mapred.job.name="%s", we're actually including the quote marks in the
job name, as subprocess escapes everything passed in the arguments. Removing the
quotes results in job names that no longer have leading quote marks.