### PR TITLE
do not forward SSH agent

### DIFF
--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -236,8 +236,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
             cmd.append("-B")
         if self.remote_context.no_host_key_check:
             cmd.extend(['-o', 'UserKnownHostsFile=/dev/null',
-                        '-o', 'StrictHostKeyChecking=no',
-                        '-o', 'ForwardAgent=yes'])
+                        '-o', 'StrictHostKeyChecking=no'])
         if self.remote_context.key_file:
             cmd.extend(["-i", self.remote_context.key_file])
         if self.remote_context.port:


### PR DESCRIPTION
Luigi should not be forwarding SSH agents.  Beyond that, not when performing file transfers, as 'scp' does not have the ability to create new sessions from the remote server.  Beyond that still, forwarding agents when when connecting to hosts without verifying the host keys first (no_host_key_check) means a MITM could remotely authenticate as the origin user.

Note, this change does not prevent the use of SSH agents.  This change prevents remote servers from automatically getting agent forwards during file transfers.

This is the warning from OpenSSH's ssh_config mainpage with regards to ForwardAgent:

    Agent forwarding should be enabled with caution.  Users with the ability to
    bypass file permissions on the remote host (for the agent's Unix-domain
    socket) can access the local agent through the forwarded connection.  An
    attacker cannot obtain key material from the agent, however they can
    perform operations on the keys that enable them to authenticate using the
    identities loaded into the agent.