### PR TITLE
Makes computeDepth take linear time

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -64,18 +64,27 @@ Graph = (function() {
     /* Compute the maximum depth of each node for layout purposes, returns the number
        of nodes at each depth level (for layout purposes) */
     function computeDepth(nodes, nodeIndex) {
-        function descend(n, depth) {
-            if (n.depth === undefined || depth > n.depth) {
-                n.depth = depth;
-                $.each(n.deps, function(i, dep) {
-                    if (nodeIndex[dep]) {
-                        descend(nodes[nodeIndex[dep]], depth + 1);
-                    }
-                });
-            }
-        }
-        descend(nodes[0], 0);
 
+        // memoized to take linear time in number of nodes and edges
+        function height(taskId) {
+            var node = nodes[nodeIndex[taskId]];
+
+            // storing height in depth here to save space
+            if (node.depth === undefined || node.depth === -1) {
+                node.depth = Math.max(0, Math.max.apply(null, node.deps.map(height)) + 1);
+            }
+            return node.depth;
+        }
+        var max_height = height(nodes[0].taskId);
+
+        // convert height to depth
+        $.each(nodes, function(i, node) {
+            if (node.depth !== undefined && node.depth !== -1) {
+                node.depth = max_height - node.depth;
+            }
+        })
+
+        // linear graph traversal, visiting each node once
         var rowSizes = [];
         function placeNodes(n, depth) {
             if (rowSizes[depth] === undefined) {


### PR DESCRIPTION
computeDepth takes quadratic time because it needs to find the maximum depth of
each node and this can require repeated traversal as longer paths are found. In
order to compute this in linear time, we instead compute the height of each node
and then subtract this from the height of the root node. Heights can be computed
in linear time by a straightforward recursive algorithm with memoization.

Using a test example with a 400-task dependency chain with each task in the
chain depending on a task with 10000 dependencies the time necessary for
computeDepth on my laptop was reduced from about 5 seconds to about 13ms. This
is in line with the expected 400x speedup from removing quadratic behavior.