### PR TITLE
Format classes will not read whole files in memory

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -76,7 +76,11 @@ class InputPipeProcessWrapper(object):
                 self._original_input = False
                 f = tempfile.NamedTemporaryFile('wb', prefix='luigi-process_tmp', delete=False)
                 self._tmp_file = f.name
-                f.write(input_pipe.read())
+                while True:
+                    chunk = input_pipe.read(io.DEFAULT_BUFFER_SIZE)
+                    if not chunk:
+                        break
+                    f.write(chunk)
                 input_pipe.close()
                 f.close()
                 self._input_pipe = FileWrapper(io.BufferedReader(io.FileIO(self._tmp_file, 'r')))


### PR DESCRIPTION
If an input pipe did not provide a file descriptor via a fileno() method (such as a S3 key object), the whole input data was read in memory to be written to a temporary file. To avoid using too much memory and improve efficiency, the data is copied immediately by chunks of the size of the file system blocks. This does not affect most cases of Format classes which pass a file descriptor to the subprocess.

Fixes issue #1467.

Below is a small test task that will trigger the bug with a huge data set. Without the fix, be prepared to have it use all memory it is allowed to get. Otherwise, don't forget to kill it before you download the whole 1.7 GB. 

```python
from luigi import ExternalTask, Parameter, Task
from luigi.format import Gzip
from luigi.s3 import S3Target


class GzippedS3PathTask(ExternalTask):
    path = Parameter()

    def output(self):
        return S3Target(self.path, format=Gzip)


class LargeS3Task(Task):
    path = 's3://3kricegenome/9311/IRIS_313-15896.snp.vcf.gz'

    def requires(self):
        return GzippedS3PathTask(self.path)

    def run(self):
        infile = self.input().open('r')
        for i in infile:
            pass
```

All tests are passing except one which is probably related to available locales on my system.