### PR TITLE
cli: Make --help useful and add --help-all

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -72,7 +72,8 @@ class core(task.Config):
 
     local_scheduler = parameter.BoolParameter(
         default=False,
-        description='Use local scheduling')
+        description='Use an in-memory central scheduler. Useful for testing.',
+        always_in_help=True)
     scheduler_host = parameter.Parameter(
         default='localhost',
         description='Hostname of machine running remote scheduler',
@@ -106,7 +107,8 @@ class core(task.Config):
         description='Configuration file for logging')
     module = parameter.Parameter(
         default=None,
-        description='Used for dynamic loading of modules')
+        description='Used for dynamic loading of modules',
+        always_in_help=True)
     parallel_scheduling = parameter.BoolParameter(
         default=False,
         description='Use multiprocessing to do scheduling in parallel.')
@@ -115,7 +117,12 @@ class core(task.Config):
         description='Run any task from the scheduler.')
     help = parameter.BoolParameter(
         default=False,
-        description='Help option flag, for --help')
+        description='Show most common flags and all task-specific flags',
+        always_in_help=True)
+    help_all = parameter.BoolParameter(
+        default=False,
+        description='Show all command line flags',
+        always_in_help=True)
 
 
 class _WorkerSchedulerFactory(object):

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -177,7 +177,7 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(t.exists())
 
     def test_direct_python_help(self):
-        returncode, stdout, stderr = self._run_cmdline(['python', 'test/cmdline_test.py', '--help'])
+        returncode, stdout, stderr = self._run_cmdline(['python', 'test/cmdline_test.py', '--help-all'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertFalse(stdout.find(b'--x') != -1)
 
@@ -187,18 +187,35 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(stdout.find(b'--x') != -1)
 
     def test_bin_luigi_help(self):
-        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', '--help'])
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', '--help-all'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertFalse(stdout.find(b'--x') != -1)
 
     def test_python_module_luigi_help(self):
-        returncode, stdout, stderr = self._run_cmdline(['python', '-m', 'luigi', '--module', 'cmdline_test', '--help'])
+        returncode, stdout, stderr = self._run_cmdline(['python', '-m', 'luigi', '--module', 'cmdline_test', '--help-all'])
         self.assertTrue(stdout.find(b'--FooBaseClass-x') != -1)
         self.assertFalse(stdout.find(b'--x') != -1)
 
     def test_bin_luigi_help_no_module(self):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--help'])
         self.assertTrue(stdout.find(b'usage:') != -1)
+
+    def test_bin_luigi_help_not_spammy(self):
+        """
+        Test that `luigi --help` fits on one screen
+        """
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--help'])
+        self.assertLessEqual(len(stdout.splitlines()), 15)
+
+    def test_bin_luigi_all_help_spammy(self):
+        """
+        Test that `luigi --help-all` doesn't fit on a screen
+
+        Naturally, I don't mind this test breaking, but it convinces me that
+        the "not spammy" test is actually testing what it claims too.
+        """
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--help-all'])
+        self.assertGreater(len(stdout.splitlines()), 15)
 
     def test_bin_luigi_no_parameters(self):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi'])


### PR DESCRIPTION
Before this commit, running `luigi --help` is going to print 300 lines
of probably not useful flags, mostly being about all the combinations of
the registered various versions of the Range flags. Instead, I changed
--help to just print.

    $ ./bin/luigi --help
    usage: luigi [--local-scheduler] [--module CORE_MODULE] [--help] [--help-all]

    optional arguments:
      --local-scheduler     Use a in-memory central scheduler. Useful for testing.
      --module CORE_MODULE  Used for dynamic loading of modules
      --help                Show most common flags and all task-specific flags
      --help-all            Show all command line flags
    Exiting due to --help was passed

And when you're interested in an actual tasks parameter, they will be
displayed when specifying that task.

    $ ./bin/luigi --module examples.foo examples.Bar --help
    ...
    --num EXAMPLES.BAR_NUM, --examples.Bar-num EXAMPLES.BAR_NUM
    ...