### PR TITLE
Fix test: do not send an email if a task is external and retry-able

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -766,8 +766,9 @@ class Worker(object):
                 # Not a running task. Probably already removed.
                 # Maybe it yielded something?
 
-            if status == FAILED and expl:
-                # If no expl, it is because of a retry-external-task failure.
+            # external task if run not implemented, retry-able if config option is enabled.
+            external_task_retryable = task.run == NotImplemented and self._config.retry_external_tasks
+            if status == FAILED and not external_task_retryable:
                 self._email_task_failure(task, expl)
 
             new_deps = []


### PR DESCRIPTION
Fixes this test:

```python
@with_config(dict(worker=dict(retry_external_tasks='true')))
@email_patch
def test_external_task_retries(self, emails):
        """
        Test that we do not send error emails on the failures of external tasks
        """
        class A(luigi.ExternalTask):
            pass

        a = A()
        luigi.build([a], workers=2, local_scheduler=True)
        self.assertEqual(emails, [])
```

This is holding up one of my other PRs :)