### PR TITLE
Distingiush local and global cli params [#1304]

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -232,9 +232,7 @@ def _run(cmdline_args=None, main_task_cls=None,
         cmdline_args.insert(0, '--local-scheduler')
 
     with CmdlineParser.global_instance(cmdline_args) as cp:
-        task_cls = cp.get_task_cls()
-        task = task_cls()
-        return _schedule_and_run([task], worker_scheduler_factory)
+        return _schedule_and_run([cp.get_task_obj()], worker_scheduler_factory)
 
 
 def build(tasks, worker_scheduler_factory=None, **env_params):

--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -86,10 +86,7 @@ def find_deps_cli():
     '''
     cmdline_args = sys.argv[1:]
     with CmdlineParser.global_instance(cmdline_args) as cp:
-        task_cls = cp.get_task_cls()
-        task = task_cls()
-        upstream_task_family = upstream().family
-        return find_deps(task, upstream_task_family)
+        return find_deps(cp.get_task_obj(), upstream().family)
 
 
 def main():

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -23,7 +23,7 @@ except ImportError:
 import mock
 import os
 import subprocess
-from helpers import unittest, parsing
+from helpers import unittest
 
 from luigi import six
 
@@ -245,18 +245,15 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--no-lock', '--local-scheduler', 'Task', '--unknown-param', 'hiiii'])
         self.assertNotEqual(0, returncode)
 
-
-class NewStyleParameters822Test(unittest.TestCase):
-    # See https://github.com/spotify/luigi/issues/822
-
-    @parsing(['FooSubClass', '--x', 'xyz', '--FooBaseClass-x', 'xyz'])
-    def test_subclasses(self):
-        self.assertEqual(FooSubClass().x, 'xyz')
-
-    @parsing(['FooBaseClass', '--FooBaseClass-x', 'xyz'])
-    def test_subclasses_2(self):
-        # https://github.com/spotify/luigi/issues/822#issuecomment-77782714
-        self.assertEqual(FooBaseClass().x, 'xyz')
+    def test_deps_py_script(self):
+        """
+        Test the deps.py script.
+        """
+        args = 'python luigi/tools/deps.py --module examples.top_artists ArtistToplistToDatabase --date-interval 2015-W10'.split()
+        returncode, stdout, stderr = self._run_cmdline(args)
+        self.assertEqual(0, returncode)
+        self.assertTrue(stdout.find(b'[FileSystem] data/streams_2015_03_04_faked.tsv') != -1)
+        self.assertTrue(stdout.find(b'[DB] localhost') != -1)
 
 
 if __name__ == '__main__':

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -100,7 +100,7 @@ class DateIntervalTest(LuigiTestCase):
 
         self.assertEqual(MyTask().di, month)
         in_parse(["MyTask", "--di", "2012-10"],
-                 lambda: self.assertEqual(MyTask().di, other))
+                 lambda task: self.assertEqual(task.di, other))
         task = MyTask(month)
         self.assertEqual(task.di, month)
         task = MyTask(di=month)
@@ -113,7 +113,7 @@ class DateIntervalTest(LuigiTestCase):
         self.assertRaises(luigi.parameter.MissingParameterException, fail1)
 
         in_parse(["MyTaskNoDefault", "--di", "2012-10"],
-                 lambda: self.assertEqual(MyTaskNoDefault().di, other))
+                 lambda task: self.assertEqual(task.di, other))
 
     def test_hours(self):
         d = DI().parse('2015')

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -16,13 +16,13 @@
 #
 
 import datetime
-from helpers import unittest, in_parse
+from helpers import LuigiTestCase, in_parse
 
 import luigi
 from luigi.parameter import DateIntervalParameter as DI
 
 
-class DateIntervalTest(unittest.TestCase):
+class DateIntervalTest(LuigiTestCase):
 
     def test_date(self):
         di = DI().parse('2012-01-01')

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -53,7 +53,7 @@ class DateParameterTest(unittest.TestCase):
 
     def test_parse_interface(self):
         in_parse(["DateTask", "--day", "2015-04-03"],
-                 lambda: self.assertEqual(DateTask().day, datetime.date(2015, 4, 3)))
+                 lambda task: self.assertEqual(task.day, datetime.date(2015, 4, 3)))
 
     def test_serialize_task(self):
         t = DateTask(datetime.date(2015, 4, 3))
@@ -71,7 +71,7 @@ class DateHourParameterTest(unittest.TestCase):
 
     def test_parse_interface(self):
         in_parse(["DateHourTask", "--dh", "2013-02-01T18"],
-                 lambda: self.assertEqual(DateHourTask().dh, datetime.datetime(2013, 2, 1, 18, 0, 0)))
+                 lambda task: self.assertEqual(task.dh, datetime.datetime(2013, 2, 1, 18, 0, 0)))
 
     def test_serialize_task(self):
         t = DateHourTask(datetime.datetime(2013, 2, 1, 18, 0, 0))
@@ -101,7 +101,7 @@ class DateMinuteParameterTest(unittest.TestCase):
 
     def test_parse_interface(self):
         in_parse(["DateMinuteTask", "--dm", "2013-02-01T1842"],
-                 lambda: self.assertEqual(DateMinuteTask().dm, datetime.datetime(2013, 2, 1, 18, 42, 0)))
+                 lambda task: self.assertEqual(task.dm, datetime.datetime(2013, 2, 1, 18, 42, 0)))
 
     def test_serialize_task(self):
         t = DateMinuteTask(datetime.datetime(2013, 2, 1, 18, 42, 0))
@@ -119,7 +119,7 @@ class MonthParameterTest(unittest.TestCase):
 
     def test_parse_interface(self):
         in_parse(["MonthTask", "--month", "2015-04"],
-                 lambda: self.assertEqual(MonthTask().month, datetime.date(2015, 4, 1)))
+                 lambda task: self.assertEqual(task.month, datetime.date(2015, 4, 1)))
 
     def test_serialize_task(self):
         task = MonthTask(datetime.date(2015, 4, 3))
@@ -137,7 +137,7 @@ class YearParameterTest(unittest.TestCase):
 
     def test_parse_interface(self):
         in_parse(["YearTask", "--year", "2015"],
-                 lambda: self.assertEqual(YearTask().year, datetime.date(2015, 1, 1)))
+                 lambda task: self.assertEqual(task.year, datetime.date(2015, 1, 1)))
 
     def test_serialize_task(self):
         task = YearTask(datetime.date(2015, 4, 3))

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -182,5 +182,5 @@ class parsing(object):
 
 
 def in_parse(cmds, deferred_computation):
-    with CmdlineParser.global_instance(cmds):
-        deferred_computation()
+    with CmdlineParser.global_instance(cmds) as cp:
+        deferred_computation(cp.get_task_obj())

--- a/test/task_history_test.py
+++ b/test/task_history_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from helpers import unittest
+from helpers import LuigiTestCase
 
 import luigi
 import luigi.scheduler
@@ -40,7 +40,7 @@ class SimpleTaskHistory(luigi.task_history.TaskHistory):
         self.actions.append(('started', task.id))
 
 
-class TaskHistoryTest(unittest.TestCase):
+class TaskHistoryTest(LuigiTestCase):
 
     def setUp(self):
         self.th = SimpleTaskHistory()
@@ -62,7 +62,3 @@ class TaskHistoryTest(unittest.TestCase):
             ('started', 'MyTask()'),
             ('finished', 'MyTask()')
         ])
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Since the command line overhaul in #1182. One unexpected behavior
was introduced, namely that --x and --MyTask-x would mean the same
thing. As a consequence, `--x 123` would set parameter x to 123 not only
for the parsed root Task specified on the command line. But for all
parmeters x of that task family. Since even Dave from Houzz was confused
by this, we decided to revert that behavior in issue #1304.

While at it. I also made these changes:

 * I decided to do a quite big refactoring. Including finally
   removing the `is_bool` kwarg from the Parameter constructor.
 * I added a test for deps.py script, as I've already been close to
   breaking it twice.