### PR TITLE
Allows package binaries to be passed to job runner

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -450,9 +450,11 @@ class HadoopJobRunner(JobRunner):
         # build arguments
         config = configuration.get_config()
         python_executable = config.get('hadoop', 'python-executable', 'python')
-        map_cmd = '{0} mrrunner.py map'.format(python_executable)
-        cmb_cmd = '{0} mrrunner.py combiner'.format(python_executable)
-        red_cmd = '{0} mrrunner.py reduce'.format(python_executable)
+        runner_arg = 'mrrunner.pex' if job.package_binary is not None else 'mrrunner.py'
+        command = '{0} {1} {{step}}'.format(python_executable, runner_arg)
+        map_cmd = command.format(step='map')
+        cmb_cmd = command.format(step='combiner')
+        red_cmd = command.format(step='reduce')
 
         output_final = job.output().path
         # atomic output: replace output with a temporary work directory
@@ -514,9 +516,14 @@ class HadoopJobRunner(JobRunner):
             arglist += ['-combiner', cmb_cmd]
         if job.reducer != NotImplemented:
             arglist += ['-reducer', red_cmd]
-        files = [runner_path, self.tmp_dir + '/packages.tar', self.tmp_dir + '/job-instance.pickle']
+        packages_fn = 'mrrunner.pex' if job.package_binary is not None else 'packages.tar'
+        files = [
+            runner_path if job.package_binary is None else None,
+            os.path.join(self.tmp_dir, packages_fn),
+            os.path.join(self.tmp_dir, 'job-instance.pickle'),
+        ]
 
-        for f in files:
+        for f in filter(None, files):
             arglist += ['-file', f]
 
         if self.output_format:
@@ -544,7 +551,10 @@ class HadoopJobRunner(JobRunner):
         arglist += ['-output', output_hadoop]
 
         # submit job
-        create_packages_archive(packages, self.tmp_dir + '/packages.tar')
+        if job.package_binary is not None:
+            shutil.copy(job.package_binary, os.path.join(self.tmp_dir, 'mrrunner.pex'))
+        else:
+            create_packages_archive(packages, os.path.join(self.tmp_dir, 'packages.tar'))
 
         job.dump(self.tmp_dir)
 
@@ -650,6 +660,7 @@ class BaseHadoopJobTask(luigi.Task):
     final_reducer = NotImplemented
 
     mr_priority = NotImplemented
+    package_binary = None
 
     _counter_dict = {}
     task_id = None

--- a/test/contrib/streaming_test.py
+++ b/test/contrib/streaming_test.py
@@ -1,0 +1,53 @@
+import mock
+import os
+
+import unittest
+
+from luigi import mrrunner, Parameter
+
+from luigi.contrib.hadoop import HadoopJobRunner, JobTask
+from luigi.contrib.hdfs import HdfsTarget
+
+
+class MockStreamingJob(JobTask):
+    package_binary = Parameter(default=None)
+
+    def output(self):
+        rv = mock.MagicMock(HdfsTarget)
+        rv.path = 'test_path'
+        return rv
+
+
+class StreamingRunTest(unittest.TestCase):
+
+    @mock.patch('luigi.contrib.hadoop.shutil')
+    @mock.patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_package_binary_run(self, rath_job, shutil):
+        job_runner = HadoopJobRunner('jar_path', end_job_with_atomic_move_dir=False)
+        job_runner.run_job(MockStreamingJob(package_binary='test_bin.pex'))
+
+        self.assertEqual(1, shutil.copy.call_count)
+        pex_src, pex_dest = shutil.copy.call_args[0]
+        runner_fname = os.path.basename(pex_dest)
+        self.assertEqual('test_bin.pex', pex_src)
+        self.assertEqual('mrrunner.pex', runner_fname)
+
+        self.assertEqual(1, rath_job.call_count)
+        mr_args = rath_job.call_args[0][0]
+        mr_args_pairs = zip(mr_args, mr_args[1:])
+        self.assertIn(('-mapper', 'python mrrunner.pex map'), mr_args_pairs)
+        self.assertIn(('-file', pex_dest), mr_args_pairs)
+
+    @mock.patch('luigi.contrib.hadoop.create_packages_archive')
+    @mock.patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
+    def test_standard_run(self, rath_job, cpa):
+        job_runner = HadoopJobRunner('jar_path', end_job_with_atomic_move_dir=False)
+        job_runner.run_job(MockStreamingJob())
+
+        self.assertEqual(1, cpa.call_count)
+
+        self.assertEqual(1, rath_job.call_count)
+        mr_args = rath_job.call_args[0][0]
+        mr_args_pairs = zip(mr_args, mr_args[1:])
+        self.assertIn(('-mapper', 'python mrrunner.py map'), mr_args_pairs)
+        self.assertIn(('-file', mrrunner.__file__.rstrip('c')), mr_args_pairs)


### PR DESCRIPTION
I've recently started using Twitter's Pants Build System to produce binaries for
my pipelines for ease of deployment. This is incompatible with how the streaming
jobs work, but luckily the pre-compiled binary already contains everything I
need to run my streaming jobs.

This allows a package_binary to be specified in a streaming job task, which then
gets used in place of both mrrunner.py and packages.tar. To use this, I updated
my runner script to act like mrrunner.py when the first argument passed is map,
reduce, or combiner by adding the following lines at its start:

    if len(sys.argv) > 1 and sys.argv[1] in ('map', 'reduce', 'combiner'):
        return luigi.mrrunner.main(sys.argv)

Then I just need to add the package_binary to my streaming job base class. This
also has the benefit of removing my need to maintain an extensive extra_modules
list because they're already included in my pre-built pex file.