### PR TITLE
Shows spinner on status info boxes while loading

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -369,8 +369,8 @@
             <section id="taskList" class="container-fluid tab-pane active">
                 <div class="row">
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='yellow' data-category='PENDING' id="PENDING_info">
-                      <span class="info-box-icon bg-yellow"><i class="fa fa-pause"></i></span>
+                    <div class="info-box status-info" data-color='yellow' data-category='PENDING' id="PENDING_info">
+                      <span class="info-box-icon bg-yellow"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Pending Tasks</span>
                         <span class="info-box-number">?</span>
@@ -379,8 +379,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='aqua' data-category='RUNNING' id="RUNNING_info">
-                      <span class="info-box-icon bg-aqua"><i class="fa fa-play"></i></span>
+                    <div class="info-box status-info" data-color='aqua' data-category='RUNNING' id="RUNNING_info">
+                      <span class="info-box-icon bg-aqua"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Running Tasks</span>
                         <span class="info-box-number">?</span>
@@ -389,8 +389,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='green' data-category='DONE' id="DONE_info">
-                      <span class="info-box-icon bg-green"><i class="fa fa-check"></i></span>
+                    <div class="info-box status-info" data-color='green' data-category='DONE' id="DONE_info">
+                      <span class="info-box-icon bg-green"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Done Tasks</span>
                         <span class="info-box-number">?</span>
@@ -399,8 +399,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='red' data-category='FAILED' id="FAILED_info">
-                      <span class="info-box-icon bg-red"><i class="fa fa-times"></i></span>
+                    <div class="info-box status-info" data-color='red' data-category='FAILED' id="FAILED_info">
+                      <span class="info-box-icon bg-red"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Failed Tasks</span>
                         <span class="info-box-number">?</span>
@@ -409,8 +409,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='maroon' data-category='UPSTREAM_FAILED' id="UPSTREAM_FAILED_info">
-                      <span class="info-box-icon bg-maroon"><i class="fa fa-warning"></i></span>
+                    <div class="info-box status-info" data-color='maroon' data-category='UPSTREAM_FAILED' id="UPSTREAM_FAILED_info">
+                      <span class="info-box-icon bg-maroon"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Upstream Failure</span>
                         <span class="info-box-number">?</span>
@@ -419,8 +419,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='gray' data-category='DISABLED' id="DISABLED_info">
-                      <span class="info-box-icon bg-gray"><i class="fa fa-minus-circle"></i></span>
+                    <div class="info-box status-info" data-color='gray' data-category='DISABLED' id="DISABLED_info">
+                      <span class="info-box-icon bg-gray"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Disabled Tasks</span>
                         <span class="info-box-number">?</span>
@@ -429,8 +429,8 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
-                    <div class="info-box" data-color='gray' data-category='UPSTREAM_DISABLED' id="UPSTREAM_DISABLED_info">
-                      <span class="info-box-icon bg-gray"><i class="fa fa-warning"></i></span>
+                    <div class="info-box status-info" data-color='gray' data-category='UPSTREAM_DISABLED' id="UPSTREAM_DISABLED_info">
+                      <span class="info-box-icon bg-gray"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">
                         <span class="info-box-text">Upstream Disabled</span>
                         <span class="info-box-number">?</span>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -10,6 +10,15 @@ function visualiserApp(luigi) {
         taskCategory: [],
         tableFilter: ""
     };
+    var taskIcons = {
+        PENDING: 'pause',
+        RUNNING: 'play',
+        DONE: 'check',
+        FAILED: 'times',
+        UPSTREAM_FAILED: 'warning',
+        DISABLED: 'minus-circle',
+        UPSTREAM_DISABLED: 'warning'
+    }
 
     function getVisType() {
         var cookieParts = document.cookie.match(/visType=(.*)/);
@@ -574,6 +583,7 @@ function visualiserApp(luigi) {
 
 
         $('#'+category+'_info').find('.info-box-number').html(taskCount);
+        $('#'+category+'_info i.fa').removeClass().addClass('fa fa-'+taskIcons[category]);
 
     }
 
@@ -619,6 +629,9 @@ function visualiserApp(luigi) {
     }
 
     function updateTasks() {
+        $('.status-info .info-box-number').text('?');
+        $('.status-info i.fa').removeClass().addClass('fa fa-spinner fa-pulse');
+
         var ajax1 = luigi.getRunningTaskList(function(runningTasks) {
             updateTaskCategory(dt, 'RUNNING', runningTasks);
         });


### PR DESCRIPTION
It can be a little confusing to tell whether the info boxes on the visualiser
tasks tab have been updated yet or not when using Filter on Server in the
datatables search box. This makes it more clear by resetting the number to a
question mark on updates and also turning the icon into a spinner while it's
waiting to load.

![image](https://cloud.githubusercontent.com/assets/2091885/10500087/5d829ef2-728a-11e5-9804-39e7052d0003.png)
