### PR TITLE
Fix DateMinuteParameter format

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -446,11 +446,24 @@ class DateMinuteParameter(DateHourParameter):
     Parameter whose value is a :py:class:`~datetime.datetime` specified to the minute.
 
     A DateMinuteParameter is a `ISO 8601 <http://en.wikipedia.org/wiki/ISO_8601>`_ formatted
-    date and time specified to the minute. For example, ``2013-07-10T19H07`` specifies July 10, 2013 at
+    date and time specified to the minute. For example, ``2013-07-10T1907`` specifies July 10, 2013 at
     19:07.
     """
 
-    date_format = '%Y-%m-%dT%HH%M'  # ISO 8601 is to use 'T' and 'H'
+    date_format = '%Y-%m-%dT%H%M'
+    deprecated_date_format = '%Y-%m-%dT%HH%M'
+
+    def parse(self, s):
+        try:
+            value = datetime.datetime.strptime(s, self.deprecated_date_format)
+            warnings.warn(
+                'Using "H" between hours and minutes is deprecated, omit it instead.',
+                DeprecationWarning,
+                stacklevel=2
+            )
+            return value
+        except ValueError:
+            return super(DateMinuteParameter, self).parse(s)
 
 
 class IntParameter(Parameter):

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -80,28 +80,32 @@ class DateHourParameterTest(unittest.TestCase):
 
 class DateMinuteParameterTest(unittest.TestCase):
     def test_parse(self):
-        dm = luigi.DateMinuteParameter().parse('2013-02-01T18H42')
+        dm = luigi.DateMinuteParameter().parse('2013-02-01T1842')
         self.assertEqual(dm, datetime.datetime(2013, 2, 1, 18, 42, 0))
 
     def test_parse_padding_zero(self):
-        dm = luigi.DateMinuteParameter().parse('2013-02-01T18H07')
+        dm = luigi.DateMinuteParameter().parse('2013-02-01T1807')
         self.assertEqual(dm, datetime.datetime(2013, 2, 1, 18, 7, 0))
+
+    def test_parse_deprecated(self):
+        dm = luigi.DateMinuteParameter().parse('2013-02-01T18H42')
+        self.assertEqual(dm, datetime.datetime(2013, 2, 1, 18, 42, 0))
 
     def test_serialize(self):
         dm = luigi.DateMinuteParameter().serialize(datetime.datetime(2013, 2, 1, 18, 42, 0))
-        self.assertEqual(dm, '2013-02-01T18H42')
+        self.assertEqual(dm, '2013-02-01T1842')
 
     def test_serialize_padding_zero(self):
         dm = luigi.DateMinuteParameter().serialize(datetime.datetime(2013, 2, 1, 18, 7, 0))
-        self.assertEqual(dm, '2013-02-01T18H07')
+        self.assertEqual(dm, '2013-02-01T1807')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["DateMinuteTask", "--dm", "2013-02-01T18H42"])[0]
+        task = luigi.interface.ArgParseInterface().parse(["DateMinuteTask", "--dm", "2013-02-01T1842"])[0]
         self.assertEqual(task.dm, datetime.datetime(2013, 2, 1, 18, 42, 0))
 
     def test_serialize_task(self):
         t = DateMinuteTask(datetime.datetime(2013, 2, 1, 18, 42, 0))
-        self.assertEqual(str(t), 'DateMinuteTask(dm=2013-02-01T18H42)')
+        self.assertEqual(str(t), 'DateMinuteTask(dm=2013-02-01T1842)')
 
 
 class MonthParameterTest(unittest.TestCase):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -391,6 +391,16 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         p = luigi.DateHourParameter(config_path=dict(section="foo", name="bar"))
         self.assertEqual(datetime.datetime(2001, 2, 3, 4, 0, 0), p.value)
 
+    @with_config({"foo": {"bar": "2001-02-03T0430"}})
+    def testDateMinute(self):
+        p = luigi.DateMinuteParameter(config_path=dict(section="foo", name="bar"))
+        self.assertEqual(datetime.datetime(2001, 2, 3, 4, 30, 0), p.value)
+
+    @with_config({"foo": {"bar": "2001-02-03T04H30"}})
+    def testDateMinuteDeprecated(self):
+        p = luigi.DateMinuteParameter(config_path=dict(section="foo", name="bar"))
+        self.assertEqual(datetime.datetime(2001, 2, 3, 4, 30, 0), p.value)
+
     @with_config({"foo": {"bar": "2001-02-03"}})
     def testDate(self):
         p = luigi.DateParameter(config_path=dict(section="foo", name="bar"))


### PR DESCRIPTION
Addresses points discussed in https://github.com/spotify/luigi/pull/625#issuecomment-125922059.

It was using H as the separator between hours and minutes, which is incorrect. The ISO 8601 standard requires a colon in the extended format or nothing in the basic format. Opt for basic format since colons don't play nice with file systems.

Added some specs for the parameter since there didn't seem to be any. Went for deprecation although I'm not entirely sure whether it is needed.