### PR TITLE
worker.py: Remove unnecessary (== RUNNING) check

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -47,7 +47,7 @@ from luigi import six
 from luigi import notifications
 from luigi.event import Event
 from luigi.task_register import load_task
-from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, RUNNING, SUSPENDED, CentralPlannerScheduler
+from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, SUSPENDED, CentralPlannerScheduler
 from luigi.target import Target
 from luigi.task import Task, flatten, getpaths, Config
 from luigi.task_register import TaskClassException
@@ -707,8 +707,6 @@ class Worker(object):
                            new_deps=new_deps,
                            assistant=self._assistant)
 
-            if status == RUNNING:
-                continue
             self._running_tasks.pop(task_id)
 
             # re-add task to reschedule missing dependencies


### PR DESCRIPTION
It must be from old times or something. RUNNING is only a concept of
luigid, you never add_task(status=RUNNING) so to say.  The status is
taken from the task queue, and the task queue is of course only
populated from the client.