### PR TITLE
Closes #1346: Dependency graph failing on firefox

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -303,7 +303,7 @@ function visualiserApp(luigi) {
     }
 
     function processHashChange(paint) {
-        var hash = location.hash;
+        var hash = decodeURIComponent(location.hash);
         if (hash == "#w") {
             switchTab("workerList");
         } else if (hash) {
@@ -317,7 +317,6 @@ function visualiserApp(luigi) {
                     luigi.getInverseDependencyGraph(taskId, depGraphCallback);
                 } else {
                     luigi.getDependencyGraph(taskId, depGraphCallback);
-                    
                 }
             }
             switchTab("dependencyGraph");


### PR DESCRIPTION
Introduced in Firefox 39, window.location.hash must be urldecoded.
https://bugzilla.mozilla.org/show_bug.cgi?id=1184589