### PR TITLE
Issue #1539 Can't pass Spark property using the conf when the option contains an equals

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -198,7 +198,7 @@ class SparkSubmitTask(ExternalProgramTask):
 
     def _dict_config(self, config):
         if config and isinstance(config, six.string_types):
-            return dict(map(lambda i: i.split('='), config.split('|')))
+            return dict(map(lambda i: i.split('=',1), config.split('|')))
 
     def _text_arg(self, name, value):
         if value:

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -198,7 +198,7 @@ class SparkSubmitTask(ExternalProgramTask):
 
     def _dict_config(self, config):
         if config and isinstance(config, six.string_types):
-            return dict(map(lambda i: i.split('=',1), config.split('|')))
+            return dict(map(lambda i: i.split('=', 1), config.split('|')))
 
     def _text_arg(self, name, value):
         if value:


### PR DESCRIPTION
In spark configuration, the conf can't have some options with an equals inside:

[spark]
conf: spark.executor.extraJavaOptions=-Darchaius.deployment.environment=dev

Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 162, in run
new_deps = self._run_get_new_deps()
File "/usr/local/lib/python2.7/dist-packages/luigi/worker.py", line 113, in _run_get_new_deps
task_gen = self.task.run()
File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/spark.py", line 235, in run
args = list(map(str, self.spark_command() + self.app_command()))
File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/spark.py", line 214, in spark_command
command += self._dict_arg('--conf', self.conf)
File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/spark.py", line 138, in conf
return self._dict_config(configuration.get_config().get("spark", "conf", None))
File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/spark.py", line 261, in _dict_config
return dict(map(lambda i: i.split('='), config.split('|')))
ValueError: dictionary update sequence element #0 has length 3; 2 is required

As a fix, split only on the first equals.