### PR TITLE
Adds a disable worker button to the visualiser

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -217,6 +217,9 @@ class RemoteScheduler(Scheduler):
     def add_worker(self, worker, info):
         return self._request('/api/add_worker', {'worker': worker, 'info': info})
 
+    def disable_worker(self, worker):
+        return self._request('/api/disable_worker', {'worker': worker})
+
     def update_resources(self, **resources):
         return self._request('/api/update_resources', resources)
 

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -257,10 +257,41 @@
           </div>
         </script>
         <script type="text/template" name="workerTemplate">
+            <div class="modal fade" id="disableWorkerModal" tabindex="-1" role="dialog" aria-labelledby="disableWorkerLabel">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="disiableWorkerLabel">Disable worker?</h4>
+                  </div>
+                  <div class="modal-body">
+                    Are you sure you want to disable this worker?
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="button" id="disableWorkerButton" data-dismiss="modal" class="btn btn-danger">Disable Worker</button>
+                  </div>
+                </div>
+              </div>
+            </div>
             {{#workers}}
+            {{#num_pending}}
             <div class="box">
+            {{/num_pending}}
+            {{^num_pending}}
+            <div class="box box-solid box-default">
+            {{/num_pending}}
                 <div class="box-header with-border">
                     <h3 class="box-title">{{name}}</h3>
+                    <div class="box-tools pull-right">
+                      {{#num_pending}}
+                      <div class="button-tooltip" data-toggle="tooltip" title="Disable Worker">
+                        <button type="button" class="btn btn-danger btn-disable-worker" data-toggle="modal" data-target="#disableWorkerModal" data-worker="{{name}}">
+                          <i class="fa fa-fire-extinguisher"></i>
+                        </button>
+                      </div>
+                      {{/num_pending}}
+                    </div>
                 </div>
                 <div class="box-body">
                     Started: {{start_time}}<br>

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -123,5 +123,9 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.disableWorker = function(workerId) {
+        jsonRPC(this.urlRoot + "/disable_worker", {'worker': workerId});
+    }
+
     return LuigiAPI;
 })();

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -544,7 +544,7 @@ function visualiserApp(luigi) {
             for (var id in tasks) {
                 var task = tasks[id];
                 var className = task.status;
-                    
+
                 var html = "<div class='taskNode' data-task-id='" + task.taskId + "'>";
                 html += "<span class=status></span>";
                 html += "<span class=name>"+task.name+"</span>";
@@ -910,6 +910,22 @@ function visualiserApp(luigi) {
         $('.navbar-nav').on('click', 'a', function () {
             var tabName = $(this).data('tab');
             updateSidebar(tabName);
+        });
+
+        $('#workerList').on('show.bs.modal', '#disableWorkerModal', function (event) {
+            var triggerButton = $(event.relatedTarget);
+            $('#disableWorkerButton').data('trigger', triggerButton);
+        });
+
+        $('#workerList').on('click', '#disableWorkerButton', function() {
+            var triggerButton = $(this).data('trigger');
+            var worker = triggerButton.data('worker');
+
+            luigi.disableWorker(worker);
+
+            // show the worker as disabled in the visualiser
+            triggerButton.parents('.box').addClass('box-solid box-default');
+            triggerButton.remove();
         });
 
         visType = getVisType();

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -794,6 +794,79 @@ class CentralPlannerTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id='A')
         self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
+    def test_disable_worker(self):
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.disable_worker(worker=WORKER)
+        work = self.sch.get_work(worker=WORKER)
+        self.assertEqual(0, work['n_unique_pending'])
+        self.assertEqual(0, work['n_pending_tasks'])
+        self.assertIsNone(work['task_id'])
+
+    def test_disable_worker_leaves_jobs_running(self):
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.get_work(worker=WORKER)
+
+        self.sch.disable_worker(worker=WORKER)
+        self.assertEqual(['A'], list(self.sch.task_list('RUNNING', '').keys()))
+        self.assertEqual(['A'], list(self.sch.worker_list()[0]['running'].keys()))
+
+    def test_disable_worker_cannot_pick_up_failed_jobs(self):
+        self.setTime(0)
+
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.get_work(worker=WORKER)
+        self.sch.disable_worker(worker=WORKER)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+
+        # increase time and prune to make the job pending again
+        self.setTime(1000)
+        self.sch.ping(worker=WORKER)
+        self.sch.prune()
+
+        # we won't try the job again
+        self.assertIsNone(self.sch.get_work(worker=WORKER)['task_id'])
+
+        # not even if other stuff is pending, changing the pending tasks code path
+        self.sch.add_task(worker='other_worker', task_id='B')
+        self.assertIsNone(self.sch.get_work(worker=WORKER)['task_id'])
+
+    def test_disable_worker_cannot_continue_scheduling(self):
+        self.sch.disable_worker(worker=WORKER)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertIsNone(self.sch.get_work(worker=WORKER)['task_id'])
+
+    def test_disable_worker_can_finish_task(self, new_status=DONE, new_deps=[]):
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.assertEqual('A', self.sch.get_work(worker=WORKER)['task_id'])
+
+        self.sch.disable_worker(worker=WORKER)
+        self.assertEqual(['A'], list(self.sch.task_list('RUNNING', '').keys()))
+
+        for dep in new_deps:
+            self.sch.add_task(worker=WORKER, task_id=dep, status='PENDING')
+        self.sch.add_task(worker=WORKER, task_id='A', status=new_status, new_deps=new_deps)
+        self.assertFalse(self.sch.task_list('RUNNING', '').keys())
+        self.assertEqual(['A'], list(self.sch.task_list(new_status, '').keys()))
+
+        self.assertIsNone(self.sch.get_work(worker=WORKER)['task_id'])
+        for task in self.sch.task_list('', '').values():
+            self.assertFalse(task['workers'])
+
+    def test_disable_worker_can_fail_task(self):
+        self.test_disable_worker_can_finish_task(new_status=FAILED)
+
+    def test_disable_worker_stays_disabled_on_new_deps(self):
+        self.test_disable_worker_can_finish_task(new_status='PENDING', new_deps=['B', 'C'])
+
+    def test_prune_worker(self):
+        self.setTime(1)
+        self.sch.add_worker(worker=WORKER, info={})
+        self.setTime(10000)
+        self.sch.prune()
+        self.setTime(20000)
+        self.sch.prune()
+        self.assertFalse(self.sch.worker_list())
+
     def test_task_list_beyond_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=3)
         for c in 'ABCD':


### PR DESCRIPTION
This allows workers to be stopped from the visualiser. Workers disabled in this
way will not be able to schedule new jobs or get_work, but they are able to
finish the jobs they're currently working on. This allows for clean transitions
to newly deployed code or safe shutdown of workers when things are going wrong.

A popup verifies the intent to disable the worker to help prevent accidental
disables.

![image](https://cloud.githubusercontent.com/assets/2091885/13305805/f55dccd8-db12-11e5-9d13-57f2573b5024.png)

![image](https://cloud.githubusercontent.com/assets/2091885/13305814/0aef13c2-db13-11e5-9d5a-8618d97f5d40.png)


