### PR TITLE
log scheduler updates with multi workers as DEBUG

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -632,15 +632,15 @@ class Worker(object):
         self._scheduler.add_worker(self._id, self._worker_info)
 
     def _log_remote_tasks(self, running_tasks, n_pending_tasks, n_unique_pending):
-        logger.info("Done")
-        logger.info("There are no more tasks to run at this time")
+        logger.debug("Done")
+        logger.debug("There are no more tasks to run at this time")
         if running_tasks:
             for r in running_tasks:
-                logger.info('%s is currently run by worker %s', r['task_id'], r['worker'])
+                logger.debug('%s is currently run by worker %s', r['task_id'], r['worker'])
         elif n_pending_tasks:
-            logger.info("There are %s pending tasks possibly being run by other workers", n_pending_tasks)
+            logger.debug("There are %s pending tasks possibly being run by other workers", n_pending_tasks)
             if n_unique_pending:
-                logger.info("There are %i pending tasks unique to this worker", n_unique_pending)
+                logger.debug("There are %i pending tasks unique to this worker", n_unique_pending)
 
     def _get_work(self):
         if self._stop_requesting_work:


### PR DESCRIPTION
when running luigi with multiple workers, this changes the logging so that updates from the scheduler saying that there isn't any more work (because one worker is taking longer) get logged as ``DEBUG`` rather than ``INFO``. This gets rid of a lot of logging noise (several messages every few seconds) if you have your logger set to ``INFO``.