### PR TITLE
[fixed] Task status messages

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -149,6 +149,25 @@ This can be useful if you have many dependencies:
             g = [y.open('r') for y in self.input()['b']]
 
 
+.. _Task.set_status_message:
+
+Task.set_status_message
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For long-running tasks it is convenient to see status messages not only on the command line or in
+your logs but also in the GUI of the central scheduler. For this purpose you can use
+:func:`~luigi.task.Task.set_status_message`:
+
+.. code:: python
+
+    class MyTask(luigi.Task):
+        def run(self):
+            for i in range(100):
+                # do some hard work here
+                if i % 10 == 0:
+                    self.set_status_message("Progress: %d / 100" % i)
+
+
 Dynamic dependencies
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -179,21 +179,26 @@ For an example of a workflow using dynamic dependencies, see
 `examples/dynamic_requirements.py <https://github.com/spotify/luigi/blob/master/examples/dynamic_requirements.py>`_.
 
 
-Task Status messages
+Task status tracking
 ~~~~~~~~~~~~~~~~~~~~
 
-For long-running tasks it is convenient to see status messages not only on the command line or in
-your logs but also in the GUI of the central scheduler. For this purpose you can use the
-``status_message_callback`` which is passed opportunistically to Task.run_:
+For long-running or remote tasks it is convenient to see extended status information not only on 
+the command line or in your logs but also in the GUI of the central scheduler. Luigi implements
+dynamic status messages and tracking urls which may point to an external monitoring system. You 
+can set this information using callbacks within Task.run_:
 
 .. code:: python
 
     class MyTask(luigi.Task):
-        def run(self, status_message_callback):
+        def run(self):
+            # set a tracking url
+            self.set_tracking_url("http://...")
+
+            # set status messages during the workload
             for i in range(100):
                 # do some hard work here
                 if i % 10 == 0:
-                    status_message_callback("Progress: %d / 100" % i)
+                    self.set_status_message("Progress: %d / 100" % i)
 
 
 .. _Events:

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -149,25 +149,6 @@ This can be useful if you have many dependencies:
             g = [y.open('r') for y in self.input()['b']]
 
 
-.. _Task.set_status_message:
-
-Task.set_status_message
-~~~~~~~~~~~~~~~~~~~~~~~
-
-For long-running tasks it is convenient to see status messages not only on the command line or in
-your logs but also in the GUI of the central scheduler. For this purpose you can use
-:func:`~luigi.task.Task.set_status_message`:
-
-.. code:: python
-
-    class MyTask(luigi.Task):
-        def run(self):
-            for i in range(100):
-                # do some hard work here
-                if i % 10 == 0:
-                    self.set_status_message("Progress: %d / 100" % i)
-
-
 Dynamic dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -196,6 +177,24 @@ In other words, you should make sure your Task.run_ method is idempotent.
 
 For an example of a workflow using dynamic dependencies, see
 `examples/dynamic_requirements.py <https://github.com/spotify/luigi/blob/master/examples/dynamic_requirements.py>`_.
+
+
+Task Status messages
+~~~~~~~~~~~~~~~~~~~~
+
+For long-running tasks it is convenient to see status messages not only on the command line or in
+your logs but also in the GUI of the central scheduler. For this purpose you can use the
+``status_message_callback`` which is passed opportunistically to Task.run_:
+
+.. code:: python
+
+    class MyTask(luigi.Task):
+        def run(self, status_message_callback):
+            for i in range(100):
+                # do some hard work here
+                if i % 10 == 0:
+                    status_message_callback("Progress: %d / 100" % i)
+
 
 .. _Events:
 

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -914,6 +914,11 @@ class JobTask(BaseHadoopJobTask):
         """
         Dump instance to file.
         """
+        _set_tracking_url = self.set_tracking_url
+        self.set_tracking_url = None
+        _set_status_message = self.set_status_message
+        self.set_status_message = None
+
         file_name = os.path.join(directory, 'job-instance.pickle')
         if self.__module__ == '__main__':
             d = pickle.dumps(self)
