### PR TITLE
Stop worker's run loop if the keep-alive thread is stopped

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -813,6 +813,7 @@ class Worker(object):
         Returns true if a worker should stay alive given.
 
         If worker-keep-alive is not set, this will always return false.
+        If the keep-alive thread has been stopped, this returns false.
         For an assistant, it will always return the value of worker-keep-alive.
         Otherwise, it will return true for nonzero n_pending_tasks.
 
@@ -821,10 +822,28 @@ class Worker(object):
         """
         if not self._config.keep_alive:
             return False
+        if not self._is_alive():
+            return False
         elif self._assistant:
             return True
         else:
             return n_pending_tasks and (n_unique_pending or not self._config.count_uniques)
+
+    def _is_alive(self):
+        """
+        Returns True if this worker is alive.
+
+        Returns False if the keep-alive thread has been stopped.
+        Returns False if the worker has not been initialized using a with statement.
+        Otherwise, this will return true.
+        """
+        try:
+            return self._keep_alive_thread.is_alive()
+        except AttributeError:
+            # self._keep_alive_thread is initialized in the __enter__ method, so this exception will occur if
+            # worker.run is called outside of a with block.
+            logger.error('Worker not fully initialized. You probably called worker.run() outside a "with" block')
+            return False
 
     def handle_interrupt(self, signum, _):
         """

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1039,6 +1039,17 @@ class AssistantTest(unittest.TestCase):
         self.assertTrue(self.assistant.run())
         self.assertEqual(list(self.sch.task_list('DONE', '').keys()), [task.task_id])
 
+    @mock.patch('luigi.worker.KeepAliveThread')
+    def test_dead_assistant(self, keep_alive_fn):
+        self.assistant = Worker(scheduler=self.sch, worker_id='Y', assistant=True, keep_alive=True)
+        task = Dummy2Task('A')
+        keep_alive_thread = keep_alive_fn.return_value
+        keep_alive_thread.is_alive.side_effect = lambda: not task.complete()
+        with self.assistant:
+            self.assistant.add(task)
+            self.assistant.run()
+        self.assertEqual(list(self.sch.task_list('DONE', '').keys()), [task.task_id])
+
 
 class ForkBombTask(luigi.Task):
     depth = luigi.IntParameter()


### PR DESCRIPTION
This is an issue for workers where assistant and keep_alive are True, and a worker's run method is executed in a different thread (which seems to be the best way to programmatically use assistant workers).  For example, this would have to be forcibly killed:

```python
scheduler = CentralPlannerScheduler()
w = worker.Worker(scheduler, worker_processes=2, assistant=True, keep_alive=True)
t = Thread(target=lambda: w.run())
with w:
    t.start()
    # submit some tasks, wait for them to finish, do some other stuff, yadda, yadda
t.join() # without this change this will not exit cleanly and will have to be killed.
```

Also, if the worker's keep-alive thread is stopped, and it is no longer reporting to the scheduler, I think it should stop asking for work.  But, let me know if you think otherwise.