### PR TITLE
Configuration.rst: Update docs for hdfs tmp_dir

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -219,9 +219,6 @@ smtp_timeout
   Optionally sets the number of seconds after which smtp attempts should
   time out.
 
-tmp-dir
-  DEPRECATED - use hdfs-tmp-dir instead
-
 worker-count-uniques
   If true, workers will only count unique pending jobs when deciding
   whether to stay alive. So if a worker can't get a job to run and other
@@ -356,6 +353,9 @@ namenode_port
 snakebite_autoconfig
   If true, attempts to automatically detect the host and port of the
   namenode for snakebite queries. Defaults to false.
+  
+tmp_dir
+  Path to where luigi will put temporary files on hdfs
 
 
 [hive]


### PR DESCRIPTION
The old path [core] tmp_dir was not even read. Nowadays [core] hdfs_tmp_dir is deprecated and [hdfs] tmp_dir is preferred. See:

https://github.com/spotify/luigi/blob/ef3a2b1b64e4be23ba145b34f0f9e2c7f12eba49/luigi/contrib/hdfs/config.py#L44