### PR TITLE
GCS: Wait for eventual consistency before returning from various operations

### DIFF
--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -122,7 +122,6 @@ class GCSClientTest(_GCSBaseTestCase):
         self.client.remove(bucket_url('test_remove'))
         self.assertFalse(self.client.exists(bucket_url('test_remove')))
 
-    @unittest.skip('Intermittent failure maybe? https://travis-ci.org/spotify/luigi/jobs/69597336')
     def test_remove_recursive(self):
         self.client.mkdir(bucket_url('test_remove_recursive'))
         self.client.put_string('hello', bucket_url('test_remove_recursive/1'))
@@ -160,20 +159,3 @@ class GCSTargetTest(_GCSBaseTestCase, FileSystemTargetTestMixin):
 
     def create_target(self, format=None):
         return gcs.GCSTarget(bucket_url(self.id()), format=format, client=self.client)
-
-    def test_text(self):
-        """
-        Skipping this test, not sure if UNICODE is working yet.
-
-        Here's a failing which caused me to mute this test for now:
-
-        https://travis-ci.org/spotify/luigi/jobs/66188889
-        """
-        pass
-
-    def test_atomicity(self):
-        """
-        Intermittent failure in
-        https://travis-ci.org/spotify/luigi/jobs/69597336
-        """
-        pass


### PR DESCRIPTION
This should help spurious test failures (and probably some prod scenarios). This obviously isn't a complete solution - just because GCS says something is
true once doesn't mean it's going to stay true, but at least we have a higher chance of succeeding various ops.

I'd love for the actual solution for the tests to include a faked client (a la moto), but it doesn't seem like that's anywhere on the roadmap :(.