### PR TITLE
Add move operations into the fs target interface

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -304,7 +304,13 @@ class GCSClient(luigi.target.FileSystem):
                 body={}).execute()
             _wait_for_consistency(lambda: self._obj_exists(dest_bucket, dest_obj))
 
-    def rename(self, source_path, destination_path):
+    def rename(self, *args, **kwargs):
+        """
+        Alias for ``move()``
+        """
+        self.move(*args, **kwargs)
+
+    def move(self, source_path, destination_path):
         """
         Rename/move an object from one GCS location to another.
         """

--- a/luigi/contrib/hdfs/abstract_client.py
+++ b/luigi/contrib/hdfs/abstract_client.py
@@ -22,7 +22,6 @@ Module containing abstract class about hdfs clients.
 import abc
 from luigi import six
 import luigi.target
-import warnings
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -31,34 +30,29 @@ class HdfsFileSystem(luigi.target.FileSystem):
     This client uses Apache 2.x syntax for file system commands, which also matched CDH4.
     """
 
-    @abc.abstractmethod
     def rename(self, path, dest):
         """
-        Rename or move a file
+        Rename or move a file.
+
+        In hdfs land, "mv" is often called rename. So we add an alias for
+        ``move()`` called ``rename()``. This is also to keep backward
+        compatibility since ``move()`` became standardized in luigi's
+        filesystem interface.
         """
-        pass
+        return self.move(path, dest)
 
     def rename_dont_move(self, path, dest):
         """
         Override this method with an implementation that uses rename2,
         which is a rename operation that never moves.
 
-        For instance, `rename2 a b` never moves `a` into `b` folder.
-
-        Currently, the hadoop cli does not support this operation.
-
-        We keep the interface simple by just aliasing this to
-        normal rename and let individual implementations redefine the method.
-
         rename2 -
         https://github.com/apache/hadoop/blob/ae91b13/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/ClientProtocol.java
         (lines 483-523)
         """
-        warnings.warn("Configured HDFS client doesn't support rename_dont_move, using normal mv operation instead.")
-        if self.exists(dest):
-            return False
-        self.rename(path, dest)
-        return True
+        # We only override this method to be able to provide a more specific
+        # docstring.
+        return super(HdfsFileSystem, self).rename_dont_move(path, dest)
 
     @abc.abstractmethod
     def remove(self, path, recursive=True, skip_trash=False):

--- a/luigi/contrib/hdfs/format.py
+++ b/luigi/contrib/hdfs/format.py
@@ -38,7 +38,7 @@ class HdfsAtomicWritePipe(luigi.format.OutputPipeProcessWrapper):
         logger.info("Aborting %s('%s'). Removing temporary file '%s'",
                     self.__class__.__name__, self.path, self.tmppath)
         super(HdfsAtomicWritePipe, self).abort()
-        remove(self.tmppath)
+        remove(self.tmppath, skip_trash=True)
 
     def close(self):
         super(HdfsAtomicWritePipe, self).close()
@@ -60,7 +60,7 @@ class HdfsAtomicWriteDirPipe(luigi.format.OutputPipeProcessWrapper):
         logger.info("Aborting %s('%s'). Removing temporary dir '%s'",
                     self.__class__.__name__, self.path, self.tmppath)
         super(HdfsAtomicWriteDirPipe, self).abort()
-        remove(self.tmppath)
+        remove(self.tmppath, skip_trash=True)
 
     def close(self):
         super(HdfsAtomicWriteDirPipe, self).close()

--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -87,7 +87,7 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
                     return False
             raise hdfs_error.HDFSCliError(cmd, p.returncode, stdout, stderr)
 
-    def rename(self, path, dest):
+    def move(self, path, dest):
         parent_dir = os.path.dirname(dest)
         if parent_dir != '' and not self.exists(parent_dir):
             self.mkdir(parent_dir)

--- a/luigi/contrib/hdfs/snakebite_client.py
+++ b/luigi/contrib/hdfs/snakebite_client.py
@@ -94,7 +94,7 @@ class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         except Exception as err:    # IGNORE:broad-except
             raise hdfs_error.HDFSCliError("snakebite.test", -1, str(err), repr(err))
 
-    def rename(self, path, dest):
+    def move(self, path, dest):
         """
         Use snakebite.rename, if available.
 
@@ -125,9 +125,9 @@ class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         from snakebite.errors import FileAlreadyExistsException
         try:
             self.get_bite().rename2(path, dest, overwriteDest=False)
-            return True
         except FileAlreadyExistsException:
