### PR TITLE
Add support for Unix sockets #1118

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
     - TOXENV=py27-nonhdfs
     - TOXENV=py33-nonhdfs
     - TOXENV=py34-nonhdfs
+    - TOXENV=py27-unixsockets
+    - TOXENV=py33-unixsockets
+    - TOXENV=py34-unixsockets
     - TOXENV=py27-cdh
     - TOXENV=py33-cdh
     - TOXENV=py34-cdh

--- a/doc/central_scheduler.rst
+++ b/doc/central_scheduler.rst
@@ -30,8 +30,9 @@ To run the server as a daemon run:
     luigid --background --pidfile <PATH_TO_PIDFILE> --logdir <PATH_TO_LOGDIR> --state-path <PATH_TO_STATEFILE>
 
 Note that this requires ``python-daemon``.
-By default, the server starts on port ``8082``
+By default, the server starts on AF_INET and AF_INET6 port ``8082``
 (which can be changed with the ``--port`` flag) and listens on all IPs.
+(To use an AF_UNIX socket use the ``--unix-socket`` flag)
 
 For a full list of configuration options and defaults,
 see the :ref:`scheduler configuration section <scheduler-config>`.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -63,6 +63,15 @@ default-scheduler-host
 default-scheduler-port
   Port of the remote scheduler api process. Defaults to 8082.
 
+default-scheduler-url
+  Full path to remote scheduler. Defaults to ``http://localhost:8082/``.
+  For TLS support use the URL scheme: ``https``,
+  example: ``https://luigi.example.com:443/``
+  (Note: you will have to terminate TLS using an HTTP proxy)
+  You can also use this to connect to a local Unix socket using the
+  non-standard URI scheme: ``http+unix``
+  example: ``http+unix://%2Fvar%2Frun%2Fluigid%2Fluigid.sock/``
+
 email-prefix
   Optional prefix to add to the subject line of all e-mails. For
   example, setting this to "[LUIGI]" would change the subject line of an

--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -20,6 +20,7 @@ def luigid(argv=sys.argv[1:]):
     parser.add_argument(u'--logdir', help=u'log directory')
     parser.add_argument(u'--state-path', help=u'Pickled state file')
     parser.add_argument(u'--address', help=u'Listening interface')
+    parser.add_argument(u'--unix-socket', help=u'Unix socket path')
     parser.add_argument(u'--port', default=8082, help=u'Listening port')
 
     opts = parser.parse_args(argv)
@@ -33,7 +34,7 @@ def luigid(argv=sys.argv[1:]):
         logging.getLogger().setLevel(logging.INFO)
         luigi.process.daemonize(luigi.server.run, api_port=opts.port,
                                 address=opts.address, pidfile=opts.pidfile,
-                                logdir=opts.logdir)
+                                logdir=opts.logdir, unix_socket=opts.unix_socket)
     else:
         if opts.logdir:
             logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format(),

--- a/luigi/process.py
+++ b/luigi/process.py
@@ -72,7 +72,7 @@ def _server_already_running(pidfile):
     return False
 
 
-def daemonize(cmd, pidfile=None, logdir=None, api_port=8082, address=None):
+def daemonize(cmd, pidfile=None, logdir=None, api_port=8082, address=None, unix_socket=None):
     import daemon
 
     logdir = logdir or "/var/log/luigi"
@@ -112,4 +112,4 @@ def daemonize(cmd, pidfile=None, logdir=None, api_port=8082, address=None):
                 return
             write_pid(pidfile)
 
-        cmd(api_port=api_port, address=address)
+        cmd(api_port=api_port, address=address, unix_socket=unix_socket)

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -240,11 +240,14 @@ def app(scheduler):
     return api_app
 
 
-def _init_api(scheduler, responder=None, api_port=None, address=None):
+def _init_api(scheduler, responder=None, api_port=None, address=None, unix_socket=None):
     if responder:
         raise Exception('The "responder" argument is no longer supported')
     api_app = app(scheduler)
-    api_sockets = tornado.netutil.bind_sockets(api_port, address=address)
+    if unix_socket is not None:
+        api_sockets = [tornado.netutil.bind_unix_socket(unix_socket)]
+    else:
+        api_sockets = tornado.netutil.bind_sockets(api_port, address=address)
     server = tornado.httpserver.HTTPServer(api_app)
     server.add_sockets(api_sockets)
 
