### PR TITLE
Fix task_to_str_to_task behaviour when a Task has insignificant parameter

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -306,8 +306,7 @@ class Task(object):
         params_str = {}
         params = dict(self.get_params())
         for param_name, param_value in six.iteritems(self.param_kwargs):
-            if params[param_name].significant:
-                params_str[param_name] = params[param_name].serialize(param_value)
+            params_str[param_name] = params[param_name].serialize(param_value)
 
         return params_str
 

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -34,6 +34,7 @@ class DummyTask(luigi.Task):
     datehour_param = luigi.DateHourParameter()
     timedelta_param = luigi.TimeDeltaParameter()
     list_param = luigi.Parameter(is_list=True)
+    insignificant_param = luigi.Parameter(significant=False)
 
 
 class TaskTest(unittest.TestCase):
@@ -50,7 +51,8 @@ class TaskTest(unittest.TestCase):
             date_param=datetime(2014, 9, 13).date(),
             datehour_param=datetime(2014, 9, 13, 9),
             timedelta_param=timedelta(44),  # doesn't support seconds
-            list_param=['in', 'flames'])
+            list_param=['in', 'flames'],
+            insignificant_param='test')
 
         original = DummyTask(**params)
         other = DummyTask.from_str_params(original.to_str_params())


### PR DESCRIPTION
Fixes issue introduced by a923a75 and adds a test case to avoid it in the future.

In a923a75, I removed insignificant parameters to be included in the output of `to_str_params`. It seems this was a bit careless, i.e. it causes an error when the serialised task is passed back to `from_str_params`.

The goal of a923a75 was to avoid passing insignificant params to scheduler and thus potentially avoid exposing it to users via UI. I guess I can come with another, less invasive way to achieve that. (possibly in another PR)