### PR TITLE
Add DJ/WSJ to list of companies.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ or held presentations about Luigi:
 * `Schibsted <http://www.schibsted.com/>`_
 * `17zuoye <https://speakerdeck.com/mvj3/luiti-an-offline-task-management-framework>`_
 * `enbrite.ly <http://enbrite.ly/>`_
+* `Dow Jones / The Wall Street Journal <http://wsj.com>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION
We've been using luigi at DJ/WSJ for about a year off/on but have started using it exclusively for all our pipeline coordination.  Love it!