### PR TITLE
Limit graph size

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -147,9 +147,19 @@ max-shown-tasks
   .. versionadded:: 1.0.20
 
   The maximum number of tasks returned in a task_list api call. This
-  will restrict the number of tasks shown in any section in the
+  will restrict the number of tasks shown in task lists in the
   visualiser. Small values can alleviate frozen browsers when there are
   too many done tasks. This defaults to 100000 (one hundred thousand).
+
+max-graph-nodes
+  .. versionadded:: 2.0.0
+
+  The maximum number of nodes returned by a dep_graph or
+  inverse_dep_graph api call. Small values can greatly speed up graph
+  display in the visualiser by limiting the number of nodes shown. Some
+  of the nodes that are not sent to the visualiser will still show up as
+  dependencies of nodes that were sent. These nodes are given TRUNCATED
+  status.
 
 no_configure_logging
   If true, logging is not configured. Defaults to false.

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -95,6 +95,7 @@ class scheduler(Config):
     disable_persist = parameter.IntParameter(default=86400,
                                              config_path=dict(section='scheduler', name='disable-persist-seconds'))
     max_shown_tasks = parameter.IntParameter(default=100000)
+    max_graph_nodes = parameter.IntParameter(default=100000)
     prune_done_tasks = parameter.BoolParameter(default=False)
 
     record_task_history = parameter.BoolParameter(default=False)
@@ -843,7 +844,7 @@ class CentralPlannerScheduler(Scheduler):
                         upstream_status_table[dep_id] = status
             return upstream_status_table[dep_id]
 
-    def _serialize_task(self, task_id, include_deps=True):
+    def _serialize_task(self, task_id, include_deps=True, deps=None):
         task = self._state.get_task(task_id)
         ret = {
             'status': task.status,
@@ -859,18 +860,41 @@ class CentralPlannerScheduler(Scheduler):
         if task.status == DISABLED:
             ret['re_enable_able'] = task.scheduler_disable_time is not None
         if include_deps:
-            ret['deps'] = list(task.deps)
+            ret['deps'] = list(task.deps if deps is None else deps)
         return ret
 
     def graph(self, **kwargs):
         self.prune()
         serialized = {}
+        seen = set()
         for task in self._state.get_active_tasks():
-            serialized[task.id] = self._serialize_task(task.id)
+            serialized.update(self._traverse_graph(task.id, seen))
         return serialized
 
-    def _recurse_deps(self, task_id, serialized):
-        if task_id not in serialized:
+    def _traverse_graph(self, root_task_id, seen=None, dep_func=None):
+        """ Returns the dependency graph rooted at task_id
+
+        This does a breadth-first traversal to find the nodes closest to the
+        root before hitting the scheduler.max_graph_nodes limit.
+
+        :param root_task_id: the id of the graph's root
+        :return: A map of task id to serialized node
+        """
+
+        if seen is None:
+            seen = set()
+        elif root_task_id in seen:
+            return {}
+
+        if dep_func is None:
+            dep_func = lambda t: t.deps
+
+        seen.add(root_task_id)
+        serialized = {}
+        queue = collections.deque([root_task_id])
+        while queue:
+            task_id = queue.popleft()
+
             task = self._state.get_task(task_id)
             if task is None or not task.family:
                 logger.warn('Missing task for id [%s]', task_id)
@@ -891,16 +915,32 @@ class CentralPlannerScheduler(Scheduler):
                     'priority': 0,
                 }
             else:
-                serialized[task_id] = self._serialize_task(task_id)
-                for dep in task.deps:
-                    self._recurse_deps(dep, serialized)
+                deps = dep_func(task)
+                serialized[task_id] = self._serialize_task(task_id, deps=deps)
+                for dep in sorted(deps):
+                    if dep not in seen:
+                        seen.add(dep)
+                        queue.append(dep)
+            if len(serialized) >= self._config.max_graph_nodes:
+                break
+
+        return serialized
 
     def dep_graph(self, task_id, **kwargs):
         self.prune()
-        serialized = {}
-        if self._state.has_task(task_id):
-            self._recurse_deps(task_id, serialized)
-        return serialized
+        if not self._state.has_task(task_id):
+            return {}
+        return self._traverse_graph(task_id)
+
+    def inverse_dep_graph(self, task_id, **kwargs):
+        self.prune()
+        if not self._state.has_task(task_id):
+            return {}
+        inverse_graph = collections.defaultdict(set)
+        for task in self._state.get_active_tasks():
+            for dep in task.deps:
+                inverse_graph[dep].add(task.id)
+        return self._traverse_graph(task_id, dep_func=lambda t: inverse_graph[t.id])
 
     def task_list(self, status, upstream_status, limit=True, search=None, **kwargs):
         """
@@ -952,26 +992,6 @@ class CentralPlannerScheduler(Scheduler):
                 worker['num_uniques'] = num_uniques[worker['name']]
                 worker['running'] = tasks
         return workers
-
-    def inverse_dep_graph(self, task_id, **kwargs):
-        self.prune()
-        serialized = {}
-        if self._state.has_task(task_id):
-            self._traverse_inverse_deps(task_id, serialized)
-        return serialized
-
-    def _traverse_inverse_deps(self, task_id, serialized):
-        stack = [task_id]
-        serialized[task_id] = self._serialize_task(task_id)
-        while len(stack) > 0:
-            curr_id = stack.pop()
-            for task in self._state.get_active_tasks():
-                if curr_id in task.deps:
-                    serialized[curr_id]["deps"].append(task.id)
-                    if task.id not in serialized:
-                        serialized[task.id] = self._serialize_task(task.id)
-                        serialized[task.id]["deps"] = []
-                        stack.append(task.id)
 
     def task_search(self, task_str, **kwargs):
         """

--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -4,8 +4,10 @@ Graph = (function() {
         "RUNNING":"#0044DD",
         "PENDING":"#EEBB00",
         "DONE":"#00DD00",
-        "DISABLED":"#808080"
-    };
+        "DISABLED":"#808080",
+        "UNKNOWN":"#000000",
+        "TRUNCATED":"#FF00FF"
+    }
 
     /* Line height for items in task status legend */
     var legendLineHeight = 20;


### PR DESCRIPTION
Like with task lists, excessively large graphs can render the visualiser
unusable. To prevent this issue, we've added a max-graph-nodes parameter that
cuts off the graph after enough nodes are seen.

In order to achieve this, the graph recursion had to be re-written as a an
iterative breadth-first traversal. The inverse dependency graph function was
re-written to be able to call this same traversal, resulting in greatly improved
complexity. Rather than scanning the entire graph once per node to find its
reverse neighbors, we scan the whole graph exactly once and store the reverse
edges in a lookup table. This improves the complexity from number of nodes times
size of graph to just number of nodes.

When the scheduler sends a truncated graph, some nodes may have dependencies
that are not displayed. In order to not give a false impression to the end
user, these nodes are added back and marked as TRUNCATED status. These nodes
show that more dependencies exist and can be clicked on for more information
but mostly preserve a smaller graph.

In order to distinguish these nodes from UNKNOWN status nodes, I added UNKNOWN
and TRUNCATED to the legend. UNKNOWN remains black while TRUNCATED is given a
light purple.

example with max-graph-nodes set to 10:
![image](https://cloud.githubusercontent.com/assets/2091885/10530136/2f639af6-7359-11e5-8710-48ac3dae368f.png)

I marked this as being part of the 2.0 release in the configuration documentation, but if that's not appropriate I can change it.

This change has been a hit with the Houzz team, as graph pages that previously hung forever have started showing something usable within 20 seconds (using a 1000 limit but having a root task that far exceeds it).