### PR TITLE
Allows disabling of worker e-mails via luigi.cfg

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -115,14 +115,19 @@ email-sender
   Default value: luigi-client@<server_name>
 
 email-type
-  Type of e-mail to send. Valid values are "plain" and "html". When set
-  to html, tracebacks are wrapped in <pre> tags to get fixed-width font.
+  Type of e-mail to send. Valid values are "plain", "html" and "none".
+  When set to html, tracebacks are wrapped in <pre> tags to get fixed-
+  width font.
+
+  New in version 2.1.0: When set to none, no e-mails will be sent.
+
   Default value is plain.
 
 error-email
   Recipient of all error e-mails. If this is not set, no error e-mails
-  are sent when luigi crashes. If luigi is run from the command line, no
-  e-mails will be sent unless output is redirected to a file.
+  are sent when luigi crashes unless the crashed job has owners set. If
+  luigi is run from the command line, no e-mails will be sent unless
+  output is redirected to a file.
 
 hdfs-tmp-dir
   Base directory in which to store temporary files on hdfs. Defaults to


### PR DESCRIPTION
After a night of excessive failures, I found that my workers were dying
whenever a job failed and they weren't able to access the overloaded
smtp server. When I tried to find the configuration option to disable
emails and get things running again, I found that there wasn't one,
although error-email falsely claims to be ablo to do that in the
documentation.

I've updated the documentation for error-email to clarify that e-mails
will still be sent for jobs that have owners and added a "none" option
to email-type that disables email sends. I also cleaned up the logging
for why emails are disabled.