### PR TITLE
Fix documentation generation

### DIFF
--- a/doc/central_scheduler.rst
+++ b/doc/central_scheduler.rst
@@ -25,9 +25,9 @@ The luigid server
 
 To run the server as a daemon run:
 
-::
+.. code-block:: console
 
-    luigid --background --pidfile <PATH_TO_PIDFILE> --logdir <PATH_TO_LOGDIR> --state-path <PATH_TO_STATEFILE>
+    $ luigid --background --pidfile <PATH_TO_PIDFILE> --logdir <PATH_TO_LOGDIR> --state-path <PATH_TO_STATEFILE>
 
 Note that this requires ``python-daemon``.
 By default, the server starts on AF_INET and AF_INET6 port ``8082``
@@ -59,7 +59,8 @@ When starting up,
 ``luigid`` will create all the necessary tables using `create_all
 <http://docs.sqlalchemy.org/en/rel_0_9/core/metadata.html#sqlalchemy.schema.MetaData.create_all>`_.
 
-Example configuration::
+Example configuration
+.. code:: ini
 
     [scheduler]
     record_task_history = True

--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -20,12 +20,12 @@ that will be installed with the pip package.
 
 Should be run like this
 
-.. code:: console
+.. code-block:: console
 
-        luigi --module my_module MyTask --x 123 --y 456 --local-scheduler
+        $ luigi --module my_module MyTask --x 123 --y 456 --local-scheduler
 
 Or alternatively like this:
 
-.. code:: console
+.. code-block:: console
 
-        python -m luigi --module my_module MyTask --x 100 --local-scheduler
+        $ python -m luigi --module my_module MyTask --x 100 --local-scheduler

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -13,15 +13,16 @@ in increasing order of preference. The order only matters in case of key conflic
 
 The config file is broken into sections, each controlling a different part of the config. Example configuration file:
 
-::
+
+.. code:: ini
 
     [hadoop]
-    version: cdh4
-    streaming-jar: /usr/lib/hadoop-xyz/hadoop-streaming-xyz-123.jar
+    version=cdh4
+    streaming-jar=/usr/lib/hadoop-xyz/hadoop-streaming-xyz-123.jar
 
     [core]
-    default-scheduler-host: luigi-host.mycompany.foo
-    error-email: foo@bar.baz
+    default-scheduler-host=luigi-host.mycompany.foo
+    error-email=foo@bar.baz
 
 
 .. _ParamConfigIngestion:
@@ -41,10 +42,10 @@ have a Task definition:
 Then you can override the default value for ``DailyReport().date`` by providing
 it in the configuration:
 
-::
+.. code:: ini
 
     [DailyReport]
-    date: 2012-01-01
+    date=2012-01-01
 
 .. _ConfigClasses:
 
@@ -54,11 +55,11 @@ Configuration classes
 Using the :ref:`ParamConfigIngestion` method. We derive the
 conventional way to do global configuration. Imagine this configuration.
 
-::
+.. code:: ini
 
     [mysection]
-    option: hello
-    intoption: 123
+    option=hello
+    intoption=123
 
 
 We can create a :py:class:`~luigi.Config` class:
@@ -380,7 +381,7 @@ namenode_port
 snakebite_autoconfig
   If true, attempts to automatically detect the host and port of the
   namenode for snakebite queries. Defaults to false.
-  
+
 tmp_dir
   Path to where luigi will put temporary files on hdfs
 
@@ -453,11 +454,11 @@ exceeding the counts in this section. Unspecified resources are assumed
 to have limit 1. Example resources section for a configuration with 2
 hive resources and 1 mysql resource:
 
-::
+.. code:: ini
 
   [resources]
-  hive: 2
-  mysql: 1
+  hive=2
+  mysql=1
 
 Note that it was not necessary to specify the 1 for mysql here, but it
 is good practice to do so when you have a fixed set of resources.
@@ -473,15 +474,15 @@ codes that could apply, for example a failing task and missing data, the
 
 We recommend that you copy this set of exit codes to your ``luigi.cfg`` file:
 
-::
+.. code:: ini
 
   [retcode]
   # The following return codes are the recommended exit codes for luigi
   # They are in increasing level of severity (for most applications)
