### PR TITLE
Use Codecov for uploading code coverage reports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@
 .. image:: https://img.shields.io/travis/spotify/luigi/master.svg?style=flat
     :target: https://travis-ci.org/spotify/luigi
  
-.. image:: https://img.shields.io/coveralls/spotify/luigi/master.svg?style=flat
-    :target: https://coveralls.io/r/spotify/luigi?branch=master
+.. image:: https://img.shields.io/codecov/c/github/spotify/luigi/master.svg?style=flat
+    :target: https://codecov.io/gh/spotify/luigi?branch=master
  
 .. image:: https://landscape.io/github/spotify/luigi/master/landscape.svg?style=flat
    :target: https://landscape.io/github/spotify/luigi/master

--- a/tox.ini
+++ b/tox.ini
@@ -20,12 +20,12 @@ deps=
   postgres: psycopg2<3.0
   gcloud: google-api-python-client>=1.4.0,<2.0
   coverage>=3.6,<3.999
-  coveralls<1.0
+  codecov>=1.4.0
   requests<3.0
   unixsocket: requests-unixsocket<1.0
   pygments
 passenv =
-  USER JAVA_HOME GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID TRAVIS
+  USER JAVA_HOME GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT CI
 setenv =
   LC_ALL = en_US.utf-8
   cdh: HADOOP_DISTRO=cdh
@@ -49,7 +49,7 @@ commands =
                                    --ignore-files=not_imported.py \
                                    {posargs:}
   coverage combine
-  coveralls
+  codecov -e TOXENV
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
> Steve from Codecov here. I wanted to create this pull request to see if Luigi would like to use Codecov as their coverage solution.

Some of our core features include:

Some of our core features include:
- Seamless overlay of coverage reports in Github with our browser extensions. [Video](https://www.youtube.com/watch?v=d6wJKODB8_g)
- Awesome pull request comments. [Example](https://gist.github.com/codecov-io/ba612976215481e7f27c)
- Github commit status integration to ensure coverage meets minimum standards
- Automatic unified builds. See [pyca/cryptography](https://codecov.io/github/pyca/cryptography) for example
- Storing build environment variables.

View the report at https://codecov.io/github/stevepeak/luigi

Love all the feedback you have and I look forward to having Luigi on Codecov :)

Cheers,
Steve