### PR TITLE
bigquery: Add ExternalBigqueryTask.

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -454,3 +454,10 @@ class BigqueryRunQueryTask(MixinBigqueryBulkComplete, luigi.Task):
         }
 
         bq_client.run_job(output.table.project_id, job, dataset=output.table.dataset)
+
+
+class ExternalBigqueryTask(MixinBigqueryBulkComplete, luigi.ExternalTask):
+    """
+    An external task for a BigQuery target.
+    """
+    pass

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -57,7 +57,14 @@ class TestRunQueryTaskWithRequires(bigquery.BigqueryRunQueryTask):
         return bigquery.BigqueryTarget(PROJECT_ID, DATASET_ID, self.table, client=self.client)
 
 
-class BulkCompleteTest(unittest.TestCase):
+class TestExternalBigqueryTask(bigquery.ExternalBigqueryTask):
+    client = MagicMock()
+
+    def output(self):
+        return bigquery.BigqueryTarget(PROJECT_ID, DATASET_ID, 'table1', client=self.client)
+
+
+class BigqueryTest(unittest.TestCase):
 
     def test_bulk_complete(self):
         parameters = ['table1', 'table2']
@@ -77,9 +84,6 @@ class BulkCompleteTest(unittest.TestCase):
 
         complete = list(TestRunQueryTask.bulk_complete(['table1']))
         self.assertEquals(complete, [])
-
-
-class RunQueryTest(unittest.TestCase):
 
     def test_query_property(self):
         task = TestRunQueryTask(table='table2')
@@ -101,3 +105,8 @@ class RunQueryTest(unittest.TestCase):
         expected_table = '[' + DATASET_ID + '.' + task.requires().output().table.table_id + ']'
         self.assertIn(expected_table, query)
         self.assertEqual(query, task.query)
+
+    def test_external_task(self):
+        task = TestExternalBigqueryTask()
+        self.assertIsInstance(task, luigi.ExternalTask)
+        self.assertIsInstance(task, bigquery.MixinBigqueryBulkComplete)


### PR DESCRIPTION
You can use `ExternalBigqueryTask` to refer to an existing table in
BigQuery, with bulk complete support.