### PR TITLE
Allows assistant to run tasks with insignificant parameters

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -294,8 +294,9 @@ class Task(object):
             params_str = {}
         kwargs = {}
         for param_name, param in cls.get_params():
-            value = param.parse_from_input(param_name, params_str[param_name])
-            kwargs[param_name] = value
+            if param.significant or param_name in params_str:
+                value = param.parse_from_input(param_name, params_str[param_name])
+                kwargs[param_name] = value
 
         return cls(**kwargs)
 

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -37,6 +37,11 @@ class DummyTask(luigi.Task):
     insignificant_param = luigi.Parameter(significant=False)
 
 
+class DefaultInsignificantParamTask(luigi.Task):
+    insignificant_param = luigi.Parameter(significant=False, default='value')
+    necessary_param = luigi.Parameter(significant=False)
+
+
 class TaskTest(unittest.TestCase):
 
     def test_tasks_doctest(self):
@@ -57,6 +62,16 @@ class TaskTest(unittest.TestCase):
         original = DummyTask(**params)
         other = DummyTask.from_str_params(original.to_str_params())
         self.assertEqual(original, other)
+
+    def test_task_from_str_insignificant(self):
+        params = {'necessary_param': 'needed'}
+        original = DefaultInsignificantParamTask(**params)
+        other = DefaultInsignificantParamTask.from_str_params(params)
+        self.assertEqual(original, other)
+
+    def test_task_missing_necessary_param(self):
+        with self.assertRaises(luigi.parameter.MissingParameterException):
+            DefaultInsignificantParamTask.from_str_params({})
 
     def test_external_tasks_loadable(self):
         task = load_task("luigi", "ExternalTask", {})


### PR DESCRIPTION
If a task has an insignificant parameter, it should be ok for an assistant to
run it with the default value of that parameter. This change allows the
assistant to do that by ignoring when insignificant parameters are not present
in Task.from_str_params.