### PR TITLE
fix: `/history` referred to wrong Bootstrap URL

### DIFF
--- a/luigi/templates/header.html
+++ b/luigi/templates/header.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>Luigi Task History</title>
-<link href="/static/visualiser/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-<script src="/static/visualiser/lib/bootstrap/js/bootstrap.min.js"></script>
+<link href="/static/visualiser/lib/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
+<script src="/static/visualiser/lib/bootstrap3/js/bootstrap.min.js"></script>


### PR DESCRIPTION
I know `/history` view is a bit of an outsider, but it still refers to the wrong path and this was easy to fix.