### PR TITLE
Unexport private parts of interface.py

### DIFF
--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -82,7 +82,7 @@ def find_deps_cli():
     '''
     Finds all tasks on all paths from provided CLI task
     '''
-    interface = luigi.interface.DynamicArgParseInterface()
+    interface = luigi.interface._DynamicArgParseInterface()
     tasks = interface.parse()
     task, = tasks
     upstream_task_family = upstream().family

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -205,7 +205,7 @@ class NewStyleParameters822Test(unittest.TestCase):
     # See https://github.com/spotify/luigi/issues/822
 
     def test_subclasses(self):
-        ap = luigi.interface.ArgParseInterface()
+        ap = luigi.interface._ArgParseInterface()
 
         task, = ap.parse(['--local-scheduler', '--no-lock', 'FooSubClass', '--x', 'xyz', '--FooBaseClass-x', 'xyz'])
         self.assertEquals(task.x, 'xyz')
@@ -214,7 +214,7 @@ class NewStyleParameters822Test(unittest.TestCase):
         self.assertRaises(BaseException, ap.parse, (['--local-scheduler', '--no-lock', 'FooBaseClass', '--x', 'xyz', '--FooSubClass-x', 'xyz']))
 
     def test_subclasses_2(self):
-        ap = luigi.interface.ArgParseInterface()
+        ap = luigi.interface._ArgParseInterface()
 
         # https://github.com/spotify/luigi/issues/822#issuecomment-77782714
         task, = ap.parse(['--local-scheduler', '--no-lock', 'FooBaseClass', '--FooBaseClass-x', 'xyz'])

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -98,9 +98,9 @@ class DateIntervalTest(unittest.TestCase):
         class MyTaskNoDefault(luigi.Task):
             di = DI()
 
