### PR TITLE
Add copy function to HdfsTarget

### DIFF
--- a/luigi/contrib/hdfs/target.py
+++ b/luigi/contrib/hdfs/target.py
@@ -155,6 +155,12 @@ class HdfsTarget(FileSystemTarget):
             self.path = path
         return move_succeeded
 
+    def copy(self, dst_dir):
+        """
+        Copy to destination directory.
+        """
+        self.fs.copy(self.path, dst_dir)
+
     def is_writable(self):
         """
         Currently only works with hadoopcli


### PR DESCRIPTION
Allows copy function of underlying file system to be accessed
by HdfsTarget