### PR TITLE
allow for use of BigQuery's flatten results flag

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -466,6 +466,12 @@ class BigqueryRunQueryTask(MixinBigqueryBulkComplete, luigi.Task):
         return CreateDisposition.CREATE_IF_NEEDED
 
     @property
+    def flatten_results(self):
+        """Flattens all nested and repeated fields in the query results.
+        allowLargeResults must be true if this is set to False."""
+        return True
+
+    @property
     def query(self):
         """The query, in text form."""
         raise NotImplementedError()
@@ -502,6 +508,7 @@ class BigqueryRunQueryTask(MixinBigqueryBulkComplete, luigi.Task):
                     'allowLargeResults': True,
                     'createDisposition': self.create_disposition,
                     'writeDisposition': self.write_disposition,
+                    'flattenResults': self.flatten_results
                 }
             }
         }

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -39,6 +39,13 @@ class TestRunQueryTask(bigquery.BigqueryRunQueryTask):
         return bigquery.BigqueryTarget(PROJECT_ID, DATASET_ID, self.table, client=self.client)
 
 
+class TestRunQueryTaskDontFlattenResults(TestRunQueryTask):
+
+    @property
+    def flatten_results(self):
+        return False
+
+
 class TestRunQueryTaskWithRequires(bigquery.BigqueryRunQueryTask):
     client = MagicMock()
     table = luigi.Parameter()
@@ -146,3 +153,11 @@ class BigqueryTest(unittest.TestCase):
 
         task.client.get_view.return_value = task.view
         self.assertTrue(task.complete())
+
+    def test_flatten_results(self):
+        task = TestRunQueryTask(table='table3')
+        self.assertTrue(task.flatten_results)
+
+    def test_dont_flatten_results(self):
+        task = TestRunQueryTaskDontFlattenResults(table='table3')
+        self.assertFalse(task.flatten_results)


### PR DESCRIPTION
In keeping with BigQuery's default behavior, this defaults to true.