### PR TITLE
flake8: Comply to E731 and E402

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,6 +17,7 @@ import os
 import datetime
 import sphinx.environment
 from docutils.utils import get_source_line
+from pkg_resources import get_distribution
 
 
 try:
@@ -112,7 +113,6 @@ copyright = u"2011-{}, Erik Bernhardsson and Elias Freider".format(datetime.date
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-from pkg_resources import get_distribution
 __version__ = get_distribution('luigi').version  # assume luigi is already installed
 # The short X.Y version.
 version = ".".join(__version__.split(".")[0:2])

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -301,7 +301,9 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
                         tracking_url_callback(tracking_url)
                     except Exception as e:
                         logger.error("Error in tracking_url_callback, disabling! %s", e)
-                        tracking_url_callback = lambda x: None
+
+                        def tracking_url_callback(x):
+                            return None
                 if err_line.find('running job') != -1:
                     # hadoop jar output
                     job_id = err_line.split('running job: ')[-1]
@@ -339,7 +341,7 @@ def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
             raise HadoopJobError(message + 'Output from tasks below:\n%s' % task_failures, out, err)
 
     if tracking_url_callback is None:
-        tracking_url_callback = lambda x: None
+        def tracking_url_callback(x): return None
 
     return track_process(arglist, tracking_url_callback, env)
 

--- a/luigi/contrib/hdfs/__init__.py
+++ b/luigi/contrib/hdfs/__init__.py
@@ -25,8 +25,18 @@ files under ``luigi/contrib/hdfs/*.py``. But for the sake of convenience and
 API stability, everything is reexported under :py:mod:`luigi.contrib.hdfs`.
 """
 
-# config.py
+# imports
 from luigi.contrib.hdfs import config as hdfs_config
+from luigi.contrib.hdfs import clients as hdfs_clients
+from luigi.contrib.hdfs import error as hdfs_error
+from luigi.contrib.hdfs import snakebite_client as hdfs_snakebite_client
+from luigi.contrib.hdfs import hadoopcli_clients as hdfs_hadoopcli_clients
+from luigi.contrib.hdfs import webhdfs_client as hdfs_webhdfs_client
+from luigi.contrib.hdfs import format as hdfs_format
+from luigi.contrib.hdfs import target as hdfs_target
+
+
+# config.py
 hdfs = hdfs_config.hdfs
 load_hadoop_cmd = hdfs_config.load_hadoop_cmd
 get_configured_hadoop_version = hdfs_config.get_configured_hadoop_version
@@ -35,11 +45,6 @@ tmppath = hdfs_config.tmppath
 
 
 # clients
-from luigi.contrib.hdfs import clients as hdfs_clients
-from luigi.contrib.hdfs import error as hdfs_error
-from luigi.contrib.hdfs import snakebite_client as hdfs_snakebite_client
-from luigi.contrib.hdfs import hadoopcli_clients as hdfs_hadoopcli_clients
-from luigi.contrib.hdfs import webhdfs_client as hdfs_webhdfs_client
 HDFSCliError = hdfs_error.HDFSCliError
 call_check = hdfs_hadoopcli_clients.HdfsClient.call_check
 list_path = hdfs_snakebite_client.SnakebiteHdfsClient.list_path
@@ -58,8 +63,6 @@ listdir = hdfs_clients.listdir
 
 
 # format.py
-from luigi.contrib.hdfs import format as hdfs_format
-
 HdfsReadPipe = hdfs_format.HdfsReadPipe
 HdfsAtomicWritePipe = hdfs_format.HdfsAtomicWritePipe
 HdfsAtomicWriteDirPipe = hdfs_format.HdfsAtomicWriteDirPipe
@@ -71,5 +74,4 @@ CompatibleHdfsFormat = hdfs_format.CompatibleHdfsFormat
 
 
 # target.py
-from luigi.contrib.hdfs import target as hdfs_target
 HdfsTarget = hdfs_target.HdfsTarget

--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -99,7 +99,9 @@ class PigJobTask(luigi.Task):
     def _build_pig_cmd(self):
         opts = self.pig_options()
 
-        line = lambda k, v: ('%s=%s%s' % (k, v, os.linesep)).encode('utf-8')
+        def line(k, v):
+            return ('%s=%s%s' % (k, v, os.linesep)).encode('utf-8')
+
         with tempfile.NamedTemporaryFile() as param_file, tempfile.NamedTemporaryFile() as prop_file:
             if self.pig_parameters():
                 items = six.iteritems(self.pig_parameters())

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -900,7 +900,8 @@ class CentralPlannerScheduler(Scheduler):
             return {}
 
         if dep_func is None:
-            dep_func = lambda t: t.deps
+            def dep_func(t):
+                return t.deps
 
         seen.add(root_task_id)
         serialized = {}
@@ -961,10 +962,13 @@ class CentralPlannerScheduler(Scheduler):
         result = {}
         upstream_status_table = {}  # used to memoize upstream status
         if search is None:
-            filter_func = lambda _: True
+            def filter_func(_):
+                return True
         else:
             terms = search.split()
-            filter_func = lambda t: all(term in t.id for term in terms)
+
+            def filter_func(t):
+                return all(term in t.id for term in terms)
         for task in filter(filter_func, self._state.get_active_tasks(status)):
             if (task.status != PENDING or not upstream_status or
                     upstream_status == self._upstream_status(task.id, upstream_status_table)):

--- a/test/clone_test.py
+++ b/test/clone_test.py
@@ -38,7 +38,8 @@ class LinearSum(luigi.Task):
             self.s = 0
         self.complete = lambda: True  # workaround since we don't write any output
 
-    complete = lambda self: False
+    def complete(self):
+        return False
 
     def f(self, x):
         return x

--- a/test/visualiser/visualiser_test.py
+++ b/test/visualiser/visualiser_test.py
@@ -15,11 +15,11 @@ import threading
 
 here = os.path.dirname(__file__)
 
-# Patch-up path so that we can import from the directory above this one.
+# Patch-up path so that we can import from the directory above this one.r
 # This seems to be necessary because the `test` directory has no __init__.py but
 # adding one makes other tests fail.
 sys.path.append(os.path.join(here, '..'))
-from server_test import ServerTestBase
+from server_test import ServerTestBase  # noqa
 
 TEST_TIMEOUT = 40
 


### PR DESCRIPTION
This unbreaks the build too. For some reason, the world of internet
changed again and our `tox -e flake8` environment suddenly started to
check these new errors.