### PR TITLE
fix .travis.yml errors reported by http://lint.travis-ci.org/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-jdk: oraclejdk7
-
 services:
   - elasticsearch
   - mysql
@@ -45,7 +43,8 @@ matrix:
 sudo: false
 
 cache:
-  - $HOME/.pip-cache
+  directories:
+    - $HOME/.pip-cache
 
 install:
   - pip install 'tox<3.0'


### PR DESCRIPTION
Fixes the following reported errors:
- value for cache section is empty, dropping
- in cache section: unexpected key $HOME/.pip-cache, dropping
- specified jdk, but setting is not relevant for python