### PR TITLE
Properly handles errors in requires functions during scheduling

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -451,6 +451,10 @@ class Worker(object):
         log_msg = "Will not schedule {task} or any dependencies due to error in complete() method:\n{tb}".format(task=task, tb=tb)
         logger.warning(log_msg)
 
+    def _log_dependency_error(self, task, tb):
+        log_msg = "Will not schedule {task} or any dependencies due to error in deps() method:\n{tb}".format(task=task, tb=tb)
+        logger.warning(log_msg)
+
     def _log_unexpected_error(self, task):
         logger.exception("Luigi unexpected framework error while scheduling %s", task)  # needs to be called from within except clause
 
@@ -458,6 +462,13 @@ class Worker(object):
         # like logger.exception but with WARNING level
         subject = "Luigi: {task} failed scheduling. Host: {host}".format(task=task, host=self.host)
         headline = "Will not schedule task or any dependencies due to error in complete() method"
+
+        message = notifications.format_task_error(headline, task, formatted_traceback)
+        notifications.send_error_email(subject, message, task.owner_email)
+
+    def _email_dependency_error(self, task, formatted_traceback):
+        subject = "Luigi: {task} failed scheduling. Host: {host}".format(task=task, host=self.host)
+        headline = "Will not schedule task or any dependencies due to error in deps() method"
 
         message = notifications.format_task_error(headline, task, formatted_traceback)
         notifications.send_error_email(subject, message, task.owner_email)
@@ -557,7 +568,14 @@ class Worker(object):
                            ' this luigi process.', task.task_id)
 
         else:
-            deps = task.deps()
+            try:
+                deps = task.deps()
+            except Exception:
+                formatted_traceback = traceback.format_exc()
+                self.add_succeeded = False
+                self._log_dependency_error(task, formatted_traceback)
+                self._email_dependency_error(task, formatted_traceback)
+                return
             status = PENDING
             runnable = True
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -570,15 +570,21 @@ class WorkerTest(unittest.TestCase):
 
         a = A()
 
-        class C(DummyTask):
+        class D(DummyTask):
             pass
+
+        d = D()
+
+        class C(DummyTask):
+            def requires(self):
+                return d
 
         c = C()
 
         class B(DummyTask):
 
             def requires(self):
-                return a, c
+                return c, a
 
         b = B()
         sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
@@ -587,6 +593,7 @@ class WorkerTest(unittest.TestCase):
         self.assertTrue(w.run())
         self.assertFalse(b.has_run)
         self.assertTrue(c.has_run)
+        self.assertTrue(d.has_run)
         self.assertFalse(a.has_run)
         w.stop()
 
@@ -734,6 +741,20 @@ class WorkerEmailTest(unittest.TestCase):
         self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
         self.worker.run()
         self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertFalse(a.has_run)
+
+    @email_patch
+    def test_requires_error(self, emails):
+        class A(DummyTask):
+
+            def requires(self):
+                raise Exception("b0rk")
+
+        a = A()
+        self.assertEqual(emails, [])
+        self.worker.add(a)
+        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.worker.run()
         self.assertFalse(a.has_run)
 
     @email_patch


### PR DESCRIPTION
We had a test that bugs in requires were properly caught and dealt with,
allowing scheduling to continue with other tasks. Unfortunately, this test
didn't really work properly because it assumed a depth-first scheduling but used
the breadth-first single-threaded scheduling. After adjusting the test to throw
an exception before the rest of the tasks were done scheduling, it failed.

In order to fix this, we wrap the call to deps in Worker._add to catch any
exceptions and log, e-mail, and not schedule the task or its dependencies. This
matches the behavior of errors in the complete function and prevents one bad
task from blocking an entire pipeline.