-  already_running: 10
-  missing_data: 20
-  task_failed: 30
-  unhandled_exception: 40
+  already_running=10
+  missing_data=20
+  task_failed=30
+  unhandled_exception=40
 
 unhandled_exception
   For exceptions during scheduling (if you raise from the ``complete()`` or

--- a/doc/example_top_artists.rst
+++ b/doc/example_top_artists.rst
@@ -72,7 +72,7 @@ Running this Locally
 
 Try running this using eg.
 
-::
+.. code-block:: console
 
     $ cd examples
     $ luigi --module top_artists AggregateArtists --local-scheduler --date-interval 2012-06
@@ -166,7 +166,7 @@ defines a dependency on the previous task (*AggregateArtists*).
 This means that if the output of *AggregateArtists* does not exist,
 the task will run before *Top10Artists*.
 
-::
+.. code-block:: console
 
     $ luigi --module examples.top_artists Top10Artists --local-scheduler --date-interval 2012-07
 
@@ -220,9 +220,9 @@ your script will try to connect to the central planner,
 by default at localhost port 8082.
 If you run
 
-::
+.. code-block:: console
 
-    luigid
+    $ luigid
 
 in the background and then run your task without the ``--local-scheduler`` flag,
 then your script will now schedule through a centralized server.

--- a/doc/execution_model.rst
+++ b/doc/execution_model.rst
@@ -90,7 +90,7 @@ If it has, it will run the full dependency graph.
 
 In your cronline you would then have something like
 
-.. code::
+.. code:: console
 
     30 0 * * * my-user luigi RunAll --module my_tasks
 

--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -58,7 +58,7 @@ jobs would catch up nicely after fixing intermittent problems.
 Luigi actually comes with a reusable tool for achieving this, called
 :class:`~luigi.tools.range.RangeDailyBase` (resp. :class:`~luigi.tools.range.RangeHourlyBase`). Simply putting
 
-.. code:: console
+.. code-block:: console
 
 	luigi --module all_reports RangeDailyBase --of AllReports --start 2015-01-01
 
@@ -77,7 +77,7 @@ hundreds of task classes scheduled concurrently with contiguousness
 requirements spanning years (which would incur redundant completeness
 checks and scheduler overload using the naive looping approach.) Usage:
 
-.. code:: console
+.. code-block:: console
 
 	luigi --module all_reports RangeDaily --of AllReports --start 2015-01-01
 
@@ -95,7 +95,7 @@ of dates for that or another reason. Most conveniently it is achieved
 with the above described range tools, just with both start (inclusive)
 and stop (exclusive) parameters specified:
 
-.. code:: console
+.. code-block:: console
 
 	luigi --module all_reports RangeDaily --of AllReportsV2 --start 2014-10-31 --stop 2014-12-25
 
@@ -107,7 +107,7 @@ tasks do not recognize or propagate parameters passed to them. The easiest
 solution is to set the parameter at the task family level as described
 :ref:`here <Parameter-class-level-parameters>`.
 
-.. code:: console
+.. code-block:: console
 
 	luigi RangeDaily --of MyTask --start 2014-10-31 --MyTask-my-param 123
 
@@ -123,4 +123,3 @@ reliable scheduling for you, but also emit events which you can use to
 set up delay monitoring. That way you can implement alerts for when
 jobs are stuck for prolonged periods lacking input data or otherwise
 requiring attention.
-

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -133,7 +133,7 @@ It is still possible to override it inside Python if you instantiate ``TaskA(x=4
 All parameters can also be set from the configuration file.
 For instance, you can put this in the config:
 
-.. code:: console
+.. code:: ini
 
     [TaskA]
     x: 45
@@ -153,4 +153,3 @@ Parameters are resolved in the following order of decreasing priority:
 4. Any default value provided to the parameter (applies on a class level)
 
 See the :class:`~luigi.parameter.Parameter` class for more information.
-

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -21,10 +21,10 @@ This needs some more documentation.
 See :doc:`/configuration` for configuration options.
 In particular using the config `error-email` should set up Luigi so that it will send emails when tasks fail.
 
-::
+.. code-block:: ini
 
     [core]
-    error-email: foo@bar.baz
+    error-email=foo@bar.baz
 
 TODO: Eventually, all email configuration should move into the [email] section.
 '''
@@ -50,7 +50,7 @@ class TestNotificationsTask(luigi.task.Task):
     You may invoke this task to quickly check if you correctly have setup your
     notifications Configuration.  You can run:
 
-    .. code:: console
+    .. code-block:: console
 
             $ luigi TestNotifications --local-scheduler
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -640,7 +640,7 @@ class TaskParameter(Parameter):
     ``MyMetaTask(my_task_param=my_tasks.MyTask)``. On the command line,
     you specify the :py:attr:`luigi.task.Task.task_family`. Like
 
-    .. code:: console
+    .. code-block:: console
 
             $ luigi --module my_tasks MyMetaTask --my_task_param my_namespace.MyTask
 


### PR DESCRIPTION
# What is this PR?

Running `tox -e docs` crashes with the following error for all branches:

```
Warning, treated as error:
git/luigi/doc/api/luigi.rst:11: WARNING: Could not lex literal_block as "python". Highlighting skipped.

ERROR: InvocationError: 'git/luigi/.tox/docs/bin/sphinx-build -W -b html -d git/luigi/.tox/docs/tmp/doctrees doc doc/_build/html'
```

The problem is that `tox` installs the latest version (`1.4b1`) of Sphinx with `pip`, which is not so permissive with highlights without language specification. The default `highlight_language` is `python` in the Sphinx config file, therefore Sphinx tries to parse every code highlights without language specification using the python lexer. In some cases it stumbles upon with non-python code blocks and drops error messages breaking the doc generation.

Previous Sphinx version (`v1.4a1`) does not generate any error message.

# Solution

There are 3 possible solution:
- Use the older version of Sphinx, and leave the documentation untouched = close our eyes and postpone the problem
- Set the default `highlight_language` to `none` and leave the documentation untouched = close our eyes and postpone the problem 
- Resolve the problem and fix the documentation itself.

# Changes

This PR solves the problem with an updated documentation. Documentation changes:
- Specify language for each and every highlight block
- Use ini lexer for luigid config blocks
- Use prompt in console blocks everywhere