### PR TITLE
Fixed: Broken Redshift Table Creation

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -216,10 +216,10 @@ class S3CopyToTable(rdbms.CopyToTable):
             query = ("CREATE {type} TABLE "
                      "{table} ({coldefs}) "
                      "{table_attributes}").format(
-                type=self.table_type(),
+                type=self.table_type,
                 table=self.table,
                 coldefs=coldefs,
-                table_attributes=self.table_attributes())
+                table_attributes=self.table_attributes)
 
             connection.cursor().execute(query)
 

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -120,6 +120,31 @@ class TestS3CopyToTable(unittest.TestCase):
 
         return
 
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_table_exist",
+                return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_to_missing_table(self,
+                                      mock_redshift_target,
+                                      mock_does_exist):
+        """
+        Test missing table creation
+        """
+        task = DummyS3CopyToTable()
+        task.run()
+
+        # The mocked connection cursor passed to
+        # S3CopyToTable.copy(self, cursor, f).
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        # Ensure `S3CopyToTable.create_table` does not throw an error.
+        assert mock_cursor.execute.called
+
+        return
+
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.copy")
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_s3_copy_to_temp_table(self, mock_redshift_target, mock_copy):

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -129,19 +129,19 @@ class TestS3CopyToTable(unittest.TestCase):
         """
         Test missing table creation
         """
+        # Ensure `S3CopyToTable.create_table` does not throw an error.
         task = DummyS3CopyToTable()
         task.run()
 
-        # The mocked connection cursor passed to
-        # S3CopyToTable.copy(self, cursor, f).
+        # Make sure the cursor was successfully used to create the table in
+        # `create_table` as expected.
         mock_cursor = (mock_redshift_target.return_value
                                            .connect
                                            .return_value
                                            .cursor
                                            .return_value)
-
-        # Ensure `S3CopyToTable.create_table` does not throw an error.
-        assert mock_cursor.execute.called
+        assert mock_cursor.execute.call_args_list[0][0][0].startswith(
+            "CREATE  TABLE %s" % task.table)
 
         return
 


### PR DESCRIPTION
Table creation is broken in `contrib.redshift`.

The definition of `table_type` and `table_attributes` had been changed to include a `@property` decorator in October, but their use in `create_table` was still expecting methods.

This fix assumes we want properties (as doing so makes it easier for subclasses to simply fill in static values).

Unit test included.