### PR TITLE
Enable multipart S3 Copy

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -338,8 +338,8 @@ class S3Client(FileSystem):
         # As the S3 copy command is completely server side, there is no issue with issuing a single
         # API call per part, however, this may in theory cause issues on systems with low ulimits for
         # number of threads when copying really large files, e.g. with a ~100GB file this will open ~1500
-        # threads.
-        pool = ThreadPool(processes=num_parts)
+        # threads. We take the max of this and 1 as if we're copying an empty file we will have  `num_part == 0`
+        pool = ThreadPool(processes=max(1, num_parts))
 
         mp = None
         try:

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -25,6 +25,8 @@ import itertools
 import logging
 import os
 import os.path
+from multiprocessing.pool import ThreadPool
+
 try:
     from urlparse import urlsplit
 except ImportError:
@@ -222,10 +224,7 @@ class S3Client(FileSystem):
         # calculate the number of parts (int division).
         # use modulo to avoid float precision issues
         # for exactly-sized fits
-        num_parts = \
-            (source_size // part_size) \
-            if source_size % part_size == 0 \
-            else (source_size // part_size) + 1
+        num_parts = (source_size + part_size - 1) // part_size
 
         mp = None
         try:
@@ -281,10 +280,9 @@ class S3Client(FileSystem):
 
         return contents
 
-    def copy(self, source_path, destination_path, part_size=67108864, **kwargs):
+    def copy(self, source_path, destination_path, **kwargs):
         """
         Copy an object from one S3 location to another.
-
         :param kwargs: Keyword arguments are passed to the boto function `copy_key`
         """
         (src_bucket, src_key) = self._path_to_bucket_and_key(source_path)
@@ -293,11 +291,13 @@ class S3Client(FileSystem):
         s3_bucket = self.s3.get_bucket(dst_bucket, validate=True)
         source_bucket = self.s3.get_bucket(src_bucket, validate=True)
 
+        multipart_size = 67108864
+
         if self.isdir(source_path):
             src_prefix = self._add_path_delimiter(src_key)
             dst_prefix = self._add_path_delimiter(dst_key)
             for key in self.list(source_path):
-                if source_bucket.lookup(key).size <= part_size:
+                if source_bucket.lookup(key).size <= multipart_size:
                     s3_bucket.copy_key(dst_prefix + key,
                                        src_bucket,
                                        src_prefix + key, **kwargs)
@@ -306,7 +306,7 @@ class S3Client(FileSystem):
                                         src_bucket,
                                         src_prefix + key, **kwargs)
 
-        elif source_bucket.lookup(src_key).size <= part_size: 
+        elif source_bucket.lookup(src_key).size <= multipart_size:
             s3_bucket.copy_key(dst_key, src_bucket, src_key, **kwargs)
         else:
             self.copy_multipart(source_path, destination_path, **kwargs)
@@ -314,6 +314,8 @@ class S3Client(FileSystem):
     def copy_multipart(self, source_path, destination_path, part_size=67108864, **kwargs):
         """
         Copy a single S3 object to another S3 object using S3 multi-part copy (for files > 5GB).
+        It will use a single thread per request so that all parts are requested to be moved simultaneously
+        for maximum speed.
 
         :param source_path: URL for S3 Source
         :param destination_path: URL for target S3 location
@@ -328,10 +330,9 @@ class S3Client(FileSystem):
 
         source_size = source_bucket.lookup(src_key).size
 
-        num_parts = \
-            (source_size // part_size) \
-            if source_size % part_size == 0 \
-            else (source_size // part_size) + 1
+        num_parts = (source_size + part_size - 1) // part_size
+
+        pool = ThreadPool(processes=num_parts)
 
         mp = None
         try:
@@ -343,9 +344,12 @@ class S3Client(FileSystem):
                 cur_pos += part_size
                 part_end = min(cur_pos - 1, source_size - 1)
                 part_num = i + 1
+                pool.apply_async(mp.copy_part_from_key, args=(src_bucket, src_key, part_num, part_start, part_end))
+                logger.info('Requesting copy of %s/%s to %s', part_num, num_parts, destination_path)
 
-                mp.copy_part_from_key(src_bucket, src_key, part_num, part_start, part_end)
-                logger.info('Copying part %s/%s to %s', part_num, num_parts, destination_path)
+            logger.info('Waiting for copy of %s to finish', destination_path)
+            pool.close()
+            pool.join()
             # finish the copy, making the file available in S3
             mp.complete_upload()
         except BaseException:

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -297,7 +297,7 @@ class S3Client(FileSystem):
             src_prefix = self._add_path_delimiter(src_key)
             dst_prefix = self._add_path_delimiter(dst_key)
             for key in self.list(source_path):
-                if source_bucket.lookup(key).size <= multipart_size:
+                if source_bucket.lookup(src_prefix + key).size <= multipart_size:
                     s3_bucket.copy_key(dst_prefix + key,
                                        src_bucket,
                                        src_prefix + key, **kwargs)

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -378,6 +378,98 @@ class TestS3Client(unittest.TestCase):
         self.assertTrue(s3_client.remove('s3://mybucket/removemedir'))
         self.assertFalse(s3_client.exists('s3://mybucket/removemedir_$folder$'))
 
+    def test_copy_multiple_parts_non_exact_fit(self):
+        """
+        Test a multipart put with two parts, where the parts are not exactly the split size.
+        """
+        # First, put a file into S3
+        self._run_copy_test(self.test_put_multipart_multiple_parts_non_exact_fit)
+
+    def test_copy_multiple_parts_exact_fit(self):
+        """
+        Test a copy multiple parts, where the parts are exactly the split size.
+        """
+        self._run_copy_test(self.test_put_multipart_multiple_parts_exact_fit)
+
+    def test_copy_less_than_split_size(self):
+        """
+        Test a copy with a file smaller than split size; should revert to regular put.
+        """
+        self._run_copy_test(self.test_put_multipart_less_than_split_size)
+
+    def test_copy_empty_file(self):
+        """
+        Test a copy with an empty file.
+        """
+        self._run_copy_test(self.test_put_multipart_empty_file)
+
+    @unittest.skip("bug in moto 0.4.21 causing failure: https://github.com/spulec/moto/issues/526")
+    def test_copy_multipart_multiple_parts_non_exact_fit(self):
+        """
+        Test a multipart copy with two parts, where the parts are not exactly the split size.
+        """
+        # First, put a file into S3
+        self._run_multipart_copy_test(self.test_put_multipart_multiple_parts_non_exact_fit)
+
+    @unittest.skip("bug in moto 0.4.21 causing failure: https://github.com/spulec/moto/issues/526")
+    def test_copy_multipart_multiple_parts_exact_fit(self):
+        """
+        Test a multipart copy with multiple parts, where the parts are exactly the split size.
+        """
+        self._run_multipart_copy_test(self.test_put_multipart_multiple_parts_exact_fit)
+
+    def test_copy_multipart_less_than_split_size(self):
+        """
+        Test a multipart copy with a file smaller than split size; should revert to regular put.
+        """
+        self._run_multipart_copy_test(self.test_put_multipart_less_than_split_size)
+
+    def test_copy_multipart_empty_file(self):
+        """
+        Test a multipart copy with an empty file.
+        """
+        self._run_multipart_copy_test(self.test_put_multipart_empty_file)
+
+    def _run_multipart_copy_test(self, put_method):
+        # Run the method to put the file into s3 into the first place
+        put_method()
+
+        # As all the multipart put methods use `self._run_multipart_test`
+        # we can just use this key
+        original = 's3://mybucket/putMe'
+        copy = 's3://mybucket/putMe_copy'
+
+        # 5MB is minimum part size, use it here so we don't have to generate huge files to test
+        # the multipart upload in moto
+        part_size = (1024 ** 2) * 5
+
+        # Copy the file from old location to new
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.copy_multipart(original, copy, part_size=part_size)
+
+        # We can't use etags to compare between multipart and normal keys,
+        # so we fall back to using the size instead
+        original_size = s3_client.get_key(original).size
+        copy_size = s3_client.get_key(copy).size
+        self.assertEqual(original_size, copy_size)
+
+    def _run_copy_test(self, put_method):
+        # Run the method to put the file into s3 into the first place
+        put_method()
+
+        # As all the multipart put methods use `self._run_multipart_test`
+        # we can just use this key
+        original = 's3://mybucket/putMe'
+        copy = 's3://mybucket/putMe_copy'
+
+        # Copy the file from old location to new
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.copy(original, copy)
+
+        original_md5 = s3_client.get_key(original).etag
+        copy_md5 = s3_client.get_key(copy).etag
+        self.assertEqual(original_md5, copy_md5)
+
     def _run_multipart_test(self, part_size, file_size, **kwargs):
         file_contents = b"a" * file_size
 
@@ -391,11 +483,9 @@ class TestS3Client(unittest.TestCase):
         s3_client.s3.create_bucket('mybucket')
         s3_client.put_multipart(tmp_file_path, s3_path, part_size=part_size, **kwargs)
         self.assertTrue(s3_client.exists(s3_path))
-        # b/c of https://github.com/spulec/moto/issues/131 have to
-        # get contents to check size
-        key_contents = s3_client.get_key(s3_path).get_contents_as_string()
-        self.assertEqual(len(file_contents), len(key_contents))
-
+        file_size = os.path.getsize(tmp_file.name)
+        key_size = s3_client.get_key(s3_path).size
+        self.assertEqual(file_size, key_size)
         tmp_file.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
`S3Client.copy()` doesn't currently support multipart, so files larger than 5GB are unable to be copied from S3 to S3 without pulling down locally and reuploading. I'm opening this PR that fixes that so I can get an automated build :) Ideally there should be some automated tests here - it doesn't look like the `copy()` method is tested at all at the moment. If I get some time over the weekend I'll add some tests here.

On a separate note, we will probably get faster performance for this if we multithread it and issue a single multipart copy instruction per thread (this is what `awscli` does). I will also have a stab at implementing this at some point, but at least the basic functionality is here already.