### PR TITLE
Add normalize(v) to Parameter to do pre-processing on arguments passed to Task

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -202,7 +202,7 @@ class Parameter(object):
         if value == _no_value:
             raise MissingParameterException("No default specified")
         else:
-            return value
+            return self.normalize(value)
 
     def parse(self, x):
         """
@@ -225,6 +225,20 @@ class Parameter(object):
         :param x: the value to serialize.
         """
         return str(x)
+
+    def normalize(self, x):
+        """
+        Given a parsed parameter value, normalizes it.
+
+        The value can either be the result of parse(), the default value or
+        arguments passed into the task's constructor by instantiation.
+
+        This is very implementation defined, but can be used to validate/clamp
+        valid values. For example, if you wanted to only accept even integers,
+        and "correct" odd values to the nearest integer, you can implement
+        normalize as ``x // 2 * 2``.
+        """
+        return x  # default impl
 
     @classmethod
     def next_in_enumeration(_cls, _value):
@@ -426,6 +440,10 @@ class BoolParameter(Parameter):
         Parses a ``bool`` from the string, matching 'true' or 'false' ignoring case.
         """
         return {'true': True, 'false': False}[str(s).lower()]
+
+    def normalize(self, value):
+        # coerce anything truthy to True
+        return bool(value) if value is not None else None
 
     @staticmethod
     def _parser_action():

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -218,7 +218,7 @@ class Task(object):
             if i >= len(positional_params):
                 raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))
             param_name, param_obj = positional_params[i]
-            result[param_name] = arg
+            result[param_name] = param_obj.normalize(arg)
 
         # Then the keyword arguments
         for param_name, arg in six.iteritems(kwargs):
@@ -226,7 +226,7 @@ class Task(object):
                 raise parameter.DuplicateParameterException('%s: parameter %s was already set as a positional parameter' % (exc_desc, param_name))
             if param_name not in params_dict:
                 raise parameter.UnknownParameterException('%s: unknown parameter %s' % (exc_desc, param_name))
-            result[param_name] = arg
+            result[param_name] = params_dict[param_name].normalize(arg)
 
         # Then use the defaults for anything not filled in
         for param_name, param_obj in params:

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -180,6 +180,12 @@ class ParameterTest(LuigiTestCase):
     def test_bool_default_true(self):
         self.assertTrue(WithDefaultTrue().x)
 
+    def test_bool_coerce(self):
+        self.assertEquals(True, WithDefaultTrue(x='yes').x)
+
+    def test_bool_no_coerce_none(self):
+        self.assertIsNone(WithDefaultTrue(x=None).x)
+
     def test_forgot_param(self):
         self.assertRaises(luigi.parameter.MissingParameterException, self.run_locally, ['ForgotParam'],)
 
@@ -232,7 +238,7 @@ class ParameterTest(LuigiTestCase):
     def test_nonpositional_param(self):
         """ Ensure we have the same behavior as in before a78338c  """
         class MyTask(luigi.Task):
-            # This could typically be "--num-threads=True"
+            # This could typically be "--num-threads=10"
             x = luigi.Parameter(significant=False, positional=False)
 
         MyTask(x='arg')


### PR DESCRIPTION
This can be used for validation as well, but for the sake of back-compat this just introduces the functionality. This starts fixing issue #1273.