### PR TITLE
Disable task history for local scheduler.

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -131,7 +131,7 @@ class core(task.Config):
 class _WorkerSchedulerFactory(object):
 
     def create_local_scheduler(self):
-        return scheduler.CentralPlannerScheduler(prune_on_get_work=True)
+        return scheduler.CentralPlannerScheduler(prune_on_get_work=True, record_task_history=False)
 
     def create_remote_scheduler(self, url):
         return rpc.RemoteScheduler(url)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -75,6 +75,12 @@ class SchedulerTest(unittest.TestCase):
         cps = luigi.scheduler.CentralPlannerScheduler()
         self.assertEqual({'a': 100, 'b': 200}, cps._resources)
 
+    @with_config({'scheduler': {'record_task_history': 'True'},
+                  'task_history': {'db_connection': 'sqlite:////none/existing/path/hist.db'}})
+    def test_local_scheduler_task_history_status(self):
+        ls = luigi.interface._WorkerSchedulerFactory().create_local_scheduler()
+        self.assertEqual(False, ls._config.record_task_history)
+
     def test_load_recovers_tasks_index(self):
         cps = luigi.scheduler.CentralPlannerScheduler()
         cps.add_task(worker='A', task_id='1')


### PR DESCRIPTION
Disables the task history in ``_WorkerSchedulerFactory.create_local_scheduler``.
Fixes issue #1496.