### PR TITLE
Enforce at least tornado version 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'tornado<5.0',
+    'tornado>=4.0,<5',
     'python-daemon<3.0',
 ]
 


### PR DESCRIPTION
Otherwise luigid will fail every request with a KeyError. More
details here: https://github.com/spotify/luigi/issues/1394

It is slightly strange that the dependency is declared as 
<5 in it's current incarnation, when tornado 5 is not released.