### PR TITLE
Use default number of attempts (3) for get_work rpc method.

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -147,7 +147,7 @@ class RemoteScheduler(Scheduler):
         return result["response"]
 
     def ping(self, worker):
-        # just one attemtps, keep-alive thread will keep trying anyway
+        # just one attempt, keep-alive thread will keep trying anyway
         self._request('/api/ping', {'worker': worker}, attempts=1)
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
@@ -172,9 +172,7 @@ class RemoteScheduler(Scheduler):
     def get_work(self, worker, host=None, assistant=False):
         return self._request(
             '/api/get_work',
-            {'worker': worker, 'host': host, 'assistant': assistant},
-            log_exceptions=False,
-            attempts=1)
+            {'worker': worker, 'host': host, 'assistant': assistant})
 
     def graph(self):
         return self._request('/api/graph', {})


### PR DESCRIPTION
Our workers die from time to time because of:
```
luigi.rpc.RPCError: Errors (1 attempts) when connecting to remote scheduler 'localhost'
```

This happens a lot more often when calling the `get_work` method than other RPC methods. Unlike all other RPC methods, `get_work` uses only one retry attempt and I don't really understand if there's a reason for it. I suspect additional two attempts were unintentionally cut off in 725172e3d8d970a505931a2556cda9a235dd2373