### PR TITLE
Fixes two small bugs with scheduler auto-disables

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -405,7 +405,7 @@ class SimpleTaskState(object):
             elif task.scheduler_disable_time is not None:
                 return
 
-        if new_status == FAILED and task.can_disable():
+        if new_status == FAILED and task.can_disable() and task.status != DISABLED:
             task.add_failure()
             if task.has_excessive_failures():
                 task.scheduler_disable_time = time.time()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -402,7 +402,7 @@ class SimpleTaskState(object):
                 self.re_enable(task)
 
             # don't allow workers to override a scheduler disable
-            elif task.scheduler_disable_time is not None:
+            elif task.scheduler_disable_time is not None and new_status != DISABLED:
                 return
 
         if new_status == FAILED and task.can_disable() and task.status != DISABLED:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -447,7 +447,7 @@ class SimpleTaskState(object):
                 task.remove = time.time() + config.remove_delay
 
         # Re-enable task after the disable time expires
-        if task.status == DISABLED and task.scheduler_disable_time:
+        if task.status == DISABLED and task.scheduler_disable_time is not None:
             if time.time() - fix_time(task.scheduler_disable_time) > config.disable_persist:
                 self.re_enable(task, config)
 

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -650,6 +650,31 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id='A')
         self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
+    def test_automatic_re_enable(self):
+        self.sch = CentralPlannerScheduler(disable_failures=2, disable_persist=100)
+        self.setTime(0)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+
+        # should be disabled now
+        self.assertEqual(DISABLED, self.sch.task_list('', '')['A']['status'])
+
+        # re-enables after 100 seconds
+        self.setTime(101)
+        self.assertEqual(FAILED, self.sch.task_list('', '')['A']['status'])
+
+    def test_automatic_re_enable_with_one_failure_allowed(self):
+        self.sch = CentralPlannerScheduler(disable_failures=1, disable_persist=100)
+        self.setTime(0)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+
+        # should be disabled now
+        self.assertEqual(DISABLED, self.sch.task_list('', '')['A']['status'])
+
+        # re-enables after 100 seconds
+        self.setTime(101)
+        self.assertEqual(FAILED, self.sch.task_list('', '')['A']['status'])
+
     def test_disable_by_worker(self):
         self.sch.add_task(worker=WORKER, task_id='A', status=DISABLED)
         self.assertEqual(len(self.sch.task_list('DISABLED', '')), 1)


### PR DESCRIPTION
First, when the scheduler automatically disables a job, it becomes re-enabled after disable_persist seconds by changing the status from DISABLED to FAILED. This is a problem if the scheduler is set to disable after 1 failure, as it immediately gets disabled again, making the disable effectively permanent. This is fixed by not counting the status change from DISABLED to FAILED as a failure toward the number needed to automatically disable.

Second, when the scheduler disables a job, that prevents most other status changes from taking effect. Due to oversight, this included setting the job as permanently DISABLED. So if you tried to disable a job that the scheduler had already disabled, it would still become re-enabled again after disable_persist seconds. This fixes that bug by allowing workers to set tasks that the scheduler has already disabled to status DISABLED.

I've combined both of these because they're both very simple fixes and will cause merge conflicts with each other if done separately. Also I only found out about the first bug while writing simplified tests for the second bug and I'd like to be able to use those.