### PR TITLE
notifications: More emails with proper coloring

### DIFF
--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -19,7 +19,6 @@ from subprocess import check_call
 import sys
 
 from helpers import LuigiTestCase
-import json
 import mock
 from psutil import Process
 from time import sleep
@@ -56,6 +55,8 @@ class WorkerTaskTest(LuigiTestCase):
 class TaskProcessTest(LuigiTestCase):
 
     def test_update_result_queue_on_success(self):
+        # IMO this test makes no sense as it tests internal behavior and have
+        # already broken once during internal non-changing refactoring
         class SuccessTask(luigi.Task):
             def on_success(self):
                 return "test success expl"
@@ -66,9 +67,11 @@ class TaskProcessTest(LuigiTestCase):
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
-            mock_put.assert_called_once_with((task.task_id, DONE, json.dumps("test success expl"), [], None))
+            mock_put.assert_called_once_with((task.task_id, DONE, "test success expl", [], None))
 
     def test_update_result_queue_on_failure(self):
+        # IMO this test makes no sense as it tests internal behavior and have
+        # already broken once during internal non-changing refactoring
         class FailTask(luigi.Task):
             def run(self):
                 raise BaseException("Uh oh.")
@@ -82,7 +85,7 @@ class TaskProcessTest(LuigiTestCase):
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
-            mock_put.assert_called_once_with((task.task_id, FAILED, json.dumps("test failure expl"), [], []))
+            mock_put.assert_called_once_with((task.task_id, FAILED, "test failure expl", [], []))
 
     def test_cleanup_children_on_terminate(self):
         """


### PR DESCRIPTION
This commits contains the following changes:

 * Make luigi send emails for task timeouts
 * Make luigi send emails for when task process dies
 * When sending normal run() failures, do proper pygments coloring
 * Remove code duplication
 * Clean tests and tests what previously was not working

As an effect of properly rendering stack traces with pygments, the
"expl" field in the worker-internal result_queue will not contain
json encoded fields anymore. We instead encode the field just before
submitting it to the scheduler. I believe this should make sense.