### PR TITLE
Improves display of unknown tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -31,6 +31,7 @@ import functools
 import itertools
 import logging
 import os
+import re
 import time
 
 from luigi import six
@@ -74,6 +75,8 @@ STATUS_TO_UPSTREAM_MAP = {
     PENDING: UPSTREAM_MISSING_INPUT,
     DISABLED: UPSTREAM_DISABLED,
 }
+
+TASK_FAMILY_RE = re.compile(r'([^(_]+)[(_]')
 
 
 class scheduler(Config):
@@ -926,8 +929,9 @@ class CentralPlannerScheduler(Scheduler):
 
                 # NOTE : If a dependency is missing from self._state there is no way to deduce the
                 #        task family and parameters.
-
-                family, params = UNKNOWN, {}
+                family_match = TASK_FAMILY_RE.match(task_id)
+                family = family_match.group(1) if family_match else UNKNOWN
+                params = {'task_id': task_id}
                 serialized[task_id] = {
                     'deps': [],
                     'status': UNKNOWN,

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -275,7 +275,8 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(suc[u'deps'], [BadReqTask(succeed=False).task_id])
 
         fail = dep_graph[BadReqTask(succeed=False).task_id]
-        self.assertEqual(fail[u'name'], 'UNKNOWN')
+        self.assertEqual(fail[u'name'], 'BadReqTask')
+        self.assertEqual(fail[u'params'], {'task_id': BadReqTask(succeed=False).task_id})
         self.assertEqual(fail[u'status'], 'UNKNOWN')
 
     def test_dep_graph_diamond(self):


### PR DESCRIPTION
Rather than showing UNKNOWN as the family for an unknown task id in the
visualiser graph, we can usually successfully infer the family from the task id.
This is far preferable to just showing UNKNOWN, as it provides useful
information while looking at dependency graphs. Including the full task id in
the params dict allows for a little more information to be gleaned.

before:
![image](https://cloud.githubusercontent.com/assets/2091885/13339793/348ee4be-dbe0-11e5-9a65-22e8111dd227.png)

after:
![image](https://cloud.githubusercontent.com/assets/2091885/13339805/4c45e1ac-dbe0-11e5-946b-09a3492eed70.png)
