### PR TITLE
docs: Fix markup in command_line.rst

### DIFF
--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -20,8 +20,12 @@ that will be installed with the pip package.
 
 Should be run like this
 
-    $ luigi --module my_module MyTask --x 123 --y 456 --local-scheduler
+.. code:: console
+
+        luigi --module my_module MyTask --x 123 --y 456 --local-scheduler
 
 Or alternatively like this:
 
-    $ python -m luigi --module my_module MyTask --x 100 --local-scheduler
+.. code:: console
+
+        python -m luigi --module my_module MyTask --x 100 --local-scheduler


### PR DESCRIPTION
Also remove $ since it was it wasnt used in luigi_patterns.rst