### PR TITLE
Assistant workers never retry failed tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -567,7 +567,8 @@ class CentralPlannerScheduler(Scheduler):
 
         for task in self._state.get_active_tasks():
             self._state.fail_dead_worker_task(task, self._config, assistant_ids)
-            if task.id not in necessary_tasks and self._state.prune(task, self._config):
+            removed = self._state.prune(task, self._config)
+            if removed and task.id not in necessary_tasks:
                 remove_tasks.append(task.id)
 
         self._state.inactivate_tasks(remove_tasks)

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -285,6 +285,19 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.prune()
         self.assertFalse(list(self.sch.task_list('', '')))
 
+    def test_re_enable_failed_task_assistant(self):
+        self.setTime(0)
+        self.sch.add_worker('X', [('assistant', True)])
+        self.sch.add_task(worker='X', task_id='A', status=FAILED, assistant=True)
+
+        # should be failed now
+        self.assertEqual(FAILED, self.sch.task_list('', '')['A']['status'])
+
+        # resets to PENDING after 100 seconds
+        self.setTime(101)
+        self.sch.ping(worker='X')  # worker still alive
+        self.assertEqual('PENDING', self.sch.task_list('', '')['A']['status'])
+
     def test_fail_job_from_dead_worker_with_live_assistant(self):
         self.setTime(0)
         self.sch.add_task(worker='X', task_id='A')


### PR DESCRIPTION
Assistant workers never retry failed tasks that are eligible for retry.

I noticed this with `ExternalTask`s, but same goes for regular task failures, given the correct retry configurations.

@erikbern I mentioned this to you on the mailing list.