### PR TITLE
Enables task failure on worker death while assistant is running

### DIFF
--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -226,6 +226,18 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.prune()
         self.assertFalse(list(self.sch.task_list('', '')))
 
+    def test_fail_job_from_dead_worker_with_live_assistant(self):
+        self.setTime(0)
+        self.sch.add_task(worker='X', task_id='A')
+        self.assertEqual('A', self.sch.get_work(worker='X')['task_id'])
+        self.sch.add_worker('Y', [('assistant', True)])
+
+        self.setTime(600)
+        self.sch.ping(worker='Y')
+        self.sch.prune()
+
+        self.assertEqual(['A'], list(self.sch.task_list('FAILED', '').keys()))
+
     def test_prune_done_tasks(self, expected=None):
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=DONE)


### PR DESCRIPTION
We avoid pruning PENDING and RUNNING tasks while an assistant is live, as the
assistant is considered a stakeholder for all runnable tasks. Unfortunately,
the prune function is where we fail RUNNING tasks for which the running worker
has died. So when an assistant is alive, it becomes impossible for a RUNNING
task whose worker has died to ever change status.

This fixes the issue by separating the function to mark RUNNING tasks as FAILED
from the pruning function and ensuring that it gets called regardless of the
presence of assistants.