### PR TITLE
Fix broken redshift test

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -103,7 +103,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         return ''
 
-    @property    
+    @property
     def prune_table(self):
         """
         Override to set equal to the name of the table which is to be pruned.

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -232,7 +232,8 @@ class S3CopyToTable(rdbms.CopyToTable):
             raise Exception("table need to be specified")
 
         path = self.s3_load_path()
-        connection = self.output().connect()
+        output = self.output()
+        connection = output.connect()
         cursor = connection.cursor()
 
         self.init_copy(connection)
@@ -240,7 +241,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         self.post_copy(cursor)
 
         # update marker table
-        self.output().touch(connection)
+        output.touch(connection)
         connection.commit()
 
         # commit and clean up

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -50,6 +50,7 @@ class DummyS3CopyToTable(luigi.contrib.redshift.S3CopyToTable):
     def s3_load_path(self):
         return 's3://%s/%s' % (BUCKET, KEY)
 
+
 class DummyS3CopyToTempTable(luigi.contrib.redshift.S3CopyToTable):
     # Class attributes taken from `DummyPostgresImporter` in
     # `../postgres_test.py`.
@@ -79,6 +80,7 @@ class DummyS3CopyToTempTable(luigi.contrib.redshift.S3CopyToTable):
 
     def queries(self):
         return self.sql
+
 
 class TestS3CopyToTable(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.copy")
@@ -134,14 +136,16 @@ class TestS3CopyToTable(unittest.TestCase):
 
         # `mock_redshift_target` is the mocked `RedshiftTarget` object
         # returned by S3CopyToTable.output(self).
-        mock_redshift_target.assert_called_once_with(database=task.database,
-                                                host=task.host,
-                                                update_id='DummyS3CopyToTable(table=stage_dummy_table)',
-                                                user=task.user,
-                                                table=task.table,
-                                                password=task.password,
-                                                table_type='TEMP',
-                                                sql=task.sql)
+        mock_redshift_target.assert_called_once_with(
+            database=task.database,
+            host=task.host,
+            update_id='DummyS3CopyToTable(table=stage_dummy_table)',
+            user=task.user,
+            table=task.table,
+            password=task.password,
+            table_type='TEMP',
+            sql=task.sql,
+        )
 
         # Check if the `S3CopyToTable.s3_load_path` class attribute was
         # successfully referenced in the `S3CopyToTable.run` method, which is
@@ -150,12 +154,12 @@ class TestS3CopyToTable(unittest.TestCase):
         mock_copy.assert_called_once_with(mock_cursor, task.s3_load_path())
 
         # Check the SQL query in `S3CopyToTable.does_table_exist`. # temp table
-        mock_cursor.execute.assert_called_once_with("select 1 as table_exists "
-                                               "from pg_table_def "
-                                               "where tablename = %s limit 1",
-                                               (task.table,))
-
-        return
+        mock_cursor.execute.assert_called_once_with(
+            "select 1 as table_exists "
+            "from pg_table_def "
+            "where tablename = %s limit 1",
+            (task.table,),
+        )
 
 
 class TestS3CopyToSchemaTable(unittest.TestCase):
@@ -174,10 +178,10 @@ class TestS3CopyToSchemaTable(unittest.TestCase):
                                            .return_value)
 
         # Check the SQL query in `S3CopyToTable.does_table_exist`.
-        mock_cursor.execute.assert_called_with("select 1 as table_exists "
-                                               "from information_schema.tables "
-                                               "where table_schema = %s and "
-                                               "table_name = %s limit 1",
-                                               tuple(task.table.split('.')))
-
-        return
+        mock_cursor.execute.assert_called_with(
+            "select 1 as table_exists "
+            "from information_schema.tables "
+            "where table_schema = %s and "
+            "table_name = %s limit 1",
+            tuple(task.table.split('.')),
+        )

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -139,12 +139,10 @@ class TestS3CopyToTable(unittest.TestCase):
         mock_redshift_target.assert_called_once_with(
             database=task.database,
             host=task.host,
-            update_id='DummyS3CopyToTable(table=stage_dummy_table)',
+            update_id='DummyS3CopyToTempTable(table=stage_dummy_table)',
             user=task.user,
             table=task.table,
             password=task.password,
-            table_type='TEMP',
-            sql=task.sql,
         )
 
         # Check if the `S3CopyToTable.s3_load_path` class attribute was
@@ -154,7 +152,7 @@ class TestS3CopyToTable(unittest.TestCase):
         mock_copy.assert_called_once_with(mock_cursor, task.s3_load_path())
 
         # Check the SQL query in `S3CopyToTable.does_table_exist`. # temp table
-        mock_cursor.execute.assert_called_once_with(
+        mock_cursor.execute.assert_any_call(
             "select 1 as table_exists "
             "from pg_table_def "
             "where tablename = %s limit 1",


### PR DESCRIPTION
Note: This includes #1389 because some lines were both broken and violated pep8.

The redshift test asserts that the output is only called once in run,
when run clearly called it twice. I fixed that by storing the output in
a local variable rather than calling it again.

The redshift test asserted that RedshiftTarget is called with arguments
table_type and sql that it does not accept, so I removed those. There
was also a typo in the update_id argument.

The redshift test verified the existence check by asserting that it was
the only redshift call. I fixed that by changing the assertion to verify
that the existence check was made, as the run makes two other calls
afterward.

It seems that this test is incomplete, but it at least no longer fails.