### PR TITLE
luigid: Add format conversion code for #916

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -322,11 +322,15 @@ class SimpleTaskState(object):
 
             # Convert from old format
             # TODO: this is really ugly, we need something more future-proof
-            # Every time we add an attribute to the Worker class, this code needs to be updated
+            # Every time we add an attribute to the Worker or Task class, this
+            # code needs to be updated
+
+            # Compatibility since 2014-06-02
             for k, v in six.iteritems(self._active_workers):
                 if isinstance(v, float):
                     self._active_workers[k] = Worker(worker_id=k, last_active=v)
 
+            # Compatibility since 2015-05-28
             if any(not hasattr(w, 'tasks') for k, w in six.iteritems(self._active_workers)):
                 # If you load from an old format where Workers don't contain tasks.
                 for k, worker in six.iteritems(self._active_workers):
@@ -334,6 +338,11 @@ class SimpleTaskState(object):
                 for task in six.itervalues(self._tasks):
                     for worker_id in task.workers:
                         self._active_workers[worker_id].tasks.add(task)
+
+            # Compatibility since 2015-04-28
+            if any(not hasattr(t, 'disable_hard_timeout') for t in six.itervalues(self._tasks)):
+                for t in six.itervalues(self._tasks):
+                    t.disable_hard_timeout = None
         else:
             logger.info("No prior state file exists at %s. Starting with clean slate", self._state_path)
 


### PR DESCRIPTION
In spotify/luigi#916 all (scheduler) tasks started to have the
disable_hard_timeout attribute which the code assumes. But the scheduler
will crash if you load an old pickle file.

Yea I know it was ages ago we merged that PR but Spotify still runs some
luigid with old state files.

I did test that this works. But I did not add any unit test, as this is
not any compatibility we want to maintain in the long run. To make the
code base a bit cleaner, I dated all the format conversion code.