### PR TITLE
Added ListParameter and TupleParameter.

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -35,7 +35,7 @@ from luigi.parameter import (
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter,
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BooleanParameter, BoolParameter,
-    TaskParameter, EnumParameter, DictParameter
+    TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter
 )
 
 from luigi import configuration
@@ -56,6 +56,6 @@ __all__ = [
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'range',
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
     'FloatParameter', 'BooleanParameter', 'BoolParameter', 'TaskParameter',
-    'EnumParameter', 'DictParameter', 'configuration', 'interface', 'file', 'run', 'build',
-    'event', 'Event'
+    'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
+    'configuration', 'interface', 'file', 'run', 'build', 'event', 'Event'
 ]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -28,6 +28,7 @@ from json import JSONEncoder
 from collections import OrderedDict, Mapping
 import operator
 import functools
+from ast import literal_eval
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -798,3 +799,105 @@ class DictParameter(Parameter):
 
     def serialize(self, x):
         return json.dumps(x, cls=DictParameter.DictParamEncoder)
+
+
+class ListParameter(Parameter):
+    """
+    Parameter whose value is a ``list``.
+
+    In the task definition, use
+
+    .. code-block:: python
+
+        class MyTask(luigi.Task):
+          grades = luigi.ListParameter()
+
+            def run(self):
+                sum = 0
+                for element in self.grades:
+                    sum += element
+                avg = sum / len(self.grades)
+
+
+    At the command line, use
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --grades <JSON string>
+
+    Simple example with two grades:
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --grades '[100,70]'
+    """
+    def parse(self, x):
+        """
+        Parse an individual value from the input.
+
+        :param str x: the value to parse.
+        :return: the parsed value.
+        """
+        return list(json.loads(x))
+
+    def serialize(self, x):
+        """
+        Opposite of :py:meth:`parse`.
+
+        Converts the value ``x`` to a string.
+
+        :param x: the value to serialize.
+        """
+        return json.dumps(x)
+
+
+class TupleParameter(Parameter):
+    """
+    Parameter whose value is a ``tuple`` or ``tuple`` of tuples.
+
+    In the task definition, use
+
+    .. code-block:: python
+
+        class MyTask(luigi.Task):
+          book_locations = luigi.TupleParameter()
+
+            def run(self):
+                for location in self.book_locations:
+                    print("Go to page %d, line %d" % (location[0], location[1]))
+
+
+    At the command line, use
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --book_locations <JSON string>
+
+    Simple example with two grades:
+
+    .. code-block:: console
+
+        $ luigi --module my_tasks MyTask --book_locations '((12,3),(4,15),(52,1))'
+    """
+
+    def parse(self, x):
+        """
+        Parse an individual value from the input.
+
+        :param str x: the value to parse.
+        :return: the parsed value.
+        """
+        try:
+            return tuple(tuple(x) for x in json.loads(x))
+        except ValueError:
+            return literal_eval(x)  # if this causes an error, let that error be raised.
+
+    def serialize(self, x):
+        """
+        Opposite of :py:meth:`parse`.
+
+        Converts the value ``x`` to a string.
+
+        :param x: the value to serialize.
+        """
+        return json.dumps(x)

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -887,8 +887,20 @@ class TupleParameter(Parameter):
         :param str x: the value to parse.
         :return: the parsed value.
         """
+        # Since the result of json.dumps(tuple) differs from a tuple string, we must handle either case.
+        # A tuple string may come from a config file or from cli execution.
+
+        # t = ((1, 2), (3, 4))
+        # t_str = '((1,2),(3,4))'
+        # t_json_str = json.dumps(t)
+        # t_json_str == '[[1, 2], [3, 4]]'
+        # json.loads(t_json_str) == t
+        # json.loads(t_str) == ValueError: No JSON object could be decoded
+
+        # Therefore, if json.loads(x) returns a ValueError, try ast.literal_eval(x).
+        # ast.literal_eval(t_str) == t
         try:
-            return tuple(tuple(x) for x in json.loads(x))
+            return tuple(tuple(x) for x in json.loads(x))  # loop required to parse tuple of tuples
         except ValueError:
             return literal_eval(x)  # if this causes an error, let that error be raised.
 

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -702,6 +702,34 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         self.assertTrue(self.run_locally_split('mynamespace.A --mynamespace.A-p 200 --expected 200'))
         self.assertFalse(self.run_locally_split('mynamespace.A --A-p 200 --expected 200'))
 
+    def testListWithNamespaceCli(self):
+        class A(luigi.Task):
+            task_namespace = 'mynamespace'
+            l = luigi.ListParameter(default=[1, 2, 3])
+            expected = luigi.ListParameter()
+
+            def complete(self):
+                if self.l != self.expected:
+                    raise ValueError
+                return True
+
+        self.assertTrue(self.run_locally_split('mynamespace.A --expected [1,2,3]'))
+        self.assertTrue(self.run_locally_split('mynamespace.A --mynamespace.A-l [1,2,3] --expected [1,2,3]'))
+
+    def testTupleWithNamespaceCli(self):
+        class A(luigi.Task):
+            task_namespace = 'mynamespace'
+            t = luigi.TupleParameter(default=((1, 2), (3, 4)))
+            expected = luigi.TupleParameter()
+
+            def complete(self):
+                if self.t != self.expected:
+                    raise ValueError
+                return True
+
+        self.assertTrue(self.run_locally_split('mynamespace.A --expected ((1,2),(3,4))'))
+        self.assertTrue(self.run_locally_split('mynamespace.A --mynamespace.A-t ((1,2),(3,4)) --expected ((1,2),(3,4))'))
+
     @with_config({"foo": {"bar": "[1,2,3]"}})
     def testListConfig(self):
         self.assertTrue(_value(luigi.ListParameter(config_path=dict(section="foo", name="bar"))))

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -56,6 +56,20 @@ class Baz(luigi.Task):
         Baz._val = self.bool
 
 
+class ListFoo(luigi.Task):
+    my_list = luigi.ListParameter()
+
+    def run(self):
+        ListFoo._val = self.my_list
+
+
+class TupleFoo(luigi.Task):
+    my_tuple = luigi.TupleParameter()
+
+    def run(self):
+        TupleFoo._val = self.my_tuple
+
+
 class ForgotParam(luigi.Task):
     param = luigi.Parameter()
 
@@ -260,6 +274,16 @@ class ParameterTest(LuigiTestCase):
 
     def test_enum_param_missing(self):
         self.assertRaises(ParameterException, lambda: luigi.parameter.EnumParameter())
+
+    def test_list_serialize_parse(self):
+        a = luigi.ListParameter()
+        b_list = [1, 2, 3]
+        self.assertEqual(b_list, a.parse(a.serialize(b_list)))
+
+    def test_tuple_serialize_parse(self):
+        a = luigi.TupleParameter()
+        b_tuple = ((1, 2), (3, 4))
+        self.assertEqual(b_tuple, a.parse(a.serialize(b_tuple)))
 
 
 class TestNewStyleGlobalParameters(LuigiTestCase):
@@ -677,6 +701,14 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         # self.assertTrue(self.run_locally_split('mynamespace.A --p 200 --expected 200'))
         self.assertTrue(self.run_locally_split('mynamespace.A --mynamespace.A-p 200 --expected 200'))
         self.assertFalse(self.run_locally_split('mynamespace.A --A-p 200 --expected 200'))
+
+    @with_config({"foo": {"bar": "[1,2,3]"}})
+    def testListConfig(self):
+        self.assertTrue(_value(luigi.ListParameter(config_path=dict(section="foo", name="bar"))))
+
+    @with_config({"foo": {"bar": "((1,2),(3,4))"}})
+    def testTupleConfig(self):
+        self.assertTrue(_value(luigi.TupleParameter(config_path=dict(section="foo", name="bar"))))
 
 
 class OverrideEnvStuff(LuigiTestCase):


### PR DESCRIPTION
Dynamic requires serializes all `Parameter`. The default `serialize(...)` method casts everything to strings. Lists and tuples need to remain lists and tuples when serialized and parsed.

This is added as a solution to Issue #1607