### PR TITLE
Pass s3 move kwargs through to copy

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -387,7 +387,7 @@ class S3Client(FileSystem):
 
         :param kwargs: Keyword arguments are passed to the boto function `copy_key`
         """
-        self.copy(source_path, destination_path)
+        self.copy(source_path, destination_path, **kwargs)
         self.remove(source_path)
 
     def listdir(self, path):


### PR DESCRIPTION
For some reason this has been missed by both me and @Tarrasch in his latest refactor. Thanks to @a86c6f7964 for catching it.