### PR TITLE
Stops KeepAliveThread and subprocesses on exception in run

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -190,8 +190,10 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
     logger = logging.getLogger('luigi-interface')
     logger.info('Done scheduling tasks')
     if env_params.workers != 0:
-        success &= w.run()
-    w.stop()
+        try:
+            success &= w.run()
+        finally:
+            w.stop()
     logger.info(execution_summary.summary(w))
     return dict(success=success, worker=w)
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -405,6 +405,9 @@ class Worker(object):
         """
         self._keep_alive_thread.stop()
         self._keep_alive_thread.join()
+        for task in self._running_tasks.values():
+            if task.is_alive():
+                task.terminate()
 
     def _generate_worker_info(self):
         # Generate as much info as possible about the worker

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -64,6 +64,16 @@ class InterfaceTest(LuigiTestCase):
 
         self.assertFalse(self._run_interface())
 
+    def test_interface_stops_worker_on_exception(self):
+        self.worker = Worker()
+        self.worker_scheduler_factory.create_worker = Mock(return_value=self.worker)
+        self.worker.add = Mock(side_effect=[True, True])
+        self.worker.run = Mock(side_effect=AttributeError)
+        self.worker.stop = Mock()
+
+        self.assertRaises(AttributeError, self._run_interface)
+        self.worker.stop.assert_called_once_with()
+
     def test_just_run_main_task_cls(self):
         class MyTestTask(luigi.Task):
             pass

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+import psutil
 from helpers import unittest, with_config, skipOnTravis
 
 import luigi.notifications
@@ -817,6 +818,23 @@ class MultipleWorkersTest(unittest.TestCase):
         w._handle_next_task()
         w._handle_next_task()
         w._handle_next_task()
+
+    def test_stop_worker_kills_subprocesses(self):
+        w = Worker(worker_processes=2)
+        hung_task = HungWorker()
+        w.add(hung_task)
+
+        w._run_task(hung_task.task_id)
+        pids = [p.pid for p in w._running_tasks.values()]
+        self.assertEqual(1, len(pids))
+        pid = pids[0]
+
+        def is_running():
+            return pid in {p.pid for p in psutil.Process().children()}
+
+        self.assertTrue(is_running())
+        w.stop()
+        self.assertFalse(is_running())
 
     def test_time_out_hung_worker(self):
         luigi.build([HungWorker(0.1)], workers=2, local_scheduler=True)


### PR DESCRIPTION
If run throws an exception with multiple workers, the KeepAliveThread and any
subprocesses will keep running until all subprocesses are complete. This can
cause communication inconsistencies with the scheduler, so we solve it here by
killing all subprocesses to immediately terminate the worker.