### PR TITLE
fix for 'allow binary opens'

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -112,7 +112,7 @@ class LocalTarget(FileSystemTarget):
                 pass
 
     def open(self, mode='r'):
-        rwmode = mode.replace('b','').replace('t','')
+        rwmode = mode.replace('b', '').replace('t', '')
         if rwmode == 'w':
             self.makedirs()
             return self.format.pipe_writer(atomic_file(self.path))

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -112,16 +112,17 @@ class LocalTarget(FileSystemTarget):
                 pass
 
     def open(self, mode='r'):
-        if mode == 'w':
+        rwmode = mode.replace('b','').replace('t','')
+        if rwmode == 'w':
             self.makedirs()
             return self.format.pipe_writer(atomic_file(self.path))
 
-        elif mode == 'r':
-            fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, 'r')))
+        elif rwmode == 'r':
+            fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, mode)))
             return self.format.pipe_reader(fileobj)
 
         else:
-            raise Exception('mode must be r/w')
+            raise Exception('mode must be r/w (got:%s)' % mode)
 
     def move(self, new_path, raise_if_exists=False):
         if raise_if_exists and os.path.exists(new_path):

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -115,7 +115,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         t.copy(self.copy)
         self.assertTrue(os.path.exists(self.path))
         self.assertTrue(os.path.exists(self.copy))
-        self.assertEqual(t.open('r').read(),LocalTarget(self.copy).open('r').read())
+        self.assertEqual(t.open('r').read(), LocalTarget(self.copy).open('r').read())
 
     def test_move(self):
         t = LocalTarget(self.path)

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -30,6 +30,9 @@ from luigi.file import LocalFileSystem
 from luigi.target import FileAlreadyExists, MissingParentDirectory
 from target_test import FileSystemTargetTestMixin
 
+import itertools
+import io
+from errno import EEXIST
 
 class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
     path = '/tmp/test.txt'
@@ -166,6 +169,68 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
         self.assertEqual(b'a\nb\nc\nd', b)
         self.assertEqual(b'a\r\nb\r\nc\r\nd', c)
+
+
+    def theoretical_io_modes(
+            self,
+            rwax='rwax',
+            bt=['','b','t'],
+            plus=['', '+']):
+        p = itertools.product(rwax, plus, bt)
+        return set(
+                [''.join(c) for c in 
+                    list(itertools.chain.from_iterable(
+                        [itertools.permutations(m) for m in 
+                            p]))])
+        
+    def valid_io_modes(self, *a, **kw):
+        modes = set()
+        t = LocalTarget(is_tmp=True)
+        t.open('w').close()
+        for mode in self.theoretical_io_modes(*a, **kw):
+            try:
+                io.FileIO(t.path, mode).close()
+            except ValueError: 
+                pass
+            except IOError as err:
+                if err.errno == EEXIST:
+                    modes.add(mode)
+                else:
+                    raise
+            else:
+                modes.add(mode)
+        return modes
+
+    def valid_write_io_modes_for_luigi(self):
+        return self.valid_io_modes('w', plus=[''])
+
+    def valid_read_io_modes_for_luigi(self):
+        return self.valid_io_modes('r', plus=[''])
+
+    def invalid_io_modes_for_luigi(self):
+        return self.valid_io_modes().difference(
+                self.valid_write_io_modes_for_luigi(), 
+                self.valid_read_io_modes_for_luigi())
+
+    def test_open_modes(self):
+        t = LocalTarget(is_tmp=True)
+        print('Valid write mode:', end=' ')
+        for mode in self.valid_write_io_modes_for_luigi():
+            print(mode, end=' ')
+            p = t.open(mode)
+            p.close()
+        print()
+        print('Valid read mode:', end=' ')
+        for mode in self.valid_read_io_modes_for_luigi():
+            print(mode, end=' ')
+            p = t.open(mode)
+            p.close()
+        print()
+        print('Invalid mode:', end=' ')
+        for mode in self.invalid_io_modes_for_luigi():
+            print(mode, end=' ')
+            self.assertRaises(Exception, t.open, mode)
+        print()
 
 
 class LocalTargetCreateDirectoriesTest(LocalTargetTest):

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -34,6 +34,7 @@ import itertools
 import io
 from errno import EEXIST
 