@@ -923,6 +928,9 @@ class JobTask(BaseHadoopJobTask):
 
         else:
             pickle.dump(self, open(file_name, "wb"))
+
+        self.set_tracking_url = _set_tracking_url
+        self.set_status_message = _set_status_message
 
     def _map_input(self, input_stream):
         """

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -416,6 +416,10 @@ class HadoopJobRunner(JobRunner):
         self.tmp_dir = False
 
     def run_job(self, job, tracking_url_callback=None):
+        if tracking_url_callback is not None:
+            warnings.warn("tracking_url_callback argument is deprecated, task.set_tracking_url is "
+                          "used instead.", DeprecationWarning)
+
         packages = [luigi] + self.modules + job.extra_modules() + list(_attached_packages)
 
         # find the module containing the job
@@ -528,7 +532,7 @@ class HadoopJobRunner(JobRunner):
 
         job.dump(self.tmp_dir)
 
-        run_and_track_hadoop_job(arglist, tracking_url_callback=tracking_url_callback)
+        run_and_track_hadoop_job(arglist, tracking_url_callback=job.set_tracking_url)
 
         if self.end_job_with_atomic_move_dir:
             luigi.contrib.hdfs.HdfsTarget(output_hadoop).move_dir(output_final)
@@ -676,7 +680,7 @@ class BaseHadoopJobTask(luigi.Task):
     # available formats are "python" and "json".
     data_interchange_format = "python"
 
-    def run(self, tracking_url_callback=None):
+    def run(self):
         # The best solution is to store them as lazy `cached_property`, but it
         # has extraneous dependency. And `property` is slow (need to be
         # calculated every time when called), so we save them as attributes
@@ -686,12 +690,7 @@ class BaseHadoopJobTask(luigi.Task):
         self.deserialize = DataInterchange[self.data_interchange_format]['deserialize']
 
         self.init_local()
-        try:
-            self.job_runner().run_job(self, tracking_url_callback=tracking_url_callback)
-        except TypeError as ex:
-            if 'unexpected keyword argument' not in ex.message:
-                raise
-            self.job_runner().run_job(self)
+        self.job_runner().run_job(self)
 
     def requires_local(self):
         """

--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pipes
 import random
+import warnings
 
 import luigi.contrib.hadoop
 import luigi.contrib.hdfs

--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -69,6 +69,10 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
         pass
 
     def run_job(self, job, tracking_url_callback=None):
+        if tracking_url_callback is not None:
+            warnings.warn("tracking_url_callback argument is deprecated, task.set_tracking_url is "
+                          "used instead.", DeprecationWarning)
+
         # TODO(jcrobak): libjars, files, etc. Can refactor out of
         # hadoop.HadoopJobRunner
         if not job.jar():
@@ -109,7 +113,7 @@ class HadoopJarJobRunner(luigi.contrib.hadoop.JobRunner):
                 raise HadoopJarJobError("job jar does not exist")
             arglist = hadoop_arglist
 
-        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback)
+        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url)
 
         for a, b in tmp_files:
             a.move(b)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -21,6 +21,7 @@ import operator
 import os
 import subprocess
 import tempfile
+import warnings
 
 from luigi import six
 

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -342,6 +342,10 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                         pass
 
     def run_job(self, job, tracking_url_callback=None):
+        if tracking_url_callback is not None:
+            warnings.warn("tracking_url_callback argument is deprecated, task.set_tracking_url is "
+                          "used instead.", DeprecationWarning)
+
         self.prepare_outputs(job)
         with tempfile.NamedTemporaryFile() as f:
             query = job.query()
@@ -361,7 +365,7 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                     arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
 
             logger.info(arglist)
-            return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback)
+            return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url)
 
 
 class HiveTableTarget(luigi.Target):

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -19,6 +19,7 @@ import logging
 import os
 import re
 import subprocess
