### PR TITLE
pass pig parameters by file

### DIFF
--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -22,7 +22,7 @@ Example configuration section in luigi.cfg::
     # pig home directory
     home: /usr/share/pig
 """
-
+from contextlib import contextmanager
 import logging
 import os
 import select
@@ -95,27 +95,32 @@ class PigJobTask(luigi.Task):
         """
         raise NotImplementedError("subclass should define pig_script_path")
 
+    @contextmanager
     def _build_pig_cmd(self):
         opts = self.pig_options()
 
-        for k, v in six.iteritems(self.pig_parameters()):
-            opts.append("-p")
-            opts.append("%s=%s" % (k, v))
+        line = lambda k, v: ('%s=%s%s' % (k, v, os.linesep)).encode('utf-8')
+        with tempfile.NamedTemporaryFile() as param_file, tempfile.NamedTemporaryFile() as prop_file:
+            if self.pig_parameters():
+                items = six.iteritems(self.pig_parameters())
+                param_file.writelines(line(k, v) for (k, v) in items)
+                opts.append('-param_file')
+                opts.append(param_file.name)
 
-        if self.pig_properties():
-            with open('pig_property_file', 'w') as prop_file:
-                prop_file.writelines(["%s=%s%s" % (k, v, os.linesep) for (k, v) in six.iteritems(self.pig_properties())])
-            opts.append('-propertyFile')
-            opts.append('pig_property_file')
+            if self.pig_properties():
+                items = six.iteritems(self.pig_properties())
+                prop_file.writelines(line(k, v) for (k, v) in items)
+                opts.append('-propertyFile')
+                opts.append(prop_file.name)
 
-        cmd = [self.pig_command_path()] + opts + ["-f", self.pig_script_path()]
+            cmd = [self.pig_command_path()] + opts + ["-f", self.pig_script_path()]
 
-        logger.info(subprocess.list2cmdline(cmd))
-        return cmd
+            logger.info(subprocess.list2cmdline(cmd))
+            yield cmd
 
     def run(self):
-        cmd = self._build_pig_cmd()
-        self.track_and_progress(cmd)
+        with self._build_pig_cmd() as cmd:
+            self.track_and_progress(cmd)
 
     def track_and_progress(self, cmd):
         temp_stdout = tempfile.TemporaryFile()

--- a/test/contrib/pig_test.py
+++ b/test/contrib/pig_test.py
@@ -101,47 +101,71 @@ class ComplexPigTest(unittest.TestCase):
         arglist_result = []
         p = subprocess.Popen
         subprocess.Popen = _get_fake_Popen(arglist_result, 0)
-        try:
-            job = ComplexTestJob()
-            job.run()
-            self.assertEqual([['/usr/share/pig/bin/pig', '-x', 'local', '-p',
-                               'YOUR_PARAM_NAME=Your param value',
-                               '-propertyFile', 'pig_property_file', '-f',
-                               'my_complex_pig_script.pig']], arglist_result)
 
-            # Check property file
-            with open('pig_property_file') as pprops_file:
-                pprops = pprops_file.readlines()
-                self.assertEqual(1, len(pprops))
-                self.assertEqual('pig.additional.jars=/path/to/your/jar\n', pprops[0])
-        finally:
-            subprocess.Popen = p
+        with tempfile.NamedTemporaryFile(delete=False) as param_file_mock, \
+                tempfile.NamedTemporaryFile(delete=False) as prop_file_mock, \
+                patch('luigi.contrib.pig.tempfile.NamedTemporaryFile',
+                      side_effect=[param_file_mock, prop_file_mock]):
+            try:
+                job = ComplexTestJob()
+                job.run()
+                self.assertEqual([['/usr/share/pig/bin/pig', '-x', 'local',
+                                   '-param_file', param_file_mock.name,
+                                   '-propertyFile', prop_file_mock.name,
+                                   '-f', 'my_complex_pig_script.pig']],
+                                 arglist_result)
+
+                # Check param file
+                with open(param_file_mock.name) as pparams_file:
+                    pparams = pparams_file.readlines()
+                    self.assertEqual(1, len(pparams))
+                    self.assertEqual('YOUR_PARAM_NAME=Your param value\n', pparams[0])
+
+                # Check property file
+                with open(prop_file_mock.name) as pprops_file:
+                    pprops = pprops_file.readlines()
+                    self.assertEqual(1, len(pprops))
+                    self.assertEqual('pig.additional.jars=/path/to/your/jar\n', pprops[0])
+            finally:
+                subprocess.Popen = p
 
     @patch('subprocess.Popen')
     def test_run__fail(self, mock):
         arglist_result = []
         p = subprocess.Popen
         subprocess.Popen = _get_fake_Popen(arglist_result, 1)
