### PR TITLE
Set upper bounds on packages, assuming semver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ cache:
   - $HOME/.pip-cache
 
 install:
-  - pip install tox
+  - pip install 'tox<3.0'
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_e05f6ccc270e_key -iv $encrypted_e05f6ccc270e_iv -in test/gcloud-credentials.json.enc -out test/gcloud-credentials.json -d

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'cached_property',
-    'pyparsing',
-    'tornado',
-    'python-daemon',
+    'cached_property<2.0',
+    'pyparsing<3.0',
+    'tornado<5.0',
+    'python-daemon<3.0',
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':

--- a/tox.ini
+++ b/tox.ini
@@ -6,21 +6,21 @@ skipsdist = True
 usedevelop = True
 install_command = pip install {opts} --allow-external mysql-connector-python {packages}
 deps=
-  mock
-  moto
+  mock<2.0
+  moto<1.0
   HTTPretty>=0.8.8
-  nose
-  unittest2
-  boto
-  sqlalchemy
-  elasticsearch
-  mysql-connector-python
-  psutil
+  nose<2.0
+  unittest2<2.0
+  boto<3.0
+  sqlalchemy<2.0
+  elasticsearch<2.0.0
+  mysql-connector-python<3.0
+  psutil<4.0
   cdh,hdp: snakebite>=2.5.2,<2.6.0
-  postgres: psycopg2
+  postgres: psycopg2<3.0
   gcloud: google-api-python-client>=1.4.0,<2.0
   coverage>=3.6,<3.999
-  coveralls
+  coveralls<1.0
 passenv =
   USER JAVA_HOME GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID
 setenv =


### PR DESCRIPTION
Every now and then some package somewhere in internet world changes,
causing our travis builds to fail. The only sensible thing to do is to
not pull the latest. We shouldn't bu unneccesarily strict either. So
assuming others use semver, I copied the current version of everything
that we currently use (based on a contemporary build [1]) and just
bumped the major number and set it as a strictly less-than constraint.

I got motivated to do this since #1103, but this is not the first
occurence.

[1]: https://travis-ci.org/spotify/luigi/jobs/73593492