### PR TITLE
allow SSH multiplexing

### DIFF
--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -91,9 +91,7 @@ class RemoteContext(object):
             return self.host
 
     def _prepare_cmd(self, cmd):
-        connection_cmd = ["ssh", self._host_ref(),
-                          "-S", "none",  # disable ControlMaster since it causes all sorts of weird behaviour with subprocesses...
-                          ]
+        connection_cmd = ["ssh", self._host_ref(), "-o", "ControlMaster=no"]
         if self.sshpass:
             connection_cmd = ["sshpass", "-e"] + connection_cmd
         else:


### PR DESCRIPTION
The SSH option for multiplexing, ControlMaster, was previously forcibly disabled in Luigi.

If a user's ssh configurations includes 'ControlMaster auto', the "weird behavior" as previously described in comment is when the 'ssh' instance spawned by Luigi happens to be the control master, the ssh forks a new process to keep the session alive.  The newly forked process does not close stderr, which prevents process.communicate() from returning.

As such, it is important to not allow luigi's SSH sessions to act as a control master.  However, the current mechanism prevents session multiplexing in its entirety rather than preventing the spawned ssh instances from becoming the control master, preventing the gain of session multiplexing benefits.

By switching luigi.contrib.ssh.RemoteContext._prepare_cmd to use "-o ControlMaster=no" rather than "-S none", the "weird behavior" discussed above is avoided without preventing the use of session multiplexing.  Users wishing to use session multiplexing can then spawn a control master outside of the context of Luigi, using a command such as "ssh -MNn user@server" started elsewhere.

NOTE: luigi.contrib.ssh.RemoteFileSystem._scp already uses ControlMaster=no, rather than disabling the use of session multiplexing without issue.