### PR TITLE
PhantomJS tests for the visualiser javascript.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - TOXENV=pypy-scheduler
     - TOXENV=py27-gcloud
     - TOXENV=py27-postgres
+    - TOXENV=visualiser
 
 sudo: false
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,6 +18,9 @@ then run one of the tox commands below.
     # You can also test particular files for even faster iterations
     tox -e py27-nonhdfs test/rpc_test.py
 
+    # The visualiser tests require phantomjs to be installed on your path
+    tox -e visualiser
+
     # And some of the others involve downloading and running Hadoop:
     tox -e py33-cdh
     tox -e py34-hdp

--- a/test/visualiser/__init__.py
+++ b/test/visualiser/__init__.py
@@ -1,0 +1,1 @@
+# Tests for visualiser javascript.

--- a/test/visualiser/phantomjs_test.js
+++ b/test/visualiser/phantomjs_test.js
@@ -1,0 +1,335 @@
+var page = require('webpage').create();
+var system = require('system');
+
+var tests = [];
+
+/*
+ * Parse command line to get Luigi scheduler URL
+ */
+if (system.args.length === 1) {
+    console.log('Usage: phantom_test.js <scheduler-url>');
+    phantom.exit();
+}
+
+var url = system.args[1];
+
+
+/*
+ * Minimal test framework
+ */
+function do_tests(page) {
+    var ok = true;
+    var retval;
+
+    tests.forEach(function (spec) {
+        var name = spec[0];
+        var test_func = spec[1];
+
+        retval = report(page.evaluate(test_func), name);
+        ok = ok && retval;
+    });
+
+    return ok;
+}
+
+function report(retval, func_name) {
+
+    if (retval === true) {
+        console.log('[ OK ]  ' + func_name);
+        return true;
+    }
+    else {
+        console.log('[FAIL]  ' + func_name);
+        console.log(retval);
+        return false;
+    }
+}
+
+phantom.onError = function(msg, trace) {
+    var msgStack = ['PHANTOM ERROR: ' + msg];
+    if (trace && trace.length) {
+        msgStack.push('TRACE:');
+        trace.forEach(function(t) {
+            msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line
+                                    + (t.function ? ' (in function ' + t.function +')' : ''));
+        });
+    }
+    console.error(msgStack.join('\n'));
+    phantom.exit(1);
+};
+
+page.onError = function(msg, trace) {
+
+  var msgStack = ['ERROR: ' + msg];
+
+  if (trace && trace.length) {
+    msgStack.push('TRACE:');
+    trace.forEach(function(t) {
+      msgStack.push(' -> ' + t.file + ': ' + t.line
+                    + (t.function ? ' (in function "' + t.function +'")' : ''));
+    });
+  }
+
+  console.error(msgStack.join('\n'));
+
+};
+
+/**
+ * def_test: define a test
+ * @param test_name: Name of test
+ * @param func: A function which will be evaluated within the page and should return
+ *    true for success or any other value for failure.
+ */
+function def_test(test_name, func) {
+    tests.push([test_name, func]);
+}
+
+
+/*
+ * Test definitions
+ */
+def_test('failed_info_test', function () {
+    var el = $('#FAILED_info .info-box-number')[0];
+    if (el.textContent === "4") {
+        return true;
+    }
+    else {
+        return el.textContent;
+    }
+});
+
+def_test('done_info_test', function () {
+    var el = $('#DONE_info .info-box-number')[0];
+    if (el.textContent === "68") {
+        return true;
+    }
+    else {
+        return el.textContent;
+    }
+});
+
+def_test('upstream_failure_info_test', function () {
+    var el = $('#UPSTREAM_FAILED_info .info-box-number')[0];
+    if (el.textContent === '45') {
+        return true;
+    }
+    else {
+        return el.textContent;
+    }
+});
+
+
+def_test('result_count_test', function () {
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 117 entries/)) {
+        return true;
+    }
+    else {
+        return el.textContent;
+    }
+});
+
+def_test('filtered_result_count_test1', function () {
+    var ret;
+    var target = $('ul.sidebar-menu li a').first();
+
+    target.click();
+
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 29 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+});
+
+
+def_test('filtered_result_count_test2', function () {
+    var ret;
+    var target = $('#FAILED_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 4 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+
+def_test('filtered_result_count_test3', function () {
+    var ret;
+    var target = $('#PENDING_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 0 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+
+def_test('filtered_result_count_test4', function () {
+    var ret;
+    var target = $('#RUNNING_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 0 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+
+def_test('filtered_result_count_test5', function () {
+    var ret;
+    var target = $('#DONE_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 68 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+
+def_test('filtered_result_count_test5', function () {
+    var ret;
+    var target = $('#DISABLED_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 0 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+def_test('filtered_result_count_test5', function () {
+    var ret;
+    var target = $('#UPSTREAM_DISABLED_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 0 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+
+def_test('filtered_result_count_test5', function () {
+    var ret;
+    var target = $('#UPSTREAM_FAILED_info').first();
+
+    target.click();
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 45 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    return ret;
+
+});
+
+def_test('searched_result_count_test1', function () {
+    var ret;
+    var dt = $('#taskTable').DataTable();
+
+    dt.search('FailingMergeSort_1').draw();
+
+
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 29 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    dt.search('').draw();
+    return ret;
+
+});
+
+def_test('searched_result_count_test1', function () {
+    var ret;
+    var target = $('#serverSide label').first();
+    var dt = $('#taskTable').DataTable();
+
+    target.click();
+    dt.search('FailingMergeSort_1').draw();
+
+
+    var el = $('#taskTable_info')[0];
+    if (el.textContent.match(/Showing \d+ to \d+ of 29 entries.*from 117 total entries/)) {
+        ret = true;
+    }
+    else {
+        ret = el.textContent;
+    }
+
+    target.click();
+    dt.search('').draw();
+    return ret;
+
+});
+
+
+page.open(url, function(status) {
+    var ok;
+
+    console.log("Loaded " + url + ", status: " + status);
+    if(status === "success") {
+        ok = do_tests(page);
+    }
+    console.log('RESULT: ' + ok);
+    phantom.exit(ok === true ? 0 : -1);
+});

--- a/test/visualiser/visualiser_test.py
+++ b/test/visualiser/visualiser_test.py
@@ -1,0 +1,207 @@
+"""
+Test the visualiser's javascript using PhantomJS.
+
+"""
+
+from __future__ import print_function
+import os
+import luigi
+import subprocess
+import sys
+import unittest
+import time
+import threading
+
+here = os.path.dirname(__file__)
+
+# Patch-up path so that we can import from the directory above this one.
+# This seems to be necessary because the `test` directory has no __init__.py but
+# adding one makes other tests fail.
+sys.path.append(os.path.join(here, '..'))
+from server_test import ServerTestBase
+
+TEST_TIMEOUT = 40
+
+
+@unittest.skipUnless(os.environ.get('TEST_VISUALISER'),
+                     'PhantomJS tests not requested in TEST_VISUALISER')
+class TestVisualiser(ServerTestBase):
+    """
+    Builds a medium-sized task tree of MergeSort results then starts
+    phantomjs  as a subprocess to interact with the scheduler.
+
+    """
+
+    def setUp(self):
+        super(TestVisualiser, self).setUp()
+
+        x = 'I scream for ice cream'
+        task = UberTask(base_task=FailingMergeSort, x=x, copies=4)
+        luigi.build([task], workers=1, scheduler_port=self.get_http_port())
+
+        self.done = threading.Event()
+
+        def _do_ioloop():
+            # Enter ioloop for maximum TEST_TIMEOUT.  Check every 2s whether the test has finished.
+            print('Entering event loop in separate thread')
+
+            for i in range(TEST_TIMEOUT):
+                try:
+                    self.wait(timeout=1)
+                except AssertionError:
+                    pass
+                if self.done.is_set():
+                    break
+
+            print('Exiting event loop thread')
+
+        self.iothread = threading.Thread(target=_do_ioloop)
+        self.iothread.start()
+
+    def tearDown(self):
+        self.done.set()
+        self.iothread.join()
+
+    def test(self):
+        port = self.get_http_port()
+        print('Server port is {}'.format(port))
+        print('Starting phantomjs')
+
+        p = subprocess.Popen('phantomjs {}/phantomjs_test.js http://localhost:{}'.format(here, port),
+                             shell=True, stdin=None)
+
+        # PhantomJS may hang on an error so poll
+        status = None
+        for x in range(TEST_TIMEOUT):
+            status = p.poll()
+            if status is not None:
+                break
+            time.sleep(1)
+
+        if status is None:
+            raise AssertionError('PhantomJS failed to complete')
+        else:
+            print('PhantomJS return status is {}'.format(status))
+            assert status == 0
+
+
+# ---------------------------------------------------------------------------
+# Code for generating a tree of tasks with some failures.
+
+def generate_task_families(task_class, n):
+    """
+    Generate n copies of a task with different task_family names.
+
+    :param task_class: a subclass of `luigi.Task`
+    :param n: number of copies of `task_class` to create
+    :return: Dictionary of task_family => task_class
+
+    """
+    ret = {}
+    for i in range(n):
+        class_name = '{}_{}'.format(task_class.task_family, i)
+        ret[class_name] = type(class_name, (task_class,), {})
+
+    return ret
+
+
+class UberTask(luigi.Task):
+    """
+    A task which depends on n copies of a configurable subclass.
+
+    """
+    _done = False
+
+    base_task = luigi.Parameter()
+    x = luigi.Parameter()
+    copies = luigi.IntParameter()
+
+    def requires(self):
+        task_families = generate_task_families(self.base_task, self.copies)
+        for class_name in task_families:
+            yield task_families[class_name](x=self.x)
+
+    def complete(self):
+        return self._done
+
+    def run(self):
+        self._done = True
+
+
+def popmin(a, b):
+    """
+    popmin(a, b) -> (i, a', b')
+
+    where i is min(a[0], b[0]) and a'/b' are the results of removing i from the
+    relevant sequence.
+    """
+    if len(a) == 0:
+        return b[0], a, b[1:]
+    elif len(b) == 0:
+        return a[0], a[1:], b
+    elif a[0] > b[0]:
+        return b[0], a, b[1:]
+    else:
+        return a[0], a[1:], b
+
+
+class MemoryTarget(luigi.Target):
+    def __init__(self):
+        self.box = None
+
+    def exists(self):
+        return self.box is not None
+
+
+class MergeSort(luigi.Task):
+    x = luigi.Parameter(description='A string to be sorted')
+
+    def __init__(self, *args, **kwargs):
+        super(MergeSort, self).__init__(*args, **kwargs)
+
+        self.result = MemoryTarget()
+
+    def requires(self):
+        # Allows us to override behaviour in subclasses
+        cls = self.__class__
+
+        if len(self.x) > 1:
+            p = len(self.x) // 2
+
+            return [cls(self.x[:p]), cls(self.x[p:])]
+
+    def output(self):
+        return self.result
+
+    def run(self):
+        if len(self.x) > 1:
+            list_1, list_2 = (x.box for x in self.input())
+
+            s = []
+            while list_1 or list_2:
+                item, list_1, list_2 = popmin(list_1, list_2)
+                s.append(item)
+        else:
+            s = self.x
+
+        self.result.box = ''.join(s)
+
+
+class FailingMergeSort(MergeSort):
+    """
+    Simply fail if the string to sort starts with ' '.
+
+    """
+    fail_probability = luigi.FloatParameter(default=0.)
+
+    def run(self):
+        if self.x[0] == ' ':
+            raise Exception('I failed')
+        else:
+            return super(FailingMergeSort, self).run()
+
+
+if __name__ == '__main__':
+    x = 'I scream for ice cream'
+    task = UberTask(base_task=FailingMergeSort, x=x, copies=4)
+    luigi.build([task], workers=1, scheduler_port=8082)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, pypy-scheduler, docs, flake8
+envlist = py{27,33,34}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, visualiser, pypy-scheduler, docs, flake8
 skipsdist = True
 
 [testenv]
@@ -50,6 +50,22 @@ commands =
                                    {posargs:}
   coverage combine
   codecov -e TOXENV
+
+[testenv:visualiser]
+usedevelop = True
+deps =
+  mock<2.0
+  nose<2.0
+  unittest2<2.0
+passenv = {[testenv]passenv}
+setenv =
+  LC_ALL = en_US.utf-8
+  NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket
+  LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
+  TEST_VISUALISER=1
+commands =
+  python --version
+  nosetests -v --tests=test/visualiser
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
These tests check that the visualiser displays the correct number of DONE/PENDING/FAILED/etc. tasks using PhantomJS.  The Python unittest starts PhantomJS in a subprocess whilst running the tornado IOLoop in-process.  I use an implementation of MergeSort to populate the scheduler with a medium-sized task-graph.