### PR TITLE
prevent infinite recursion for _input_pipe and _output_pipe

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -144,7 +144,7 @@ class InputPipeProcessWrapper(object):
             self._finish()
 
     def __getattr__(self, name):
-        if name == '_process':
+        if name in ['_process', '_input_pipe']:
             raise AttributeError(name)
         try:
             return getattr(self._process.stdout, name)
@@ -225,7 +225,7 @@ class OutputPipeProcessWrapper(object):
         self._finish()
 
     def __getattr__(self, name):
-        if name == '_process':
+        if name in ['_process', '_output_pipe']:
             raise AttributeError(name)
         try:
             return getattr(self._process.stdin, name)

--- a/test/contrib/test_ssh.py
+++ b/test/contrib/test_ssh.py
@@ -27,7 +27,7 @@ import subprocess
 from helpers import unittest
 import target_test
 
-from luigi.contrib.ssh import RemoteContext, RemoteFileSystem, RemoteTarget
+from luigi.contrib.ssh import RemoteContext, RemoteFileSystem, RemoteTarget, RemoteCalledProcessError
 from luigi.target import MissingParentDirectory, FileAlreadyExists
 
 working_ssh_host = os.environ.get('SSH_TEST_HOST', 'localhost')
@@ -190,6 +190,14 @@ class TestRemoteFilesystem(unittest.TestCase):
             pass
 
         self.assertEquals([self.target.path], list(self.fs.listdir(self.directory)))
+
+
+class TestGetAttrRecursion(unittest.TestCase):
+    def test_recursion_on_delete(self):
+        target = RemoteTarget("/etc/this/does/not/exist", working_ssh_host)
+        with self.assertRaises(RemoteCalledProcessError):
+            with target.open('w') as fh:
+                fh.write("test")
 
 
 class TestRemoteTargetAtomicity(unittest.TestCase, target_test.FileSystemTargetTestMixin):


### PR DESCRIPTION
Basically, the same problem corrected for _process in 9f6c33f5c9247e931e9993f1146632d2f651d63a

This can be exposed by trying to use luigi.contrib.ssh.RemoteTarget to upload to a nested directory without permissions to create the dirname of the path, such as the following, as a user without write access to "/etc" on the remote host.

luigi.contrib.ssh.RemoteTarget("/etc/this/fails", hostname)