### PR TITLE
Allows the usage of Hive Metastore

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -183,7 +183,7 @@ class MetastoreClient(HiveClient):
                 try:
                     partition_str = self.partition_spec(partition)
                     thrift_table = client.get_partition_by_name(database, table, partition_str)
-                except NoSuchObjectException as e:
+                except hive_metastore.ttypes.NoSuchObjectException as e:
                     return ''
             else:
                 thrift_table = client.get_table(database, table)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -180,8 +180,11 @@ class MetastoreClient(HiveClient):
     def table_location(self, table, database='default', partition=None):
         with HiveThriftContext() as client:
             if partition is not None:
-                partition_str = self.partition_spec(partition)
-                thrift_table = client.get_partition_by_name(database, table, partition_str)
+                try:
+                    partition_str = self.partition_spec(partition)
+                    thrift_table = client.get_partition_by_name(database, table, partition_str)
+                except NoSuchObjectException as e:
+                    return ''
             else:
                 thrift_table = client.get_table(database, table)
             return thrift_table.sd.location

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -26,7 +26,6 @@ from luigi import six
 
 import luigi
 import luigi.contrib.hadoop
-import hive_metastore
 from luigi.target import FileAlreadyExists, FileSystemTarget
 from luigi.task import flatten
 
@@ -182,6 +181,7 @@ class MetastoreClient(HiveClient):
         with HiveThriftContext() as client:
             if partition is not None:
                 try:
+                    import hive_metastore.ttypes
                     partition_str = self.partition_spec(partition)
                     thrift_table = client.get_partition_by_name(database, table, partition_str)
                 except hive_metastore.ttypes.NoSuchObjectException as e:

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -184,7 +184,7 @@ class MetastoreClient(HiveClient):
                     import hive_metastore.ttypes
                     partition_str = self.partition_spec(partition)
                     thrift_table = client.get_partition_by_name(database, table, partition_str)
-                except hive_metastore.ttypes.NoSuchObjectException as e:
+                except hive_metastore.ttypes.NoSuchObjectException:
                     return ''
             else:
                 thrift_table = client.get_table(database, table)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -26,6 +26,7 @@ from luigi import six
 
 import luigi
 import luigi.contrib.hadoop
+import hive_metastore
 from luigi.target import FileAlreadyExists, FileSystemTarget
 from luigi.task import flatten
 

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -244,8 +244,11 @@ class HiveThriftContext(object):
 
 
 def get_default_client():
-    if get_hive_syntax() == "apache":
+    syntax = get_hive_syntax()
+    if syntax == "apache":
         return ApacheHiveCommandClient()
+    elif syntax == "metastore":
+        return MetastoreClient()
     else:
         return HiveCommandClient()
 

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -252,6 +252,10 @@ class HiveCommandClientTest(unittest.TestCase):
         client = luigi.contrib.hive.get_default_client()
         self.assertEqual(luigi.contrib.hive.ApacheHiveCommandClient, type(client))
 
+        hive_syntax.get_config.return_value.get.return_value = "metastore"
+        client = luigi.contrib.hive.get_default_client()
+        self.assertEqual(luigi.contrib.hive.MetastoreClient, type(client))
+
     @mock.patch('subprocess.Popen')
     def test_run_hive_command(self, popen):
         # I'm testing this again to check the return codes


### PR DESCRIPTION
The usage of Hive Metastore greatly speeds up table and partition lookup in luigi.
Although the MetastoreClient was already implemented, the code always looked for one of two alternatives of the hive command, which is slow.

This PR's settings are only active if
```
[hive]
release: metastore
```
is set