### PR TITLE
cli: Mention incorrect taskname over missing args

### DIFF
--- a/luigi/cmdline_parser.py
+++ b/luigi/cmdline_parser.py
@@ -71,6 +71,9 @@ class CmdlineParser(object):
         self._possibly_exit_with_help(parser, known_args)
         if not root_task:
             raise SystemExit('No task specified')
+        else:
+            # Check that what we believe to be the task is correctly spelled
+            Register.get_task_cls(root_task)
         known_args = parser.parse_args(args=cmdline_args)
         self.known_args = known_args  # Also publically expose parsed arguments
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -259,6 +259,17 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(stdout.find(b'[FileSystem] data/streams_2015_03_04_faked.tsv') != -1)
         self.assertTrue(stdout.find(b'[DB] localhost') != -1)
 
+    def test_bin_mentions_misspelled_task(self):
+        """
+        Test that the error message is informative when a task is misspelled.
+
+        In particular it should say that the task is misspelled and not that
+        the local parameters do not exist.
+        """
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', 'HooBaseClass', '--x 5'])
+        self.assertTrue(stderr.find(b'FooBaseClass') != -1)
+        self.assertTrue(stderr.find(b'--x') != 0)
+
 
 if __name__ == '__main__':
     # Needed for one of the tests

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -78,8 +78,12 @@ class RetcodesTest(LuigiTestCase):
             self.run_with_config(dict(already_running='3'), 'Task', 3, extra_args=['--local-scheduler'])
 
     def test_unhandled_exception(self):
-        self.run_and_expect('UnknownTask', 4)
-        self.run_and_expect('UnknownTask --retcode-unhandled-exception 2', 2)
+        def new_func(*args, **kwargs):
+            raise Exception()
+
+        with mock.patch('luigi.worker.Worker.add', new_func):
+            self.run_and_expect('Task', 4)
+            self.run_and_expect('Task --retcode-unhandled-exception 2', 2)
 
         class TaskWithRequiredParam(luigi.Task):
             param = luigi.Parameter()


### PR DESCRIPTION
Currently, if you misspell your task in a invocation like this:

    luigi MyTaskk --my-param 123

Luigi will compalin that `--my-param 123` isn't recognized. While that
is technically correct as well, it's more user friendly to first control
that the user entered a correct task name.