### PR TITLE
Support inverted arguments for BoolParameter

### DIFF
--- a/luigi/cmdline_parser.py
+++ b/luigi/cmdline_parser.py
@@ -94,18 +94,17 @@ class CmdlineParser(object):
             help = param_obj.description if any((is_the_root_task, help_all, param_obj.always_in_help)) else argparse.SUPPRESS
             flag_name_underscores = param_name if is_without_section else task_name + '_' + param_name
             global_flag_name = '--' + flag_name_underscores.replace('_', '-')
-            parser.add_argument(global_flag_name,
-                                help=help,
-                                action=param_obj._parser_action(),
-                                dest=param_obj._parser_global_dest(param_name, task_name)
-                                )
+            param_obj._parser_add_arguments(parser=parser,
+                                            flag_name=global_flag_name,
+                                            dest=param_obj._parser_global_dest(param_name, task_name),
+                                            help=help)
+
             if is_the_root_task:
                 local_flag_name = '--' + param_name.replace('_', '-')
-                parser.add_argument(local_flag_name,
-                                    help=help,
-                                    action=param_obj._parser_action(),
-                                    dest=param_name
-                                    )
+                param_obj._parser_add_arguments(parser=parser,
+                                                flag_name=local_flag_name,
+                                                dest=param_name,
+                                                help=help)
 
         return parser
 

--- a/luigi/cmdline_parser.py
+++ b/luigi/cmdline_parser.py
@@ -93,14 +93,14 @@ class CmdlineParser(object):
             is_the_root_task = task_name == root_task
             help = param_obj.description if any((is_the_root_task, help_all, param_obj.always_in_help)) else argparse.SUPPRESS
             flag_name_underscores = param_name if is_without_section else task_name + '_' + param_name
-            global_flag_name = '--' + flag_name_underscores.replace('_', '-')
+            global_flag_name = flag_name_underscores.replace('_', '-')
             param_obj._parser_add_arguments(parser=parser,
                                             flag_name=global_flag_name,
                                             dest=param_obj._parser_global_dest(param_name, task_name),
                                             help=help)
 
             if is_the_root_task:
-                local_flag_name = '--' + param_name.replace('_', '-')
+                local_flag_name = param_name.replace('_', '-')
                 param_obj._parser_add_arguments(parser=parser,
                                                 flag_name=local_flag_name,
                                                 dest=param_name,
@@ -128,7 +128,7 @@ class CmdlineParser(object):
         res = {}
         for (param_name, param_obj) in self._get_task_cls().get_params():
             attr = getattr(self.known_args, param_name)
-            if attr:
+            if attr is not None:
                 res.update(((param_name, param_obj.parse(attr)),))
 
         return res

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -95,7 +95,8 @@ class core(task.Config):
         description="Maximum number of workers running the same command")
     no_lock = parameter.BoolParameter(
         default=False,
-        description='Ignore if similar process is already running')
+        description='Ignore if similar process is already running',
+        omit_inverted_argument=True)
     lock_pid_dir = parameter.Parameter(
         default=os.path.join(tempfile.gettempdir(), 'luigi'),
         description='Directory to store the pid file')
@@ -121,11 +122,13 @@ class core(task.Config):
     help = parameter.BoolParameter(
         default=False,
         description='Show most common flags and all task-specific flags',
-        always_in_help=True)
+        always_in_help=True,
+        omit_inverted_argument=True)
     help_all = parameter.BoolParameter(
         default=False,
         description='Show all command line flags',
-        always_in_help=True)
+        always_in_help=True,
+        omit_inverted_argument=True)
 
 
 class _WorkerSchedulerFactory(object):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -188,7 +188,7 @@ class Parameter(object):
         if cp_parser:
             dest = self._parser_global_dest(param_name, task_name)
             found = getattr(cp_parser.known_args, dest, None)
