### PR TITLE
Computes number of columns per graph level more accurately

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -110,8 +110,8 @@ Graph = (function() {
             return rowStartPosition(depth-1)+Math.max(rowHeight * nodeHeight + 100);
         }
         $.each(nodes, function(i, node) {
-            var levelCols = Math.min(rowSizes[node.depth], numCols)
-            var numRows = Math.ceil(rowSizes[node.depth] / levelCols);
+            var numRows = Math.ceil(rowSizes[node.depth] / numCols);
+            var levelCols = Math.ceil(rowSizes[node.depth] / numRows);
             var row = node.xOrder % numRows;
             var col = node.xOrder / numRows;
             node.x = ((col + 1) / (levelCols + 1)) * (graphWidth - 200);


### PR DESCRIPTION
The number of columns per level was computed to be the minimum of the
number of columns allowed in the viewport and the number of items in the
row. This is an overestimate, however, due to the way that columns are
filled in. Suppose we have 6 columns and 7 items. We'll put two items in
each column, as ceil(7 / 6) = 2. Because there are only 7 items, we only
end up using 5 columns. Because we are laying out for 6, this means we
don't use enough horizontal space.

To fix this, we can either use a variable number of items per column or
adjust the layout to display the number of columns actually used. I opt
for the second choice here, as the code is simpler and it looks nicer
with the binary tree example graph I was using.