### PR TITLE
Adds a resources tab to the visualiser

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -205,6 +205,9 @@ class RemoteScheduler(Scheduler):
     def worker_list(self):
         return self._request('/api/worker_list', {})
 
+    def resource_list(self):
+        return self._request('/api/resource_list', {})
+
     def task_search(self, task_str):
         return self._request('/api/task_search', {'task_str': task_str})
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1031,6 +1031,41 @@ class CentralPlannerScheduler(Scheduler):
                 worker['running'] = tasks
         return workers
 
+    def resource_list(self):
+        """
+        Resources usage info and their consumers (tasks).
+        """
+        self.prune()
+        resources = [
+            dict(
+                name=resource,
+                num_total=r_dict['total'],
+                num_used=r_dict['used']
+            ) for resource, r_dict in six.iteritems(self.resources())]
+        if self._resources is not None:
+            consumers = collections.defaultdict(dict)
+            for task in self._state.get_running_tasks():
+                if task.status == RUNNING and task.resources:
+                    for resource, amount in six.iteritems(task.resources):
+                        consumers[resource][task.id] = self._serialize_task(task.id, False)
+            for resource in resources:
+                tasks = consumers[resource['name']]
+                resource['num_consumer'] = len(tasks)
+                resource['running'] = tasks
+        return resources
+
+    def resources(self):
+        ''' get total resources and available ones '''
+        used_resources = self._used_resources()
+        ret = collections.defaultdict(dict)
+        for resource, total in self._resources.iteritems():
+            ret[resource]['total'] = total
+            if resource in used_resources:
+                ret[resource]['used'] = used_resources[resource]
+            else:
+                ret[resource]['used'] = 0
+        return ret
+
     def task_search(self, task_str, **kwargs):
         """
         Query for a subset of tasks by task_id.

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -300,6 +300,51 @@
             {{/workers}}
         </script>
 
+        <script type="text/template" name="resourceTemplate">
+        {{#resources}}
+        <div class="box">
+            <div class="box-header with-border">
+                <h3 class="box-title">{{name}}</h3>
+                {{#num_consumer}}
+                <div class="box-tools pull-right">
+                    <i class="fa fa-navicon" data-toggle="collapse" data-target="#collapse-{{name}}" aria-expanded="false" aria-controls="collapse-{{name}}"></i>
+                </div><!-- /.box-tools -->
+                {{/num_consumer}}
+            </div><!-- /.box-header -->
+            <div class="box-body">
+                <div class="progress">
+                    <div class="progress-bar progress-bar-{{bar_type}}" style="width: {{percent_used}}%">
+                        <b>{{num_used}}/{{num_total}}</b>
+                    </div>
+                </div>
+
+                {{#num_consumer}}
+                <div class="collapse" id="collapse-{{name}}">
+                    <table class="table table-striped worker-table">
+                        <thead>
+                            <th>Name</th>
+                            <th>Priority</th>
+                            <th>Time</th>
+                            <th>Actions</th>
+                        </thead>
+                        <tbody>
+                            {{#tasks}}
+                            <tr>
+                                <td>{{displayName}}</td>
+                                <td>{{priority}}</td>
+                                <td>{{displayTime}}</td>
+                                <td><a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a></td>
+                            </tr>
+                            {{/tasks}}
+                        </tbody>
+                    </table>
+                </div>
+                {{/num_consumer}}
+            </div><!-- /.box-body -->
+        </div><!-- /.box -->
+        {{/resources}}
+        </script>
+
         <script type="text/template" name="sidebarTemplate">
             <ul class="sidebar-menu">
                 <li class="header">TASK FAMILIES</li>
@@ -354,6 +399,7 @@
                                 <li><a href="#" data-tab="taskList">Task List</a></li>
                                 <li><a href="#g" data-tab="dependencyGraph">Dependency Graph</a></li>
                                 <li><a href="#w" data-tab="workerList">Workers</a></li>
+                                <li><a href="#r" data-tab="resourceList">Resources</a></li>
                             </ul>
                         </div>
                     </div>
@@ -500,6 +546,8 @@
                 </div>
             </section>
             <section id="workerList" class="container-fluid tab-pane active">
+            </section>
+            <section id="resourceList" class="tab-pane">
             </section>
         </div> <!-- /.tab-content -->
         </div> <!-- /.content -->

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -117,5 +117,11 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getResourceList = function(callback) {
+        jsonRPC(this.urlRoot + "/resource_list", {}, function(response) {
+            callback(flatten_running(response.response));
+        });
+    };
+
     return LuigiAPI;
 })();

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -240,6 +240,40 @@ function visualiserApp(luigi) {
         return renderTemplate("workerTemplate", {"workers": workers.map(processWorker)});
     }
 
+    function processResource(resource) {
+        resource.tasks = resource.running.map(taskToDisplayTask);
+        resource.percent_used = 100 * resource.num_used / resource.num_total;
+        if (resource.percent_used >= 100) {
+            resource.bar_type = 'danger';
+        } else if (resource.percent_used > 50) {
+            resource.bar_type = 'warning';
+        } else {
+            resource.bar_type = 'success';
+        }
+        return resource;
+    }
+
+    function renderResources(resources) {
+        return renderTemplate("resourceTemplate", {
+            "resources": resources.map(processResource).sort(function(r1, r2) {
+                if (r1.percent_used > r2.percent_used)
+                    return -1;
+                else if (r1.percent_used < r2.percent_used)
+                    return 1;
+                else if (r1.num_used > r2.num_used)
+                    return -1;
+                else if (r1.num_used < r2.num_used)
+                    return 1;
+                else if (r1.name < r2.name)
+                    return -1;
+                else if (r1.name > r2.name)
+                    return 1;
+                else
+                    return 0;
+            })
+        });
+    }
+
     function switchTab(tabId) {
         $(".tabButton").parent().removeClass("active");
         $(".tab-pane").removeClass("active");
@@ -351,6 +385,8 @@ function visualiserApp(luigi) {
         var hash = decodeURIComponent(location.hash);
         if (hash == "#w") {
             switchTab("workerList");
+        } else if (hash == "#r") {
+            switchTab("resourceList");
         } else if (hash) {
             var taskId = decodeURIComponent(hash.substr(1));
             $("#searchError").empty();
@@ -773,6 +809,10 @@ function visualiserApp(luigi) {
 
         luigi.getWorkerList(function(workers) {
             $("#workerList").append(renderWorkers(workers));
+        });
+
+        luigi.getResourceList(function(resources) {
+            $("#resourceList").append(renderResources(resources));
         });
 
         dt = $('#taskTable').DataTable({


### PR DESCRIPTION
This tab allows a quick view of resource utilization in the visualiser. It also
shows which jobs are running for each resource, but this information is
collapsed by default. This is very helpful when jobs for debugging/tracking when
jobs for a particular resource are getting backed up.

![image](https://cloud.githubusercontent.com/assets/2091885/13306741/328a4cc8-db1b-11e5-8982-c761f7490c8d.png)
