### PR TITLE
Fix incorrect usage of Redshift/PostgresQuery 'query' property.

### DIFF
--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -362,7 +362,7 @@ class PostgresQuery(rdbms.Query):
     def run(self):
         connection = self.output().connect()
         cursor = connection.cursor()
-        sql = self.query()
+        sql = self.query
 
         logger.info('Executing query from task: {name}'.format(name=self.__class__))
         cursor.execute(sql)

--- a/test/postgres_test.py
+++ b/test/postgres_test.py
@@ -95,10 +95,7 @@ class DummyPostgresQuery(luigi.postgres.PostgresQuery):
         ('some_text', 'text'),
         ('some_int', 'int'),
     )
-
-    def query(self):
-        sql = 'SELECT * FROM foo'
-        return sql
+    query = 'SELECT * FROM foo'
 
 
 @attr('postgres')


### PR DESCRIPTION
'query' was defined as a property within rdbms.py, but referenced and used (within postgres.py and postgres_test.py) as if it were a method.

I believe it is more appropriate for query to be a property than a method.

Using PostgresQuery or RedshiftQuery is as easy as ...

```python
from luigi import configuration
from luigi.contrib import redshift

config = configuration.get_config()


class QueryExample(redshift.RedshiftQuery):
    query = luigi.Parameter()
    table = luigi.Parameter()

    host = config.get('redshift', 'host')
    database = config.get('redshift', 'database')
    user = config.get('redshift', 'user')
    password = config.get('redshift', 'password')
    aws_access_key_id = config.get('s3', 'aws_access_key_id')
    aws_secret_access_key = config.get('s3', 'aws_secret_access_key')
```