### PR TITLE
remove python-pip as a build or install requirement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: extra
 Maintainer: Elias Freider <freider@spotify.com>
 Build-Depends:	debhelper (>= 7),
 		python-all (>= 2.7),
-		python-pip,
 		python-psycopg2,
 		python-pyparsing,
 		python-simplejson,
@@ -34,7 +33,6 @@ Depends:	${shlibs:Depends},
 		${misc:Depends},
 		${python:Depends},
 		python-daemon,
-		python-pip,
 		python-pyparsing,
 		python-sqlalchemy,
 		python-tornado (>= 2.3)


### PR DESCRIPTION
'pip' should not be used to install prereqs, these should be done via debian packages, both during build time as well as runtime.

spotify/luigi#1280