### PR TITLE
make the wait_interval jitter configurable

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -243,6 +243,11 @@ worker-wait-interval
   for another job after the scheduler has said that it does not have any
   available jobs.
 
+worker-wait-jitter
+  Size of jitter to add to the worker wait interval such that the multiple
+  workers do not ask the scheduler for another job at the same time.
+  Default: 5.0
+
 
 [elasticsearch]
 ---------------

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -968,3 +968,39 @@ class WorkerConfigurationTest(unittest.TestCase):
         """
         Worker(wait_interval=1)  # This shouldn't raise
         self.assertRaises(AssertionError, Worker, wait_interval=0)
+
+
+class WorkerWaitJitterTest(unittest.TestCase):
+    @with_config({'worker': {'wait_jitter': '10.0'}})
+    @mock.patch("random.uniform")
+    @mock.patch("time.sleep")
+    def test_wait_jitter(self, mock_sleep, mock_random):
+        """ verify configured jitter amount """
+        mock_random.return_value = 1.0
+
+        w = Worker()
+        x = w._sleeper()
+        six.next(x)
+        mock_random.assert_called_with(0, 10.0)
+        mock_sleep.assert_called_with(2.0)
+
+        mock_random.return_value = 2.0
+        six.next(x)
+        mock_random.assert_called_with(0, 10.0)
+        mock_sleep.assert_called_with(3.0)
+
+    @mock.patch("random.uniform")
+    @mock.patch("time.sleep")
+    def test_wait_jitter_default(self, mock_sleep, mock_random):
+        """ verify default jitter is as expected """
+        mock_random.return_value = 1.0
+        w = Worker()
+        x = w._sleeper()
+        six.next(x)
+        mock_random.assert_called_with(0, 5.0)
+        mock_sleep.assert_called_with(2.0)
+
+        mock_random.return_value = 3.3
+        six.next(x)
+        mock_random.assert_called_with(0, 5.0)
+        mock_sleep.assert_called_with(4.3)


### PR DESCRIPTION
This change allows for the configuration of how much a randomness to add to the
sleep value for a worker.