### PR TITLE
Fix scope when setting up multiprocessing with coverage

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -31,10 +31,10 @@ def patch_process_for_coverage():
                     cov.stop()
                     cov.save()
 
-    if sys.version_info >= (3, 4):
-        klass._bootstrap = ProcessWithCoverage._bootstrap
-    else:
-        multiprocessing.Process = ProcessWithCoverage
+        if sys.version_info >= (3, 4):
+            klass._bootstrap = ProcessWithCoverage._bootstrap
+        else:
+            multiprocessing.Process = ProcessWithCoverage
 
 
 if os.getenv('FULL_COVERAGE', 'false') == 'true':


### PR DESCRIPTION
If one were to set `parallel=False` in `.coveragerc`, installing via `pip install -e .` (or uninstalling) would error out as `ProcessWithCoverage` would not yet be defined since `COVERAGE_PROCESS_START` env variable would not be set. 

It also doesn't make sense to assign `ProcessWithCoverage` outside the `if Collector._collectors` scope when the class itself may not yet be define (if that makes sense).