### PR TITLE
Shows last update time instead of start time in visualizer

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -60,7 +60,7 @@ function visualiserApp(luigi) {
     function taskToDisplayTask(task) {
         var taskName = task.name;
         var taskParams = JSON.stringify(task.params);
-        var displayTime = new Date(Math.floor(task.start_time*1000)).toLocaleString();
+        var displayTime = new Date(Math.floor(task.last_updated*1000)).toLocaleString();
         var time_running = -1;
         if (task.status == "RUNNING" && "time_running" in task) {
             var current_time = new Date().getTime();
@@ -77,7 +77,7 @@ function visualiserApp(luigi) {
             priority: task.priority,
             resources: JSON.stringify(task.resources),
             displayTime: displayTime,
-            displayTimestamp: task.start_time,
+            displayTimestamp: task.last_updated,
             timeRunning: time_running,
             trackingUrl: task.tracking_url,
             status: task.status,


### PR DESCRIPTION
The time field in the visualiser datatable not very helpful, as I don't really
need to know when a job was scheduled. I usually know that, as I control
scheduling. Instead, I want to know when the job finished or failed or was
disabled. In order to make the time column more useful, this sets the time as
the last time the status was changed. The old start_time field is kept in the
task_list api response for backward compatibility with any tools that might make
that api call.