### PR TITLE
contrib/hive: Escape names in Hive partition spec

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -158,7 +158,7 @@ class HiveCommandClient(HiveClient):
         """
         Turns a dict into the a Hive partition specification string.
         """
-        return ','.join(["{0}='{1}'".format(k, v) for (k, v) in
+        return ','.join(["`{0}`='{1}'".format(k, v) for (k, v) in
                          sorted(six.iteritems(partition), key=operator.itemgetter(0))])
 
 

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -154,7 +154,7 @@ class HiveCommandClientTest(unittest.TestCase):
 
     def test_partition_spec(self):
         returned = self.client.partition_spec({'a': 'b', 'c': 'd'})
-        self.assertEqual("a='b',c='d'", returned)
+        self.assertEqual("`a`='b',`c`='d'", returned)
 
     @mock.patch("luigi.contrib.hive.run_hive_cmd")
     def test_apacheclient_table_exists(self, run_command):


### PR DESCRIPTION
In [newish versions of Hive](http://mail-archives.apache.org/mod_mbox/hive-commits/201503.mbox/%3C20150310220045.68294AC02E7@hades.apache.org%3E), if people use a word like `date`, `user`, or `interval` as a partition key, an error will occur:
```
Failed to recognize predicate 'DATE'. Failed rule: 'identifier' in ...
```

This change escapes partition key names when generating Hive DML partition specifications, allowing use of any word as a partition key.

This fix should be fully compatible with any version of Hive.