### PR TITLE
Clean inner counter after flush

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -845,6 +845,7 @@ class JobTask(BaseHadoopJobTask):
                 continue
             args = list(key) + [count]
             self._incr_counter(*args)
+            self._counter_dict[key] = 0
 
     def _incr_counter(self, *args):
         """


### PR DESCRIPTION
When using LoaclJobRunner, I found counter is flushed twice, like
(threshold is 10000)
````
reporter:counter:reducer.users,5374
...
reporter:counter:reducer.users,5374
````