### PR TITLE
Make `tox -e docs` so doesn't create temp-files

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,22 @@
 
 import sys
 import os
+import sphinx.environment
+from docutils.utils import get_source_line
+
+
+def _warn_node(self, msg, node):
+    """
+    Mute warnings that are like ``WARNING: nonlocal image URI found: https://img. ...``
+
+    Solution was found by googling, copied it from SO:
+
+    http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
+    """
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 if os.environ.get('READTHEDOCS', None) == 'True':
     # Run sphinx-apidoc automatically in readthedocs

--- a/tox.ini
+++ b/tox.ini
@@ -75,26 +75,5 @@ commands =
     # build API docs
     sphinx-apidoc -o doc/api -T luigi --separate
 
-    # Store backup
-    cp README.rst README.rst.copy
-
-    # github images are local
-    sed -i.orig 's@https://raw\.githubusercontent\.com/spotify/luigi/master/doc/@@g' README.rst
-    # remove badges
-    sed -i.orig '/.. image::/d' README.rst
-    sed -i.orig '/:target:/d' README.rst
-
     # build HTML docs
     sphinx-build -W -b html -d {envtmpdir}/doctrees doc doc/_build/html
-
-    # remove temporary README.rst
-    rm README.rst.orig
-
-    # Copy back original README.rst
-    mv README.rst.copy README.rst
-
-whitelist_externals =
-    cp
-    mv
-    sed
-    rm


### PR DESCRIPTION
Otherwise your directory becomes unclean, and the tox logic is much
simpler and safer now.