### PR TITLE
clarify #569 multiple workers limitation

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -119,7 +119,8 @@ class Task(object):
 
     #: Number of seconds after which to time out the run function.
     #: No timeout if set to 0.
-    #: Defaults to 0 or value in luigi.cfg
+    #: Defaults to 0 or worker-timeout value in config file
+    #: Only works when using multiple workers.
     worker_timeout = None
 
     @property


### PR DESCRIPTION
I stumbled over this for a while - updated docs to help the next person:
- added mention of the name of the config item (dashed not underscored was another stumbling point)
- multiple workers caveat is important
- mention of config file name wasn't the whole story so removed it