### PR TITLE
Prevent execution summary to fail on parameters set to None

### DIFF
--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -187,7 +187,11 @@ def _ranging_attributes(attributes, param_class):
     """
     Checks if there is a continuous range
     """
-    next_attributes = {param_class.next_in_enumeration(attribute) for attribute in attributes}
+    try:
+        next_attributes = {param_class.next_in_enumeration(attribute) for attribute in attributes}
+    except TypeError:
+        # Assume some value such as None was encountered that doesn't have an obvious ordering.
+        return None, None
     in_first = attributes.difference(next_attributes)
     in_second = next_attributes.difference(attributes)
     if len(in_first) == 1 and len(in_second) == 1:


### PR DESCRIPTION
In some cases where a task parameter type that can usually be enumerated is set to some value such as None, the execution summary will fail while trying to group sequences of tasks. This change adds exception handling to prevent some tasks to make the execution summary fail.

This should fix issue #1573 . It's a change that currently allows us to continue running from the master branch. However, our practice of using None as a default value for DateParameter may simply be wrong and in that case I would recommend not to merge this branch.