### PR TITLE
Display decoded error message in graphs.

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -245,8 +245,9 @@ function visualiserApp(luigi) {
         updateSidebar(tabId);
     }
 
-    function showErrorTrace(error) {
-        $("#errorModal").empty().append(renderTemplate("errorTemplate", decodeError(error)));
+    function showErrorTrace(data) {
+        data.error = decodeError(data.error)
+        $("#errorModal").empty().append(renderTemplate("errorTemplate", data));
         $("#errorModal").modal({});
     }
 


### PR DESCRIPTION
Error message was incorrectly passed to decodeError function and as a result was displayed to a user in a JSON encoded form (most notably without line breaks). 