### PR TITLE
Clone from non-parameters

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -334,16 +334,15 @@ class Task(object):
         :param kwargs:
         :return:
         """
-        k = self.param_kwargs.copy()
-        k.update(six.iteritems(kwargs))
-
         if cls is None:
             cls = self.__class__
 
         new_k = {}
         for param_name, param_class in cls.get_params():
-            if param_name in k:
-                new_k[param_name] = k[param_name]
+            if param_name in kwargs:
+                new_k[param_name] = kwargs[param_name]
+            elif hasattr(self, param_name):
+                new_k[param_name] = getattr(self, param_name)
 
         return cls(**new_k)
 

--- a/test/clone_test.py
+++ b/test/clone_test.py
@@ -68,3 +68,20 @@ class CloneTest(unittest.TestCase):
         t = PowerSum(lo=42, hi=45, p=2)
         luigi.build([t], local_scheduler=True)
         self.assertEqual(t.s, 42 ** 2 + 43 ** 2 + 44 ** 2)
+
+    def test_inheritance_from_non_parameter(self):
+        """
+        Cloning can pull non-source-parameters from source to target parameter.
+        """
+
+        class SubTask(luigi.Task):
+            lo = 1
+
+            @property
+            def hi(self):
+                return 2
+
+        t1 = SubTask()
+        t2 = t1.clone(cls=LinearSum)
+        self.assertEqual(t2.lo, 1)
+        self.assertEqual(t2.hi, 2)

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -242,14 +242,6 @@ class Y2(luigi.Task):
     pass
 
 
-@inherits(X)
-class Z(luigi.Task):
-    n = None
-
-    def requires(self):
-        return self.clone_parent()
-
-
 @requires(X)
 class Y3(luigi.Task):
     n = luigi.IntParameter(default=43)
@@ -262,9 +254,6 @@ class CloneParentTest(unittest.TestCase):
         x = X()
         self.assertEqual(y.requires(), x)
         self.assertEqual(y.n, 42)
-
-        z = Z()
-        self.assertEqual(z.requires(), x)
 
     def test_requires(self):
         y2 = Y2()


### PR DESCRIPTION
Currently `Task.clone` only propagates values from source to target when both attributes are Parameters.    This PR propagates data from source to target parameter regardless of whether the source attribute is a parameter or something else (property, class or instance-level attribute, etc). 

The use case for this has come up in cases where we interface between generic and specific tasks. A simplified example, consider some generic classes to POST several files referenced in a manifest to an external url:

``` python
class Upload(luigi.Task):
    url = luigi.Parameter()
    file = luigi.Parameter()

class UploadFromManifest(luigi.Task):
    url = luigi.Parameter()
    manifest = luigi.Parameter()

    def run(self):
        files = open(manifest).readlines()
        yield [self.clone(cls=Upload, file=file) for file in files]   
```

as well as a more specific subtask where url is derived from a more fundamental parameter:

``` python
class MonthlyReport(UploadFromManifest):
    month = luigi.Parameter()
    manifest = luigi.Parameter()

    @property
    def url(self):
        return 'http://test.com/reports/%s' % self.month
```

This fails at the clone step because, although url is defined for `MonthlyReport`, it's not a parameter and thus not propagated to `Upload`
