### PR TITLE
Log underlying RPC exception.

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -130,6 +130,7 @@ class RemoteScheduler(Scheduler):
                 last_exception = e
                 if log_exceptions:
                     logger.exception("Failed connecting to remote scheduler %r", self._url)
+                    logger.exception(e)
                 continue
         else:
             raise RPCError(


### PR DESCRIPTION
Trying to get more visibility into `RPCError`... and it seems we don't log the underlying exception, thereby hiding the details which would be useful for debugging these.

```
HTTPError: 500 Server Error: Internal Server Error
Traceback (most recent call last):
  File "/apps/production/enterprise/current/enterprise/jobs/twitterads.py", line 55, in <module>
    luigi.run(main_task_cls=TwitterAdsBootstrap)
  File "/apps/production/enter
prise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/interface.py", line 331, in run
    return _schedule_and_run(tasks, worker_scheduler_factory)
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/interface.py", line 184, in _schedule_and_run
    success &= w.run()
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/worker.py", line 756, in run
    self._handle_next_task()
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/worker.py", line 686, in _handle_next_task
    assistant=self._assistant)
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/worker.py", line 359, in _add_task
    self._scheduler.add_task(*args, **kwargs)
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/rpc.py", line 169, in add_task
    'assistant': assistant,
  File "/apps/production/
enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/rpc.py", line 145, in _request
    page = self._fetch(url, body, log_exceptions, attempts)
  File "/apps/production/enterprise/virtualenvs/enterprise/local/lib/python2.7/site-packages/luigi/rpc.py", line 138, in _fetch
    last_exception
luigi.rpc.RPCError: Errors (3 attempts) when connecting to remote scheduler 'http://127.0.0.1:12300'
```