### PR TITLE
Allow scheduler to listen on unix socket normally

### DIFF
--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -41,4 +41,4 @@ def luigid(argv=sys.argv[1:]):
                                 filename=os.path.join(opts.logdir, "luigi-server.log"))
         else:
             logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format())
-        luigi.server.run(api_port=opts.port, address=opts.address)
+        luigi.server.run(api_port=opts.port, address=opts.address, unix_socket=opts.unix_socket)


### PR DESCRIPTION
Previously, the scheduler would only listen on a supplied unix
socket when run in the background.  When run normally, it would
ignore the given unix socket and serve on the default port.  This
is fixed by passing the given unix_socket to server.run when
the scheduler is run normally.  Fixes #1437