### PR TITLE
AWS EC2 Container Service support

### DIFF
--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Outlier Bio, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+EC2 Container Service wrapper for Luigi
+
+From the AWS website:
+
+  Amazon EC2 Container Service (ECS) is a highly scalable, high performance
+  container management service that supports Docker containers and allows you
+  to easily run applications on a managed cluster of Amazon EC2 instances.
+
+To use ECS, you create a taskDefinition_ JSON that defines the `docker run`_
+command for one or more containers in a task or service, and then submit this
+JSON to the API to run the task.
+
+This `boto3-powered`_ wrapper allows you to create Luigi Tasks to submit ECS
+``taskDefinition`` s. You can either pass a dict (mapping directly to the
+``taskDefinition`` JSON) OR an Amazon Resource Name (arn) for a previously
+registered ``taskDefinition``.
+
+Requires:
+
+- boto3 package
+- Amazon AWS credentials discoverable by boto3 (e.g., by using ``aws configure``
+  from awscli_)
+- A running ECS cluster (see `ECS Get Started`_)
+
+Written and maintained by Jake Feala (@jfeala) for Outlier Bio (@outlierbio)
+
+.. _`docker run`: https://docs.docker.com/reference/commandline/run
+.. _taskDefinition: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html
+.. _`boto3-powered`: https://boto3.readthedocs.org
+.. _awscli: https://aws.amazon.com/cli
+.. _`ECS Get Started`: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted.html
+
+"""
+
+import time
+import logging
+import luigi
+
+logger = logging.getLogger('luigi-interface')
+
+try:
+    import boto3
+    client = boto3.client('ecs')
+except ImportError:
+    logger.warning('boto3 is not installed. ECSTasks require boto3')
+
+POLL_TIME = 2
+
+
+def _get_task_statuses(task_ids):
+    """
+    Retrieve task statuses from ECS API
+
+    Returns list of {RUNNING|PENDING|STOPPED} for each id in task_ids
+    """
+    response = client.describe_tasks(tasks=task_ids)
+
+    # Error checking
+    if response['failures'] != []:
+        raise Exception('There were some failures:\n{0}'.format(
+            response['failures']))
+    status_code = response['ResponseMetadata']['HTTPStatusCode']
+    if status_code != 200:
+        msg = 'Task status request received status code {0}:\n{1}'
+        raise Exception(msg.format(status_code, response))
+
+    return [t['lastStatus'] for t in response['tasks']]
+
+
+def _track_tasks(task_ids):
+    """Poll task status until STOPPED"""
+    while True:
+        statuses = _get_task_statuses(task_ids)
+        if all([status == 'STOPPED' for status in statuses]):
+            logger.info('ECS tasks {0} STOPPED'.format(','.join(task_ids)))
+            break
+        time.sleep(POLL_TIME)
+        logger.debug('ECS task status for tasks {0}: {1}'.format(
+            ','.join(task_ids), status))
+
+
+class ECSTask(luigi.Task):
+
+    """
+    Base class for an Amazon EC2 Container Service Task
+
+    Amazon ECS requires you to register "tasks", which are JSON descriptions
+    for how to issue the ``docker run`` command. This Luigi Task can either
+    run a pre-registered ECS taskDefinition, OR register the task on the fly
+    from a Python dict.
+
+    :param task_def_arn: pre-registered task definition ARN (Amazon Resource
+        Name), of the form::
+
+            arn:aws:ecs:<region>:<user_id>:task-definition/<family>:<tag>
+
+    :param task_def: dict describing task in taskDefinition JSON format, for
+        example::
+
+            task_def = {
+                'family': 'hello-world',
+                'volumes': [],
+                'containerDefinitions': [
+                    {
+                        'memory': 1,
+                        'essential': True,
+                        'name': 'hello-world',
+                        'image': 'ubuntu',
+                        'command': ['/bin/echo', 'hello world']
+                    }
+                ]
+            }
+
+    """
+
+    task_def_arn = luigi.Parameter(default=None)
+    task_def = luigi.Parameter(default=None)
+
+    @property
+    def ecs_task_ids(self):
+        """Expose the ECS task ID"""
+        if hasattr(self, '_task_ids'):
+            return self._task_ids
+
+    @property
+    def command(self):
+        """
+        Command passed to the containers
+
+        Override to return list of dicts with keys 'name' and 'command',
+        describing the container names and commands to pass to the container.
+        Directly corresponds to the `overrides` parameter of runTask API. For
+        example::
+
+            [
+                {
+                    'name': 'myContainer',
+                    'command': ['/bin/sleep', '60']
+                }
+            ]
+
+        """
+        pass
+
+    def run(self):
+        if (not self.task_def and not self.task_def_arn) or \
+           (self.task_def and self.task_def_arn):
+            raise ValueError(('Either (but not both) a task_def (dict) or'
+                              'task_def_arn (string) must be assigned'))
+        if not self.task_def_arn:
+            # Register the task and get assigned taskDefinition ID (arn)
+            response = client.register_task_definition(**self.task_def)
+            self.task_def_arn = response['taskDefinition']['taskDefinitionArn']
+
+        # Submit the task to AWS ECS and get assigned task ID
+        # (list containing 1 string)
+        if self.command:
+            overrides = {'containerOverrides': self.command}
+        else:
+            overrides = {}
+        response = client.run_task(taskDefinition=self.task_def_arn,
+                                   overrides=overrides)
+        self._task_ids = [task['taskArn'] for task in response['tasks']]
+
+        # Wait on task completion
+        _track_tasks(self._task_ids)

--- a/test/contrib/ecs_test.py
+++ b/test/contrib/ecs_test.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Outlier Bio, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Integration test for the Luigi wrapper of EC2 Container Service (ECSTask)
+
+Requires:
+
+- boto3 package
+- Amazon AWS credentials discoverable by boto3 (e.g., by using ``aws configure``
+from awscli_)
+- A running ECS cluster (see `ECS Get Started`_)
+
+Written and maintained by Jake Feala (@jfeala) for Outlier Bio (@outlierbio)
+
+.. _awscli: https://aws.amazon.com/cli
+.. _`ECS Get Started`: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_GetStarted.html
+"""
+
+import unittest
+
+import luigi
+from luigi.contrib.ecs import ECSTask, _get_task_statuses
+
+try:
+    import boto3
+    client = boto3.client('ecs')
+except ImportError:
+    raise unittest.SkipTest('boto3 is not installed. ECSTasks require boto3')
+
+TEST_TASK_DEF = {
+    'family': 'hello-world',
+    'volumes': [],
+    'containerDefinitions': [
+        {
+            'memory': 1,
+            'essential': True,
+            'name': 'hello-world',
+            'image': 'ubuntu',
+            'command': ['/bin/echo', 'hello world']
+        }
+    ]
+}
+
+
+class ECSTaskNoOutput(ECSTask):
+
+    def complete(self):
+        if self.ecs_task_ids:
+            return all([status == 'STOPPED'
+                        for status in _get_task_statuses(self.ecs_task_ids)])
+        return False
+
+
+class ECSTaskOverrideCommand(ECSTaskNoOutput):
+
+    @property
+    def command(self):
+        return [{'name': 'hello-world', 'command': ['/bin/sleep', '10']}]
+
+
+class TestECSTask(unittest.TestCase):
+
+    def setUp(self):
+        # Register the test task definition
+        response = client.register_task_definition(**TEST_TASK_DEF)
+        self.arn = response['taskDefinition']['taskDefinitionArn']
+
+    def test_unregistered_task(self):
+        t = ECSTaskNoOutput(task_def=TEST_TASK_DEF)
+        luigi.build([t], local_scheduler=True)
+
+    def test_registered_task(self):
+        t = ECSTaskNoOutput(task_def_arn=self.arn)
+        luigi.build([t], local_scheduler=True)
+
+    def test_override_command(self):
+        t = ECSTaskOverrideCommand(task_def_arn=self.arn)
+        luigi.build([t], local_scheduler=True)


### PR DESCRIPTION
From the AWS website,

> Amazon EC2 Container Service (ECS) is a highly scalable, high performance
> container management service that supports Docker containers and allows you
> to easily run applications on a managed cluster of Amazon EC2 instances.

To use ECS, you create a "task definition" JSON that defines the `docker run` command for one or more containers in a task or service, and then submit this JSON to the API to run the task.

This wrapper allows you to create Luigi Tasks to submit ECS tasks. You can either pass a dict (mapping directly to the `taskDefinition` JSON) or an Amazon Resource Name (arn) for a previously registered `taskDefinition`.

Testing was performed on the default cluster created through the ECS console [first run wizard](https://console.aws.amazon.com/ecs/home#/firstRun)

Requires boto3, configured with valid AWS credentials