### PR TITLE
None (null) becomes 'None' (string) when yielding a task.

### DIFF
--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -25,6 +25,7 @@ import luigi.interface
 import luigi.notifications
 from luigi.mock import MockTarget
 from luigi.parameter import ParameterException
+from luigi.worker import Worker
 from worker_test import email_patch
 
 luigi.notifications.DEBUG = True
@@ -688,3 +689,45 @@ class TestTaskParameter(LuigiTestCase):
         self.assertEqual(MetaTask.saved_value, MetaTask)
         self.assertTrue(luigi.run(['--local-scheduler', '--no-lock'] + 'mynamespace.MetaTask --a other_namespace.OtherTask'.split()))
         self.assertEqual(MetaTask.saved_value, OtherTask)
+
+
+class ForNone(luigi.Task):
+    p = luigi.Parameter(default=None)
+    has_run = False
+
+    def run(self):
+        if self.p == 'None':
+            raise Exception("None was passed as string 'None'")
+        self.has_run = True
+
+    def complete(self):
+        return self.has_run
+
+class AForNone(ForNone):
+    method = luigi.Parameter()
+
+class BForNoneYieldVersion(ForNone):
+    def run(self):
+        yield AForNone(p=None, method='yield')
+
+    def requires(self):
+        return []
+
+class BForNoneRequiresVersion(ForNone):
+    def requires(self):
+        return [AForNone(p=None, method='requires')]
+
+
+class NoneParameterPassed(unittest.TestCase):
+
+    def test_none_parameter_with_yield(self):
+        w = Worker()
+        w.add(BForNoneYieldVersion())
+        w.run()
+        self.assertTrue(w.run_succeeded)
+
+    def test_none_parameter_with_requires(self):
+        w = Worker()
+        w.add(BForNoneRequiresVersion())
+        w.run()
+        self.assertTrue(w.run_succeeded)


### PR DESCRIPTION
When you yield a task with a parameter value of None (null) the new task has the parameter value of 'None' (string).  

If you return a task in the requires method with a parameter of None (null) that gets passed as None (null), which seems like the correct behaviour.  