+import warnings
 
 from luigi import six
 

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -194,6 +194,10 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         return job_jar
 
     def run_job(self, job, tracking_url_callback=None):
+        if tracking_url_callback is not None:
+            warnings.warn("tracking_url_callback argument is deprecated, task.set_tracking_url is "
+                          "used instead.", DeprecationWarning)
+
         job_jar = self.build_job_jar(job)
         jars = [job_jar] + self.get_libjars() + job.extra_jars()
         scalding_core = self.get_scalding_core()
@@ -216,7 +220,7 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         env['HADOOP_CLASSPATH'] = hadoop_cp
         logger.info("Submitting Hadoop job: HADOOP_CLASSPATH=%s %s",
                     hadoop_cp, subprocess.list2cmdline(arglist))
-        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, tracking_url_callback, env=env)
+        luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url, env=env)
 
         for a, b in tmp_files:
             a.move(b)

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -229,3 +229,12 @@ class RemoteScheduler(Scheduler):
 
     def re_enable_task(self, task_id):
         return self._request('/api/re_enable_task', {'task_id': task_id})
+
+    def set_task_status_message(self, task_id, status_message):
+        self._request('/api/set_task_status_message', {
+            'task_id': task_id,
+            'status_message': status_message
+        })
+
+    def get_task_status_message(self, task_id):
+        return self._request('/api/get_task_status_message', {'task_id': task_id})

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -228,6 +228,7 @@
                 {{#error}}<button class="btn btn-danger btn-xs showError" title="Show error" data-toggle="tooltip"><i class="fa fa-bug"></i></button>{{/error}}
                 {{#re_enable}}<a class="btn btn-warning btn-xs re-enable-button" title="Re-enable" data-toggle="tooltip" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}
                 {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
+                {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name={{displayName}}><i class="fa fa-comment"></i></button>{{/statusMessage}}
             </div>
         </script>
         <script type="text/template" name="rowDetailsTemplate">
@@ -251,6 +252,23 @@
                 <pre class="pre-scrollable">{{error}}</pre>
               </div>
               <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+            </div>
+          </div>
+        </script>
+        <script type="text/template" name="statusMessageTemplate">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="myModalLabel">Status message for {{displayName}}</h4>
+              </div>
+              <div class="modal-body">
+                <pre class="pre-scrollable">{{statusMessage}}</pre>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-info refresh"><i class="fa fa-refresh"></i> Refresh</button>
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </div>
             </div>
@@ -320,6 +338,7 @@
                         <td>{{displayTime}}</td>
                         <td><a href="#{{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
                             {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
+                            {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>{{/statusMessage}}
                         </td>
                       </tr>
                       {{/tasks}}
@@ -407,6 +426,8 @@
     </head>
     <body class="skin-green-light fixed">
         <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        </div>
+        <div class="modal fade" id="statusMessageModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         </div>
 
         <div class="wrapper">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -87,6 +87,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getTaskStatusMessage = function(taskId, callback) {
+        return jsonRPC(this.urlRoot + "/get_task_status_message", {task_id: taskId}, function(response) {
+            callback(response.response);
+        });
+    };
+
     LuigiAPI.prototype.getRunningTaskList = function(callback) {
         return jsonRPC(this.urlRoot + "/task_list", {status: "RUNNING", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -84,7 +84,8 @@ function visualiserApp(luigi) {
             status: task.status,
             graph: (task.status == "PENDING" || task.status == "RUNNING" || task.status == "DONE"),
             error: task.status == "FAILED",
-            re_enable: task.status == "DISABLED" && task.re_enable_able
+            re_enable: task.status == "DISABLED" && task.re_enable_able,
+            statusMessage: task.status_message
         };
     }
 
@@ -287,6 +288,16 @@ function visualiserApp(luigi) {
         data.error = decodeError(data.error)
         $("#errorModal").empty().append(renderTemplate("errorTemplate", data));
         $("#errorModal").modal({});
+    }
+
+    function showStatusMessage(data) {
+        $("#statusMessageModal").empty().append(renderTemplate("statusMessageTemplate", data));
+        $("#statusMessageModal .refresh").on('click', function() {
+            luigi.getTaskStatusMessage(data.taskId, function(data) {
+                $("#statusMessageModal pre").html(data.statusMessage);
+            });
+        }).trigger('click');
+        $("#statusMessageModal").modal({});
     }
 
     function preProcessGraph(dependencyGraph) {
@@ -815,6 +826,11 @@ function visualiserApp(luigi) {
 
         luigi.getWorkerList(function(workers) {
             $("#workerList").append(renderWorkers(workers));
+
+            $('.worker-table tbody').on('click', 'td .statusMessage', function() {
+                var data = $(this).data();
+                showStatusMessage(data);
+            });
         });
 
         luigi.getResourceList(function(resources) {
@@ -911,6 +927,11 @@ function visualiserApp(luigi) {
             luigi.reEnable($(this).attr("data-task-id"), function(data) {
                 updateTasks();
             });
+        });
+
+        $('#taskTable tbody').on('click', 'td.details-control .statusMessage', function () {
+            var data = $(this).data();
+            showStatusMessage(data);
         });
 
         $('.navbar-nav').on('click', 'a', function () {

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,6 +289,9 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
+        self.set_tracking_url = None
+        self.set_status_message = None
+
     def initialized(self):
         """
         Returns ``True`` if the Task is initialized and ``False`` otherwise.

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -510,6 +510,8 @@ class Task(object):
         """
         Sets the status message of the task to message, i.e., invokes _status_message_callback if it
         is a callable. This propagates the message down to the scheduler.
+
+        See :ref:`Task.set_status_message`
         """
         if hasattr(self._status_message_callback, "__call__"):
             self._status_message_callback(message)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,7 +289,6 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
-        self.status_message = None
         self._status_message_callback = None
 
     def initialized(self):
@@ -509,14 +508,11 @@ class Task(object):
 
     def set_status_message(self, message):
         """
-        Sets the status message of the task to message. If the value actually changed w.r.t the
-        current value, the _status_message_callback is invoked which propagates the change down to
-        the scheduler.
+        Sets the status message of the task to message, i.e., invokes _status_message_callback if it
+        is a callable. This propagates the message down to the scheduler.
         """
-        if message != self.status_message:
-            self.status_message = message
-            if hasattr(self._status_message_callback, "__call__"):
-                self._status_message_callback(message)
+        if hasattr(self._status_message_callback, "__call__"):
+            self._status_message_callback(message)
 
 
 class MixinNaiveBulkComplete(object):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,8 +289,6 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
-        self._status_message_callback = None
-
     def initialized(self):
         """
         Returns ``True`` if the Task is initialized and ``False`` otherwise.
@@ -505,16 +503,6 @@ class Task(object):
 
         Default behavior is to send an None value"""
         pass
-
-    def set_status_message(self, message):
-        """
-        Sets the status message of the task to message, i.e., invokes _status_message_callback if it
-        is a callable. This propagates the message down to the scheduler.
-
-        See :ref:`Task.set_status_message`
-        """
-        if hasattr(self._status_message_callback, "__call__"):
-            self._status_message_callback(message)
 
 
 class MixinNaiveBulkComplete(object):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -289,6 +289,9 @@ class Task(object):
         self.task_id = task_id_str(self.task_family, self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
+        self.status_message = None
+        self._status_message_callback = None
+
     def initialized(self):
         """
         Returns ``True`` if the Task is initialized and ``False`` otherwise.
@@ -503,6 +506,17 @@ class Task(object):
 
         Default behavior is to send an None value"""
         pass
+
+    def set_status_message(self, message):
+        """
+        Sets the status message of the task to message. If the value actually changed w.r.t the
+        current value, the _status_message_callback is invoked which propagates the change down to
+        the scheduler.
+        """
+        if message != self.status_message:
+            self.status_message = message
+            if hasattr(self._status_message_callback, "__call__"):
+                self._status_message_callback(message)
 
 
 class MixinNaiveBulkComplete(object):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -94,18 +94,18 @@ class TaskProcess(multiprocessing.Process):
 
     Mainly for convenience since this is run in a separate process. """
 
-    def __init__(self, task, worker_id, result_queue, random_seed=False, worker_timeout=0,
-                 tracking_url_callback=None, status_message_callback=None):
+    def __init__(self, task, worker_id, result_queue, tracking_url_callback,
+                 status_message_callback, random_seed=False, worker_timeout=0):
         super(TaskProcess, self).__init__()
         self.task = task
         self.worker_id = worker_id
         self.result_queue = result_queue
+        self.tracking_url_callback = tracking_url_callback
+        self.status_message_callback = status_message_callback
         self.random_seed = random_seed
         if task.worker_timeout is not None:
             worker_timeout = task.worker_timeout
         self.timeout_time = time.time() + worker_timeout if worker_timeout else None
-        self.tracking_url_callback = tracking_url_callback
-        self.status_message_callback = status_message_callback
 
     def _run_get_new_deps(self):
         self.task.set_tracking_url = self.tracking_url_callback
@@ -745,11 +745,9 @@ class Worker(object):
             self._scheduler.set_task_status_message(task.task_id, message)
 
         return TaskProcess(
-            task, self._id, self._task_result_queue,
+            task, self._id, self._task_result_queue, update_tracking_url, update_status_message,
             random_seed=bool(self.worker_processes > 1),
-            worker_timeout=self._config.timeout,
-            tracking_url_callback=update_tracking_url,
-            status_message_callback=update_status_message
+            worker_timeout=self._config.timeout
         )
 
     def _purge_children(self):

--- a/test/task_status_message_test.py
+++ b/test/task_status_message_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import LuigiTestCase
+
+import luigi
+import luigi.scheduler
+import luigi.worker
+
+luigi.notifications.DEBUG = True
+
+
+class TaskStatusMessageTest(LuigiTestCase):
+
+    def test_run(self):
+        message = "test message"
+        sch = luigi.scheduler.CentralPlannerScheduler()
+        with luigi.worker.Worker(scheduler=sch) as w:
+            class MyTask(luigi.Task):
+                def run(self):
+                    self.set_status_message(message)
+
+            task = MyTask()
+            w.add(task)
+            w.run()
+
+            self.assertEqual(sch.get_task_status_message(task.task_id)["statusMessage"], message)

--- a/test/task_status_message_test.py
+++ b/test/task_status_message_test.py
@@ -31,8 +31,8 @@ class TaskStatusMessageTest(LuigiTestCase):
         sch = luigi.scheduler.CentralPlannerScheduler()
         with luigi.worker.Worker(scheduler=sch) as w:
             class MyTask(luigi.Task):
-                def run(self, status_message_callback):
-                    status_message_callback(message)
+                def run(self):
+                    self.set_status_message(message)
 
             task = MyTask()
             w.add(task)

--- a/test/task_status_message_test.py
+++ b/test/task_status_message_test.py
@@ -31,8 +31,8 @@ class TaskStatusMessageTest(LuigiTestCase):
         sch = luigi.scheduler.CentralPlannerScheduler()
         with luigi.worker.Worker(scheduler=sch) as w:
             class MyTask(luigi.Task):
-                def run(self):
-                    self.set_status_message(message)
+                def run(self, status_message_callback):
+                    status_message_callback(message)
 
             task = MyTask()
             w.add(task)

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -63,7 +63,7 @@ class TaskProcessTest(LuigiTestCase):
 
         task = SuccessTask()
         result_queue = multiprocessing.Queue()
-        task_process = TaskProcess(task, 1, result_queue)
+        task_process = TaskProcess(task, 1, result_queue, lambda: None, lambda: None)
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
@@ -81,7 +81,7 @@ class TaskProcessTest(LuigiTestCase):
 
         task = FailTask()
         result_queue = multiprocessing.Queue()
-        task_process = TaskProcess(task, 1, result_queue)
+        task_process = TaskProcess(task, 1, result_queue, lambda: None, lambda: None)
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
@@ -100,7 +100,7 @@ class TaskProcessTest(LuigiTestCase):
         queue = mock.Mock()
         worker_id = 1
 
-        task_process = TaskProcess(task, worker_id, queue)
+        task_process = TaskProcess(task, worker_id, queue, lambda: None, lambda: None)
         task_process.start()
 
         parent = Process(task_process.pid)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -315,8 +315,7 @@ class WorkerTest(unittest.TestCase):
                 return self.has_run
 
             def run(self):
-                if self.set_tracking_url is not None:
-                    self.set_tracking_url(tracking_url)
+                self.set_tracking_url(tracking_url)
                 self.has_run = True
 
         a = A()

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -266,7 +266,7 @@ class WorkerTest(unittest.TestCase):
         self.assertFalse(a.has_run)
         self.assertFalse(b.has_run)
 
-    def test_tracking_url(self):
+    def test_tracking_url_deprecated(self):
         tracking_url = 'http://test_url.com/'
 
         class A(Task):
@@ -287,7 +287,7 @@ class WorkerTest(unittest.TestCase):
         self.assertEqual(1, len(tasks))
         self.assertEqual(tracking_url, tasks[a.task_id]['tracking_url'])
 
-    def test_type_error_in_tracking_run(self):
+    def test_type_error_in_tracking_run_deprecated(self):
         class A(Task):
             num_runs = 0
 
@@ -304,6 +304,27 @@ class WorkerTest(unittest.TestCase):
 
         # Should only run and fail once, not retry because of the type error
         self.assertEqual(1, a.num_runs)
+
+    def test_tracking_url(self):
+        tracking_url = 'http://test_url.com/'
+
+        class A(Task):
+            has_run = False
+
+            def complete(self):
+                return self.has_run
+
+            def run(self):
+                if self.set_tracking_url is not None:
+                    self.set_tracking_url(tracking_url)
+                self.has_run = True
+
+        a = A()
+        self.assertTrue(self.w.add(a))
+        self.assertTrue(self.w.run())
+        tasks = self.sch.task_list('DONE', '')
+        self.assertEqual(1, len(tasks))
+        self.assertEqual(tracking_url, tasks[a.task_id]['tracking_url'])
 
     def test_fail(self):
         class CustomException(BaseException):


### PR DESCRIPTION
> This PR is a fixed version of PR #1621 which has a faulty commit history.

This PR adds status messages to tasks which are also visible on the scheduler GUI.

Examples:

![task list](https://dl.dropboxusercontent.com/u/1021570/luigi1.png "Usage in Task List")

![worker list](https://dl.dropboxusercontent.com/u/1021570/luigi2.png "Usage in Worker List")

Status messages are meant to change during the run method in an [opportunistic way](https://github.com/riga/luigi/blob/statusTexts/luigi/task.py#L515). Especially for long-running non-Hadoop tasks, the ability to read those messages directly in the scheduler GUI is quite helpful (at least for us). Internally, message changes are propagated to the scheduler via a ``_status_message_callback`` which is - in contrast to ``tracking_url_callback`` - not passed to the run method, but set by the ``TaskProcess``.

Usage example:
```python
class MyTask(luigi.Task):
    ...
    def run(self):
        for i in range(100):
            # do some hard work here
            if i % 10 == 0:
                self.set_status_message("Progress: %s / 100" % i)
```

I know that you don't like PR's that affect core code (which is reasonable =) ), but imho this feature is both lightweight *and* really helpful.