### PR TITLE
Keeps scheduler updated with running tasks during ping

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -249,6 +249,20 @@ worker-wait-jitter
   Default: 5.0
 
 
+[worker]
+--------
+
+These parameters control the main worker thread and its interactions with
+the scheduler.
+
+task-ping-ratio
+  .. versionadded:: 2.0.0
+
+  Ratio of number of pings that do not contain task information to
+  number that do. Keeping this high means that most pings will be
+  light-weight. Defaults to 60.
+
+
 [elasticsearch]
 ---------------
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -146,9 +146,9 @@ class RemoteScheduler(Scheduler):
         result = json.loads(page)
         return result["response"]
 
-    def ping(self, worker):
+    def ping(self, worker, running_tasks=None):
         # just one attempt, keep-alive thread will keep trying anyway
-        self._request('/api/ping', {'worker': worker}, attempts=1)
+        self._request('/api/ping', {'worker': worker, 'running_tasks': running_tasks}, attempts=1)
 
     def add_task(self, worker, task_id, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None, priority=0,


### PR DESCRIPTION
If the rpc fails to receive a get_work response, it will do an automatic retry
and invisibly return the results of the next call. After this point, the
scheduler will think that the worker is RUNNING the task from the first get_work
call while the worker has no idea that anything happened.

Without further communication, the scheduler will continue to think that the
worker is doing the task until it dies. In the worst case, the scheduler will
end up doing this to all of the leaf tasks for a given worker, which will then
be stuck forever requesting work that depends on tasks that are perputually
RUNNING. This case has happened to me in production.

In order to avoid this issue, this commit adds a list of currently running tasks
to some pings. This list is optional is can be left out of the majority of pings
to keep the pings small and allow for backward compatibility with older workers.
When the scheduler sees that a RUNNING task is not in the sent task list, it
marks that task as FAILED after two consecutive such pings. Two pings are
required to avoid race conditions when tasks have just started or finished.

In order to also handle a related case where the main worker thread dies but the
KeepAliveThread and subprocesses are still alive, the KeepAliveThread checks
that each task is still alive before including it in a ping. This way a long-
running task won't keep all other tasks marked as RUNNING in the scheduler after
the main worker thread stops updating the running task list.

The scheduler could potentially see that a worker is running tasks that are not
RUNNING in the scheduler. I'm not sure what to do about that, so I've left it as
a TODO for now.