### PR TITLE
Parameter hook

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -27,7 +27,6 @@ except ImportError:
 import logging
 import traceback
 import warnings
-from collections import OrderedDict
 
 from luigi import six
 


### PR DESCRIPTION
This PR addresses issue #1253. It adds a classmethod ``param_hook`` to ``Task`` to allow for composition of parameters in accordance with instance caching.

The example use case in #1253 becomes:

```python
class A(Task):
    log = Parameter(default="/var/log.txt")

class B(Task):
    logPath = Parameter(default="~/")

class C(A, B):
    logFile = Parameter(default="log.txt")

    @classmethod
    def param_hook(cls, result, args, kwargs):
        log = os.path.join(result["logPath"], result["logFile"])
        # now, we can either set a default log value
        result.setdefault("log", log)
        # or force it
        result["log"] = log
```