### PR TITLE
examples: pyspark_wc: Make parameter insignificant

### DIFF
--- a/examples/pyspark_wc.py
+++ b/examples/pyspark_wc.py
@@ -73,7 +73,7 @@ class PySparkWordCount(SparkSubmitTask):
     """
     driver_memory = '2g'
     executor_memory = '3g'
-    total_executor_cores = luigi.IntParameter(default=100)
+    total_executor_cores = luigi.IntParameter(default=100, significant=False)
 
     name = "PySpark Word Count"
     app = 'wordcount.py'


### PR DESCRIPTION
The parameter is clearly not significant, as the output path does not depend on it.