### PR TITLE
Add a serialize method to TaskParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -557,3 +557,9 @@ class TaskParameter(Parameter):
         Parse a task_famly using the :class:`~luigi.task_register.Register`
         """
         return task_register.Register.get_task_cls(input)
+
+    def serialize(self, cls):
+        """
+        Converts the :py:class:`luigi.task.Task` (sub) class to its family name.
+        """
+        return cls.task_family


### PR DESCRIPTION
Without this method it is not possible to program a task requiring
another task with a TaskParameter. This commit also provides a test
case for this scenario.