### PR TITLE
Sort task families in sidebar alphabetically

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -187,6 +187,9 @@ function visualiserApp(luigi) {
         $.each(counts, function (name) {
             taskList.push({name: name, count: counts[name]});
         });
+        taskList.sort(function(a,b){
+          return a.name.localeCompare(b.name);
+        });
         return renderTemplate("sidebarTemplate", {"tasks": taskList});
     }
 


### PR DESCRIPTION
The task families in the sidebar of the visualiser were previously unsorted, which made it pretty difficult to find something in there. This commit sorts them alphabetically.