### PR TITLE
Deprecate SUSPENDED status

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -389,10 +389,6 @@ class SimpleTaskState(object):
         if new_status == FAILED:
             assert config is not None
 
-        # not sure why we have SUSPENDED, as it can never be set
-        if new_status == SUSPENDED:
-            new_status = PENDING
-
         if new_status == DISABLED and task.status == RUNNING:
             return
 
@@ -619,7 +615,7 @@ class CentralPlannerScheduler(Scheduler):
         if expl is not None:
             task.expl = expl
 
-        if not (task.status == RUNNING and status == PENDING):
+        if not (task.status == RUNNING and status == PENDING) or new_deps:
             # don't allow re-scheduling of task while it is running, it must either fail or succeed first
             if status == PENDING or status != task.status:
                 # Update the DB only if there was a acctual change, to prevent noise.

--- a/luigi/task_status.py
+++ b/luigi/task_status.py
@@ -22,6 +22,6 @@ PENDING = 'PENDING'
 FAILED = 'FAILED'
 DONE = 'DONE'
 RUNNING = 'RUNNING'
-SUSPENDED = 'SUSPENDED'
+SUSPENDED = 'SUSPENDED'  # Only kept for backward compatibility with old clients
 UNKNOWN = 'UNKNOWN'
 DISABLED = 'DISABLED'


### PR DESCRIPTION
The reason is just to simplify the code, it's confusing when there are
so many statuses. And it's not obvious at all how it's utilized and that
it's only associated with the new_deps parameter.

This makes so new clients will not send the status SUSPENDED. Server
will still just convert it to PENDING as previously.

Hence, it will work for "old client new server", but not vice verse.