### PR TITLE
Add missing event.BROKEN_TASK trigger

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -583,10 +583,11 @@ class Worker(object):
         else:
             try:
                 deps = task.deps()
-            except Exception:
+            except Exception as ex:
                 formatted_traceback = traceback.format_exc()
                 self.add_succeeded = False
                 self._log_dependency_error(task, formatted_traceback)
+                task.trigger_event(Event.BROKEN_TASK, task, ex)
                 self._email_dependency_error(task, formatted_traceback)
                 return
             status = PENDING


### PR DESCRIPTION
After implementing https://github.com/spotify/luigi/pull/1357, event BROKEN_TASK  has been no longer triggered on broken dependency