### PR TITLE
add EnumParameter

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -36,7 +36,7 @@ from luigi.parameter import (
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter,
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BooleanParameter, BoolParameter,
-    TaskParameter,
+    TaskParameter, EnumParameter
 )
 
 from luigi import configuration
@@ -57,5 +57,6 @@ __all__ = [
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'range',
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
     'FloatParameter', 'BooleanParameter', 'BoolParameter', 'TaskParameter',
-    'configuration', 'interface', 'file', 'run', 'build', 'event', 'Event'
+    'EnumParameter', 'configuration', 'interface', 'file', 'run', 'build',
+    'event', 'Event'
 ]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -667,9 +667,22 @@ class EnumParameter(Parameter):
     """
     A parameter whose value is an :class:`~enum.Enum`.
 
-    .. code:: python
+    In the task definition, use
 
-        my_param = EnumParameter(enum=MyEnum)
+    .. code-block:: python
+
+        class Models(enum.IntEnum):
+          Honda = 1
+
+        class MyTask(luigi.Task):
+          my_param = luigi.EnumParameter(enum=Models)
+
+    At the command line, use,
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --my-param Honda
+
     """
 
     def __init__(self, *args, **kwargs):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -661,3 +661,28 @@ class TaskParameter(Parameter):
         Converts the :py:class:`luigi.task.Task` (sub) class to its family name.
         """
         return cls.task_family
+
+
+class EnumParameter(Parameter):
+    """
+    A parameter whose value is an :class:`~enum.Enum`.
+
+    .. code:: python
+
+        my_param = EnumParameter(enum=MyEnum)
+    """
+
+    def __init__(self, *args, **kwargs):
+        if 'enum' not in kwargs:
+            raise ParameterException('An enum class must be specified.')
+        self._enum = kwargs.pop('enum')
+        super(EnumParameter, self).__init__(*args, **kwargs)
+
+    def parse(self, s):
+        try:
+            return self._enum[s]
+        except KeyError:
+            raise ValueError('Invalid enum value - could not be parsed')
+
+    def serialize(self, e):
+        return e.name

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -18,6 +18,7 @@
 import datetime
 from helpers import with_config, LuigiTestCase, parsing, in_parse, RunOnceTask
 from datetime import timedelta
+import enum
 
 import luigi
 import luigi.date_interval
@@ -119,6 +120,10 @@ class MyConfigWithoutSection(luigi.Config):
 
 class NoopTask(luigi.Task):
     pass
+
+
+class MyEnum(enum.Enum):
+    A = 1
 
 
 def _value(parameter):
@@ -244,6 +249,17 @@ class ParameterTest(LuigiTestCase):
         MyTask(x='arg')
         self.assertRaises(luigi.parameter.UnknownParameterException,
                           lambda: MyTask('arg'))
+
+    def test_enum_param_valid(self):
+        p = luigi.parameter.EnumParameter(enum=MyEnum)
+        self.assertEqual(MyEnum.A, p.parse('A'))
+
+    def test_enum_param_invalid(self):
+        p = luigi.parameter.EnumParameter(enum=MyEnum)
+        self.assertRaises(ValueError, lambda: p.parse('B'))
+
+    def test_enum_param_missing(self):
+        self.assertRaises(ParameterException, lambda: luigi.parameter.EnumParameter())
 
 
 class TestNewStyleGlobalParameters(LuigiTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps=
   sqlalchemy<2.0
   elasticsearch<2.0.0
   psutil<4.0
+  enum34>1.1.0
   cdh,hdp: snakebite>=2.5.2,<2.6.0
   cdh,hdp: hdfs>=2.0.4,<3.0.0  # The webhdfs library
   postgres: psycopg2<3.0


### PR DESCRIPTION
This adds parameter for enums, which has been a built-in module since python 3.4.

Example:

```python
class Models(enum.IntEnum):
  Honda = 1

class MyTask(luigi.Task):
  my_param = luigi.EnumParameter(enum=Models)
```

```bash
$ MyTask --my-param Honda
```