### PR TITLE
Sets task.run to None instead of NotImplemented in ExternalTasks

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -535,7 +535,7 @@ def externalize(task):
 
     See :py:class:`ExternalTask`.
     """
-    task.run = NotImplemented
+    task.run = None
     return task
 
 
@@ -547,7 +547,7 @@ class ExternalTask(Task):
     the framework that this Task's :py:meth:`output` is generated outside of
     Luigi.
     """
-    run = NotImplemented
+    run = None
 
 
 class WrapperTask(Task):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -16,6 +16,8 @@
 #
 
 import doctest
+import pickle
+
 from helpers import unittest
 from datetime import datetime, timedelta
 
@@ -83,6 +85,11 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(flatten(42), [42])
         self.assertEqual(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
         self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
+
+    def test_externalized_task_picklable(self):
+        task = luigi.task.externalize(luigi.Task())
+        pickled_task = pickle.dumps(task)
+        self.assertEqual(task, pickle.loads(pickled_task))
 
 
 if __name__ == '__main__':

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -221,6 +221,51 @@ class WorkerTest(unittest.TestCase):
         self.assertFalse(a.has_run)
         self.assertFalse(b.has_run)
 
+    def test_externalized_dep(self):
+        class A(Task):
+            has_run = False
+
+            def run(self):
+                self.has_run = True
+
+            def complete(self):
+                return self.has_run
+        a = A()
+
+        class B(A):
+            def requires(self):
+                return luigi.task.externalize(a)
+        b = B()
+
+        self.assertTrue(self.w.add(b))
+        self.assertTrue(self.w.run())
+
+        self.assertFalse(a.has_run)
+        self.assertFalse(b.has_run)
+
+    def test_legacy_externalized_dep(self):
+        class A(Task):
+            has_run = False
+
+            def run(self):
+                self.has_run = True
+
+            def complete(self):
+                return self.has_run
+        a = A()
+        a.run = NotImplemented
+
+        class B(A):
+            def requires(self):
+                return a
+        b = B()
+
+        self.assertTrue(self.w.add(b))
+        self.assertTrue(self.w.run())
+
+        self.assertFalse(a.has_run)
+        self.assertFalse(b.has_run)
+
     def test_tracking_url(self):
         tracking_url = 'http://test_url.com/'
 


### PR DESCRIPTION
Using NotImplemented prevents externalized tasks from being pickled, preventing
the use of parallel scheduling due to pickle being the serializer used in
multiprocessing. This uses the picklable None instead, resolving #1608