### PR TITLE
Add an index on task_events.task_id.

### DIFF
--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -208,7 +208,7 @@ class TaskEvent(Base):
     """
     __tablename__ = 'task_events'
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'))
+    task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'), index=True)
     event_name = sqlalchemy.Column(sqlalchemy.String(20))
     ts = sqlalchemy.Column(sqlalchemy.TIMESTAMP, index=True, nullable=False)
 


### PR DESCRIPTION
TL;DR: In the task history code, `task_events` is often queried with `task_id` as the filter column. In our deployment using an RDS Postgres instance for the task history db, this change reduced `/api/add_task` calls from 200ms to 15ms.

Background:

We at Remind recently noticed that most requests to the central scheduler's `/api/add_task` endpoint were taking 200ms. This seemed wrong. An initial profile showed that most of that time was spent in db_task_history.py. Logging SQLAlchemy queries with timing yielded:

```
2016-03-31 00:04:49,301 [sqlalchemy.engine.base.Engine] INFO: SELECT task_events.id AS task_events_id, task_events.task_id AS task_events_task_id, task_events.event_name AS task_events_event_name, task_events.ts AS task_events_ts 
FROM task_events 
WHERE %(param_1)s = task_events.task_id ORDER BY task_events.ts DESC, task_events.id DESC
2016-03-31 00:04:49,302 [sqlalchemy.engine.base.Engine] INFO: {'param_1': 134441}
2016-03-31 00:04:49,506 [sqlalchemy.timing] DEBUG: Query Time: 0.205163
```

i.e., filtering the `task_events` table by `task_id`, which did not have an index, and was therefore taking 200ms.