### PR TITLE
tests: Rename assertEquals --> assertEqual

### DIFF
--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -224,12 +224,12 @@ class NewStyleParameters822Test(unittest.TestCase):
 
     @parsing(['FooSubClass', '--x', 'xyz', '--FooBaseClass-x', 'xyz'])
     def test_subclasses(self):
-        self.assertEquals(FooSubClass().x, 'xyz')
+        self.assertEqual(FooSubClass().x, 'xyz')
 
     @parsing(['FooBaseClass', '--FooBaseClass-x', 'xyz'])
     def test_subclasses_2(self):
         # https://github.com/spotify/luigi/issues/822#issuecomment-77782714
-        self.assertEquals(FooBaseClass().x, 'xyz')
+        self.assertEqual(FooBaseClass().x, 'xyz')
 
 
 if __name__ == '__main__':

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -99,7 +99,7 @@ class GCSClientTest(_GCSBaseTestCase):
     def test_download(self):
         self.client.put_string('hello', bucket_url('test_download'))
         fp = self.client.download(bucket_url('test_download'))
-        self.assertEquals(b'hello', fp.read())
+        self.assertEqual(b'hello', fp.read())
 
     def test_rename(self):
         self.client.put_string('hello', bucket_url('test_rename_1'))
@@ -151,7 +151,7 @@ class GCSClientTest(_GCSBaseTestCase):
 
             self.client.put(fp.name, bucket_url('test_put_file'))
             self.assertTrue(self.client.exists(bucket_url('test_put_file')))
-            self.assertEquals(big, self.client.download(bucket_url('test_put_file')).read())
+            self.assertEqual(big, self.client.download(bucket_url('test_put_file')).read())
 
 
 @attr('gcloud')

--- a/test/contrib/test_ssh.py
+++ b/test/contrib/test_ssh.py
@@ -189,7 +189,7 @@ class TestRemoteFilesystem(unittest.TestCase):
         with self.target.open('w'):
             pass
 
-        self.assertEquals([self.target.path], list(self.fs.listdir(self.directory)))
+        self.assertEqual([self.target.path], list(self.fs.listdir(self.directory)))
 
 
 class TestGetAttrRecursion(unittest.TestCase):

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -66,7 +66,7 @@ class DateIntervalTest(unittest.TestCase):
         self.assertEqual(di.dates(), [datetime.date(2012, 1, 1) + datetime.timedelta(i) for i in range(31)])
         self.assertRaises(NotImplementedError, di.next)
         self.assertRaises(NotImplementedError, di.prev)
-        self.assertEquals(di.to_string(), '2012-01-01-2012-02-01')
+        self.assertEqual(di.to_string(), '2012-01-01-2012-02-01')
 
     def test_exception(self):
         self.assertRaises(ValueError, DI().parse, 'xyz')
@@ -106,7 +106,7 @@ class DateIntervalTest(unittest.TestCase):
         task = MyTask(di=month)
         self.assertEqual(task.di, month)
         task = MyTask(other)
-        self.assertNotEquals(task.di, month)
+        self.assertNotEqual(task.di, month)
 
         def fail1():
             return MyTaskNoDefault()
@@ -117,7 +117,7 @@ class DateIntervalTest(unittest.TestCase):
 
     def test_hours(self):
         d = DI().parse('2015')
