### PR TITLE
Travis: Run tox with fixed hashseed

### DIFF
--- a/scripts/ci/conditional_tox.sh
+++ b/scripts/ci/conditional_tox.sh
@@ -7,5 +7,5 @@ if [[ $ENDENV == gcloud ]]
 then
   [[ $DIDNT_CREATE_GCP_CREDS = 1 ]] || tox
 else
-  tox
+  tox --hashseed 1
 fi


### PR DESCRIPTION
The idea is that different (randomly generated) hash seeds could be one of the reasons that we are seeing intermittent failures on Travis. While I doubt this particular change will help, it should make the tests run somewhat more consistently on Travis.

I choose 1 arbitrarily of course.