### PR TITLE
Make the Worker a context manager

### DIFF
--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -61,10 +61,7 @@ class FibTestBase(unittest.TestCase):
 class FibTest(FibTestBase):
 
     def test_invoke(self):
-        w = luigi.worker.Worker()
-        w.add(Fib(100))
-        w.run()
-        w.stop()
+        luigi.build([Fib(100)], local_scheduler=True)
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_10'), b'55\n')
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 

--- a/test/instance_test.py
+++ b/test/instance_test.py
@@ -59,11 +59,7 @@ class InstanceTest(unittest.TestCase):
             def run(self):
                 test.assertTrue(self.requires().has_run)
 
-        w = luigi.worker.Worker()
-        w.add(B(1))
-        w.add(B(2))
-        w.run()
-        w.stop()
+        luigi.build([B(1), B(2)], local_scheduler=True)
 
     def test_external_instance_cache(self):
         class A(luigi.Task):

--- a/test/instance_wrap_test.py
+++ b/test/instance_wrap_test.py
@@ -95,9 +95,6 @@ class InstanceWrapperTest(unittest.TestCase):
         r = ReportReader(d)
         ex = CurrencyExchanger(r, 'USD')
 
-        w = luigi.worker.Worker()
-        w.add(ex)
-        w.run()
-        w.stop()
+        luigi.build([ex], local_scheduler=True)
         self.assertEqual(ex.get_line(0), (decimal.Decimal('10.0'), 'USD'))
         self.assertEqual(ex.get_line(1), (decimal.Decimal('5.0'), 'USD'))

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -70,10 +70,6 @@ class ExceptionFormatTest(unittest.TestCase):
 
     def setUp(self):
         self.sch = CentralPlannerScheduler()
-        self.w = Worker(scheduler=self.sch)
-
-    def tear_down(self):
-        self.w.stop()
 
     def test_fail_run(self):
         task = FailRunTask(foo='foo', bar='bar')
@@ -95,8 +91,9 @@ class ExceptionFormatTest(unittest.TestCase):
                            'email-prefix': '[TEST] '}})
     @mock.patch('luigi.notifications.send_error_email')
     def _run_task(self, task, mock_send):
-        self.w.add(task)
-        self.w.run()
+        with Worker(scheduler=self.sch) as w:
+            w.add(task)
+            w.run()
 
         self.assertEqual(mock_send.call_count, 1)
         args, kwargs = mock_send.call_args
@@ -108,8 +105,9 @@ class ExceptionFormatTest(unittest.TestCase):
                            'email-type': 'html'}})
     @mock.patch('luigi.notifications.send_error_email')
     def _run_task_html(self, task, mock_send):
-        self.w.add(task)
-        self.w.run()
+        with Worker(scheduler=self.sch) as w:
+            w.add(task)
+            w.run()
 
         self.assertEqual(mock_send.call_count, 1)
         args, kwargs = mock_send.call_args

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -47,9 +47,6 @@ class RecursionTest(unittest.TestCase):
         MockTarget.fs.get_all_data()['/tmp/popularity/2009-01-01.txt'] = b'0\n'
 
     def test_invoke(self):
-        w = luigi.worker.Worker()
-        w.add(Popularity(datetime.date(2010, 1, 1)))
-        w.run()
-        w.stop()
+        luigi.build([Popularity(datetime.date(2009, 1, 5))], local_scheduler=True)
 
-        self.assertEqual(MockTarget.fs.get_data('/tmp/popularity/2010-01-01.txt'), b'365\n')
+        self.assertEqual(MockTarget.fs.get_data('/tmp/popularity/2009-01-05.txt'), b'4\n')

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -95,11 +95,10 @@ class SchedulerVisualisationTest(unittest.TestCase):
             self.assert_(t.complete())
 
     def _build(self, tasks):
-        w = luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1)
-        for t in tasks:
-            w.add(t)
-        w.run()
-        w.stop()
+        with luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1) as w:
+            for t in tasks:
+                w.add(t)
+            w.run()
 
     def _remote(self):
         return self.scheduler

--- a/test/task_history_test.py
+++ b/test/task_history_test.py
@@ -42,23 +42,18 @@ class SimpleTaskHistory(luigi.task_history.TaskHistory):
 
 class TaskHistoryTest(LuigiTestCase):
 
-    def setUp(self):
-        self.th = SimpleTaskHistory()
-        self.sch = luigi.scheduler.CentralPlannerScheduler(task_history_impl=self.th)
-        self.w = luigi.worker.Worker(scheduler=self.sch)
-
-    def tearDown(self):
-        self.w.stop()
-
     def test_run(self):
-        class MyTask(luigi.Task):
-            pass
+        th = SimpleTaskHistory()
+        sch = luigi.scheduler.CentralPlannerScheduler(task_history_impl=th)
+        with luigi.worker.Worker(scheduler=sch) as w:
+            class MyTask(luigi.Task):
+                pass
 
-        self.w.add(MyTask())
-        self.w.run()
+            w.add(MyTask())
+            w.run()
 
-        self.assertEqual(self.th.actions, [
-            ('scheduled', 'MyTask()'),
-            ('started', 'MyTask()'),
-            ('finished', 'MyTask()')
-        ])
+            self.assertEqual(th.actions, [
+                ('scheduled', 'MyTask()'),
+                ('started', 'MyTask()'),
+                ('finished', 'MyTask()')
+            ])

--- a/test/worker_external_task_test.py
+++ b/test/worker_external_task_test.py
@@ -80,11 +80,10 @@ class WorkerExternalTaskTest(unittest.TestCase):
 
     def _build(self, tasks):
         self.scheduler = CentralPlannerScheduler(prune_on_get_work=True)
-        w = luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1)
-        for t in tasks:
-            w.add(t)
-        w.run()
-        w.stop()
+        with luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1) as w:
+            for t in tasks:
+                w.add(t)
+            w.run()
 
     def test_external_dependency_already_complete(self):
         """

--- a/test/worker_multiprocess_test.py
+++ b/test/worker_multiprocess_test.py
@@ -50,10 +50,10 @@ class MultiprocessWorkerTest(unittest.TestCase):
         self.scheduler = RemoteScheduler()
         self.scheduler.add_worker = Mock()
         self.scheduler.add_task = Mock()
-        self.worker = Worker(scheduler=self.scheduler, worker_id='X', worker_processes=2)
+        self.worker = Worker(scheduler=self.scheduler, worker_id='X', worker_processes=2).__enter__()
 
     def tearDown(self):
-        self.worker.stop()
+        self.worker.__exit__(None, None, None)
 
     def gw_res(self, pending, task_id):
         return dict(n_pending_tasks=pending,


### PR DESCRIPTION
This way, we will shut down the KeepAliveThread even when there is an
error during the scheduling phase.  And context managers is a more
pythonic construct than the invented stop() method. This was also a now
removed TODO in the code.

I also put the side effect of starting the KeepAliveThread into the
__enter__ block. I found it surprising that constructing a Worker()
would start a new thread.

A lot of test cases had to be rewritten. While at it, I cleaned up some
of the tests and also added many forgotten cleanups. Hopefully tests are
more stable from now on.