### PR TITLE
Add DictParameter

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -29,14 +29,13 @@ from luigi.file import File, LocalTarget
 
 from luigi import rpc
 from luigi.rpc import RemoteScheduler, RPCError
-
 from luigi import parameter
 from luigi.parameter import (
     Parameter,
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter,
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BooleanParameter, BoolParameter,
-    TaskParameter, EnumParameter
+    TaskParameter, EnumParameter, DictParameter
 )
 
 from luigi import configuration
@@ -57,6 +56,6 @@ __all__ = [
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'range',
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
     'FloatParameter', 'BooleanParameter', 'BoolParameter', 'TaskParameter',
-    'EnumParameter', 'configuration', 'interface', 'file', 'run', 'build',
+    'EnumParameter', 'DictParameter', 'configuration', 'interface', 'file', 'run', 'build',
     'event', 'Event'
 ]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -23,6 +23,8 @@ See :ref:`Parameter` for more info on how to define parameters.
 import abc
 import datetime
 import warnings
+import json
+
 try:
     from ConfigParser import NoOptionError, NoSectionError
 except ImportError:
@@ -30,9 +32,10 @@ except ImportError:
 
 from luigi import task_register
 from luigi import six
-
+from frozendict import frozendict
 from luigi import configuration
 from luigi.cmdline_parser import CmdlineParser
+
 
 _no_value = object()
 
@@ -699,3 +702,18 @@ class EnumParameter(Parameter):
 
     def serialize(self, e):
         return e.name
+
+
+class DictParameter(Parameter):
+    """
+    Parameter whose value is a ``dict``.
+    """
+
+    def parse(self, s):
+        """
+        Parses a ``dict`` from a JSON string using standard JSON library.
+        """
+        mutable_dict = json.loads(s)
+        immutable_dict = frozendict(mutable_dict)
+        frozendict.__repr__ = mutable_dict.__repr__
+        return immutable_dict

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -25,8 +25,7 @@ import datetime
 import warnings
 import json
 from json import JSONEncoder
-from collections import OrderedDict
-import collections
+from collections import OrderedDict, Mapping
 import operator
 import functools
 
@@ -708,7 +707,7 @@ class EnumParameter(Parameter):
         return e.name
 
 
-class FrozenOrderedDict(collections.Mapping):
+class FrozenOrderedDict(Mapping):
     """
     It is an immutable wrapper around ordered dictionaries that implements the complete :py:class:`collections.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability and ordering are desired.

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -750,16 +750,24 @@ class DictParameter(Parameter):
     .. code-block:: python
 
         class MyTask(luigi.Task):
-          dict_param = luigi.DictParameter()
+          tags = luigi.DictParameter()
 
             def run(self):
-                value = self.dict_param[key]
+                logging.info("Find server with role: %s", self.tags['role'])
+                server = aws.ec2.find_my_resource(self.tags)
 
-    At the command line, use,
+
+    At the command line, use
 
     .. code-block:: console
 
-        $ luigi --module my_tasks MyTask --dict-param <JSON string>
+        $ luigi --module my_tasks MyTask --tags <JSON string>
+
+    Simple example with two tags:
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --tags '{"role": "web", "env": "staging"}'
 
     It can be used to define dynamic parameters, when you do not know the exact list of your parameters (e.g. list of
     tags, that are dynamically constructed outside Luigi), or you have a complex parameter containing logically related

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ with open('README.rst') as fobj:
 install_requires = [
     'tornado>=4.0,<5',
     'python-daemon<3.0',
+    'frozendict<=0.5'
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ with open('README.rst') as fobj:
 
 install_requires = [
     'tornado>=4.0,<5',
-    'python-daemon<3.0',
-    'frozendict<=0.5'
+    'python-daemon<3.0'
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as fobj:
 
 install_requires = [
     'tornado>=4.0,<5',
-    'python-daemon<3.0'
+    'python-daemon<3.0',
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':

--- a/test/dict_parameter_test.py
+++ b/test/dict_parameter_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import unittest, in_parse
+
+import luigi
+import luigi.interface
+import json
+import collections
+
+
+class DictParameterTask(luigi.Task):
+    param = luigi.DictParameter()
+
+
+class DictParameterTest(unittest.TestCase):
+
+    _dict = collections.OrderedDict([('username', 'me'), ('password', 'secret')])
+
+    def test_parse(self):
+        d = luigi.DictParameter().parse(json.dumps(DictParameterTest._dict))
+        self.assertEqual(d, DictParameterTest._dict)
+
+    def test_serialize(self):
+        d = luigi.DictParameter().serialize(DictParameterTest._dict)
+        self.assertEqual(d, '{"username": "me", "password": "secret"}')
+
+    def test_parse_interface(self):
+        in_parse(["DictParameterTask", "--param", '{"username": "me", "password": "secret"}'],
+                 lambda task: self.assertEqual(task.param, DictParameterTest._dict))
+
+    def test_serialize_task(self):
+        t = DictParameterTask(DictParameterTest._dict)
+        self.assertEqual(str(t), 'DictParameterTask(param={"username": "me", "password": "secret"})')
+
+    def test_parse_invalid_input(self):
+        self.assertRaises(ValueError, lambda: luigi.DictParameter().parse('{"invalid"}'))

--- a/test/dict_parameter_test.py
+++ b/test/dict_parameter_test.py
@@ -39,6 +39,12 @@ class DictParameterTest(unittest.TestCase):
         d = luigi.DictParameter().serialize(DictParameterTest._dict)
         self.assertEqual(d, '{"username": "me", "password": "secret"}')
 
+    def test_parse_and_serialize(self):
+        inputs = ['{"username": "me", "password": "secret"}', '{"password": "secret", "username": "me"}']
+        for json_input in inputs:
+            _dict = luigi.DictParameter().parse(json_input)
+            self.assertEqual(json_input, luigi.DictParameter().serialize(_dict))
+
     def test_parse_interface(self):
         in_parse(["DictParameterTask", "--param", '{"username": "me", "password": "secret"}'],
                  lambda task: self.assertEqual(task.param, DictParameterTest._dict))


### PR DESCRIPTION
# What is this PR?

This adds parameter for dictionaries.

## Example 

Create a simple task with a single `DictParameter`:

```python
class Task(luigi.Task):
    tags = luigi.DictParameter()

    def run(self):
        environment = self.tags['environment']
        print('I am running in {}'.format(environment))
```

Configure your `tags` parameter with a JSON string and execute your task:

```DictTask --tags '{"environment":"prod","role":"hadoop"}'```

## Implementation details

`DictParameter` parses a `dict` from a JSON string using the stanard JSON library. It uses an  immutable wrapper around dictionaries (`frozendict`), because immutability is required for two reason:
- Execution summary crashes in case of unhashable parameters.  Sample traceback is attached.
- Tasks with unhashable parameters are not cached

[Execution summary crash on unhashable parameters](https://github.com/spotify/luigi/files/152737/execution_summary_unhashable.txt)



