### PR TITLE
tests: Start using LuigiTestCase

### DIFF
--- a/test/_test_ftp.py
+++ b/test/_test_ftp.py
@@ -18,7 +18,7 @@
 import datetime
 import ftplib
 import os
-from helpers import unittest
+from helpers import unittest, LuigiTestCase
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -36,7 +36,7 @@ USER = "luigi"
 PWD = "some_password"
 
 
-class TestFTPFilesystem(unittest.TestCase):
+class TestFTPFilesystem(LuigiTestCase):
 
     def setUp(self):
         """ Creates structure
@@ -89,7 +89,7 @@ class TestFTPFilesystem(unittest.TestCase):
         self.assertFalse("test" in list_dir)
 
 
-class TestFTPFilesystemUpload(unittest.TestCase):
+class TestFTPFilesystemUpload(LuigiTestCase):
 
     def test_single(self):
         """ Test upload file with creation of intermediate folders """
@@ -119,7 +119,7 @@ class TestFTPFilesystemUpload(unittest.TestCase):
         ftp.close()
 
 
-class TestRemoteTarget(unittest.TestCase):
+class TestRemoteTarget(LuigiTestCase):
 
     def test_put(self):
         """ Test RemoteTarget put method with uploading to an FTP """

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -18,9 +18,9 @@
 import luigi
 import tempfile
 import shlex
-from helpers import unittest
 from luigi.contrib.hadoop_jar import HadoopJarJobError, HadoopJarJobTask
 from mock import patch
+from helpers import LuigiTestCase
 
 
 class TestHadoopJarJob(HadoopJarJobTask):
@@ -48,7 +48,7 @@ class TestRemoteHadoopJarTwoParamJob(TestRemoteHadoopJarJob):
     param2 = luigi.Parameter()
 
 
-class HadoopJarJobTaskTest(unittest.TestCase):
+class HadoopJarJobTaskTest(LuigiTestCase):
     @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
     def test_good(self, mock_job):
         mock_job.return_value = None

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -18,7 +18,6 @@
 import os
 import sys
 import json
-import unittest
 
 import luigi
 import luigi.format
@@ -30,6 +29,7 @@ import minicluster
 import mock
 from luigi.mock import MockTarget
 from nose.plugins.attrib import attr
+from helpers import LuigiTestCase
 
 luigi.notifications.DEBUG = True
 
@@ -246,7 +246,7 @@ class CommonTests(object):
         test_case.assertFalse(success)
 
 
-class MapreduceLocalTest(unittest.TestCase):
+class MapreduceLocalTest(LuigiTestCase):
     use_hdfs = False
 
     def run_and_check(self, args):
@@ -312,7 +312,7 @@ class MapreduceIntegrationTest(minicluster.MiniClusterTestCase):
         CommonTests.test_failing_job(self)
 
 
-class CreatePackagesArchive(unittest.TestCase):
+class CreatePackagesArchive(LuigiTestCase):
 
     def setUp(self):
         sys.path.append(os.path.join('test', 'create_packages_archive_root'))

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -15,15 +15,15 @@
 # limitations under the License.
 #
 
-from helpers import unittest
 import os
 import luigi
 import luigi.contrib.hdfs
 from luigi import six
 from luigi.mock import MockTarget
-from helpers import with_config
+from helpers import with_config, LuigiTestCase
 from luigi.contrib.spark import SparkJobError, SparkSubmitTask, PySparkTask, PySpark1xJob, Spark1xJob, SparkJob
 from mock import patch, MagicMock
+
 
 BytesIO = six.BytesIO
 
@@ -136,7 +136,7 @@ class TestPySpark1xJob(PySpark1xJob):
         return luigi.LocalTarget('output')
 
 
-class SparkSubmitTaskTest(unittest.TestCase):
+class SparkSubmitTaskTest(LuigiTestCase):
     ss = 'ss-stub'
 
     @with_config({'spark': {'spark-submit': ss, 'master': "yarn-client", 'hadoop-conf-dir': 'path'}})
@@ -202,7 +202,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
         proc.return_value.kill.check_called()
 
 
-class PySparkTaskTest(unittest.TestCase):
+class PySparkTaskTest(LuigiTestCase):
     ss = 'ss-stub'
 
     @with_config({'spark': {'spark-submit': ss, 'master': "spark://host:7077"}})
@@ -236,7 +236,7 @@ class PySparkTaskTest(unittest.TestCase):
         sc.textFile.return_value.saveAsTextFile.assert_called_with('output')
 
 
-class SparkJobTest(unittest.TestCase):
+class SparkJobTest(LuigiTestCase):
     hcd = 'hcd-stub'
     ycd = 'ycd-stub'
     sj = 'sj-stub'
@@ -268,7 +268,7 @@ class SparkJobTest(unittest.TestCase):
             self.fail("Should have thrown SparkJobError")
 
 
-class Spark1xTest(unittest.TestCase):
+class Spark1xTest(LuigiTestCase):
     ss = 'ss-stub'
 
     @with_config({'spark': {'spark-submit': ss}})
@@ -295,7 +295,7 @@ class Spark1xTest(unittest.TestCase):
             self.fail("Should have thrown SparkJobError")
 
 
-class PySpark1xTest(unittest.TestCase):
+class PySpark1xTest(LuigiTestCase):
     ss = 'ss-stub'
 
     @with_config({'spark': {'spark-submit': ss}})

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -31,6 +31,7 @@ import sqlalchemy
 from luigi.contrib import sqla
 from luigi.mock import MockFile
 from nose.plugins.attrib import attr
+from helpers import LuigiTestCase
 
 if six.PY3:
     unicode = str
@@ -51,7 +52,7 @@ class BaseTask(luigi.Task):
 
 
 @attr('sqlalchemy')
-class TestSQLA(unittest.TestCase):
+class TestSQLA(LuigiTestCase):
     NUM_WORKERS = 1
 
     def _clear_tables(self):

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -16,13 +16,13 @@
 #
 
 import datetime
-from helpers import unittest
+from helpers import unittest, LuigiTestCase
 
 import luigi
 from luigi.parameter import DateIntervalParameter as DI
 
 
-class DateIntervalTest(unittest.TestCase):
+class DateIntervalTest(LuigiTestCase):
 
     def test_date(self):
         di = DI().parse('2012-01-01')

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from helpers import unittest
+from helpers import unittest, LuigiTestCase
 
 from luigi import six
 
@@ -34,7 +34,7 @@ class ParamTask(luigi.Task):
     param2 = luigi.IntParameter()
 
 
-class DbTaskHistoryTest(unittest.TestCase):
+class DbTaskHistoryTest(LuigiTestCase):
 
     @with_config(dict(task_history=dict(db_connection='sqlite:///:memory:')))
     def setUp(self):
@@ -84,7 +84,7 @@ class DbTaskHistoryTest(unittest.TestCase):
         self.history.task_finished(task.task_id, successful=True)
 
 
-class MySQLDbTaskHistoryTest(unittest.TestCase):
+class MySQLDbTaskHistoryTest(LuigiTestCase):
 
     @with_config(dict(task_history=dict(db_connection='mysql+mysqlconnector://travis@localhost/luigi_test')))
     def setUp(self):

--- a/test/factorial_test.py
+++ b/test/factorial_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from helpers import unittest
+from helpers import LuigiTestCase
 
 import luigi
 
@@ -43,7 +43,7 @@ class Factorial(luigi.Task):
         return False
 
 
-class FactorialTest(unittest.TestCase):
+class FactorialTest(LuigiTestCase):
 
     def test_invoke(self):
         luigi.build([Factorial(100)], local_scheduler=True)

--- a/test/minicluster.py
+++ b/test/minicluster.py
@@ -21,6 +21,7 @@ import os
 import luigi.contrib.hadoop
 import luigi.contrib.hdfs
 from nose.plugins.attrib import attr
+from helpers import LuigiTestCase
 
 import unittest
 
@@ -31,7 +32,7 @@ except ImportError:
 
 
 @attr('minicluster')
-class MiniClusterTestCase(unittest.TestCase):
+class MiniClusterTestCase(LuigiTestCase):
 
     """ Base class for test cases that rely on Hadoop's minicluster functionality. This
     in turn depends on Snakebite's minicluster setup:

--- a/test/task_history_test.py
+++ b/test/task_history_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from helpers import unittest
+from helpers import unittest, LuigiTestCase
 
 import luigi
 import luigi.scheduler
@@ -40,7 +40,7 @@ class SimpleTaskHistory(luigi.task_history.TaskHistory):
         self.actions.append(('started', task_id))
 
 
-class TaskHistoryTest(unittest.TestCase):
+class TaskHistoryTest(LuigiTestCase):
 
     def setUp(self):
         self.th = SimpleTaskHistory()


### PR DESCRIPTION
It's required for spotify/luigi#1182 since from that PR an on all tasks
need to be instantiated in a context where command line parameters have
already been parsed, and LuigiTestCase will provide an "empty" parsing
context.