### PR TITLE
Replace all instances of SIGUSR1 with SIGTERM; addresses #1360

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -164,7 +164,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
             'core', 'no_configure_logging', False):
         setup_interface_logging(logging_conf)
 
-    kill_signal = signal.SIGUSR1 if env_params.take_lock else None
+    kill_signal = signal.SIGTERM if env_params.take_lock else None
     if (not env_params.no_lock and
             not(lock.acquire_for(env_params.lock_pid_dir, env_params.lock_size, kill_signal))):
         raise PidLockAlreadyTakenExit()

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -367,7 +367,7 @@ class Worker(object):
         self.run_succeeded = True
         self.unfulfilled_counts = collections.defaultdict(int)
 
-        signal.signal(signal.SIGUSR1, self.handle_interrupt)
+        signal.signal(signal.SIGTERM, self.handle_interrupt)
 
         self._keep_alive_thread = KeepAliveThread(self._scheduler, self._id, self._config.ping_interval)
         self._keep_alive_thread.daemon = True
@@ -783,9 +783,9 @@ class Worker(object):
 
     def handle_interrupt(self, signum, _):
         """
-        Stops the assistant from asking for more work on SIGUSR1
+        Stops the assistant from asking for more work on SIGTERM
         """
-        if signum == signal.SIGUSR1:
+        if signum == signal.SIGTERM:
             self._config.keep_alive = False
             self._stop_requesting_work = True
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -158,7 +158,7 @@ class WorkerTest(unittest.TestCase):
         self.w.add(d)
 
         self.assertFalse(d.complete())
-        self.w.handle_interrupt(signal.SIGUSR1, None)
+        self.w.handle_interrupt(signal.SIGTERM, None)
         self.w.run()
         self.assertFalse(d.complete())
 


### PR DESCRIPTION
PR #1137 put in place `signal.SIGUSR1` which breaks luigi on Windows machines. Replacing all instances of `SIGUSR1` with `SIGTERM` appears to fix the issue.