### PR TITLE
Provide the ability to conditionally install the SIGUSR1 hook on workers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -267,6 +267,19 @@ worker-wait-jitter
   Default: 5.0
 
 
+[worker]
+
+no_install_shutdown_handler
+  By default, workers will stop requesting new work and finish running
+  pending tasks after receiving a `SIGUSR1` signal. This provides a hook
+  for gracefully shutting down workers that are in the process of running
+  (potentially expensive) tasks. If set to true, Luigi will NOT install
+  this shutdown hook on workers. Note this hook does not work on Windows
+  operating systems, or when jobs are launched outside the main execution
+  thread.
+  Defaults to false.
+
+
 [elasticsearch]
 ---------------
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -309,6 +309,9 @@ class worker(Config):
                                          config_path=dict(section='core', name='retry-external-tasks'),
                                          description='If true, incomplete external tasks will be '
                                          'retested for completion while Luigi is running.')
+    no_install_shutdown_handler = BoolParameter(default=False,
+                                                description='If true, the SIGUSR1 shutdown handler will'
+                                                'NOT be install on the worker')
 
 
 class KeepAliveThread(threading.Thread):
@@ -379,10 +382,13 @@ class Worker(object):
         self.run_succeeded = True
         self.unfulfilled_counts = collections.defaultdict(int)
 
-        try:
-            signal.signal(signal.SIGUSR1, self.handle_interrupt)
-        except AttributeError:
-            pass
+        # note that ``signal.signal(signal.SIGUSR1, fn)`` only works inside the main execution thread, which is why we
+        # provide the ability to conditionally install the hook.
+        if not self._config.no_install_shutdown_handler:
+            try:
+                signal.signal(signal.SIGUSR1, self.handle_interrupt)
+            except AttributeError:
+                pass
 
         # Keep info about what tasks are running (could be in other processes)
         if worker_processes == 1:


### PR DESCRIPTION
The reason for this is that we can only install signal hooks inside the main execution thread. So this change provides the ability to skip this if we are programmatically launching jobs/creating workers outside the main execution thread.

@Tarrasch - as discussed in my last PR :)