### PR TITLE
gitignore: Ignore .hypothesis/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .coverage.*
 doc/api/*.rst
 test/gcloud-credentials.json
+.hypothesis/
 
 .nicesetup
 


### PR DESCRIPTION
afaict it's the python quickcheck library that stores it's stuff.