-        try:
-            job = ComplexTestJob()
-            job.run()
-        except PigJobError as e:
-            p = e
-            self.assertEqual('stderr', p.err)
-            self.assertEqual([['/usr/share/pig/bin/pig', '-x', 'local', '-p',
-                               'YOUR_PARAM_NAME=Your param value',
-                               '-propertyFile', 'pig_property_file', '-f',
-                               'my_complex_pig_script.pig']], arglist_result)
 
-            # Check property file
-            with open('pig_property_file') as pprops_file:
-                pprops = pprops_file.readlines()
-                self.assertEqual(1, len(pprops))
-                self.assertEqual('pig.additional.jars=/path/to/your/jar\n', pprops[0])
-        else:
-            self.fail("Should have thrown PigJobError")
-        finally:
-            subprocess.Popen = p
+        with tempfile.NamedTemporaryFile(delete=False) as param_file_mock, \
+                tempfile.NamedTemporaryFile(delete=False) as prop_file_mock, \
+                patch('luigi.contrib.pig.tempfile.NamedTemporaryFile',
+                      side_effect=[param_file_mock, prop_file_mock]):
+            try:
+                job = ComplexTestJob()
+                job.run()
+            except PigJobError as e:
+                p = e
+                self.assertEqual('stderr', p.err)
+                self.assertEqual([['/usr/share/pig/bin/pig', '-x', 'local',
+                                   '-param_file', param_file_mock.name,
+                                   '-propertyFile', prop_file_mock.name, '-f',
+                                   'my_complex_pig_script.pig']],
+                                 arglist_result)
+
+                # Check param file
+                with open(param_file_mock.name) as pparams_file:
+                    pparams = pparams_file.readlines()
+                    self.assertEqual(1, len(pparams))
+                    self.assertEqual('YOUR_PARAM_NAME=Your param value\n', pparams[0])
+
+                # Check property file
+                with open(prop_file_mock.name) as pprops_file:
+                    pprops = pprops_file.readlines()
+                    self.assertEqual(1, len(pprops))
+                    self.assertEqual('pig.additional.jars=/path/to/your/jar\n', pprops[0])
+            else:
+                self.fail("Should have thrown PigJobError")
+            finally:
+                subprocess.Popen = p
 
 
 def _get_fake_Popen(arglist_result, return_code, *args, **kwargs):


### PR DESCRIPTION
PigJobTask expose sensitive data to logs. For example:

```
INFO [pid 2464] Worker Worker(salt=466800829, workers=1, host=win91.dev.mail.ru, username=e.iskandarov, pid=2464) running   FalsePositive(java_home=/usr/lib/jvm/jre, secrets_conf=contrib/mario_secrets.yaml, site=mail.ru, max_number_of_files=180, mailru_input_dir=/data/mras/logs/dstat_falsepositive_snippets, mycom_input_dir=/data/mras/logs/dstatr_falsepositive_snippets)
INFO /usr/lib/pig/bin/pig -p mpop_user_jdbc=jdbc:mysql://mras-test2.mail.ru:3306/mPOP?user=mras&password=mras -p hdfs_input=/data/mras/logs/dstat_falsepositive_snippets/dstat_falsepositive_snippets-2014-09-20_00001 -p mras_jdbc=jdbc:mysql://mras-test2.mail.ru:3306/mras?useUnicode=true&characterEncoding=UTF-8&user=mras&password=mras -p site=mail.ru -p udf_path=/home/e.iskandarov/workspace/mario-jobs/mario_jobs/false_positive/rule_udf.py -p mpop_domain_jdbc=jdbc:mysql://mras-test2.mail.ru:3306/mPOP?user=mras&password=mras -p job_name=false_positive_processing -propertyFile pig_property_file -f /home/e.iskandarov/workspace/mario-jobs/mario_jobs/false_positive/false_positive.pig
```
As you can see there are mysql connection parameters. This is not desired behavior.

With my patch luigi build pig command line arguments using pig `-param_file` parameter like `-propertyFile` do. All parameters stay in file and do not visible in logs:

```
INFO [pid 2009] Worker Worker(salt=314780808, workers=1, host=win91.dev.mail.ru, username=e.iskandarov, pid=2009) running   FalsePositive(java_home=/usr/lib/jvm/jre, secrets_conf=contrib/mario_secrets.yaml, site=mail.ru, max_number_of_files=180, mailru_input_dir=/data/mras/logs/dstat_falsepositive_snippets, mycom_input_dir=/data/mras/logs/dstatr_falsepositive_snippets)
INFO /usr/lib/pig/bin/pig -param_file pig_param_file -propertyFile pig_property_file -f /home/e.iskandarov/workspace/mario-jobs/mario_jobs/false_positive/false_positive.pig
```