### PR TITLE
Add __str__ to HadoopJobError

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -245,6 +245,9 @@ class HadoopJobError(RuntimeError):
         self.out = out
         self.err = err
 
+    def __str__(self):
+        return self.message
+
 
 def run_and_track_hadoop_job(arglist, tracking_url_callback=None, env=None):
     """


### PR DESCRIPTION
When we run a `luigi.contrib.hadoop.JobTask` from a shell (using python2.7) and encounter an error within the map or reduce code, the command line output shows a repr of (self.message, self.out, self.err) rather than printing them:

```
ERROR: [pid 26338] Worker Worker(salt=361416478, workers=1, host=HOSTNAME, username=USERNAME, pid=26338) failed    JOB(ARGS)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 147, in run
    new_deps = self._run_get_new_deps()
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 98, in _run_get_new_deps
    task_gen = self.task.run()
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 686, in run
    self.job_runner().run_job(self)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 526, in run_job
    run_and_track_hadoop_job(arglist)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 344, in run_and_track_hadoop_job
    return track_process(arglist, tracking_url_callback, env)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 339, in track_process
    raise HadoopJobError(message + 'Output from tasks below:\n%s' % task_failures, out, err)
HadoopJobError: ('Streaming job failed with exit code 1. Output from tasks below:\n---------- http://HOSTNAME:50060/tasklog?attemptid=attempt_201511261058_10681_m_000039_0&start=-100000:\nTraceback (most recent call last):\n  File "mrrunner.py", line 89, in main\n    Runner().run(kind, stdin=stdin, stdout=stdout)\n  File "mrrunner.py", line 51, in run\n    self.job.run_mapper(stdin, stdout)\n  File "luigi/contrib/hadoop.py", line 958, in run_mapper\n    self.internal_writer(outputs, stdout)\n  File "luigi/contrib/hadoop.py", line 987, in internal_writer\n    for output in outputs:\n  File "luigi/contrib/hadoop.py", line 929, in _map_input\n    for output in self.mapper(*record):\n  File "JOB.py", line 44, in mapper\n
...
```

I would much sooner see:
```
ERROR: [pid 28400] Worker Worker(salt=130622606, workers=1, host=HOSTNAME, username=USERNAME, pid=28400) failed    JOB(ARGS)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 147, in run
    new_deps = self._run_get_new_deps()
  File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 98, in _run_get_new_deps
    task_gen = self.task.run()
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 689, in run
    self.job_runner().run_job(self)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 529, in run_job
    run_and_track_hadoop_job(arglist)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 347, in run_and_track_hadoop_job
    return track_process(arglist, tracking_url_callback, env)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 342, in track_process
    raise HadoopJobError(message + 'Output from tasks below:\n%s' % task_failures, out, err)
HadoopJobError: Streaming job failed with exit code 1. Output from tasks below:
---------- http://HOSTNAME:50060/tasklog?attemptid=attempt_201511261058_10683_m_000005_1&start=-100000:
Traceback (most recent call last):
  File "mrrunner.py", line 89, in main
    Runner().run(kind, stdin=stdin, stdout=stdout)
  File "mrrunner.py", line 51, in run
    self.job.run_mapper(stdin, stdout)
  File "luigi/contrib/hadoop.py", line 961, in run_mapper
    self.internal_writer(outputs, stdout)
  File "luigi/contrib/hadoop.py", line 990, in internal_writer
    for output in outputs:
  File "luigi/contrib/hadoop.py", line 932, in _map_input
    for output in self.mapper(*record):
REST OF MY STACK TRACE
AttributeError: MY ATTRIBUTE ERROR MESSAGE
...
```

The reason for the discrepancy in formatting is due to passing >1 arguments to RuntimeError via HadoopJobError's __init__ :

```
In [12]: raise RuntimeError('a\nb\nc', 'd', 'e')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-12-ab75f26d5464> in <module>()
----> 1 raise RuntimeError('a\nb\nc', 'd', 'e')

RuntimeError: ('a\nb\nc', 'd', 'e')

In [13]: raise RuntimeError('a\nb\nc')
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-13-86a4af9edaa2> in <module>()
----> 1 raise RuntimeError('a\nb\nc')

RuntimeError: a
b
c
```