### PR TITLE
Optionally hides DONE nodes in dependency graph

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -189,11 +189,12 @@ class RemoteScheduler(Scheduler):
     def graph(self):
         return self._request('/api/graph', {})
 
-    def dep_graph(self, task_id):
-        return self._request('/api/dep_graph', {'task_id': task_id})
+    def dep_graph(self, task_id, include_done=True):
+        return self._request('/api/dep_graph', {'task_id': task_id, 'include_done': include_done})
 
-    def inverse_dep_graph(self, task_id):
-        return self._request('/api/inverse_dep_graph', {'task_id': task_id})
+    def inverse_dep_graph(self, task_id, include_done=True):
+        return self._request('/api/inverse_dep_graph', {
+            'task_id': task_id, 'include_done': include_done})
 
     def task_list(self, status, upstream_status, search=None):
         return self._request('/api/task_list', {

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -895,7 +895,13 @@ class CentralPlannerScheduler(Scheduler):
             serialized.update(self._traverse_graph(task.id, seen))
         return serialized
 
-    def _traverse_graph(self, root_task_id, seen=None, dep_func=None):
+    def _filter_done(self, task_ids):
+        for task_id in task_ids:
+            task = self._state.get_task(task_id)
+            if task is None or task.status != DONE:
+                yield task_id
+
+    def _traverse_graph(self, root_task_id, seen=None, dep_func=None, include_done=True):
         """ Returns the dependency graph rooted at task_id
 
         This does a breadth-first traversal to find the nodes closest to the
@@ -940,6 +946,8 @@ class CentralPlannerScheduler(Scheduler):
                 }
             else:
                 deps = dep_func(task)
+                if not include_done:
+                    deps = list(self._filter_done(deps))
                 serialized[task_id] = self._serialize_task(task_id, deps=deps)
                 for dep in sorted(deps):
                     if dep not in seen:
@@ -953,13 +961,13 @@ class CentralPlannerScheduler(Scheduler):
 
         return serialized
 
-    def dep_graph(self, task_id, **kwargs):
+    def dep_graph(self, task_id, include_done=True, **kwargs):
         self.prune()
         if not self._state.has_task(task_id):
             return {}
-        return self._traverse_graph(task_id)
+        return self._traverse_graph(task_id, include_done=include_done)
 
-    def inverse_dep_graph(self, task_id, **kwargs):
+    def inverse_dep_graph(self, task_id, include_done=True, **kwargs):
         self.prune()
         if not self._state.has_task(task_id):
             return {}
@@ -967,7 +975,8 @@ class CentralPlannerScheduler(Scheduler):
         for task in self._state.get_active_tasks():
             for dep in task.deps:
                 inverse_graph[dep].add(task.id)
-        return self._traverse_graph(task_id, dep_func=lambda t: inverse_graph[t.id])
+        return self._traverse_graph(
+            task_id, dep_func=lambda t: inverse_graph[t.id], include_done=include_done)
 
     def task_list(self, status, upstream_status, limit=True, search=None, **kwargs):
         """

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -522,6 +522,9 @@
                         <label class="btn btn-default" for="invertCheckbox">Show Upstream Dependencies
                             <input type="checkbox" id="invertCheckbox"/>
                         </label>
+                        <label class="btn btn-default" for="hideDoneCheckbox">Hide Done
+                            <input type="checkbox" id="hideDoneCheckbox"/>
+                        </label>
                       </div>
                       <div class="form-group col-md-3">
                         <label>Visualisation Type</label>

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -45,14 +45,14 @@ var LuigiAPI = (function() {
         }
     }
 
-    LuigiAPI.prototype.getDependencyGraph = function (taskId, callback) {
-        return jsonRPC(this.urlRoot + "/dep_graph", {task_id: taskId}, function(response) {
+    LuigiAPI.prototype.getDependencyGraph = function (taskId, callback, include_done) {
+        return jsonRPC(this.urlRoot + "/dep_graph", {task_id: taskId, include_done: include_done}, function(response) {
             callback(flatten(response.response, taskId));
         });
     };
 
-    LuigiAPI.prototype.getInverseDependencyGraph = function (taskId, callback) {
-        return jsonRPC(this.urlRoot + "/inverse_dep_graph", {task_id: taskId}, function(response) {
+    LuigiAPI.prototype.getInverseDependencyGraph = function (taskId, callback, include_done) {
+        return jsonRPC(this.urlRoot + "/inverse_dep_graph", {task_id: taskId, include_done: include_done}, function(response) {
             callback(flatten(response.response, taskId));
         });
     }

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1,6 +1,7 @@
 function visualiserApp(luigi) {
     var templates = {};
     var invertDependencies = false;
+    var hideDone = false;
     var typingTimer = 0;
     var visType;
     var dt; // DataTable instantiated in $(document).ready()
@@ -395,9 +396,9 @@ function visualiserApp(luigi) {
                 var depGraphCallback = makeGraphCallback(visType, taskId, paint);
 
                 if (invertDependencies) {
-                    luigi.getInverseDependencyGraph(taskId, depGraphCallback);
+                    luigi.getInverseDependencyGraph(taskId, depGraphCallback, !hideDone);
                 } else {
-                    luigi.getDependencyGraph(taskId, depGraphCallback);
+                    luigi.getDependencyGraph(taskId, depGraphCallback, !hideDone);
                 }
             }
             switchTab("dependencyGraph");
@@ -442,6 +443,11 @@ function visualiserApp(luigi) {
         invertDependencies = $('#invertCheckbox')[0].checked;
         $("#invertCheckbox").click(function() {
             invertDependencies = this.checked;
+            processHashChange(true);
+        });
+        hideDone = $('#hideDoneCheckbox')[0].checked;
+        $('#hideDoneCheckbox').click(function() {
+            hideDone = this.checked;
             processHashChange(true);
         });
         $("a[href=#list]").click(function() { location.hash=""; });

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -82,6 +82,22 @@ class FailingTask(luigi.Task):
         raise Exception("Error Message")
 
 
+class OddFibTask(luigi.Task):
+    n = luigi.IntParameter()
+    done = luigi.BoolParameter(default=True, significant=False)
+
+    def requires(self):
+        if self.n > 1:
+            yield OddFibTask(self.n - 1, self.done)
+            yield OddFibTask(self.n - 2, self.done)
+
+    def complete(self):
+        return self.n % 2 == 0 and self.done
+
+    def run(self):
+        assert False
+
+
 class SchedulerVisualisationTest(unittest.TestCase):
 
     def setUp(self):
@@ -296,6 +312,34 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         d2 = dep_graph[FactorTask(product=2).task_id]
         self.assertEqual(sorted(d2[u'deps']), [])
+
+    def test_dep_graph_skip_done(self):
+        task = OddFibTask(9)
+        self._build([task])
+        remote = self._remote()
+
+        task_id = task.task_id
+        self.assertEqual(9, len(remote.dep_graph(task_id, include_done=True)))
+
+        skip_done_graph = remote.dep_graph(task_id, include_done=False)
+        self.assertEqual(5, len(skip_done_graph))
+        for task in skip_done_graph.values():
+            self.assertNotEqual('DONE', task['status'])
+            self.assertLess(len(task['deps']), 2)
+
+    def test_inverse_dep_graph_skip_done(self):
+        self._build([OddFibTask(9, done=False)])
+        self._build([OddFibTask(9, done=True)])
+        remote = self._remote()
+
+        task_id = OddFibTask(1).task_id
+        self.assertEqual(9, len(remote.inverse_dep_graph(task_id, include_done=True)))
+
+        skip_done_graph = remote.inverse_dep_graph(task_id, include_done=False)
+        self.assertEqual(5, len(skip_done_graph))
+        for task in skip_done_graph.values():
+            self.assertNotEqual('DONE', task['status'])
+            self.assertLess(len(task['deps']), 2)
 
     def test_task_list_single(self):
         self._build([FactorTask(7)])


### PR DESCRIPTION
Often when viewing the dependency graph, I'm trying to figure out why a
particular task hasn't run yet. This can be difficult due to the presence of
hundreds or even thousands of DONE tasks cluttering up the view. In order to aid
debugging, this adds a "Hide Done" checkbox to the dependency graph view in the
visualiser. When checked, the scheduler will ignore DONE tasks (other than the
root) when doing graph traversal (including inverse graph traversal).

![image](https://cloud.githubusercontent.com/assets/2091885/13361739/5f5c5b3c-dc75-11e5-9cb6-9c43e69f4b31.png)

vs

![image](https://cloud.githubusercontent.com/assets/2091885/13361752/732608e8-dc75-11e5-9244-0cfb83ddf804.png)
