### PR TITLE
Added a config option to disable TLS in SMTP entirely.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -215,6 +215,9 @@ smtp_port
 smtp_ssl
   If true, connects to smtp through SSL. Defaults to false.
 
+smtp_tls
+  If true, connects to smtp through TLS. Defaults to true.
+
 smtp_timeout
   Optionally sets the number of seconds after which smtp attempts should
   time out.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -215,8 +215,8 @@ smtp_port
 smtp_ssl
   If true, connects to smtp through SSL. Defaults to false.
 
-smtp_tls
-  If true, connects to smtp through TLS. Defaults to true.
+smtp_without_tls
+  If true, connects to smtp without TLS. Defaults to false.
 
 smtp_timeout
   Optionally sets the number of seconds after which smtp attempts should

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -125,6 +125,7 @@ def send_email_smtp(config, sender, subject, message, recipients, image_png):
     import smtplib
 
     smtp_ssl = config.getboolean('core', 'smtp_ssl', False)
+    smtp_tls = config.getboolean('core', 'smtp_tls', True)
     smtp_host = config.get('core', 'smtp_host', 'localhost')
     smtp_port = config.getint('core', 'smtp_port', 0)
     smtp_local_hostname = config.get('core', 'smtp_local_hostname', None)
@@ -137,7 +138,7 @@ def send_email_smtp(config, sender, subject, message, recipients, image_png):
     smtp_password = config.get('core', 'smtp_password', None)
     smtp = smtplib.SMTP(**kwargs) if not smtp_ssl else smtplib.SMTP_SSL(**kwargs)
     smtp.ehlo_or_helo_if_needed()
-    if smtp.has_extn('starttls'):
+    if smtp.has_extn('starttls') and smtp_tls:
         smtp.starttls()
     if smtp_login and smtp_password:
         smtp.login(smtp_login, smtp_password)

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -125,7 +125,7 @@ def send_email_smtp(config, sender, subject, message, recipients, image_png):
     import smtplib
 
     smtp_ssl = config.getboolean('core', 'smtp_ssl', False)
-    smtp_tls = config.getboolean('core', 'smtp_tls', True)
+    smtp_without_tls = config.getboolean('core', 'smtp_without_tls', False)
     smtp_host = config.get('core', 'smtp_host', 'localhost')
     smtp_port = config.getint('core', 'smtp_port', 0)
     smtp_local_hostname = config.get('core', 'smtp_local_hostname', None)
@@ -138,7 +138,7 @@ def send_email_smtp(config, sender, subject, message, recipients, image_png):
     smtp_password = config.get('core', 'smtp_password', None)
     smtp = smtplib.SMTP(**kwargs) if not smtp_ssl else smtplib.SMTP_SSL(**kwargs)
     smtp.ehlo_or_helo_if_needed()
-    if smtp.has_extn('starttls') and smtp_tls:
+    if smtp.has_extn('starttls') and not smtp_without_tls:
         smtp.starttls()
     if smtp_login and smtp_password:
         smtp.login(smtp_login, smtp_password)

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -196,7 +196,8 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
                            "smtp_local_hostname": "ptms",
                            "smtp_timeout": "1200",
                            "smtp_login": "Robin",
-                           "smtp_password": "dooH"}})
+                           "smtp_password": "dooH",
+                           "smtp_tls": "True"}})
     def test_sends_smtp_email(self):
         """
         Call notificaions.send_email_smtp with fixture parameters

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -197,10 +197,10 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
                            "smtp_timeout": "1200",
                            "smtp_login": "Robin",
                            "smtp_password": "dooH",
-                           "smtp_tls": "True"}})
+                           "smtp_without_tls": "False"}})
     def test_sends_smtp_email(self):
         """
-        Call notificaions.send_email_smtp with fixture parameters
+        Call notificaions.send_email_smtp with fixture parameters with smtp_without_tls  set to False
         and check that sendmail is properly called.
         """
 
@@ -219,7 +219,42 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
 
                 SMTP.assert_called_once_with(**smtp_kws)
                 SMTP.return_value.login.assert_called_once_with("Robin", "dooH")
+                SMTP.return_value.starttls.assert_called_once_with()
                 SMTP.return_value.sendmail\
+                    .assert_called_once_with(self.sender, self.recipients,
+                                             self.mocked_email_msg)
+
+    @with_config({"core": {"smtp_ssl": "False",
+                           "smtp_host": "my.smtp.local",
+                           "smtp_port": "999",
+                           "smtp_local_hostname": "ptms",
+                           "smtp_timeout": "1200",
+                           "smtp_login": "Robin",
+                           "smtp_password": "dooH",
+                           "smtp_without_tls": "True"}})
+    def test_sends_smtp_email_without_tls(self):
+        """
+        Call notificaions.send_email_smtp with fixture parameters with smtp_without_tls  set to True
+        and check that sendmail is properly called without also calling
+        starttls.
+        """
+        smtp_kws = {"host": "my.smtp.local",
+                    "port": 999,
+                    "local_hostname": "ptms",
+                    "timeout": 1200}
+
+        with mock.patch('smtplib.SMTP') as SMTP:
+            with mock.patch('luigi.notifications.generate_email') as generate_email:
+                generate_email.return_value \
+                    .as_string.return_value = self.mocked_email_msg
+
+                notifications.send_email_smtp(configuration.get_config(),
+                                              *self.notification_args)
+
+                SMTP.assert_called_once_with(**smtp_kws)
+                self.assertEqual(SMTP.return_value.starttls.called, False)
+                SMTP.return_value.login.assert_called_once_with("Robin", "dooH")
+                SMTP.return_value.sendmail \
                     .assert_called_once_with(self.sender, self.recipients,
                                              self.mocked_email_msg)
 


### PR DESCRIPTION
I've implemented a config option which allows to disable TLS encryption in SMTP, if the user desires so. If it's not specified, it defaults to True, so it doesn't change the behaviour for those, who don't have it set.