### PR TITLE
Prefer list2command over ' '.join()

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -254,7 +254,7 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
     :param env:
     :return:
     """
-    logger.info('%s', ' '.join(arglist))
+    logger.info('%s', subprocess.list2cmdline(arglist))
 
     def write_luigi_history(arglist, history):
         """
@@ -452,7 +452,7 @@ class HadoopJobRunner(JobRunner):
 
         for libjar in self.libjars_in_hdfs:
             run_cmd = luigi.contrib.hdfs.load_hadoop_cmd() + ['fs', '-get', libjar, self.tmp_dir]
-            logger.debug(' '.join(run_cmd))
+            logger.debug(subprocess.list2cmdline(run_cmd))
             subprocess.call(run_cmd)
             libjars.append(os.path.join(self.tmp_dir, os.path.basename(libjar)))
 

--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -74,7 +74,7 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
         """
 
         cmd = load_hadoop_cmd() + ['fs', '-stat', path]
-        logger.debug('Running file existence check: %s', u' '.join(cmd))
+        logger.debug('Running file existence check: %s', subprocess.list2cmdline(cmd))
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, universal_newlines=True)
         stdout, stderr = p.communicate()
         if p.returncode == 0:

--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -110,7 +110,7 @@ class PigJobTask(luigi.Task):
 
         cmd = [self.pig_command_path()] + opts + ["-f", self.pig_script_path()]
 
-        logger.info(' '.join(cmd))
+        logger.info(subprocess.list2cmdline(cmd))
         return cmd
 
     def run(self):

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -184,12 +184,12 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         arglist = ['java', '-cp', scala_cp, 'scala.tools.nsc.Main',
                    '-classpath', classpath,
                    '-d', build_dir, job_src]
-        logger.info('Compiling scala source: %s', ' '.join(arglist))
+        logger.info('Compiling scala source: %s', subprocess.list2cmdline(arglist))
         subprocess.check_call(arglist)
 
         # build job jar file
         arglist = ['jar', 'cf', job_jar, '-C', build_dir, '.']
-        logger.info('Building job jar: %s', ' '.join(arglist))
+        logger.info('Building job jar: %s', subprocess.list2cmdline(arglist))
         subprocess.check_call(arglist)
         return job_jar
 
@@ -215,7 +215,7 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         hadoop_cp = ':'.join(filter(None, jars))
         env['HADOOP_CLASSPATH'] = hadoop_cp
         logger.info("Submitting Hadoop job: HADOOP_CLASSPATH=%s %s",
-                    hadoop_cp, ' '.join(arglist))
+                    hadoop_cp, subprocess.list2cmdline(arglist))
         luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, env=env)
 
         for a, b in tmp_files:

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -454,7 +454,7 @@ class SparkJob(luigi.Task):
         spark_class = configuration.get_config().get('spark', 'spark-class')
 
         temp_stderr = tempfile.TemporaryFile()
-        logger.info('Running: %s %s', spark_class, ' '.join(args))
+        logger.info('Running: %s %s', spark_class, subprocess.list2cmdline(args))
         proc = subprocess.Popen([spark_class] + args, stdout=subprocess.PIPE,
                                 stderr=temp_stderr, env=env, close_fds=True)
 


### PR DESCRIPTION
Just a nice convenienve. The motivation is that it becomes easier to
copy these logs and paste directly into the terminal without manually
escaping spaces and whatnot.