### PR TITLE
bigquery: New task to create views.

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -216,6 +216,59 @@ class BigqueryClient(object):
 
             response = request.execute()
 
+    def get_view(self, table):
+        """Returns the SQL query for a view, or None if it doesn't exist or is not a view.
+
+        :param table: The table containing the view.
+        :type table: BQTable
+        """
+
+        request = self.client.tables().get(projectId=table.project_id,
+                                           datasetId=table.dataset_id,
+                                           tableId=table.table_id)
+
+        try:
+            response = request.execute()
+        except http.HttpError as ex:
+            if ex.resp.status == 404:
+                return None
+            raise
+
+        return response['view']['query'] if 'view' in response else None
+
+    def update_view(self, table, view):
+        """Updates the SQL query for a view.
+
+        If the output table exists, it is replaced with the supplied view query. Otherwise a new
+        table is created with this view.
+
+        :param table: The table to contain the view.
+        :type table: BQTable
+        :param view: The SQL query for the view.
+        :type view: str
+        """
+
+        body = {
+            'tableReference': {
+                'projectId': table.project_id,
+                'datasetId': table.dataset_id,
+                'tableId': table.table_id
+            },
+            'view': {
+                'query': view
+            }
+        }
+
+        if self.table_exists(table):
+            self.client.tables().update(projectId=table.project_id,
+                                        datasetId=table.dataset_id,
+                                        tableId=table.table_id,
+                                        body=body).execute()
+        else:
+            self.client.tables().insert(projectId=table.project_id,
+                                        datasetId=table.dataset_id,
+                                        body=body).execute()
+
     def run_job(self, project_id, body, dataset=None):
         """Runs a bigquery "job". See the documentation for the format of body.
 
@@ -454,6 +507,45 @@ class BigqueryRunQueryTask(MixinBigqueryBulkComplete, luigi.Task):
         }
 
         bq_client.run_job(output.table.project_id, job, dataset=output.table.dataset)
+
+
+class BigqueryCreateViewTask(luigi.Task):
+    """
+    Creates (or updates) a view in BigQuery.
+
+    The output of this task needs to be a BigQueryTarget.
+    Instances of this class should specify the view SQL in the view property.
+
+    If a view already exist in BigQuery at output(), it will be updated.
+    """
+
+    @property
+    def view(self):
+        """The SQL query for the view, in text form."""
+        raise NotImplementedError()
+
+    def complete(self):
+        output = self.output()
+        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not %s' % (output)
+
+        if not output.exists():
+            return False
+
+        existing_view = output.client.get_view(output.table)
+        return existing_view == self.view
+
+    def run(self):
+        output = self.output()
+        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not %s' % (output)
+
+        view = self.view
+        assert view, 'No view was provided'
+
+        logger.info('Create view')
+        logger.info('Destination: %s', output)
+        logger.info('View SQL: %s', view)
+
+        output.client.update_view(output.table, view)
 
 
 class ExternalBigqueryTask(MixinBigqueryBulkComplete, luigi.ExternalTask):


### PR DESCRIPTION
This is handy to keep a set of views in sync with BigQuery (e.g. from a CD pipeline).

Example task:
```python
import luigi.contrib.bigquery as bigquery

class BQView(bigquery.BigqueryCreateViewTask):
    view='''SELECT * FROM [dataset.table] LIMIT 10'''

    def output(self):
        return bigquery.BigqueryTarget('project_id', 'dataset', 'view')
```