### PR TITLE
Removes leftover popovers when updating graph data

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -227,6 +227,7 @@ Graph = (function() {
     };
 
     DependencyGraph.prototype.updateData = function(taskList) {
+        $('.popover').popover('destroy');
         this.graph = createGraph(taskList);
         bounds = findBounds(this.graph.nodes);
         this.renderGraph();


### PR DESCRIPTION
This is necessary because the popover that's visible when you click on a node
to view its subgraph does not go away on its own. When it remains, it cannot be
removed through normal user actions. It can either obscure the graph or linger
outside of the bounds of the new graph, causing the page to scroll below where
it normally would to display the popover. By destroying the popovers, this
problem is solved.

Before:
![image](https://cloud.githubusercontent.com/assets/2091885/10355483/6ab62580-6d21-11e5-9dfc-f8e850bd1cc3.png)
