### PR TITLE
Wire up tracking

### DIFF
--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -68,7 +68,7 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
     def __init__(self):
         pass
 
-    def run_job(self, job):
+    def run_job(self, job, tracking_url_callback=None):
         # TODO(jcrobak): libjars, files, etc. Can refactor out of
         # hadoop.HadoopJobRunner
         if not job.jar():
@@ -109,7 +109,7 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
                 raise HadoopJarJobError("job jar does not exist")
             arglist = hadoop_arglist
 
-        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist)
+        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback)
 
         for a, b in tmp_files:
             a.move(b)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -334,7 +334,7 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                     except FileAlreadyExists:
                         pass
 
-    def run_job(self, job):
+    def run_job(self, job, tracking_url_callback=None):
         self.prepare_outputs(job)
         with tempfile.NamedTemporaryFile() as f:
             query = job.query()
@@ -354,7 +354,7 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                     arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
 
             logger.info(arglist)
-            return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist)
+            return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback)
 
 
 class HiveTableTarget(luigi.Target):

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -193,7 +193,7 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         subprocess.check_call(arglist)
         return job_jar
 
-    def run_job(self, job):
+    def run_job(self, job, tracking_url_callback=None):
         job_jar = self.build_job_jar(job)
         jars = [job_jar] + self.get_libjars() + job.extra_jars()
         scalding_core = self.get_scalding_core()
@@ -216,7 +216,7 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         env['HADOOP_CLASSPATH'] = hadoop_cp
         logger.info("Submitting Hadoop job: HADOOP_CLASSPATH=%s %s",
                     hadoop_cp, subprocess.list2cmdline(arglist))
-        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, env=env)
+        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback, env=env)
 
         for a, b in tmp_files:
             a.move(b)

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -152,7 +152,8 @@ class RemoteScheduler(Scheduler):
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None, priority=0,
-                 family='', module=None, params=None, assistant=False):
+                 family='', module=None, params=None, assistant=False,
+                 tracking_url=None):
         self._request('/api/add_task', {
             'task_id': task_id,
             'worker': worker,
@@ -167,6 +168,7 @@ class RemoteScheduler(Scheduler):
             'module': module,
             'params': params,
             'assistant': assistant,
+            'tracking_url': tracking_url,
         })
 
     def get_work(self, worker, host=None, assistant=False):

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -227,6 +227,7 @@
                 <a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip"><i class="fa fa-sitemap"></i></a>
                 {{#error}}<button class="btn btn-danger btn-xs showError" title="Show error" data-toggle="tooltip"><i class="fa fa-bug"></i></button>{{/error}}
                 {{#re_enable}}<a class="btn btn-warning btn-xs re-enable-button" title="Re-enable" data-toggle="tooltip" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
+                {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
             </div>
         </script>
         <script type="text/template" name="rowDetailsTemplate">
@@ -286,7 +287,9 @@
                         <td>{{priority}}</td>
                         <td>{{resources}}</td>
                         <td>{{displayTime}}</td>
-                        <td><a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a></td>
+                        <td><a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
+                            {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
+                        </td>
                       </tr>
                       {{/tasks}}
                       {{/num_running}}

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -78,7 +78,7 @@ function visualiserApp(luigi) {
             displayTime: displayTime,
             displayTimestamp: task.start_time,
             timeRunning: time_running,
-            trackingUrl: task.trackingUrl,
+            trackingUrl: task.tracking_url,
             status: task.status,
             graph: (task.status == "PENDING" || task.status == "RUNNING" || task.status == "DONE"),
             error: task.status == "FAILED",

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -84,7 +84,7 @@ class HadoopJarJobTaskTest(unittest.TestCase):
                             raise AssertionError
 
             task = TestRemoteHadoopJarTwoParamJob(temp_file.name, 'test')
-            mock_job.side_effect = lambda x: check_space(x, task.task_id)
+            mock_job.side_effect = lambda x, _: check_space(x, task.task_id)
             task.run()
 
     @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')


### PR DESCRIPTION
This adds an optional tracking_url_callback parameter to the run function of
tasks. The worker passes a callback that updates the scheduler with the url. The
scheduler can then display the url in the visualiser.

I combined this with a second commit to pass the tracking_url_callback to run_and_track_hadoop_job so that hadoop tracking urls will show up in the scheduler.

![image](https://cloud.githubusercontent.com/assets/2091885/10384941/7bee0152-6df7-11e5-907e-73ff9906b7a7.png)
![image](https://cloud.githubusercontent.com/assets/2091885/10384967/b9fdba82-6df7-11e5-832d-5763b77c2f01.png)