### PR TITLE
Revert exception pickling

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -128,8 +128,6 @@ class TaskProcess(multiprocessing.Process):
         expl = ''
         missing = []
         new_deps = []
-        exception = None
-
         try:
             # Verify that all the tasks are fulfilled!
             missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]
@@ -169,19 +167,16 @@ class TaskProcess(multiprocessing.Process):
             logger.exception("[pid %s] Worker %s failed    %s", os.getpid(), self.worker_id, self.task)
             self.task.trigger_event(Event.FAILURE, self.task, ex)
             subject = "Luigi: %s FAILED" % self.task
-            exception = ex
 
             raw_error_message = self.task.on_failure(ex)
             notification_error_message = notifications.wrap_traceback(raw_error_message)
             expl = json.dumps(raw_error_message)
-
             formatted_error_message = notifications.format_task_error(subject, self.task,
                                                                       formatted_exception=notification_error_message)
             notifications.send_error_email(subject, formatted_error_message, self.task.owner_email)
         finally:
-            # multiprocessing.Queue will pickle it
-            self.result_queue.put((
-                self.task.task_id, status, expl, missing, new_deps, exception))
+            self.result_queue.put(
+                (self.task.task_id, status, expl, missing, new_deps))
 
     def _recursive_terminate(self):
         import psutil
@@ -331,7 +326,7 @@ class Worker(object):
     * asks for stuff to do (pulls it in a loop and runs it)
     """
 
-    def __init__(self, scheduler=None, worker_id=None, worker_processes=1, assistant=False, raise_on_error=False, **kwargs):
+    def __init__(self, scheduler=None, worker_id=None, worker_processes=1, assistant=False, **kwargs):
         if scheduler is None:
             scheduler = CentralPlannerScheduler()
 
@@ -373,9 +368,6 @@ class Worker(object):
         # Stuff for execution_summary
         self._add_task_history = []
         self._get_work_response_history = []
-
-        # whether to raise when a task throws an exception
-        self._raise_on_error = raise_on_error
 
     def _add_task(self, *args, **kwargs):
         """
@@ -669,8 +661,7 @@ class Worker(object):
                 continue
 
             logger.info(error_msg)
-            self._task_result_queue.put(
-                (task_id, FAILED, error_msg, [], [], None))
+            self._task_result_queue.put((task_id, FAILED, error_msg, [], []))
 
     def _handle_next_task(self):
         """
@@ -685,7 +676,7 @@ class Worker(object):
             self._purge_children()  # Deal with subprocess failures
 
             try:
-                task_id, status, expl, missing, new_requirements, exception = (
+                task_id, status, expl, missing, new_requirements = (
                     self._task_result_queue.get(
                         timeout=self._config.wait_interval))
             except Queue.Empty:
@@ -719,9 +710,6 @@ class Worker(object):
             if status == RUNNING:
                 continue
             self._running_tasks.pop(task_id)
-
-            if status == FAILED and exception and self._raise_on_error:
-                raise exception
 
             # re-add task to reschedule missing dependencies
             if missing:

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -48,12 +48,9 @@ class SuccessTask(luigi.Task):
 
 
 class FailTask(luigi.Task):
-    def __init__(self):
-        super(FailTask, self).__init__()
-        self.ex = BaseException("Uh oh.")
 
     def run(self):
-        raise self.ex
+        raise BaseException("Uh oh.")
 
     def on_failure(self, exception):
         return "test failure expl"
@@ -88,7 +85,7 @@ class TaskProcessTest(unittest.TestCase):
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
-            mock_put.assert_called_once_with((task.task_id, DONE, json.dumps("test success expl"), [], None, None))
+            mock_put.assert_called_once_with((task.task_id, DONE, json.dumps("test success expl"), [], None))
 
     def test_update_result_queue_on_failure(self):
         task = FailTask()
@@ -97,7 +94,7 @@ class TaskProcessTest(unittest.TestCase):
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
-            mock_put.assert_called_once_with((task.task_id, FAILED, json.dumps("test failure expl"), [], [], task.ex))
+            mock_put.assert_called_once_with((task.task_id, FAILED, json.dumps("test failure expl"), [], []))
 
     def test_cleanup_children_on_terminate(self):
         """

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -192,11 +192,15 @@ class WorkerTest(unittest.TestCase):
         self.assertFalse(b.has_run)
 
     def test_fail(self):
+        class CustomException(BaseException):
+            def __init__(self, msg):
+                self.msg = msg
+
         class A(Task):
 
             def run(self):
                 self.has_run = True
-                raise Exception()
+                raise CustomException('bad things')
 
             def complete(self):
                 return self.has_run

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -111,7 +111,6 @@ class WorkerTest(unittest.TestCase):
         # InstanceCache.disable()
         self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         self.w = Worker(scheduler=self.sch, worker_id='X')
-        self.w_raise = Worker(scheduler=self.sch, worker_id='X_raise', raise_on_error=True)
         self.w2 = Worker(scheduler=self.sch, worker_id='Y')
         self.time = time.time
 
@@ -222,41 +221,6 @@ class WorkerTest(unittest.TestCase):
 
         self.assertTrue(self.w.add(b))
         self.assertFalse(self.w.run())
-
-        self.assertTrue(a.has_run)
-        self.assertFalse(b.has_run)
-
-    def test_fail_raised(self):
-        class A(Task):
-
-            def run(self):
-                self.has_run = True
-                raise BaseException()
-
-            def complete(self):
-                return self.has_run
-
-        a = A()
-
-        class B(Task):
-
-            def requires(self):
-                return a
-
-            def run(self):
-                self.has_run = True
-
-            def complete(self):
-                return self.has_run
-
-        b = B()
-
-        a.has_run = False
-        b.has_run = False
-
-        self.assertTrue(self.w_raise.add(b))
-        with self.assertRaises(BaseException):
-            self.w_raise.run()
 
         self.assertTrue(a.has_run)
         self.assertFalse(b.has_run)


### PR DESCRIPTION
This reverts #1205 in order to resolve #1227. WorkerTest.test_fail is also modified such that it fails without the reversion.