### PR TITLE
Use updated message check

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -106,7 +106,7 @@ class TaskProcess(multiprocessing.Process):
         try:
             task_gen = self.task.run(tracking_url_callback=self.tracking_url_callback)
         except TypeError as ex:
-            if 'unexpected keyword argument' not in getattr(ex, 'message', ex.args[0]):
+            if 'unexpected keyword argument' not in str(ex):
                 raise
             run_again = True
         if run_again:


### PR DESCRIPTION
The previous code triggers a DeprecationWarning

"""
DeprecationWarning: BaseException.message has been deprecated as of
Python 2.6
"""