### PR TITLE
Make luigi always log task status changes

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -376,11 +376,16 @@ class Worker(object):
         Call ``self._scheduler.add_task``, but store the values too so we can
         implement :py:func:`luigi.execution_summary.summary`.
         """
-        task = self._scheduled_tasks.get(kwargs['task_id'])
+        task_id = kwargs['task_id']
+        status = kwargs['status']
+        runnable = kwargs['runnable']
+        task = self._scheduled_tasks.get(task_id)
         if task:
-            msg = (task, kwargs['status'], kwargs['runnable'])
+            msg = (task, status, runnable)
             self._add_task_history.append(msg)
         self._scheduler.add_task(*args, **kwargs)
+
+        logger.info('Informed scheduler that task   %s   has status   %s', task_id, status)
 
     def stop(self):
         """
@@ -564,8 +569,6 @@ class Worker(object):
                        params=task.to_str_params(),
                        family=task.task_family,
                        module=task.task_module)
-
-        logger.info('Scheduled %s (%s)', task.task_id, status)
 
     def _validate_dependency(self, dependency):
         if isinstance(dependency, Target):


### PR DESCRIPTION
I find debugging luigi logs a bit hard. Most task status changes are
emitted when luigi client says "Scheduler MyTask() (DONE)". But not all
status changes are logged (but I still expect them to be). I've made it
output what it does on every call to /api/add_task.