### PR TITLE
fix for 'allow binary opens'

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -112,7 +112,7 @@ class LocalTarget(FileSystemTarget):
                 pass
 
     def open(self, mode='r'):
-        if mode[:1] == 'w':
+        if mode[:1] == 'w' and '+' not in mode:
             self.makedirs()
             return self.format.pipe_writer(atomic_file(self.path))
 


### PR DESCRIPTION
This commit prevents 'append' and 'update' modes, and is a fix to the previous commit, which was intended to allow 'binary' mode.