### PR TITLE
Add __repr__() to Parameter for nicer docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,36 @@ import sys
 import os
 import sphinx.environment
 from docutils.utils import get_source_line
+import luigi
+import luigi.parameter
+
+
+def parameter_repr(self):
+    """
+    When building documentation, we want Parameter objects to show their
+    description in a nice way
+    """
+    significance = 'Insignificant ' if not self.significant else ''
+    class_name = self.__class__.__name__
+    has_default = self._default != luigi.parameter._no_value
+    default = ' (defaults to {})'.format(self._default) if has_default else ''
+    description = (': ' + self.description if self.description else '')
+    return significance + class_name + default + description
+
+luigi.parameter.Parameter.__repr__ = parameter_repr
+
+
+def assertIn(needle, haystack):
+    """
+    We test repr of Parameter objects, since it'll be used for readthedocs
+    """
+    assert needle in haystack
+
+# TODO: find a better place to put this!
+assertIn('IntParameter', repr(luigi.IntParameter()))
+assertIn('defaults to 37', repr(luigi.IntParameter(default=37)))
+assertIn('hi mom', repr(luigi.IntParameter(description='hi mom')))
+assertIn('Insignificant BoolParameter', repr(luigi.BoolParameter(significant=False)))
 
 
 def _warn_node(self, msg, node):


### PR DESCRIPTION
Currently, the documentation page for Range doesn't look nice. One
reason is that the parmeters are documented like this:

     start = <luigi.parameter.DateParameter object>

This patch makes it look like this:

     now = IntParameter (defaults to None): set to override current time. In seconds since epoch

Also see the screenshots in the upcoming PR.