### PR TITLE
Delete the marker file (_$folder$) when removing a directory

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -145,6 +145,11 @@ class S3Client(FileSystem):
         delete_key_list = [
             k for k in s3_bucket.list(self._add_path_delimiter(key))]
 
+        # delete the directory marker file if it exists
+        s3_dir_with_suffix_key = s3_bucket.get_key(key + S3_DIRECTORY_MARKER_SUFFIX_0)
+        if s3_dir_with_suffix_key:
+            delete_key_list.append(s3_dir_with_suffix_key)
+
         if len(delete_key_list) > 0:
             for k in delete_key_list:
                 logger.debug('Deleting %s from bucket %s', k, bucket)

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -310,6 +310,12 @@ class TestS3Client(unittest.TestCase):
             lambda: s3_client.remove('s3://mybucket/removemedir', recursive=False)
         )
 
+        # test that the marker file created by Hadoop S3 Native FileSystem is removed
+        s3_client.put(self.tempFilePath, 's3://mybucket/removemedir/file')
+        s3_client.put_string("", 's3://mybucket/removemedir_$folder$')
+        self.assertTrue(s3_client.remove('s3://mybucket/removemedir'))
+        self.assertFalse(s3_client.exists('s3://mybucket/removemedir_$folder$'))
+
     def _run_multipart_test(self, part_size, file_size):
         file_contents = b"a" * file_size
 


### PR DESCRIPTION
When calling remove() on an S3Target pointing to a "directory", all files inside the directory are removed as expected. But when using Hadoop S3 Native FileSystem to store files in S3, each "directory" comes with a marker with the suffix _$folder$. This marker was not deleted by remove() causing bugs such as letting Hadoop think that the directory still exists when it does not. This patch fixes this.