### PR TITLE
EnumParameter docs: Use Enum not IntEnum

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -677,7 +677,7 @@ class EnumParameter(Parameter):
 
     .. code-block:: python
 
-        class Model(enum.IntEnum):
+        class Model(enum.Enum):
           Honda = 1
           Volvo = 2
 


### PR DESCRIPTION
I think at some point IntEnum was preferable as you wouldn't run into the bug fixed by #1487, but that's not relevant any more. Let's change this example to avoid creating a misconception that you need to use IntEnums.