### PR TITLE
Refactor s3 to s3 copying

### DIFF
--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -445,7 +445,7 @@ class TestS3Client(unittest.TestCase):
 
         # Copy the file from old location to new
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
-        s3_client.copy_multipart(original, copy, part_size=part_size)
+        s3_client.copy(original, copy, part_size=part_size, threads=4)
 
         # We can't use etags to compare between multipart and normal keys,
         # so we fall back to using the size instead
@@ -464,11 +464,13 @@ class TestS3Client(unittest.TestCase):
 
         # Copy the file from old location to new
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
-        s3_client.copy(original, copy)
+        s3_client.copy(original, copy, threads=4)
 
-        original_md5 = s3_client.get_key(original).etag
-        copy_md5 = s3_client.get_key(copy).etag
-        self.assertEqual(original_md5, copy_md5)
+        # We can't use etags to compare between multipart and normal keys,
+        # so we fall back to using the file size
+        original_size = s3_client.get_key(original).size
+        copy_size = s3_client.get_key(copy).size
+        self.assertEqual(original_size, copy_size)
 
     def _run_multipart_test(self, part_size, file_size, **kwargs):
         file_contents = b"a" * file_size

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -430,6 +430,41 @@ class TestS3Client(unittest.TestCase):
         """
         self._run_multipart_copy_test(self.test_put_multipart_empty_file)
 
+    def test_copy_dir(self):
+        """
+        Test copying 20 files from one folder to another
+        """
+
+        n = 20
+        copy_part_size = (1024 ** 2) * 5
+
+        # Note we can't test the multipart copy due to moto issue #526
+        # so here I have to keep the file size smaller than the copy_part_size
+        file_size = 5000
+
+        s3_dir = 's3://mybucket/copydir/'
+        file_contents = b"a" * file_size
+        tmp_file = tempfile.NamedTemporaryFile(mode='wb', delete=True)
+        tmp_file_path = tmp_file.name
+        tmp_file.write(file_contents)
+        tmp_file.flush()
+
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.s3.create_bucket('mybucket')
+
+        for i in range(n):
+            file_path = s3_dir + str(i)
+            s3_client.put_multipart(tmp_file_path, file_path)
+            self.assertTrue(s3_client.exists(file_path))
+
+        s3_dest = 's3://mybucket/copydir_new/'
+        s3_client.copy(s3_dir, s3_dest, threads=10, part_size=copy_part_size)
+
+        for i in range(n):
+            original_size = s3_client.get_key(s3_dir + str(i)).size
+            copy_size = s3_client.get_key(s3_dest + str(i)).size
+            self.assertEqual(original_size, copy_size)
+
     def _run_multipart_copy_test(self, put_method):
         # Run the method to put the file into s3 into the first place
         put_method()


### PR DESCRIPTION
I've simplified the threading model here, and I’ve increased the default number of simultaneous copy calls to the AWS S3 API to 100.

This should also fix #1582

I'm anticipating this might break the [s3 copy tests I put in](https://github.com/humanlongevity/luigi/commit/e1aaa128d32179ce15090b67969acb090c8bc775) due to https://github.com/spulec/moto/issues/526 - let's see.