### PR TITLE
docs: Exclpitly state version compatibility

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -16,6 +16,9 @@
 #
 """
 This module contains the bindings for command line integration and dynamic loading of tasks
+
+If you don't want to run luigi from the command line. You may use the methods
+defined in this module to programatically run luigi.
 """
 
 import logging

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -22,6 +22,10 @@ The worker communicates with the scheduler and does two things:
 
 When running in local mode, the worker talks directly to a :py:class:`~luigi.scheduler.CentralPlannerScheduler` instance.
 When you run a central server, the worker will talk to the scheduler using a :py:class:`~luigi.rpc.RemoteScheduler` instance.
+
+Everything in this module is private to luigi and may change in incompatible
+ways between versions. The exception is the exception types and the
+:py:class:`worker` config class.
 """
 
 import collections


### PR DESCRIPTION
I just want to clarify that one should not use or depend on interface of
the Worker class.