### PR TITLE
Have snakebite HDFS client fallback to HADOOP_USER_NAME from env

### DIFF
--- a/luigi/contrib/hdfs/config.py
+++ b/luigi/contrib/hdfs/config.py
@@ -36,7 +36,11 @@ except ImportError:
 
 class hdfs(luigi.Config):
     client_version = luigi.IntParameter(default=None)
-    effective_user = luigi.Parameter(default=None)
+    effective_user = luigi.Parameter(
+        default=os.getenv('HADOOP_USER_NAME'),
+        description="Optionally specifies the effective user for snakebite. "
+                    "If not set the environment variable HADOOP_USER_NAME is "
+                    "used, else USER")
     snakebite_autoconfig = luigi.BoolParameter(default=False)
     namenode_host = luigi.Parameter(default=None)
     namenode_port = luigi.IntParameter(default=None)


### PR DESCRIPTION
It turns out that the HADOOP_USER_NAME environment variable propagates nicely to the `hadoop jar` and `hdfs dfs` invocations that luigi triggers but the same is not true for the in proc snakebite client.

The attached patch rectifies this, provided that effective_user is not explicitly set in configuration.