### PR TITLE
Make sure insignificant parameters are hidden in Scheduler's UI.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -271,7 +271,7 @@ class Task(object):
         task_id_parts = []
         param_objs = dict(params)
         for param_name, param_value in param_values:
-            if dict(params)[param_name].significant:
+            if param_objs[param_name].significant:
                 task_id_parts.append('%s=%s' % (param_name, param_objs[param_name].serialize(param_value)))
 
         self.task_id = '%s(%s)' % (self.task_family, ', '.join(task_id_parts))

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -300,7 +300,9 @@ class Task(object):
         return cls(**kwargs)
 
     def to_str_params(self):
-        ''' Convert all parameters to a str->str hash.'''
+        """
+        Convert all parameters to a str->str hash.
+        """
         params_str = {}
         params = dict(self.get_params())
         for param_name, param_value in six.iteritems(self.param_kwargs):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -306,7 +306,8 @@ class Task(object):
         params_str = {}
         params = dict(self.get_params())
         for param_name, param_value in six.iteritems(self.param_kwargs):
-            params_str[param_name] = params[param_name].serialize(param_value)
+            if params[param_name].significant:
+                params_str[param_name] = params[param_name].serialize(param_value)
 
         return params_str
 


### PR DESCRIPTION
Documentation says:

```
 An insignificant Parameter might also be used to specify a password 
or other sensitive information that should not be made public via the scheduler.
```
However, currently, insignificant parameters are displayed in the tooltip when hovering over a task's node in the visualisation's graph. 

Another way to fix it could be to do the string magic and strip task parameters from the task id in the front-end part (it's already done like this elsewhere in the front-end code). However, it seems a bit wasteful, considering the `params` list is already passed via scheduler's api.

I'm not sure if there aren't any implications of the solutions I proposed, though.