### PR TITLE
Task status messages

### DIFF
--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -208,7 +208,7 @@ class TaskEvent(Base):
     """
     __tablename__ = 'task_events'
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
-    task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'))
+    task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'), index=True)
     event_name = sqlalchemy.Column(sqlalchemy.String(20))
     ts = sqlalchemy.Column(sqlalchemy.TIMESTAMP, index=True, nullable=False)
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -229,3 +229,12 @@ class RemoteScheduler(Scheduler):
 
     def re_enable_task(self, task_id):
         return self._request('/api/re_enable_task', {'task_id': task_id})
+
+    def set_task_status_message(self, task_id, status_message):
+        self._request('/api/set_task_status_message', {
+            'task_id': task_id,
+            'status_message': status_message
+        })
+
+    def get_task_status_message(self, task_id):
+        return self._request('/api/get_task_status_message', {'task_id': task_id})

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -228,6 +228,7 @@
                 {{#error}}<button class="btn btn-danger btn-xs showError" title="Show error" data-toggle="tooltip"><i class="fa fa-bug"></i></button>{{/error}}
                 {{#re_enable}}<a class="btn btn-warning btn-xs re-enable-button" title="Re-enable" data-toggle="tooltip" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
                 {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
+                {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name={{displayName}}><i class="fa fa-comment"></i></button>{{/statusMessage}}
             </div>
         </script>
         <script type="text/template" name="rowDetailsTemplate">
@@ -251,6 +252,23 @@
                 <pre class="pre-scrollable">{{error}}</pre>
               </div>
               <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+            </div>
+          </div>
+        </script>
+        <script type="text/template" name="statusMessageTemplate">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="myModalLabel">Status message for {{displayName}}</h4>
+              </div>
+              <div class="modal-body">
+                <pre class="pre-scrollable">{{statusMessage}}</pre>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-info refresh"><i class="fa fa-refresh"></i> Refresh</button>
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </div>
             </div>
@@ -320,6 +338,7 @@
                         <td>{{displayTime}}</td>
                         <td><a href="#{{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
                             {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
+                            {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>{{/statusMessage}}
                         </td>
                       </tr>
                       {{/tasks}}
@@ -407,6 +426,8 @@
     </head>
     <body class="skin-green-light fixed">
         <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        </div>
+        <div class="modal fade" id="statusMessageModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         </div>
 
         <div class="wrapper">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -87,6 +87,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getTaskStatusMessage = function(taskId, callback) {
+        return jsonRPC(this.urlRoot + "/get_task_status_message", {task_id: taskId}, function(response) {
+            callback(response.response);
+        });
+    };
+
     LuigiAPI.prototype.getRunningTaskList = function(callback) {
         return jsonRPC(this.urlRoot + "/task_list", {status: "RUNNING", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -84,7 +84,8 @@ function visualiserApp(luigi) {
             status: task.status,
             graph: (task.status == "PENDING" || task.status == "RUNNING" || task.status == "DONE"),
             error: task.status == "FAILED",
-            re_enable: task.status == "DISABLED" && task.re_enable_able
+            re_enable: task.status == "DISABLED" && task.re_enable_able,
+            statusMessage: task.status_message
         };
     }
 
@@ -287,6 +288,16 @@ function visualiserApp(luigi) {
         data.error = decodeError(data.error)
         $("#errorModal").empty().append(renderTemplate("errorTemplate", data));
         $("#errorModal").modal({});
+    }
+
+    function showStatusMessage(data) {
+        $("#statusMessageModal").empty().append(renderTemplate("statusMessageTemplate", data));
+        $("#statusMessageModal .refresh").on('click', function() {
+            luigi.getTaskStatusMessage(data.taskId, function(data) {
+                $("#statusMessageModal pre").html(data.statusMessage);
+            });
+        }).trigger('click');
+        $("#statusMessageModal").modal({});
     }
 
     function preProcessGraph(dependencyGraph) {
@@ -815,6 +826,11 @@ function visualiserApp(luigi) {
 
         luigi.getWorkerList(function(workers) {
             $("#workerList").append(renderWorkers(workers));
+
+            $('.worker-table tbody').on('click', 'td .statusMessage', function() {
+                var data = $(this).data();
+                showStatusMessage(data);
+            });
         });
 
         luigi.getResourceList(function(resources) {
@@ -911,6 +927,11 @@ function visualiserApp(luigi) {
             luigi.reEnable($(this).attr("data-task-id"), function(data) {
                 updateTasks();
             });
+        });
+
+        $('#taskTable tbody').on('click', 'td.details-control .statusMessage', function () {
+            var data = $(this).data();
+            showStatusMessage(data);
         });
 
         $('.navbar-nav').on('click', 'a', function () {

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,7 +289,7 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
-        self._status_message = None
+        self.status_message = None
         self._status_message_callback = None
 
     def initialized(self):
@@ -507,14 +507,9 @@ class Task(object):
         Default behavior is to send an None value"""
         pass
 
