### PR TITLE
make saving data for the execution summary optional

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -275,6 +275,10 @@ retry_external_tasks
   PENDING until the workflow is reinvoked.
   Defaults to false for backwards compatibility.
 
+save_summary_data
+  If true, save task metadata for all tasks executed by the worker for use
+  in the execution summary.
+  Default: True
 
 [worker]
 

--- a/test/execution_summary_test.py
+++ b/test/execution_summary_test.py
@@ -95,6 +95,29 @@ class ExecutionSummaryTest(LuigiTestCase):
         for i, line in enumerate(result):
             self.assertEqual(line, expected[i])
 
+    @with_config({'worker': {'save_summary_data': 'False'}})
+    def test_config_no_summary_data(self):
+        class Foo(luigi.Task):
+            num = luigi.IntParameter()
+
+            def run(self):
+                pass
+
+            def complete(self):
+                return True
+
+        self.run_task(Foo(num=1))
+        summary = self.summary()
+        expected = ['',
+                    '===== Luigi Execution Summary =====',
+                    '',
+                    'Did not schedule any tasks',
+                    ''
+                    '===== Luigi Execution Summary ====='
+                    '']
+        result = summary.split('\n')
+        self.assertEqual(result, expected)
+
     @with_config({'execution_summary': {'summary-length': '1'}})
     def test_config_summary_limit(self):
         class Bar(luigi.Task):


### PR DESCRIPTION
When a worker executes a large number of tasks, this has the same impact as a
memory leak.