### PR TITLE
Enables disabling of old workers while allowing them to finish currently running tasks

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -55,7 +55,7 @@ def get_info(pid_dir, my_pid=None):
     return my_pid, my_cmd, pid_file
 
 
-def acquire_for(pid_dir, num_available=1):
+def acquire_for(pid_dir, num_available=1, kill_signal=None):
     """
     Makes sure the process is only run once at the same time with the same name.
 
@@ -80,7 +80,10 @@ def acquire_for(pid_dir, num_available=1):
         pid_cmds = dict((pid, getpcmd(pid)) for pid in pids)
         matching_pids = list(filter(lambda pid: pid_cmds[pid] == my_cmd, pids))
 
-        if len(matching_pids) >= num_available:
+        if kill_signal is not None:
+            for pid in map(int, matching_pids):
+                os.kill(pid, kill_signal)
+        elif len(matching_pids) >= num_available:
             # We are already running under a different pid
             print('Pid(s)', ', '.join(matching_pids), 'already running')
             return False

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -154,6 +154,15 @@ class WorkerTest(unittest.TestCase):
         self.assertTrue(a.has_run)
         self.assertTrue(b.has_run)
 
+    def test_stop_getting_new_work(self):
+        d = DummyTask()
+        self.w.add(d)
+
+        self.assertFalse(d.complete())
+        self.w.handle_interrupt(signal.SIGUSR1, None)
+        self.w.run()
+        self.assertFalse(d.complete())
+
     def test_external_dep(self):
         class A(ExternalTask):
 


### PR DESCRIPTION
This PR is split into two commits. The first one adds a signal handler for SIGUSR1 to workers, which prevents them from calling get_work. This allows old workers to be replaced without killing currently running tasks. By doing this, we prevent old code from being run going forward without losing progress on long-running tasks.

The second commit adds a --take-lock argument that causes a job to send SIGUSR1 to jobs that would otherwise occupy its lock. I've been using this successfully with an assistant that is automatically run with code deploys to ensure that the latest code is always being run without continuous deployment constantly killing all of my jobs.