### PR TITLE
Shortens task graphs by counting each node only once

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -58,21 +58,35 @@ Graph = (function() {
     /* Compute the maximum depth of each node for layout purposes, returns the number
        of nodes at each depth level (for layout purposes) */
     function computeDepth(nodes, nodeIndex) {
-        var rowSizes = [];
         function descend(n, depth) {
-            n.depth = depth;
+            if (n.depth === undefined || depth > n.depth) {
+                n.depth = depth;
+                $.each(n.deps, function(i, dep) {
+                    if (nodeIndex[dep]) {
+                        descend(nodes[nodeIndex[dep]], depth + 1);
+                    }
+                });
+            }
+        }
+        descend(nodes[0], 0);
+
+        var rowSizes = [];
+        function placeNodes(n, depth) {
             if (rowSizes[depth] === undefined) {
                 rowSizes[depth] = 0;
             }
-            n.xOrder = rowSizes[depth];
-            rowSizes[depth]++;
-            $.each(n.deps, function(i, dep) {
-                if (nodeIndex[dep]) {
-                    descend(nodes[nodeIndex[dep]], depth + 1);
-                }
-            });
+            if (n.xOrder === undefined && depth === n.depth) {
+                n.xOrder = rowSizes[depth];
+                rowSizes[depth]++;
+                $.each(n.deps, function(i, dep) {
+                    if (nodeIndex[dep]) {
+                        placeNodes(nodes[nodeIndex[dep]], depth + 1);
+                    }
+                });
+            }
         }
-        descend(nodes[0], 0);
+        placeNodes(nodes[0], 0);
+
         return rowSizes;
     }
 


### PR DESCRIPTION
In computeDepth in graph.js, the entire dependency tree is traversed and each
node is given a depth and position within its depth. This computation is a bit
off, however, as a node may be encountered multiple times during traversal. This
could be easily fixed by stopping the recursion when we hit a seen node, but
then we could end up with a node depending on a node at a higher level than
itself.

Instead, I turn this into a two-stage affair. In the first stage, we do the full
traversal and only remember the maximum depth for each node. In the second stage
we traverse the whole tree again and only place nodes when we hit them for the
first time at the right depth. The second step requires a tree traversal rather
than just iterating over the nodes array because it groups child nodes together
and results in a much more readable and nicer-looking graph.

This shrinks each level's height by a factor of about the average in-degree, which partially addresses #1283.

Before:
<img width="308" alt="screen shot 2015-10-07 at 4 47 04 pm" src="https://cloud.githubusercontent.com/assets/2091885/10354249/357296be-6d13-11e5-8186-26f4f9d312b2.png">

After:
<img width="304" alt="screen shot 2015-10-07 at 4 47 38 pm" src="https://cloud.githubusercontent.com/assets/2091885/10354250/3c6ec960-6d13-11e5-813c-d92a73bea744.png">