-            yield (self._parse_or_no_value(found), None)
+            yield (self.parse(found) if found is not None else _no_value, None)
         yield (self._get_value_from_config(task_name, param_name), None)
         yield (self._get_value_from_config(task_name, param_name.replace('_', '-')),
                'Configuration [{}] {} (with dashes) should be avoided. Please use underscores.'.format(
@@ -258,27 +258,17 @@ class Parameter(object):
         """
         return None
 
-    def _parse_or_no_value(self, x):
-        if not x:
-            return _no_value
-        else:
-            return self.parse(x)
-
     @staticmethod
     def _parser_global_dest(param_name, task_name):
         return task_name + '_' + param_name
 
-    @staticmethod
-    def _parser_action():
-        return "store"
-
     def _parser_add_arguments(self, parser, flag_name, dest, help):
         """
-        Updates the given parser with an argument to set this Parameter.        
+        Updates the given parser with an argument to set this Parameter.
         """
-        parser.add_argument(flag_name,
+        parser.add_argument('--{}'.format(flag_name),
                             dest=dest,
-                            action=self._parser_action(),
+                            action='store',
                             help=help)
 
 
@@ -525,10 +515,14 @@ class BoolParameter(Parameter):
     """
     A Parameter whose value is a ``bool``. This parameter have an implicit
     default value of ``False``.
+
+    :param bool omit_inverted_argument: specify ``True`` if the parameter should not have
+                                        the inverted argument --no-NAME created. Default: ``False``.
     """
 
-    def __init__(self, *args, **kwargs):
-        super(BoolParameter, self).__init__(*args, **kwargs)
+    def __init__(self, omit_inverted_argument=False, **kwargs):
+        super(BoolParameter, self).__init__(**kwargs)
+        self._omit_inverted_argument = omit_inverted_argument
         if self._default == _no_value:
             self._default = False
 
@@ -542,9 +536,18 @@ class BoolParameter(Parameter):
         # coerce anything truthy to True
         return bool(value) if value is not None else None
 
-    @staticmethod
-    def _parser_action():
-        return 'store_true'
+    def _parser_add_arguments(self, parser, flag_name, dest, help):
+        parser.add_argument('--{}'.format(flag_name),
+                            dest=dest,
+                            action='store_true',
+                            default=None,
+                            help=help)
+        if not self._omit_inverted_argument:
+            parser.add_argument('--no-{}'.format(flag_name),
+                                dest=dest,
+                                action='store_false',
+                                default=None,
+                                help=help)
 
 
 class BooleanParameter(BoolParameter):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -272,6 +272,15 @@ class Parameter(object):
     def _parser_action():
         return "store"
 
+    def _parser_add_arguments(self, parser, flag_name, dest, help):
+        """
+        Updates the given parser with an argument to set this Parameter.        
+        """
+        parser.add_argument(flag_name,
+                            dest=dest,
+                            action=self._parser_action(),
+                            help=help)
+
 
 _UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -32,10 +32,10 @@ from luigi.mock import MockTarget
 
 
 class SomeTask(luigi.Task):
-    n = luigi.IntParameter()
+    z = luigi.IntParameter()
 
     def output(self):
-        return MockTarget('/tmp/test_%d' % self.n)
+        return MockTarget('/tmp/test_%d' % self.z)
 
     def run(self):
         f = self.output().open('w')
@@ -96,17 +96,17 @@ class CmdlineTest(unittest.TestCase):
 
     @mock.patch("logging.getLogger")
     def test_cmdline_main_task_cls(self, logger):
-        luigi.run(['--local-scheduler', '--no-lock', '--n', '100'], main_task_cls=SomeTask)
+        luigi.run(['--local-scheduler', '--no-lock', '--z', '100'], main_task_cls=SomeTask)
         self.assertEqual(dict(MockTarget.fs.get_all_data()), {'/tmp/test_100': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_local_scheduler(self, logger):
-        luigi.run(['SomeTask', '--no-lock', '--n', '101'], local_scheduler=True)
+        luigi.run(['SomeTask', '--no-lock', '--z', '101'], local_scheduler=True)
         self.assertEqual(dict(MockTarget.fs.get_all_data()), {'/tmp/test_101': b'done'})
 
     @mock.patch("logging.getLogger")
     def test_cmdline_other_task(self, logger):
-        luigi.run(['--local-scheduler', '--no-lock', 'SomeTask', '--n', '1000'])
+        luigi.run(['--local-scheduler', '--no-lock', 'SomeTask', '--z', '1000'])
         self.assertEqual(dict(MockTarget.fs.get_all_data()), {'/tmp/test_1000': b'done'})
 
     @mock.patch("logging.getLogger")
@@ -133,7 +133,7 @@ class CmdlineTest(unittest.TestCase):
     def test_cmdline_logger(self, setup_mock, warn):
         with mock.patch("luigi.interface.core") as env_params:
             env_params.return_value.logging_conf_file = None
-            luigi.run(['SomeTask', '--n', '7', '--local-scheduler', '--no-lock'])
+            luigi.run(['SomeTask', '--z', '7', '--local-scheduler', '--no-lock'])
             self.assertEqual([mock.call(None)], setup_mock.call_args_list)
 
         with mock.patch("luigi.configuration.get_config") as getconf:
@@ -141,7 +141,7 @@ class CmdlineTest(unittest.TestCase):
             getconf.return_value.getint.return_value = 0
 
             luigi.interface.setup_interface_logging.call_args_list = []
-            luigi.run(['SomeTask', '--n', '42', '--local-scheduler', '--no-lock'])
+            luigi.run(['SomeTask', '--z', '42', '--local-scheduler', '--no-lock'])
             self.assertEqual([], setup_mock.call_args_list)
 
     @mock.patch('argparse.ArgumentParser.print_usage')

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -27,7 +27,7 @@ import luigi.worker
 
 
 class DummyTask(luigi.Task):
-    n = luigi.Parameter()
+    x = luigi.Parameter()
 
     def __init__(self, *args, **kwargs):
         super(DummyTask, self).__init__(*args, **kwargs)
@@ -126,7 +126,7 @@ class CustomizedWorkerTest(unittest.TestCase):
 
     def test_cmdline_custom_worker(self):
         self.assertFalse(self.worker_scheduler_factory.worker.complete())
-        luigi.run(['DummyTask', '--n', '4'], worker_scheduler_factory=self.worker_scheduler_factory)
+        luigi.run(['DummyTask', '--x', '4'], worker_scheduler_factory=self.worker_scheduler_factory)
         self.assertTrue(self.worker_scheduler_factory.worker.complete())
 
 if __name__ == '__main__':

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -25,21 +25,21 @@ from luigi.mock import MockTarget
 
 
 class Fib(luigi.Task):
-    n = luigi.IntParameter(default=100)
+    N = luigi.IntParameter(default=100)
 
     def requires(self):
-        if self.n >= 2:
-            return [Fib(self.n - 1), Fib(self.n - 2)]
+        if self.N >= 2:
+            return [Fib(self.N - 1), Fib(self.N - 2)]
         else:
             return []
 
     def output(self):
-        return MockTarget('/tmp/fib_%d' % self.n)
+        return MockTarget('/tmp/fib_%d' % self.N)
 
     def run(self):
-        if self.n == 0:
+        if self.N == 0:
             s = 0
-        elif self.n == 1:
+        elif self.N == 1:
             s = 1
         else:
             s = 0
@@ -66,7 +66,7 @@ class FibTest(FibTestBase):
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
 
     def test_cmdline(self):
-        luigi.run(['--local-scheduler', '--no-lock', 'Fib', '--n', '100'])
+        luigi.run(['--local-scheduler', '--no-lock', 'Fib', '--N', '100'])
 
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_10'), b'55\n')
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -871,3 +871,28 @@ class TaskAsParameterName1335Test(LuigiTestCase):
             task = luigi.IntParameter()
 
         self.assertTrue(self.run_locally_split('MyTask --task 5'))
+
+
+class BoolParameterTest(LuigiTestCase):
+    def test_inverted_bool_parameter_argument(self):
+        """
+        Ensure that BoolParameter's value can be set to both True and False via option.
+        """
+
+        class MyTask(luigi.Task):
+            b1 = luigi.BoolParameter()
+            b2 = luigi.BoolParameter(default=True)
+            b3 = luigi.BoolParameter(default=False)
+
+            def complete(self):
+                return False
+
+            def run(self):
+                assert self.b1
+                assert not self.b2
+                assert self.b3
+
+        # Test that local and global parameters take effect as expcected. They must be
+        # tested separately because different code paths are involved.
+        self.assertTrue(self.run_locally_split('MyTask --b1 --no-b2 --b3'))
+        self.assertTrue(self.run_locally_split('MyTask --MyTask-b1 --no-MyTask-b2 --MyTask-b3'))


### PR DESCRIPTION
Add two command-line arguments for BoolParameter's instead of one, specifically one to set it to `True` (e.g, `--foo`) and another (`--no-foo`) to set it to `False`. This is necessary because `BoolParameter` currently uses `argparse`'s "store_true" action, which does not take a parameter. This change allows `BoolParameter`'s to have a default of `True` and still be settable to `False`.

For cases where an inverted argument does not make sense, the caller should set `omit_inverted_argument=True` on the `BoolParameter`. (For example, this has been done for the `--help` and `--help-all` options, as `--no-help` is of no help at all.)
