### PR TITLE
Removed hardcoded delimiter option from base copy method

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -99,15 +99,18 @@ class S3CopyToTable(rdbms.CopyToTable):
         * IGNOREHEADER 1
         * TRUNCATECOLUMNS
         * IGNOREBLANKLINES
+        * DELIMITER '\t'
         """
         return ''
 
     def table_attributes(self):
-        '''Add extra table attributes, for example:
+        """
+        Add extra table attributes, for example:
+
         DISTSTYLE KEY
         DISTKEY (MY_FIELD)
         SORTKEY (MY_FIELD_2, MY_FIELD_3)
-        '''
+        """
         return ''
 
     def do_truncate_table(self):
@@ -188,15 +191,12 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         Defines copying from s3 into redshift.
         """
-
         cursor.execute("""
          COPY %s from '%s'
          CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'
-         delimiter '%s'
          %s
          ;""" % (self.table, f, self.aws_access_key_id,
-                 self.aws_secret_access_key, self.column_separator,
-                 self.copy_options))
+                 self.aws_secret_access_key, self.copy_options))
 
     def output(self):
         """


### PR DESCRIPTION
The base S3CopyToTable class included a hardcoded delimiter option as part of the COPY command used with Redshift. This was causing issues when trying to copy a CSV file after adding the CSV copy option. Since it is a base class, I felt that the delimiter command should be passed in as an option rather than required in the copy method. 

Status: **Requesting Merge**
Reference: [Redshift COPY Command Documentation](http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html)

## Changes
- Removed hardcoded delimiter command
- Added example of delimiter command into copy_option comment