### PR TITLE
Add main module for luigi package

### DIFF
--- a/luigi/__main__.py
+++ b/luigi/__main__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from luigi.cmdline import luigi_run
+
+if __name__ == '__main__':
+    luigi_run()

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -170,6 +170,12 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self._run_cmdline(args)
         self.assertTrue(t.exists())
 
+    def test_python_module(self):
+        t = luigi.LocalTarget(is_tmp=True)
+        args = ['python', '-m', 'luigi', '--module', 'cmdline_test', 'WriteToFile', '--filename', t.path, '--local-scheduler', '--no-lock']
+        self._run_cmdline(args)
+        self.assertTrue(t.exists())
+
     def test_direct_python_help(self):
         returncode, stdout, stderr = self._run_cmdline(['python', 'test/cmdline_test.py', '--help'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
@@ -185,6 +191,11 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertFalse(stdout.find(b'--x') != -1)
 
+    def test_python_module_luigi_help(self):
+        returncode, stdout, stderr = self._run_cmdline(['python', '-m', 'luigi', '--module', 'cmdline_test', '--help'])
+        self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
+        self.assertFalse(stdout.find(b'--x') != -1)
+
     def test_bin_luigi_help_no_module(self):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--help'])
         self.assertTrue(stdout.find(b'usage:') != -1)
@@ -193,8 +204,17 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi'])
         self.assertTrue(stderr.find(b'No task specified') != -1)
 
+    def test_python_module_luigi_no_parameters(self):
+        returncode, stdout, stderr = self._run_cmdline(['python', '-m', 'luigi'])
+        self.assertTrue(stderr.find(b'No task specified') != -1)
+
     def test_bin_luigi_help_class(self):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', 'FooBaseClass', '--help'])
+        self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
+        self.assertTrue(stdout.find(b'--x') != -1)
+
+    def test_python_module_help_class(self):
+        returncode, stdout, stderr = self._run_cmdline(['python', '-m', 'luigi', '--module', 'cmdline_test', 'FooBaseClass', '--help'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertTrue(stdout.find(b'--x') != -1)
 


### PR DESCRIPTION
I have an issue launching luigi jobs in development environment.

The purpose of this PR better to describe on an example:
```
$ pwd
/home/e.iskandarov/workspace/mario-jobs
$ ls mario_jobs
common.py  false_positive  __init__.py  return_path  sort_out_inbox_senders  tests
$ luigi --module mario_jobs.false_positive FalsePositiveLauncher --site=mail.ru --local-scheduler
Traceback (most recent call last):
  File "/home/e.iskandarov/.virtualenvs/luigi/bin/luigi", line 9, in <module>
    load_entry_point('luigi==1.3.0', 'console_scripts', 'luigi')()
  File "/home/e.iskandarov/.virtualenvs/luigi/lib/python2.7/site-packages/luigi/cmdline.py", line 13, in luigi_run
    luigi.interface.run(argv, use_dynamic_argparse=True)
  File "/home/e.iskandarov/.virtualenvs/luigi/lib/python2.7/site-packages/luigi/interface.py", line 421, in run
    tasks = interface.parse(cmdline_args, main_task_cls=main_task_cls)
  File "/home/e.iskandarov/.virtualenvs/luigi/lib/python2.7/site-packages/luigi/interface.py", line 329, in parse
    __import__(module)
ImportError: No module named mario_jobs.false_positive
```

This happened because in that case current working directory was not in `PYTHONPATH`.

To overcome this problem I add `__main__` module for `luigi` package and it works perfectly fine for development purposes.

```
$ python -m luigi --module mario_jobs.false_positive FalsePositiveLauncher --site=mail.ru --local-scheduler
DEBUG Checking if FalsePositiveLauncher(site=mail.ru) is complete
...
```