### PR TITLE
Close pool to prevent stale processes

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -172,6 +172,12 @@ class SingleProcessPool(object):
     def apply_async(self, function, args):
         return function(*args)
 
+    def close(self):
+        pass
+
+    def join(self):
+        pass
+
 
 class DequeQueue(collections.deque):
     """
@@ -419,6 +425,9 @@ class Worker(object):
             self._log_unexpected_error(task)
             task.trigger_event(Event.BROKEN_TASK, task, ex)
             self._email_unexpected_error(task, formatted_traceback)
+        finally:
+            pool.close()
+            pool.join()
         return self.add_succeeded
 
     def _add(self, task, is_complete):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy
 elasticsearch
 snakebite>=2.5.2
 mysql-connector-python
+psutil


### PR DESCRIPTION
Processes end up hanging around until the Pool is garbage collected. This could be a while, or never if the GC is disabled.