### PR TITLE
Make luigi client work without tornado

### DIFF
--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -3,10 +3,6 @@ import argparse
 import logging
 import sys
 
-import luigi.interface
-import luigi.server
-import luigi.process
-import luigi.configuration
 from luigi.retcodes import run_with_retcodes
 
 
@@ -15,6 +11,9 @@ def luigi_run(argv=sys.argv[1:]):
 
 
 def luigid(argv=sys.argv[1:]):
+    import luigi.server
+    import luigi.process
+    import luigi.configuration
     parser = argparse.ArgumentParser(description=u'Central luigi server')
     parser.add_argument(u'--background', help=u'Run in background mode', action='store_true')
     parser.add_argument(u'--pidfile', help=u'Write pidfile')


### PR DESCRIPTION
If I download luigi without installing tornado, I still would like to
try it out using say the local scheduler or a scheduler that's running
somewhere else. Or as in my case, having a different python version
that has tornado running luigid.

This means that you now can just download the luigi source code and get
started quite quickly by just running:

    PYTHONPATH=. python3 -m examples.foo

or

    PYTHONPATH=. python3 -m luigi --module examples.foo examples.Foo --local-scheduler