### PR TITLE
Use DequeQueue instead of multiprocess.Queue if worker_process==1

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -239,11 +239,9 @@ class DequeQueue(collections.deque):
     """
 
     def put(self, obj, block=None, timeout=None):
-        del block, timeout
         return self.append(obj)
 
     def get(self, block=None, timeout=None):
-        del block, timeout
         return self.pop()
 
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -238,10 +238,12 @@ class DequeQueue(collections.deque):
     deque wrapper implementing the Queue interface.
     """
 
-    def put(self, *args, **kwargs):
-        return self.append(*args)
+    def put(self, obj, block=None, timeout=None):
+        del block, timeout
+        return self.append(obj)
 
-    def get(self, **kwargs):
+    def get(self, block=None, timeout=None):
+        del block, timeout
         return self.pop()
 
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -238,8 +238,11 @@ class DequeQueue(collections.deque):
     deque wrapper implementing the Queue interface.
     """
 
-    put = collections.deque.append
-    get = collections.deque.pop
+    def put(self, *args, **kwargs):
+        return self.append(*args)
+
+    def get(self, **kwargs):
+        return self.pop()
 
 
 class AsyncCompletionException(Exception):
@@ -377,7 +380,11 @@ class Worker(object):
         self._keep_alive_thread.start()
 
         # Keep info about what tasks are running (could be in other processes)
-        self._task_result_queue = multiprocessing.Queue()
+        if worker_processes == 1:
+            self._task_result_queue = DequeQueue()
+        else:
+            self._task_result_queue = multiprocessing.Queue()
+
         self._running_tasks = {}
 
         # Stuff for execution_summary


### PR DESCRIPTION
I changed DequeuQueue to ignore **kwargs.  Elsewhere in the code queue.get() is called with a timeout= argument.