### PR TITLE
Uses popovers instead of tooltips for svg graph

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -180,14 +180,15 @@ Graph = (function() {
                 .attr("data-task-id", node.taskId)
                 .appendTo(g);
 
-            var titleText = node.taskId;
+            var titleText = node.name;
+            var content = $.map(node.params, function (value, name) { return name + ": " + value; }).join("<br>");
             g.attr("title", titleText)
-                .tooltip({
+                .popover({
+                    trigger: 'hover',
                     container: 'body',
                     html: true,
-                    title: function() {
-                        return $(this).prop('title');
-                    }
+                    placement: 'top',
+                    content: content
                 });
         });
 


### PR DESCRIPTION
The graph tooltips don't display very well for long names. This splits up the
names and puts them in a popover for a nicer display.

Before:
![screen shot 2015-09-18 at 3 28 06 pm](https://cloud.githubusercontent.com/assets/2091885/9972524/2645fa62-5e1a-11e5-96d4-5d917363430d.png)

After:
![screen shot 2015-09-18 at 3 28 32 pm](https://cloud.githubusercontent.com/assets/2091885/9972529/2dc926ce-5e1a-11e5-90ac-3c32024d405d.png)

The only downside is that the params appear in arbitrary order, but this could be fixed by sending the right order from the scheduler if it bugs anyone enough.