### PR TITLE
Fixes to visualizer for tasks with multi-line parameters

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -224,7 +224,7 @@
 
         <script type="text/template" name="actionsTemplate">
             <div class="span2">
-                <a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip"><i class="fa fa-sitemap"></i></a>
+                <a href="#{{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip"><i class="fa fa-sitemap"></i></a>
                 {{#error}}<button class="btn btn-danger btn-xs showError" title="Show error" data-toggle="tooltip"><i class="fa fa-bug"></i></button>{{/error}}
                 {{#re_enable}}<a class="btn btn-warning btn-xs re-enable-button" title="Re-enable" data-toggle="tooltip" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
                 {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
@@ -265,7 +265,7 @@
                 <div class="box-body">
                     Started: {{start_time}}<br>
                     Last Checkin: {{active}}<br>
-                    Root Task: <a href="#{{{first_task}}}">{{first_task}}</a><br>
+                    Root Task: <a href="#{{{encoded_first_task}}}">{{first_task}}</a><br>
                     Running: {{num_running}}<br>
                     Pending: {{num_pending}}<br>
                     Unique Pending: {{num_uniques}}<br>
@@ -287,7 +287,7 @@
                         <td>{{priority}}</td>
                         <td>{{resources}}</td>
                         <td>{{displayTime}}</td>
-                        <td><a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
+                        <td><a href="#{{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
                             {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
                         </td>
                       </tr>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -71,6 +71,7 @@ function visualiserApp(luigi) {
         }
         return {
             taskId: task.taskId,
+            encodedTaskId: encodeURIComponent(task.taskId),
             taskName: taskName,
             taskParams: taskParams,
             priority: task.priority,
@@ -224,6 +225,7 @@ function visualiserApp(luigi) {
     }
 
     function processWorker(worker) {
+        worker.encoded_first_task = encodeURIComponent(worker.first_task);
         worker.tasks = worker.running.map(taskToDisplayTask);
         worker.tasks.sort(function(task1, task2) { return task1.timeRunning - task2.timeRunning; });
         worker.start_time = new Date(worker.started * 1000).toLocaleString();
@@ -307,7 +309,7 @@ function visualiserApp(luigi) {
         if (hash == "#w") {
             switchTab("workerList");
         } else if (hash) {
-            var taskId = hash.substr(1);
+            var taskId = decodeURIComponent(hash.substr(1));
             $("#searchError").empty();
             $("#searchError").removeClass();
             if (taskId != "g") {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -58,7 +58,7 @@ function visualiserApp(luigi) {
     }
 
     function taskToDisplayTask(task) {
-        var taskIdParts = /([A-Za-z0-9_]*)\((.*)\)/.exec(task.taskId);
+        var taskIdParts = /([A-Za-z0-9_]*)\(([\s\S]*)\)/.exec(task.taskId);
         var taskName = taskIdParts[1];
         var taskParams = taskIdParts[2];
         var displayTime = new Date(Math.floor(task.start_time*1000)).toLocaleString();


### PR DESCRIPTION
When running tasks that have a string parameter that span multiple lines, there were a couple small issues with the visualizer (perhaps this is related to #1364). For example, this is a task that would cause issues:

```
$ cat multiline_config.cfg
[Example]
a_parameter: This is a parameter that spans
  multiple lines.

$ cat multiline_example.py
import time
import luigi


class Example(luigi.Task):

    a_parameter = luigi.Parameter()

    def output(self):
        []

    def run(self):
        time.sleep(30)

$ LUIGI_CONFIG_PATH=multiline_config.cfg luigi --module multiline_example Example
```

When visiting the index page, the task is not displayed and spinners are shown instead of the number of tasks in each category:

![image](https://cloud.githubusercontent.com/assets/1062277/10943032/a1f75846-82e0-11e5-942a-da21d78a94b1.png)

This is because of a regex using `.*`, which does not match across line breaks, when parsing the task ID. 71dd897 fixes this so the tasks and category numbers are properly displayed:

![image](https://cloud.githubusercontent.com/assets/1062277/10943061/d769c6da-82e0-11e5-8c2f-d1d295ff630f.png)

Now, the tasks shows up, but when clicking on a link to the dependency graph, the url is `http://localhost:8082/static/visualiser/index.html#Example(a_parameter=This is a parameter that spansmultiple lines.)`, which loses the newline character between "spans" and "multiple", causing the task to not be found:

![image](https://cloud.githubusercontent.com/assets/1062277/10942975/5e829378-82e0-11e5-909f-29c6548c9dc2.png)


9cb2913 fixes this by URI encoding the task id and decoding before retrieving the dependency graph:

![image](https://cloud.githubusercontent.com/assets/1062277/10943102/04973606-82e1-11e5-9420-7fa4fcad4050.png)