+
 class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
     path = '/tmp/test.txt'
     copy = '/tmp/test.copy.txt'
@@ -170,19 +171,16 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertEqual(b'a\nb\nc\nd', b)
         self.assertEqual(b'a\r\nb\r\nc\r\nd', c)
 
-
     def theoretical_io_modes(
             self,
             rwax='rwax',
-            bt=['','b','t'],
+            bt=['', 'b', 't'],
             plus=['', '+']):
         p = itertools.product(rwax, plus, bt)
-        return set(
-                [''.join(c) for c in 
-                    list(itertools.chain.from_iterable(
-                        [itertools.permutations(m) for m in 
-                            p]))])
-        
+        return set( [''.join(c) for c in
+            list(itertools.chain.from_iterable(
+                [itertools.permutations(m) for m in p]))])
+
     def valid_io_modes(self, *a, **kw):
         modes = set()
         t = LocalTarget(is_tmp=True)
@@ -190,7 +188,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         for mode in self.theoretical_io_modes(*a, **kw):
             try:
                 io.FileIO(t.path, mode).close()
-            except ValueError: 
+            except ValueError:
                 pass
             except IOError as err:
                 if err.errno == EEXIST:
@@ -209,7 +207,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
     def invalid_io_modes_for_luigi(self):
         return self.valid_io_modes().difference(
-                self.valid_write_io_modes_for_luigi(), 
+                self.valid_write_io_modes_for_luigi(),
                 self.valid_read_io_modes_for_luigi())
 
     def test_open_modes(self):

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -115,7 +115,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
         t.copy(self.copy)
         self.assertTrue(os.path.exists(self.path))
         self.assertTrue(os.path.exists(self.copy))
-        self.assertEqual(t.open('r').read(), LocalTarget(self.copy).open('r').read())
+        self.assertEqual(t.open('r').read(),LocalTarget(self.copy).open('r').read())
 
     def test_move(self):
         t = LocalTarget(self.path)
@@ -177,8 +177,8 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
             bt=['', 'b', 't'],
             plus=['', '+']):
         p = itertools.product(rwax, plus, bt)
-        return set([''.join(c) for c in
-                list(itertools.chain.from_iterable(
+        return set([''.join(c) for c in list(
+            itertools.chain.from_iterable(
                 [itertools.permutations(m) for m in p]))])
 
     def valid_io_modes(self, *a, **kw):
@@ -208,7 +208,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
     def invalid_io_modes_for_luigi(self):
         return self.valid_io_modes().difference(
             self.valid_write_io_modes_for_luigi(),
-                self.valid_read_io_modes_for_luigi())
+            self.valid_read_io_modes_for_luigi())
 
     def test_open_modes(self):
         t = LocalTarget(is_tmp=True)

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -177,8 +177,8 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
             bt=['', 'b', 't'],
             plus=['', '+']):
         p = itertools.product(rwax, plus, bt)
-        return set( [''.join(c) for c in
-            list(itertools.chain.from_iterable(
+        return set([''.join(c) for c in
+                list(itertools.chain.from_iterable(
                 [itertools.permutations(m) for m in p]))])
 
     def valid_io_modes(self, *a, **kw):
@@ -207,7 +207,7 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
     def invalid_io_modes_for_luigi(self):
         return self.valid_io_modes().difference(
-                self.valid_write_io_modes_for_luigi(),
+            self.valid_write_io_modes_for_luigi(),
                 self.valid_read_io_modes_for_luigi())
 
     def test_open_modes(self):


### PR DESCRIPTION
The previous commit's intent was to enable 'binary' mode. This commit fixes it, preventing 'append' and 'update' modes.