### PR TITLE
Adding check that a module was defined on the command line before trying to import it

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -286,7 +286,8 @@ class DynamicArgParseInterface(ArgParseInterface):
         args, unknown = parser.parse_known_args(args=[a for a in cmdline_args if a != '--help'])
         module = args.module
 
-        __import__(module)
+        if module:
+            __import__(module)
 
         return self.parse_task(cmdline_args)
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -187,6 +187,14 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertFalse(stdout.find(b'--x') != -1)
 
+    def test_bin_luigi_help_no_module(self):
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--help'])
+        self.assertTrue(stdout.find(b'usage:') != -1)
+
+    def test_bin_luigi_no_parameters(self):
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi'])
+        self.assertTrue(stderr.find(b'No task specified') != -1)
+
     def test_bin_luigi_help_class(self):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', 'FooBaseClass', '--help'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)


### PR DESCRIPTION
The following commands (from the command line) are broken:

````
luigi
luigi --help
````

Entering either of them results in an __import__ error. This patch checks to make sure that a module was specified on the command line before trying to import it. This allows expected behavior to work, and people can use the "--help" option to see the command line.