@@ -252,7 +255,7 @@ def _init_api(scheduler, responder=None, api_port=None, address=None):
     return [s.getsockname() for s in api_sockets]
 
 
-def run(api_port=8082, address=None, scheduler=None, responder=None):
+def run(api_port=8082, address=None, unix_socket=None, scheduler=None, responder=None):
     """
     Runs one instance of the API server.
     """
@@ -262,7 +265,13 @@ def run(api_port=8082, address=None, scheduler=None, responder=None):
     # load scheduler state
     scheduler.load()
 
-    _init_api(scheduler, responder, api_port, address)
+    _init_api(
+        scheduler=scheduler,
+        responder=responder,
+        api_port=api_port,
+        address=address,
+        unix_socket=unix_socket,
+    )
 
     # prune work DAG every 60 seconds
     pruner = tornado.ioloop.PeriodicCallback(scheduler.prune, 60000)

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -94,8 +94,8 @@ class CustomizedWorkerSchedulerFactory(object):
     def create_local_scheduler(self):
         return self.scheduler
 
-    def create_remote_scheduler(self, host, port):
-        return CustomizedRemoteScheduler(host=host, port=port)
+    def create_remote_scheduler(self, url):
+        return CustomizedRemoteScheduler(url)
 
     def create_worker(self, scheduler, worker_processes=None, assistant=False):
         return self.worker

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -99,7 +99,7 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
         self.run_task(task)
 
         task_record = six.advance_iterator(self.history.find_all_by_name('DummyTask'))
-        print (task_record.events)
+        print(task_record.events)
         self.assertEqual(task_record.events[0].event_name, DONE)
 
     def test_utc_conversion(self):
@@ -111,7 +111,7 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
         task_record = six.advance_iterator(self.history.find_all_by_name('DummyTask'))
         last_event = task_record.events[0]
         try:
-            print (from_utc(str(last_event.ts)))
+            print(from_utc(str(last_event.ts)))
         except ValueError:
             self.fail("Failed to convert timestamp {} to UTC".format(last_event.ts))
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -33,7 +33,7 @@ class RPCTest(central_planner_test.CentralPlannerTest, ServerTestBase):
 
     def setUp(self):
         super(RPCTest, self).setUp()
-        self.sch = luigi.rpc.RemoteScheduler(port=self.get_http_port())
+        self.sch = luigi.rpc.RemoteScheduler(self.get_url(''))
         self.sch._wait = lambda: None
 
     @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/72276513')

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -649,7 +649,7 @@ class WorkerEmailTest(unittest.TestCase):
 
     @email_patch
     def test_connection_error(self, emails):
-        sch = RemoteScheduler(host="this_host_doesnt_exist", port=1337, connect_timeout=1)
+        sch = RemoteScheduler('http://tld.invalid:1337', connect_timeout=1)
         worker = Worker(scheduler=sch)
 
         self.waits = 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-{cdh,hdp,nonhdfs,gcloud,postgres}, pypy-scheduler, docs, pep8
+envlist = py{27,33,34}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsockets}, pypy-scheduler, docs, pep8
 skipsdist = True
 
 [testenv]
@@ -21,6 +21,8 @@ deps=
   gcloud: google-api-python-client>=1.4.0,<2.0
   coverage>=3.6,<3.999
   coveralls<1.0
+  unixsockets: requests<3.0
+  unixsockets: requests-unixsocket<1.0
 passenv =
   USER JAVA_HOME GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID TRAVIS
 setenv =
@@ -34,6 +36,7 @@ setenv =
   cdh,hdp: NOSE_ATTR=minicluster
   gcloud: NOSE_ATTR=gcloud
   nonhdfs: NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres
+  unixsockets: NOSE_ATTR=unixsockets
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
   COVERAGE_PROCESS_START={toxinidir}/.coveragerc
   FULL_COVERAGE=true


### PR DESCRIPTION
This also adds support for TLS!

Simply use https://exmaple.com/ for TLS or [http+unix://%2Fvar%2Frun%2Fluigid%2Fluigid.sock](http:/%2Fvar%2Frun%2Fluigid%2Fluigid.sock) for Unix sockets

There doesn't seem to be any actual tests to see if the real fetch method works, as all the tests that cover RemoteScheduler patches "._fetch"