-        task = luigi.interface.ArgParseInterface().parse(["MyTask"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["MyTask"])[0]
         self.assertEqual(task.di, month)
-        task = luigi.interface.ArgParseInterface().parse(["MyTask", "--di", "2012-10"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["MyTask", "--di", "2012-10"])[0]
         self.assertEqual(task.di, other)
         task = MyTask(month)
         self.assertEqual(task.di, month)
@@ -110,10 +110,10 @@ class DateIntervalTest(unittest.TestCase):
         self.assertNotEquals(task.di, month)
 
         def fail1():
-            luigi.interface.ArgParseInterface().parse(["MyTaskNoDefault"])[0]
+            luigi.interface._ArgParseInterface().parse(["MyTaskNoDefault"])[0]
         self.assertRaises(luigi.parameter.MissingParameterException, fail1)
 
-        task = luigi.interface.ArgParseInterface().parse(["MyTaskNoDefault", "--di", "2012-10"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["MyTaskNoDefault", "--di", "2012-10"])[0]
         self.assertEqual(task.di, other)
 
     def test_hours(self):

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -52,7 +52,7 @@ class DateParameterTest(unittest.TestCase):
         self.assertEqual(d, '2015-04-03')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["DateTask", "--day", "2015-04-03"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["DateTask", "--day", "2015-04-03"])[0]
         self.assertEqual(task.day, datetime.date(2015, 4, 3))
 
     def test_serialize_task(self):
@@ -70,7 +70,7 @@ class DateHourParameterTest(unittest.TestCase):
         self.assertEqual(dh, '2013-02-01T18')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["DateHourTask", "--dh", "2013-02-01T18"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["DateHourTask", "--dh", "2013-02-01T18"])[0]
         self.assertEqual(task.dh, datetime.datetime(2013, 2, 1, 18, 0, 0))
 
     def test_serialize_task(self):
@@ -100,7 +100,7 @@ class DateMinuteParameterTest(unittest.TestCase):
         self.assertEqual(dm, '2013-02-01T1807')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["DateMinuteTask", "--dm", "2013-02-01T1842"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["DateMinuteTask", "--dm", "2013-02-01T1842"])[0]
         self.assertEqual(task.dm, datetime.datetime(2013, 2, 1, 18, 42, 0))
 
     def test_serialize_task(self):
@@ -118,7 +118,7 @@ class MonthParameterTest(unittest.TestCase):
         self.assertEqual(m, '2015-04')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["MonthTask", "--month", "2015-04"])[0]
+        task = luigi.interface._ArgParseInterface().parse(["MonthTask", "--month", "2015-04"])[0]
         self.assertEqual(task.month, datetime.date(2015, 4, 1))
 
     def test_serialize_task(self):
@@ -136,7 +136,8 @@ class YearParameterTest(unittest.TestCase):
         self.assertEqual(year, '2015')
 
     def test_parse_interface(self):
-        task = luigi.interface.ArgParseInterface().parse(["YearTask", "--year", "2015"])[0]
+
+        task = luigi.interface._ArgParseInterface().parse(["YearTask", "--year", "2015"])[0]
         self.assertEqual(task.year, datetime.date(2015, 1, 1))
 
     def test_serialize_task(self):

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -22,7 +22,6 @@ from helpers import unittest
 
 import luigi
 import luigi.notifications
-from luigi.interface import ArgParseInterface
 from luigi.mock import MockTarget
 from luigi.parameter import MissingParameterException
 from luigi.util import common_params, copies, delegates, inherits, requires

--- a/test/dynamic_import_test.py
+++ b/test/dynamic_import_test.py
@@ -30,7 +30,7 @@ class ExtraArgs(luigi.Task):
 class CmdlineTest(LuigiTestCase):
 
     def test_dynamic_loading(self):
-        interface = luigi.interface.DynamicArgParseInterface()
+        interface = luigi.interface._DynamicArgParseInterface()
         with tempfile.NamedTemporaryFile(dir='test/', prefix="_foo_module", suffix='.py') as temp_module_file:
             temp_module_file.file.write(b'''
 import luigi

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -21,7 +21,7 @@ import luigi
 import luigi.date_interval
 import luigi.notifications
 import sys
-from luigi.interface import core, Interface, WorkerSchedulerFactory
+from luigi.interface import core, _WorkerSchedulerFactory
 from luigi.worker import Worker
 from mock import Mock, patch
 from helpers import LuigiTestCase
@@ -35,7 +35,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker = Worker()
         self.worker.stop = Mock()
 
-        self.worker_scheduler_factory = WorkerSchedulerFactory()
+        self.worker_scheduler_factory = _WorkerSchedulerFactory()
         self.worker_scheduler_factory.create_worker = Mock(return_value=self.worker)
         self.worker_scheduler_factory.create_local_scheduler = Mock()
         super(InterfaceTest, self).setUp()
@@ -51,12 +51,6 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=True)
 
         self.assertTrue(self._run_interface())
-
-    def test_interface_default_override_defaults(self):
-        self.worker.add = Mock(side_effect=[True, True])
-        self.worker.run = Mock(return_value=True)
-
-        self.assertTrue(Interface.run([self.task_a, self.task_b], self.worker_scheduler_factory))
 
     def test_interface_run_with_add_failure(self):
         self.worker.add = Mock(side_effect=[True, False])
@@ -84,7 +78,7 @@ class InterfaceTest(LuigiTestCase):
             luigi.run(main_task_cls=MyOtherTestTask)
 
     def _run_interface(self):
-        return Interface.run([self.task_a, self.task_b], self.worker_scheduler_factory, {'no_lock': True})
+        return luigi.interface.build([self.task_a, self.task_b], worker_scheduler_factory=self.worker_scheduler_factory)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The purpose is to make the documentation page pleaner[1] and to not make
it easy for users of luigi to misuse luigi and start relying on things
so we don't dare changing it later.

This will of course break for people who've considered those exports to
be sane to use, but I think that's fine since we're making proper
releases of the luigi package.

[1]: http://luigi.readthedocs.org/en/latest/api/luigi.interface.html