### PR TITLE
Removes status selectors from graph and worker viz tabs

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -347,6 +347,9 @@
 
         <div class="content-wrapper">
           <div class="content">
+
+        <div class="tab-content">
+            <section id="taskList" class="container-fluid tab-pane active">
                 <div class="row">
                   <div class="col-md-3 col-sm-6 col-xs-12">
                     <div class="info-box" data-color='yellow' data-category='PENDING' id="PENDING_info">
@@ -423,9 +426,6 @@
                   <div id="currentFilter" class="col-md-6 col-sm-12 col-xs-12"></div>
                   <div id="warnings" class="col-md-6 col-sm-12 col-xs-12"></div>
                 </div>
-
-        <div class="tab-content">
-            <section id="taskList" class="container-fluid tab-pane active">
                 <div class="col-md-8 col-md-offset-2">
                     <div id="checkboxes"></div>
                 </div>


### PR DESCRIPTION
The status selectors aren't used on these tabs, so they serve only to confuse.