### PR TITLE
cli: Allow for --task as a parameter name

### DIFF
--- a/luigi/cmdline_parser.py
+++ b/luigi/cmdline_parser.py
@@ -65,7 +65,7 @@ class CmdlineParser(object):
         # We have to parse again now. As the positionally first unrecognized
         # argument (the task) could be different.
         known_args, _ = self._build_parser().parse_known_args(args=cmdline_args)
-        root_task = known_args.task
+        root_task = known_args.root_task
         parser = self._build_parser(root_task=root_task,
                                     help_all=known_args.core_help_all)
         self._possibly_exit_with_help(parser, known_args)
@@ -80,7 +80,11 @@ class CmdlineParser(object):
 
         # Unfortunately, we have to set it as optional to argparse, so we can
         # parse out stuff like `--module` before we call for `--help`.
-        parser.add_argument('task', nargs='?', help='Task family to run. Is not optional.')
+        parser.add_argument('root_task',
+                            nargs='?',
+                            help='Task family to run. Is not optional.',
+                            metavar='Required root task',
+                            )
 
         for task_name, is_without_section, param_name, param_obj in Register.get_all_params():
             is_the_root_task = task_name == root_task
@@ -112,7 +116,7 @@ class CmdlineParser(object):
         """
         Get the task class
         """
-        return Register.get_task_cls(self.known_args.task)
+        return Register.get_task_cls(self.known_args.root_task)
 
     def _get_task_kwargs(self):
         """

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -781,3 +781,13 @@ class LocalParameters1304Test(LuigiTestCase):
         # The SystemExit is assumed to be thrown by argparse
         self.assertRaises(SystemExit, self.run_locally_split, 'RangeDailyBase --of Blah --start 2015-01-01 --task-limit 1 --blah-arg 123')
         self.assertTrue(self.run_locally_split('RangeDailyBase --of Blah --start 2015-01-01 --task-limit 1 --Blah-blah-arg 123'))
+
+
+class TaskAsParameterName1335Test(LuigiTestCase):
+    def test_parameter_can_be_named_task(self):
+
+        class MyTask(luigi.Task):
+            # Indeed, this is not the most realistic example, but still ...
+            task = luigi.IntParameter()
+
+        self.assertTrue(self.run_locally_split('MyTask --task 5'))


### PR DESCRIPTION
Note that this does not make --task specify the task name as it did with
the old OptParser.

I didn't find a general solution, with this implementation, the name
--root-task still fails to parse. I could chose an arbitrary string, but
I figured it's kind of "good" to prohibit users from calling a parameter
--root-task, as it would be confusing that won't be the actual root
task.

This fixes spotify/luigi#1335.