-            return False
+            # Unfortunately python2 don't allow exception chaining.
+            raise luigi.target.FileAlreadyExists()
 
     def remove(self, path, recursive=True, skip_trash=False):
         """

--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -105,7 +105,7 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
                                 buffer_size=buffer_size, chunk_size=chunk_size,
                                 buffer_char=buffer_char)
 
-    def rename(self, path, dest):
+    def move(self, path, dest):
         parts = dest.rstrip('/').split('/')
         if len(parts) > 1:
             dir_path = '/'.join(parts[0:-1])

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -83,6 +83,14 @@ class LocalFileSystem(FileSystem):
         else:
             os.remove(path)
 
+    def move(self, old_path, new_path, raise_if_exists=False):
+        if raise_if_exists and os.path.exists(new_path):
+            raise RuntimeError('Destination exists: %s' % new_path)
+        d = os.path.dirname(new_path)
+        if d and not os.path.exists(d):
+            self.fs.mkdir(d)
+        os.rename(old_path, new_path)
+
 
 class LocalTarget(FileSystemTarget):
     fs = LocalFileSystem()
@@ -124,12 +132,7 @@ class LocalTarget(FileSystemTarget):
             raise Exception('mode must be r/w')
 
     def move(self, new_path, raise_if_exists=False):
-        if raise_if_exists and os.path.exists(new_path):
-            raise RuntimeError('Destination exists: %s' % new_path)
-        d = os.path.dirname(new_path)
-        if d and not os.path.exists(d):
-            self.fs.mkdir(d)
-        os.rename(self.path, new_path)
+        self.fs.move(self.path, new_path, raise_if_exists=raise_if_exists)
 
     def move_dir(self, new_path):
         self.move(new_path)

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -302,7 +302,13 @@ class S3Client(FileSystem):
         else:
             s3_bucket.copy_key(dst_key, src_bucket, src_key, **kwargs)
 
-    def rename(self, source_path, destination_path, **kwargs):
+    def rename(self, *args, **kwargs):
+        """
+        Alias for ``move()``
+        """
+        self.move(*args, **kwargs)
+
+    def move(self, source_path, destination_path, **kwargs):
         """
         Rename/move an object from one S3 location to another.
 

--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -64,9 +64,9 @@ class ConfigurationTest(MiniClusterTestCase):
         client.mkdir('d/b')
         self.assertEqual(2, len(list(client.listdir('d'))))
         target = hdfs.HdfsTarget('d/a', fs=client)
-        self.assertFalse(target.move_dir('d/b'))
+        self.assertRaises(luigi.target.FileSystemException, lambda: target.move_dir('d/b'))
         self.assertEqual(2, len(list(client.listdir('d'))))
-        self.assertTrue(target.move_dir('d/c'))
+        target.move_dir('d/c')
         self.assertEqual(2, len(list(client.listdir('d'))))
 
     @helpers.with_config({"hdfs": {}}, replace_sections=True)

--- a/test/contrib/test_ssh.py
+++ b/test/contrib/test_ssh.py
@@ -247,6 +247,9 @@ class TestRemoteTargetAtomicity(unittest.TestCase, target_test.FileSystemTargetT
         file_content = f.read()
         self.assertEqual(file_content, 'hello')
 
+    test_move_on_fs = None  # ssh don't have move (yet?)
+    test_rename_dont_move_on_fs = None  # ssh don't have move (yet?)
+
 
 class TestRemoteTargetCreateDirectories(TestRemoteTargetAtomicity):
     path = '/tmp/%s/xyz/luigi_remote_atomic_test.txt' % random.randint(0, 999999999)

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -32,10 +32,11 @@ from target_test import FileSystemTargetTestMixin
 
 
 class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
-    path = '/tmp/test.txt'
-    copy = '/tmp/test.copy.txt'
+    PATH_PREFIX = '/tmp/test.txt'
 
     def setUp(self):
+        self.path = self.PATH_PREFIX + '-' + str(self.id())
+        self.copy = self.PATH_PREFIX + '-copy-' + str(self.id())
         if os.path.exists(self.path):
             os.remove(self.path)
         if os.path.exists(self.copy):

--- a/test/snakebite_test.py
+++ b/test/snakebite_test.py
@@ -21,6 +21,7 @@ import posixpath
 import time
 import unittest
 
+import luigi.target
 from luigi import six
 from nose.plugins.attrib import attr
 
@@ -94,10 +95,11 @@ class TestSnakebiteClient(MiniClusterTestCase):
         self.assertTrue(self.snakebite.exists(foo))  # For sanity
         self.assertTrue(self.snakebite.exists(bar))  # For sanity
 
-        self.assertFalse(self.snakebite.rename_dont_move(foo, bar))
+        self.assertRaises(luigi.target.FileAlreadyExists,
+                          lambda: self.snakebite.rename_dont_move(foo, bar))
         self.assertTrue(self.snakebite.exists(foo))
         self.assertTrue(self.snakebite.exists(bar))
 
-        self.assertTrue(self.snakebite.rename_dont_move(foo, foo + '2'))
+        self.snakebite.rename_dont_move(foo, foo + '2')
         self.assertFalse(self.snakebite.exists(foo))
         self.assertTrue(self.snakebite.exists(foo + '2'))

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -244,3 +244,25 @@ class FileSystemTargetTestMixin(object):
             result = f.read()
 
         self.assertEqual(test_data, result)
+
+    def test_move_on_fs(self):
+        # We're cheating and retrieving the fs from target.
+        # TODO: maybe move to "filesystem_test.py" or something
+        t = self.create_target()
+        t._touchz()
+        fs = t.fs
+        self.assertTrue(t.exists())
+        fs.move(t.path, t.path+"-yay")
+        self.assertFalse(t.exists())
+
+    def test_rename_dont_move_on_fs(self):
+        # We're cheating and retrieving the fs from target.
+        # TODO: maybe move to "filesystem_test.py" or something
+        t = self.create_target()
+        t._touchz()
+        fs = t.fs
+        self.assertTrue(t.exists())
+        fs.rename_dont_move(t.path, t.path+"-yay")
+        self.assertFalse(t.exists())
+        self.assertRaises(luigi.target.FileAlreadyExists,
+                          lambda: fs.rename_dont_move(t.path, t.path+"-yay"))


### PR DESCRIPTION
Also, make so that `rename_dont_move` reports success/failure by raising
exceptions instead of returning a bool value. As it's kind of
unexpected and unpythonic to return True/False based on success or not.