### PR TITLE
Allows assistant to work on orphaned tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -194,6 +194,7 @@ class Task(object):
         self.disable_hard_timeout = disable_hard_timeout
         self.failures = Failures(disable_window)
         self.scheduler_disable_time = None
+        self.runnable = False
 
     def __repr__(self):
         return "Task(%r)" % vars(self)
@@ -640,6 +641,7 @@ class CentralPlannerScheduler(Scheduler):
         if runnable:
             task.workers.add(worker_id)
             self._state.get_worker(worker_id).tasks.add(task)
+            task.runnable = runnable
 
         if expl is not None:
             task.expl = expl
@@ -734,7 +736,7 @@ class CentralPlannerScheduler(Scheduler):
 
         for task in tasks:
             upstream_status = self._upstream_status(task.id, upstream_table)
-            in_workers = (assistant and task.workers) or worker_id in task.workers
+            in_workers = (assistant and getattr(task, 'runnable', bool(task.workers))) or worker_id in task.workers
             if task.status == RUNNING and in_workers:
                 # Return a list of currently running tasks to the client,
                 # makes it easier to troubleshoot

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -238,6 +238,18 @@ class CentralPlannerTest(unittest.TestCase):
 
         self.assertEqual(['A'], list(self.sch.task_list('FAILED', '').keys()))
 
+    def test_assistant_request_runnable_task(self):
+        self.setTime(0)
+        self.sch.add_task(worker='X', task_id='A', runnable=True)
+        self.setTime(600)
+        self.sch.prune()
+
+        self.assertEqual('A', self.sch.get_work(worker='Y', assistant=True)['task_id'])
+
+    def test_assistant_request_external_task(self):
+        self.sch.add_task(worker='X', task_id='A', runnable=False)
+        self.assertIsNone(self.sch.get_work(worker='Y', assistant=True)['task_id'])
+
     def test_prune_done_tasks(self, expected=None):
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=DONE)


### PR DESCRIPTION
Assistants keep PENDING tasks alive in order to work on them, but aren't
actually able to work on them because we check whether tasks have live workers
before we give them to assistants. This is to prevent assistants from working on
external tasks. In order to allow assistants to work on tasks with no live
workers but not work on external tasks, we store whether a task is runnable in
the scheduler.

To keep compatibility with old pickle files, we treat tasks without runnable set
as runnable. This should minimize the problems caused be the changed schema.