### PR TITLE
Fixing escape for null sequence in postgres COPY FROM

### DIFF
--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -258,7 +258,7 @@ class CopyToTable(rdbms.CopyToTable):
         Default behaviour is to escape special characters and identify any self.null_values.
         """
         if value in self.null_values:
-            return r'\N'
+            return r'\\N'
         else:
             return default_escape(six.text_type(value))
 
@@ -286,7 +286,7 @@ class CopyToTable(rdbms.CopyToTable):
             column_names = [c[0] for c in self.columns]
         else:
             raise Exception('columns must consist of column strings or (column string, type string) tuples (was %r ...)' % (self.columns[0],))
-        cursor.copy_from(file, self.table, null=r'\N', sep=self.column_separator, columns=column_names)
+        cursor.copy_from(file, self.table, null=r'\\N', sep=self.column_separator, columns=column_names)
 
     def run(self):
         """

--- a/test/postgres_with_server_test.py
+++ b/test/postgres_with_server_test.py
@@ -81,6 +81,7 @@ class TestPostgresTask(CopyToTestDB):
         yield None, '-100', '5143.213'
         yield '\t\n\r\\N', 0, 0
         yield u'éцү我', 0, 0
+        yield '', 0, r'\N'  # Test working default null charcter
 
 
 class MetricBase(CopyToTestDB):
@@ -139,6 +140,7 @@ class TestPostgresImportTask(unittest.TestCase):
             (None, -100, 5143.213),
             ('\t\n\r\\N', 0.0, 0),
             (u'éцү我', 0, 0),
+            (u'', 0, None),  # Test working default null charcter
         ))
 
     def test_multimetric(self):


### PR DESCRIPTION
copy_from (and as such the whole CopyTable class in postgres) doesn't work because \N isn't recognized as null sequence. Adding a second backslash fixes this. 
It should be possible to choose an own null-sequence anyway when using CopyTable..