-    @property
-    def status_message(self):
-        return self._status_message
-
-    @status_message.setter
-    def status_message(self, message):
-        if message != self._status_message:
-            self._status_message = message
+    def set_status_message(self, message):
+        if message != self.status_message:
+            self.status_message = message
             if hasattr(self._status_message_callback, "__call__"):
                 self._status_message_callback(message)
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,6 +289,9 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
+        self._status_message = None
+        self._status_message_callback = None
+
     def initialized(self):
         """
         Returns ``True`` if the Task is initialized and ``False`` otherwise.
@@ -503,6 +506,17 @@ class Task(object):
 
         Default behavior is to send an None value"""
         pass
+
+    @property
+    def status_message(self):
+        return self._status_message
+
+    @status_message.setter
+    def status_message(self, message):
+        if message != self._status_message:
+            self._status_message = message
+            if hasattr(self._status_message_callback, "__call__"):
+                self._status_message_callback(message)
 
 
 class MixinNaiveBulkComplete(object):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -508,6 +508,11 @@ class Task(object):
         pass
 
     def set_status_message(self, message):
+        """
+        Sets the status message of the task to message. If the value actually changed w.r.t the
+        current value, the _status_message_callback is invoked which propagates the change down to
+        the scheduler.
+        """
         if message != self.status_message:
             self.status_message = message
             if hasattr(self._status_message_callback, "__call__"):

--- a/test/task_status_message_test.py
+++ b/test/task_status_message_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import LuigiTestCase
+
+import luigi
+import luigi.scheduler
+import luigi.worker
+
+luigi.notifications.DEBUG = True
+
+
+class TaskStatusMessageTest(LuigiTestCase):
+
+    def test_run(self):
+        message = "test message"
+        sch = luigi.scheduler.CentralPlannerScheduler()
+        with luigi.worker.Worker(scheduler=sch) as w:
+            class MyTask(luigi.Task):
+                def run(self):
+                    self.set_status_message(message)
+
+            task = MyTask()
+            w.add(task)
+            w.run()
+
+            self.assertEqual(sch.get_task_status_message(task.task_id)["statusMessage"], message)


### PR DESCRIPTION
This PR adds status messages to tasks which are also visible on the scheduler GUI.

Examples:

![task list](https://dl.dropboxusercontent.com/u/1021570/luigi1.png "Usage in Task List")

![worker list](https://dl.dropboxusercontent.com/u/1021570/luigi2.png "Usage in Worker List")

Status messages are meant to change during the run method in an [opportunistic way](https://github.com/riga/luigi/blob/statusTexts/luigi/task.py#L515). Especially for long-running non-Hadoop tasks, the ability to read those messages directly in the scheduler GUI is quite helpful (at least for us). Internally, message changes are propagated to the scheduler via a ``_status_message_callback`` which is - in contrast to ``tracking_url_callback`` - not passed to the run method, but set by the ``TaskProcess``.

Usage example:
```python
class MyTask(luigi.Task):
    ...
    def run(self):
        for i in range(100):
            # do some hard work here
            if i % 10 == 0:
                self.set_status_message("Progress: %s / 100" % i)
```

I know that you don't like PR's that affect core code (which is reasonable =) ), but imho this feature is both lightweight *and* really helpful.