-        self.assertEquals(len(list(d.hours())), 24 * 365)
+        self.assertEqual(len(list(d.hours())), 24 * 365)
 
     def test_cmp(self):
         operators = [lambda x, y: x == y,
@@ -135,6 +135,6 @@ class DateIntervalTest(unittest.TestCase):
         for from_a, to_a, di_a in dates:
             for from_b, to_b, di_b in dates:
                 for op in operators:
-                    self.assertEquals(
+                    self.assertEqual(
                         op((from_a, to_a), (from_b, to_b)),
                         op(di_a, di_b))

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -180,7 +180,7 @@ class ParameterTest(LuigiTestCase):
     def test_forgot_param_in_dep(self, emails):
         # A programmatic missing parameter will cause an error email to be sent
         self.run_locally(['ForgotParamDep'])
-        self.assertNotEquals(emails, [])
+        self.assertNotEqual(emails, [])
 
     def test_default_param_cmdline(self):
         self.assertEqual(WithDefault().x, 'xyz')
@@ -240,7 +240,7 @@ class TestNewStyleGlobalParameters(LuigiTestCase):
         MockTarget.fs.clear()
 
     def expect_keys(self, expected):
-        self.assertEquals(set(MockTarget.fs.get_all_data().keys()), set(expected))
+        self.assertEqual(set(MockTarget.fs.get_all_data().keys()), set(expected))
 
     def test_x_arg(self):
         self.run_locally(['Banana', '--x', 'foo', '--y', 'bar', '--style', 'x-arg'])
@@ -639,11 +639,11 @@ class TestSerializeDateParameters(LuigiTestCase):
 
     def testSerialize(self):
         date = datetime.date(2013, 2, 3)
-        self.assertEquals(luigi.DateParameter().serialize(date), '2013-02-03')
-        self.assertEquals(luigi.YearParameter().serialize(date), '2013')
-        self.assertEquals(luigi.MonthParameter().serialize(date), '2013-02')
+        self.assertEqual(luigi.DateParameter().serialize(date), '2013-02-03')
+        self.assertEqual(luigi.YearParameter().serialize(date), '2013')
+        self.assertEqual(luigi.MonthParameter().serialize(date), '2013-02')
         dt = datetime.datetime(2013, 2, 3, 4, 5)
-        self.assertEquals(luigi.DateHourParameter().serialize(dt), '2013-02-03T04')
+        self.assertEqual(luigi.DateHourParameter().serialize(dt), '2013-02-03T04')
 
 
 class TestTaskParameter(LuigiTestCase):

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -57,7 +57,7 @@ class RemoteSchedulerTest(unittest.TestCase):
         with mock.patch.object(scheduler, '_fetcher') as fetcher:
             fetcher.raises = socket.timeout
             fetcher.fetch.side_effect = [socket.timeout, socket.timeout, '{"response":{}}']
-            self.assertEquals(scheduler.get_work("fake_worker"), {})
+            self.assertEqual(scheduler.get_work("fake_worker"), {})
 
 
 class RPCTest(central_planner_test.CentralPlannerTest, ServerTestBase):

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -245,14 +245,14 @@ class TestS3Client(unittest.TestCase):
         s3_client.put_string("", 's3://mybucket/hello/frank')
         s3_client.put_string("", 's3://mybucket/hello/world')
 
-        self.assertEquals(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
-                          list(s3_client.listdir('s3://mybucket/hello')))
-        self.assertEquals(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
-                          list(s3_client.listdir('s3://mybucket/hello/')))
-        self.assertEquals(['frank', 'world'],
-                          list(s3_client.list('s3://mybucket/hello')))
-        self.assertEquals(['frank', 'world'],
-                          list(s3_client.list('s3://mybucket/hello/')))
+        self.assertEqual(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
+                         list(s3_client.listdir('s3://mybucket/hello')))
+        self.assertEqual(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
+                         list(s3_client.listdir('s3://mybucket/hello/')))
+        self.assertEqual(['frank', 'world'],
+                         list(s3_client.list('s3://mybucket/hello')))
+        self.assertEqual(['frank', 'world'],
+                         list(s3_client.list('s3://mybucket/hello/')))
 
     def test_remove(self):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -78,28 +78,28 @@ class TaskTest(unittest.TestCase):
     def test_id_to_name_and_params(self):
         task_id = "InputText(date=2014-12-29)"
         (name, params) = luigi.task.id_to_name_and_params(task_id)
-        self.assertEquals(name, "InputText")
-        self.assertEquals(params, dict(date="2014-12-29"))
+        self.assertEqual(name, "InputText")
+        self.assertEqual(params, dict(date="2014-12-29"))
 
     def test_id_to_name_and_params_multiple_args(self):
         task_id = "InputText(date=2014-12-29,foo=bar)"
         (name, params) = luigi.task.id_to_name_and_params(task_id)
-        self.assertEquals(name, "InputText")
-        self.assertEquals(params, dict(date="2014-12-29", foo="bar"))
+        self.assertEqual(name, "InputText")
+        self.assertEqual(params, dict(date="2014-12-29", foo="bar"))
 
     def test_id_to_name_and_params_list_args(self):
         task_id = "InputText(date=2014-12-29,foo=[bar,baz-foo])"
         (name, params) = luigi.task.id_to_name_and_params(task_id)
-        self.assertEquals(name, "InputText")
-        self.assertEquals(params, dict(date="2014-12-29", foo=["bar", "baz-foo"]))
+        self.assertEqual(name, "InputText")
+        self.assertEqual(params, dict(date="2014-12-29", foo=["bar", "baz-foo"]))
 
     def test_flatten(self):
         flatten = luigi.task.flatten
-        self.assertEquals(sorted(flatten({'a': 'foo', 'b': 'bar'})), ['bar', 'foo'])
-        self.assertEquals(sorted(flatten(['foo', ['bar', 'troll']])), ['bar', 'foo', 'troll'])
-        self.assertEquals(flatten('foo'), ['foo'])
-        self.assertEquals(flatten(42), [42])
-        self.assertEquals(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+        self.assertEqual(sorted(flatten({'a': 'foo', 'b': 'bar'})), ['bar', 'foo'])
+        self.assertEqual(sorted(flatten(['foo', ['bar', 'troll']])), ['bar', 'foo', 'troll'])
+        self.assertEqual(flatten('foo'), ['foo'])
+        self.assertEqual(flatten(42), [42])
+        self.assertEqual(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
         self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
 
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -678,7 +678,7 @@ class WorkerEmailTest(unittest.TestCase):
         self.assertEqual(emails, [])
         worker.add(a)
         self.assertEqual(self.waits, 2)  # should attempt to add it 3 times
-        self.assertNotEquals(emails, [])
+        self.assertNotEqual(emails, [])
         self.assertTrue(emails[0].find("Luigi: Framework error while scheduling %s" % (a,)) != -1)
         worker.stop()
 
@@ -941,8 +941,8 @@ class TaskLimitTest(unittest.TestCase):
         w.run()
         self.assertFalse(t.complete())
         leaf_tasks = [ForkBombTask(3, 2, branch) for branch in [(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1)]]
-        self.assertEquals(3, sum(t.complete() for t in leaf_tasks),
-                          "should have gracefully completed as much as possible even though the single last leaf didn't get scheduled")
+        self.assertEqual(3, sum(t.complete() for t in leaf_tasks),
+                         "should have gracefully completed as much as possible even though the single last leaf didn't get scheduled")
 
     @with_config({'core': {'worker-task-limit': '7'}})
     def test_task_limit_not_exceeded(self):


### PR DESCRIPTION
Otherwise you get deprecation warnings thrown at you in Python 3.