### PR TITLE
Fix examples: foo_complex.py luigi run arguments to include task namespace

### DIFF
--- a/examples/foo_complex.py
+++ b/examples/foo_complex.py
@@ -73,4 +73,4 @@ if __name__ == "__main__":
     if os.path.exists('/tmp/bar'):
         shutil.rmtree('/tmp/bar')
 
-    luigi.run(['--task', 'Foo', '--workers', '2'])
+    luigi.run(['examples.Foo', '--workers', '2', '--local-scheduler'])

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,0 +1,11 @@
+import luigi
+
+
+class HelloWorldTask(luigi.Task):
+    task_namespace = 'examples'
+
+    def run(self):
+        print("{task} says: Hello world!".format(task=self.__class__.__name__))
+
+if __name__ == '__main__':
+    luigi.run(['examples.HelloWorldTask', '--workers', '1', '--local-scheduler'])


### PR DESCRIPTION
Fixes run arguments in `foo_complex.py` example