### PR TITLE
Fix of process locking functionality on Windows

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -33,14 +33,23 @@ def getpcmd(pid):
 
     :param pid:
     """
-    cmd = 'ps -o pid,args'
-    with os.popen(cmd, 'r') as p:
-        # Skip the column titles
-        p.readline()
-        for line in p:
-            spid, scmd = line.strip().split(' ', 1)
-            if int(spid) == int(pid):
-                return scmd
+    if os.name == "nt":
+        # Use wmic command instead of ps on Windows.
+        cmd = 'wmic path win32_process where ProcessID=%s get Commandline' % (pid, )
+        with os.popen(cmd, 'r') as p:
+            lines = [line for line in p.readlines() if line.strip("\r\n ") != ""]
+            if lines:
+                _, val = lines
+                return val
+    else:
+        cmd = 'ps -o pid,args'
+        with os.popen(cmd, 'r') as p:
+            # Skip the column titles
+            p.readline()
+            for line in p:
+                spid, scmd = line.strip().split(' ', 1)
+                if int(spid) == int(pid):
+                    return scmd
 
 
 def get_info(pid_dir, my_pid=None):


### PR DESCRIPTION
This is the re-submission of PR #1547.
I restarted from the master branch due to the merge problem.

Below is the original PR message:
---
The current version of
luigi.lock.getpcmd does not work properly on Windows, because Windows does not have ps command which is used to get command in the function. As a result, locking functionality does not work on Windows.
Fix the function to use wmic command instead of ps when luigi is run on Windows.