### PR TITLE
Modify hadoopcli_clients to ignore Hadoop Native Libraries

### DIFF
--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -133,8 +133,8 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
         stdout = self.call_check(cmd)
         lines = stdout.split('\n')
         for line in stdout.split('\n'):
-            if line.startswith("OpenJDK 64-Bit Server VM warning") or line.startswith("It's highly recommended") or not line:
-                lines.pop(lines.index(line))
+            if line.startswith("OpenJDK 64-Bit Server VM warning") or line.startswith("It's highly recommended") or line.endswith('using builtin-java classes where applicable') or not line:
+                lines.pop(lines.index(line)) # ignoring native libraries warnings
             else:
                 (dir_count, file_count, content_size, ppath) = stdout.split()
         results = {'content_size': content_size, 'dir_count': dir_count, 'file_count': file_count}
@@ -185,8 +185,8 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
         for line in lines:
             if not line:
                 continue
-            elif line.startswith('OpenJDK 64-Bit Server VM warning') or line.startswith('It\'s highly recommended') or line.startswith('Found'):
-                continue  # "hadoop fs -ls" outputs "Found %d items" as its first line
+            elif line.startswith('OpenJDK 64-Bit Server VM warning') or line.startswith('It\'s highly recommended') or line.startswith('Found') or line.endswith('using builtin-java classes where applicable'):
+                continue  # "hadoop fs -ls" outputs "Found %d items" as its first line and ignoring native libraries warnings
             elif ignore_directories and line[0] == 'd':
                 continue
             elif ignore_files and line[0] == '-':


### PR DESCRIPTION
By default, Mac brew installs w/o 'native-hadoop' libraries, leading to the following WARN message on stdout when running Hadoop commands:
```
› hadoop fs -ls /user/cloudera                                      
16/02/25 10:44:07 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Found 5 items
drwx------   - cloudera cloudera          0 2016-02-25 08:55 /user/cloudera/.Trash
drwxr-xr-x   - cloudera cloudera          0 2015-12-05 13:52 /user/cloudera/.sparkStaging
drwx------   - cloudera cloudera          0 2016-02-23 13:14 /user/cloudera/.staging
drwxr-xr-x   - cloudera cloudera          0 2016-02-08 20:08 /user/cloudera/ch01-identity
drwxr-xr-x   - cloudera cloudera          0 2016-02-23 13:14 /user/cloudera/oozie-oozi
```

This breaks .listdir commands with the following behavior:

```
>>> list(hdfsClient.listdir('/user/cloudera'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.5/site-packages/luigi/contrib/hdfs/hadoopcli_clients.py", line 197, in listdir
    size = int(data[-4])
ValueError: invalid literal for int() with base 10: 'builtin-java'
```

This commit resolves the exception and yields expected output:
```
>>> list(hdfsClient.listdir('/user/cloudera'))
['/user/cloudera/.Trash', '/user/cloudera/.sparkStaging', '/user/cloudera/.staging', '/user/cloudera/ch01-identity', '/user/cloudera/oozie-oozi']
```

This is a similar class of messages as resolved by PR#492 (https://github.com/spotify/luigi/pull/492).