### PR TITLE
Only require significant parameters to be supplied in the params_str …

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -294,8 +294,9 @@ class Task(object):
             params_str = {}
         kwargs = {}
         for param_name, param in cls.get_params():
-            value = param.parse_from_input(param_name, params_str[param_name])
-            kwargs[param_name] = value
+            if param.significant or param_name in params_str:
+                value = param.parse_from_input(param_name, params_str[param_name])
+                kwargs[param_name] = value
 
         return cls(**kwargs)
 


### PR DESCRIPTION
…when trying to create a task instance from the str->str hash.

Otherwise, the method results in a KeyError since insignificant parameters are not incorporated in the str->str hash created by the to_str_params method.