### PR TITLE
bigquery: Ensure the dataset exists on bulk_complete.

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -329,13 +329,13 @@ class MixinBigqueryBulkComplete(object):
 
         # Query the available tables for all datasets
         client = tasks_with_params[0][0].output().client
-
-        available = {dataset: set(client.list_tables(dataset)) for dataset in datasets}
+        available_datasets = filter(client.dataset_exists, datasets)
+        available_tables = {d: set(client.list_tables(d)) for d in available_datasets}
 
         # Return parameter_tuples belonging to available tables
         for t, p in tasks_with_params:
             table = t.output().table
-            if table.table_id in available.get(table.dataset, []):
+            if table.table_id in available_tables.get(table.dataset, []):
                 yield p
 
 

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -149,11 +149,20 @@ class BulkCompleteTest(unittest.TestCase):
         parameters = ['table1', 'table2']
 
         client = MagicMock()
+        client.dataset_exists.return_value = True
         client.list_tables.return_value = ['table2', 'table3']
         TestRunQueryTask.client = client
 
         complete = list(TestRunQueryTask.bulk_complete(parameters))
         self.assertEquals(complete, ['table2'])
+
+    def test_dataset_doesnt_exist(self):
+        client = MagicMock()
+        client.dataset_exists.return_value = False
+        TestRunQueryTask.client = client
+
+        complete = list(TestRunQueryTask.bulk_complete(['table1']))
+        self.assertEquals(complete, [])
 
 
 class RunQueryTest(unittest.TestCase):


### PR DESCRIPTION
Without this patch checking for a range in a dataset that doesn't
exist would raise an Exception. Make sure we don't end up there
by only searching available datasets.