### PR TITLE
Log missing targets on unfulfilled dependencies

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -99,6 +99,12 @@ class LocalTarget(FileSystemTarget):
         self.format = format
         self.is_tmp = is_tmp
 
+    def __str__(self):
+        '''
+        Return a sensible string representation. Here the file system path is used
+        '''
+        return self.path
+
     def makedirs(self):
         """
         Create all parent folders if they do not exist.

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -117,14 +117,19 @@ class TaskProcess(multiprocessing.Process):
 
         status = FAILED
         error_message = ''
-        missing = []
+        missing_tasks = []
+        missing_targets = []
         new_deps = []
         try:
             # Verify that all the tasks are fulfilled!
-            missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]
-            if missing:
-                deps = 'dependency' if len(missing) == 1 else 'dependencies'
-                raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing)))
+            missing_deps = [dep for dep in self.task.deps() if not dep.complete()]
+            missing_targets = [tgt for tgt in flatten(dep.output()) for dep in missing_deps if not tgt.exists()]
+            for missing_target in missing_targets:
+                logger.warn('Missing Target: %s' % missing_target)
+            missing_taskids = [dep.task_id for dep in missing_deps]
+            if missing_taskids:
+                deps = 'dependency' if len(missing_taskids) == 1 else 'dependencies'
+                raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing_taskids)))
             self.task.trigger_event(Event.START, self.task)
             t0 = time.time()
             status = None
@@ -165,7 +170,7 @@ class TaskProcess(multiprocessing.Process):
             notifications.send_error_email(subject, formatted_error_message, self.task.owner_email)
         finally:
             self.result_queue.put(
-                (self.task.task_id, status, error_message, missing, new_deps))
+                (self.task.task_id, status, error_message, missing_taskids, new_deps))
 
     def _recursive_terminate(self):
         import psutil

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -124,10 +124,10 @@ class TaskProcess(multiprocessing.Process):
             # Verify that all the tasks are fulfilled!
             missing_deps = [dep for dep in self.task.deps() if not dep.complete()]
             missing_targets = [tgt for tgt in flatten(dep.output()) for dep in missing_deps if not tgt.exists()]
-            for missing_target in missing_targets:
-                logger.warn('Missing Target: %s' % missing_target)
             missing_taskids = [dep.task_id for dep in missing_deps]
             if missing_taskids:
+                for missing_target in missing_targets:
+                    logger.warn('Missing Target: %s' % missing_target)
                 deps = 'dependency' if len(missing_taskids) == 1 else 'dependencies'
                 raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing_taskids)))
             self.task.trigger_event(Event.START, self.task)

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -127,7 +127,7 @@ class TaskProcess(multiprocessing.Process):
             missing_taskids = [dep.task_id for dep in missing_deps]
             if missing_taskids:
                 for missing_target in missing_targets:
-                    logger.warn('Missing Target: %s' % missing_target)
+                    logger.error('Missing Target: %s' % missing_target)
                 deps = 'dependency' if len(missing_taskids) == 1 else 'dependencies'
                 raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing_taskids)))
             self.task.trigger_event(Event.START, self.task)

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -117,7 +117,7 @@ class TaskProcess(multiprocessing.Process):
 
         status = FAILED
         error_message = ''
-        missing_tasks = []
+        missing_taskids = []
         missing_targets = []
         new_deps = []
         try:


### PR DESCRIPTION
This is a proposed solution for issue #1189

It seems that probably the most commonly occuring problem for us, using luigi for commandline and file-system based workflows, is `RuntimeError: Unfulfilled dependency at run time: ...`. [1]

It also turns out that it can often be quite hard to figure out which of the outputs of that task (since we typically have multiple outputs), that is missing.

To that end, I suggest something like this, where the missing targets are at least logged (with 'WARNING' level in this case), before firing the "Unfulfilled dependency" error.

Maybe it is even better to include them in the error message, but it seems that it will get very long?

For a nice string representation of the missing targets, I also added a __str__() representation for the LocalTarget class. One should implement similar for the other target classes, to get a nice output, but I don't know them well enough to do that off-arm right now.

An example output of the logs that this gets us (with our custom log formatting though, but you should get the idea ... and with some parameters cleared out for brevity):

```log
2015-09-02 22:35:13 |  WARNING | Missing Target: /exp/20150627-crossval/data/mm_test_small.smi.h1_3.sign.r1.10_50_rand_trn.csr.logg
2015-09-02 22:35:13 |    ERROR | [pid 20380] Worker Worker(...blabla...) failed    UnGzipFile(...blabla...)
Traceback (most recent call last):
  File "/home/samuel/.pyenv/versions/2.7.8/lib/python2.7/site-packages/luigi/worker.py", line 132, in run
    raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing_taskids)))
RuntimeError: Unfulfilled dependency at run time: CreateSparseTrainDataset(...blabla...)
```

... so, you see that we get a `WARNING` about the missing file target, just before the `ERROR`, which would make life much easier for us.

What do you think, except that my code probably could use some improvements?

----
[1] Probably this is extra common in our case, since some of our commandline apps unfortunately produce outputs of which we can not control the file name, so we have to just try to create a luigi output that matches the file name that is created, and sometimes this goes wrong.