### PR TITLE
Fixes viz issues triggered by the task_id change

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1048,7 +1048,8 @@ class CentralPlannerScheduler(Scheduler):
 
     def fetch_error(self, task_id, **kwargs):
         if self._state.has_task(task_id):
-            return {"taskId": task_id, "error": self._state.get_task(task_id).expl}
+            task = self._state.get_task(task_id)
+            return {"taskId": task_id, "error": task.expl, 'displayName': task.pretty_id}
         else:
             return {"taskId": task_id, "error": ""}
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -865,6 +865,7 @@ class CentralPlannerScheduler(Scheduler):
     def _serialize_task(self, task_id, include_deps=True, deps=None):
         task = self._state.get_task(task_id)
         ret = {
+            'display_name': task.pretty_id,
             'status': task.status,
             'workers': list(task.workers),
             'worker_running': task.worker_running,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -219,6 +219,11 @@ class Task(object):
         return (self.disable_failures is not None or
                 self.disable_hard_timeout is not None)
 
+    @property
+    def pretty_id(self):
+        param_str = ', '.join('{}={}'.format(key, value) for key, value in self.params.items())
+        return '{}({})'.format(self.family, param_str)
+
 
 class Worker(object):
     """
@@ -969,7 +974,7 @@ class CentralPlannerScheduler(Scheduler):
             terms = search.split()
 
             def filter_func(t):
-                return all(term in t.id for term in terms)
+                return all(term in t.pretty_id for term in terms)
         for task in filter(filter_func, self._state.get_active_tasks(status)):
             if (task.status != PENDING or not upstream_status or
                     upstream_status == self._upstream_status(task.id, upstream_status_table)):

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -985,6 +985,13 @@ class CentralPlannerScheduler(Scheduler):
             return {'num_tasks': len(result)}
         return result
 
+    def _first_task_display_name(self, worker):
+        task_id = worker.info.get('first_task', '')
+        if self._state.has_task(task_id):
+            return self._state.get_task(task_id).pretty_id
+        else:
+            return task_id
+
     def worker_list(self, include_running=True, **kwargs):
         self.prune()
         workers = [
@@ -992,6 +999,7 @@ class CentralPlannerScheduler(Scheduler):
                 name=worker.id,
                 last_active=worker.last_active,
                 started=getattr(worker, 'started', None),
+                first_task_display_name=self._first_task_display_name(worker),
                 **worker.info
             ) for worker in self._state.get_active_workers()]
         workers.sort(key=lambda worker: worker['started'], reverse=True)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -931,6 +931,7 @@ class CentralPlannerScheduler(Scheduler):
                     'start_time': UNKNOWN,
                     'params': params,
                     'name': family,
+                    'display_name': task_id,
                     'priority': 0,
                 }
             else:
@@ -940,6 +941,9 @@ class CentralPlannerScheduler(Scheduler):
                     if dep not in seen:
                         seen.add(dep)
                         queue.append(dep)
+
+            if task_id != root_task_id:
+                del serialized[task_id]['display_name']
             if len(serialized) >= self._config.max_graph_nodes:
                 break
 

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -245,7 +245,7 @@
             <div class="modal-content">
               <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                <h4 class="modal-title" id="myModalLabel">Traceback for {{taskId}}</h4>
+                <h4 class="modal-title" id="myModalLabel">Traceback for {{displayName}}</h4>
               </div>
               <div class="modal-body">
                 <pre class="pre-scrollable">{{error}}</pre>

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -265,7 +265,7 @@
                 <div class="box-body">
                     Started: {{start_time}}<br>
                     Last Checkin: {{active}}<br>
-                    Root Task: <a href="#{{{encoded_first_task}}}">{{first_task}}</a><br>
+                    Root Task: <a href="#{{{encoded_first_task}}}">{{first_task_display_name}}</a><br>
                     Running: {{num_running}}<br>
                     Pending: {{num_pending}}<br>
                     Unique Pending: {{num_uniques}}<br>

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -283,7 +283,7 @@
                       <tbody>
                       {{#tasks}}
                       <tr>
-                        <td>{{taskName}}({{taskParams}})</td>
+                        <td>{{displayName}}</td>
                         <td>{{priority}}</td>
                         <td>{{resources}}</td>
                         <td>{{displayTime}}</td>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -73,6 +73,7 @@ function visualiserApp(luigi) {
             encodedTaskId: encodeURIComponent(task.taskId),
             taskName: taskName,
             taskParams: taskParams,
+            displayName: task.display_name,
             priority: task.priority,
             resources: JSON.stringify(task.resources),
             displayTime: displayTime,
@@ -290,7 +291,7 @@ function visualiserApp(luigi) {
             $("#searchError").empty();
             $("#searchError").removeClass();
             if(dependencyGraph.length > 0) {
-                $("#dependencyTitle").text(taskId);
+                $("#dependencyTitle").text(dependencyGraph[0].display_name);
                 if(dependencyGraph != '{}'){
                     for (var id in dependencyGraph) {
                         if (dependencyGraph[id].deps.length > 0) {
@@ -319,7 +320,7 @@ function visualiserApp(luigi) {
             $("#searchError").empty();
             $("#searchError").removeClass();
             if(dependencyGraph.length > 0) {
-              $("#dependencyTitle").text(taskId);
+              $("#dependencyTitle").text(dependencyGraph[0].display_name);
               $("#graphPlaceholder").get(0).graph.updateData(dependencyGraph);
               $("#graphContainer").show();
               bindGraphEvents();

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -311,6 +311,22 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(remote.task_list('FAILED', ''), {})
         self.assertEqual(remote.task_list('PENDING', ''), {})
 
+    def test_dep_graph_root_has_display_name(self):
+        root_task = FactorTask(12)
+        self._build([root_task])
+
+        dep_graph = self._remote().dep_graph(root_task.task_id)
+        self.assertEqual('FactorTask(product=12)', dep_graph[root_task.task_id]['display_name'])
+
+    def test_dep_graph_non_root_nodes_lack_display_name(self):
+        root_task = FactorTask(12)
+        self._build([root_task])
+
+        dep_graph = self._remote().dep_graph(root_task.task_id)
+        for task_id, node in dep_graph.items():
+            if task_id != root_task.task_id:
+                self.assertNotIn('display_name', node)
+
     def test_task_list_failed(self):
         self._build([FailingTask(8)])
         remote = self._remote()


### PR DESCRIPTION
With the task_id change, a couple issues cropped up in the visualiser. Most annoyingly, server-side filtering broke because the task_id no longer contains the same data shown in the data table. This is fixed by reconstructing a task_id similar to the old one for server-side filtering.

Less annoyingly, task display names in the visualiser changed from TaskClass(param=val) to TaskClass({"param": "val"}). This is fixed by passing the display name computed for filtering in the server to the visualiser for display.

Finally, there were a few places in the visualiser where the new task id was displayed: the first tasks in the workers tab, the graph name in the graph tab, and error popups in the graph tab. All three of these are fixed to show a nice display name that is more helpful to users.

We should probably also show a nicer display name in worker error messages, but this PR is focusing on the visualiser.