### PR TITLE
Test for orphaned subprocesses

### DIFF
--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -15,10 +15,14 @@
 # limitations under the License.
 #
 import multiprocessing
+from subprocess import check_call
+import sys
 
 from helpers import unittest
-import mock
 import json
+import mock
+from psutil import Process
+from time import sleep
 
 import luigi
 import luigi.date_interval
@@ -50,6 +54,13 @@ class FailTask(luigi.Task):
 
     def on_failure(self, exception):
         return "test failure expl"
+
+
+class HangingSubprocessTask(luigi.Task):
+
+    def run(self):
+        python = sys.executable
+        check_call([python, '-c', 'while True: pass'])
 
 
 class WorkerTaskTest(unittest.TestCase):
@@ -84,6 +95,29 @@ class TaskProcessTest(unittest.TestCase):
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
             mock_put.assert_called_once_with((task.task_id, FAILED, json.dumps("test failure expl"), [], []))
+
+    def test_cleanup_children_on_terminate(self):
+        """
+        Subprocesses spawned by tasks should be terminated on terminate
+        """
+        task = HangingSubprocessTask()
+        queue = mock.Mock()
+        worker_id = 1
+
+        task_process = TaskProcess(task, worker_id, queue)
+        task_process.start()
+
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
+        [child] = parent.children()
+        task_process.terminate()
+        child.wait(timeout=1.0)  # wait for terminate to complete
+
+        self.assertFalse(parent.is_running())
+        self.assertFalse(child.is_running())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the test requested in https://github.com/spotify/luigi/pull/1187#issuecomment-137130124 .

I've tweaked the implementation of `_recursive_terminate` to send SIGINT instead of SIGKILL (which allows processes to cleanup after themselves). While using this I also ran into a race condition where a subprocess finishes between the time terminate() is called and the signal is sent, so I added some try/catch blocks to handle this gracefully.

