### PR TITLE
fix pickling for HdfsTarget

### DIFF
--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -19,6 +19,7 @@ import functools
 import re
 from helpers import unittest
 import random
+import pickle
 
 import helpers
 import luigi
@@ -449,6 +450,10 @@ class HdfsTargetTests(MiniClusterTestCase, FileSystemTargetTestMixin):
     def test_tmppath_username(self):
         self.assertRegexpMatches(hdfs.tmppath('/path/to/stuff', include_unix_username=True),
                                  "^/tmp/[a-z0-9_]+/path/to/stuff-luigitemp-\d+")
+
+    def test_pickle(self):
+        t = hdfs.HdfsTarget("/tmp/dir")
+        pickle.dumps(t)
 
 
 @attr('minicluster')


### PR DESCRIPTION
A simple HdfsTarget instance no longer is pickleable due to instance methods being stored as attributes on CompatibleHdfsFormat (since aab71dac71091e8794e235358caeafb7240a648a).

We have some scenarios where an HdfsTarget is stored as an attribute on a hadoop task instance, which then must be pickled to submit the job to the cluster.