### PR TITLE
Added initgroups kwarg if python-daemon version is over 2.1.0

### DIFF
--- a/test/worker_multiprocess_test.py
+++ b/test/worker_multiprocess_test.py
@@ -46,14 +46,13 @@ class DummyTask(Task):
 
 class MultiprocessWorkerTest(unittest.TestCase):
 
-    def setUp(self):
+    def run(self, result=None):
         self.scheduler = RemoteScheduler()
         self.scheduler.add_worker = Mock()
         self.scheduler.add_task = Mock()
-        self.worker = Worker(scheduler=self.scheduler, worker_id='X', worker_processes=2).__enter__()
-
-    def tearDown(self):
-        self.worker.__exit__(None, None, None)
+        with Worker(scheduler=self.scheduler, worker_id='X', worker_processes=2) as worker:
+            self.worker = worker
+            super(MultiprocessWorkerTest, self).run(result)
 
     def gw_res(self, pending, task_id):
         return dict(n_pending_tasks=pending,

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -109,18 +109,16 @@ class DynamicRequiresOtherModule(Task):
 
 class WorkerTest(unittest.TestCase):
 
-    def setUp(self):
-        # InstanceCache.disable()
+    def run(self, result=None):
         self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
-        self.w = Worker(scheduler=self.sch, worker_id='X').__enter__()
-        self.w2 = Worker(scheduler=self.sch, worker_id='Y').__enter__()
         self.time = time.time
+        with Worker(scheduler=self.sch, worker_id='X') as w, Worker(scheduler=self.sch, worker_id='Y') as w2:
+            self.w = w
+            self.w2 = w2
+            super(WorkerTest, self).run(result)
 
-    def tearDown(self):
         if time.time != self.time:
             time.time = self.time
-        self.w.__exit__(None, None, None)
-        self.w2.__exit__(None, None, None)
 
     def setTime(self, t):
         time.time = lambda: t
@@ -712,13 +710,12 @@ def custom_email_patch(config):
 
 class WorkerEmailTest(unittest.TestCase):
 
-    def setUp(self):
+    def run(self, result=None):
         super(WorkerEmailTest, self).setUp()
         sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
-        self.worker = Worker(scheduler=sch, worker_id="foo").__enter__()
-
-    def tearDown(self):
-        self.worker.__exit__(None, None, None)
+        with Worker(scheduler=sch, worker_id="foo") as worker:
+            self.worker = worker
+            super(WorkerEmailTest, self).run(result)
 
     @email_patch
     def test_connection_error(self, emails):
@@ -967,13 +964,12 @@ class Dummy2Task(Task):
 
 
 class AssistantTest(unittest.TestCase):
-    def setUp(self):
+    def run(self, result=None):
         self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
-        self.w = Worker(scheduler=self.sch, worker_id='X').__enter__()
         self.assistant = Worker(scheduler=self.sch, worker_id='Y', assistant=True)
-
-    def tearDown(self):
-        self.w.__exit__(None, None, None)
+        with Worker(scheduler=self.sch, worker_id='X') as w:
+            self.w = w
+            super(AssistantTest, self).run(result)
 
     def test_get_work(self):
         d = Dummy2Task('123')


### PR DESCRIPTION
python-daemon in its upgrade to 2.1.0 included a new kwarg that broke the daemonization.

This commit checks its version and ads the "initgroup" kwarg if needed. Tested manually with python-daemon 2.0.0 and 2.1.0 versions.