### PR TITLE
Remove luigi.contrib.client, lazify fs operations

### DIFF
--- a/luigi/contrib/hdfs/__init__.py
+++ b/luigi/contrib/hdfs/__init__.py
@@ -51,7 +51,6 @@ HdfsClientCdh3 = hdfs_hadoopcli_clients.HdfsClientCdh3
 HdfsClientApache1 = hdfs_hadoopcli_clients.HdfsClientApache1
 create_hadoopcli_client = hdfs_hadoopcli_clients.create_hadoopcli_client
 get_autoconfig_client = hdfs_clients.get_autoconfig_client
-client = hdfs_clients.client
 exists = hdfs_clients.exists
 rename = hdfs_clients.rename
 remove = hdfs_clients.remove

--- a/luigi/contrib/hdfs/clients.py
+++ b/luigi/contrib/hdfs/clients.py
@@ -30,11 +30,11 @@ import logging
 logger = logging.getLogger('luigi-interface')
 
 
-def get_autoconfig_client(show_warnings=True):
+def get_autoconfig_client():
     """
     Creates the client as specified in the `luigi.cfg` configuration.
     """
-    configured_client = hdfs_config.get_configured_hdfs_client(show_warnings=show_warnings)
+    configured_client = hdfs_config.get_configured_hdfs_client()
     if configured_client == "snakebite":
         return hdfs_snakebite_client.SnakebiteHdfsClient()
     if configured_client == "snakebite_with_hadoopcli_fallback":
@@ -44,10 +44,14 @@ def get_autoconfig_client(show_warnings=True):
         return hdfs_hadoopcli_clients.create_hadoopcli_client()
     raise Exception("Unknown hdfs client " + hdfs_config.get_configured_hdfs_client())
 
-# Suppress warnings so that importing luigi.contrib.hdfs doesn't show a deprecated warning.
-client = get_autoconfig_client(show_warnings=False)
-exists = client.exists
-rename = client.rename
-remove = client.remove
-mkdir = client.mkdir
-listdir = client.listdir
+
+def _with_ac(method_name):
+    def result(*args, **kwargs):
+        return getattr(get_autoconfig_client(), method_name)(*args, **kwargs)
+    return result
+
+exists = _with_ac('exists')
+rename = _with_ac('rename')
+remove = _with_ac('remove')
+mkdir = _with_ac('mkdir')
+listdir = _with_ac('listdir')

--- a/luigi/contrib/hdfs/config.py
+++ b/luigi/contrib/hdfs/config.py
@@ -72,7 +72,7 @@ def get_configured_hadoop_version():
     return hadoopcli().version.lower()
 
 
-def get_configured_hdfs_client(show_warnings=True):
+def get_configured_hdfs_client():
     """
     This is a helper that fetches the configuration value for 'client' in
     the [hdfs] section. It will return the client that retains backwards
@@ -85,12 +85,11 @@ def get_configured_hdfs_client(show_warnings=True):
         "snakebite",
     ]
     if six.PY3 and (custom in conf_usinf_snakebite):
-        if show_warnings:
-            warnings.warn(
-                "snakebite client not compatible with python3 at the moment"
-                "falling back on hadoopcli",
-                stacklevel=2
-            )
+        warnings.warn(
+            "snakebite client not compatible with python3 at the moment"
+            "falling back on hadoopcli",
+            stacklevel=2
+        )
         return "hadoopcli"
     return custom
 

--- a/test/minicluster.py
+++ b/test/minicluster.py
@@ -52,7 +52,7 @@ class MiniClusterTestCase(unittest.TestCase):
             cls.cluster.terminate()
 
     def setUp(self):
-        self.fs = luigi.contrib.hdfs.client
+        self.fs = luigi.contrib.hdfs.get_autoconfig_client()
         cfg_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "testconfig")
         hadoop_bin = os.path.join(os.environ['HADOOP_HOME'], 'bin/hadoop')
         cmd = "{} --config {}".format(hadoop_bin, cfg_path)


### PR DESCRIPTION
This patch makes two related changes. It removes luigi.contrib.client
and turns the functions luigi.contrib.{exists,remove,...} into
functions that creates a new autoconfigured hdfs client for each
invocation.

The problem with the luigi.contrib.client convenience object is that it
requires effects when you load the module. That is bad not only because
of the side effects, but it also means that it'll ignore command line
parameters. That is considered a bug. It'll mean that for example
`--hdfs-client hadoopcli` will not be honored. This is also why I
lazified the file system operations, so that the configs are read after
the command line parameters have been parsed (as opposed to at module
load time)