### PR TITLE
Fixed: Rdbms and Redshift Properties

### DIFF
--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -95,6 +95,7 @@ class CopyToTable(luigi.task.MixinNaiveBulkComplete, luigi.Task):
             query = "CREATE TABLE {table} ({coldefs})".format(table=self.table, coldefs=coldefs)
             connection.cursor().execute(query)
 
+    @property
     def update_id(self):
         """
         This update id will be a unique identifier for this insert on this table.

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -141,6 +141,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         return ''
 
+    @property
     def do_truncate_table(self):
         """
         Return True if table should be truncated before copying new data in.
@@ -167,6 +168,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         return ''
 
+    @property
     def queries(self):
         """
         Override to return a list of queries to be executed in order.
@@ -271,7 +273,7 @@ class S3CopyToTable(rdbms.CopyToTable):
             user=self.user,
             password=self.password,
             table=self.table,
-            update_id=self.update_id())
+            update_id=self.update_id)
 
     def does_table_exist(self, connection):
         """
@@ -302,7 +304,7 @@ class S3CopyToTable(rdbms.CopyToTable):
             logger.info("Creating table %s", self.table)
             connection.reset()
             self.create_table(connection)
-        elif self.do_truncate_table():
+        elif self.do_truncate_table:
             logger.info("Truncating table %s", self.table)
             self.truncate_table(connection)
         elif self.do_prune():
@@ -314,7 +316,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         Performs post-copy sql - such as cleansing data, inserting into production table (if copied to temp table), etc.
         """
         logger.info('Executing post copy queries')
-        for query in self.queries():
+        for query in self.queries:
             cursor.execute(query)
 
 
@@ -471,7 +473,7 @@ class KillOpenRedshiftSessions(luigi.Task):
             user=self.user,
             password=self.password,
             table=self.__class__.__name__,
-            update_id=self.update_id())
+            update_id=self.update_id)
 
     def run(self):
         """

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -69,7 +69,7 @@ class S3CopyToTable(rdbms.CopyToTable):
       * `s3_load_path`.
     """
 
-    @abc.abstractproperty
+    @abc.abstractmethod
     def s3_load_path(self):
         """
         Override to return the load path.

--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -276,7 +276,7 @@ class CopyToTable(rdbms.CopyToTable):
             user=self.user,
             password=self.password,
             table=self.table,
-            update_id=self.update_id()
+            update_id=self.update_id
         )
 
     def copy(self, cursor, file):

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -36,12 +36,12 @@ class DummyS3CopyToTable(luigi.contrib.redshift.S3CopyToTable):
     password = 'dummy_password'
     table = luigi.Parameter(default='dummy_table')
     columns = (
-        ('some_text', 'text'),
+        ('some_text', 'varchar(255)'),
         ('some_int', 'int'),
     )
 
-    aws_access_key_id = AWS_ACCESS_KEY
-    aws_secret_access_key = AWS_SECRET_KEY
+    aws_access_key_id = 'AWS_ACCESS_KEY'
+    aws_secret_access_key = 'AWS_SECRET_KEY'
     copy_options = ''
     prune_table = ''
     prune_column = ''
@@ -51,35 +51,17 @@ class DummyS3CopyToTable(luigi.contrib.redshift.S3CopyToTable):
         return 's3://%s/%s' % (BUCKET, KEY)
 
 
-class DummyS3CopyToTempTable(luigi.contrib.redshift.S3CopyToTable):
-    # Class attributes taken from `DummyPostgresImporter` in
-    # `../postgres_test.py`.
-    host = 'dummy_host'
-    database = 'dummy_database'
-    user = 'dummy_user'
-    password = 'dummy_password'
+class DummyS3CopyToTempTable(DummyS3CopyToTable):
+    # Extend/alter DummyS3CopyToTable for temp table copying
     table = luigi.Parameter(default='stage_dummy_table')
-    columns = (
-        ('some_text', 'text'),
-        ('some_int', 'int'),
-    )
 
-    aws_access_key_id = AWS_ACCESS_KEY
-    aws_secret_access_key = AWS_SECRET_KEY
-    copy_options = ''
-    sql = ["insert into dummy_table select * from stage_dummy_table;"]
+    table_type = 'TEMP'
+
     prune_date = 'current_date - 30'
     prune_column = 'dumb_date'
     prune_table = 'stage_dummy_table'
 
-    def s3_load_path(self):
-        return 's3://%s/%s' % (BUCKET, KEY)
-
-    def table_type(self):
-        return 'TEMP'
-
-    def queries(self):
-        return self.sql
+    queries = ["insert into dummy_table select * from stage_dummy_table;"]
 
 
 class TestS3CopyToTable(unittest.TestCase):


### PR DESCRIPTION
Same as PR #1393 b/c I screwed up the rebase...

Changed Rdbms' update_id to a @property. Appropriate changes were made to Redshift.py and Postgres.py. Also changed Redshift's do_truncate_table and queries to properties. Finally, fixed references to properties as self.<property> rather than their previous method forms self.<property_method>().