### PR TITLE
Allow central scheduler logging to be configured based on the logging…

### DIFF
--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -48,7 +48,9 @@ def luigid(argv=sys.argv[1:]):
                 if logging_conf is not None and not os.path.exists(logging_conf):
                     raise Exception("Error: Unable to locate specified logging configuration file!")
             if logging_conf is not None:
+                print("Configuring logging from file: {}".format(logging_conf))
                 logging.config.fileConfig(logging_conf)
             else:
+                print("Defaulting to basic logging; consider specifying logging_conf_file in luigi.cfg.")
                 logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format())
         luigi.server.run(api_port=opts.port, address=opts.address, unix_socket=opts.unix_socket)

--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import logging
+import logging.config
 import sys
 
 from luigi.retcodes import run_with_retcodes
@@ -40,5 +41,14 @@ def luigid(argv=sys.argv[1:]):
             logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format(),
                                 filename=os.path.join(opts.logdir, "luigi-server.log"))
         else:
-            logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format())
+            config = luigi.configuration.get_config()
+            logging_conf = None
+            if not config.getboolean('core', 'no_configure_logging', False):
+                logging_conf = config.get('core', 'logging_conf_file', None)
+                if logging_conf is not None and not os.path.exists(logging_conf):
+                    logging_conf = None
+            if logging_conf is not None:
+                logging.config.fileConfig(logging_conf)
+            else:
+                logging.basicConfig(level=logging.INFO, format=luigi.process.get_log_format())
         luigi.server.run(api_port=opts.port, address=opts.address, unix_socket=opts.unix_socket)

--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -46,7 +46,7 @@ def luigid(argv=sys.argv[1:]):
             if not config.getboolean('core', 'no_configure_logging', False):
                 logging_conf = config.get('core', 'logging_conf_file', None)
                 if logging_conf is not None and not os.path.exists(logging_conf):
-                    logging_conf = None
+                    raise Exception("Error: Unable to locate specified logging configuration file!")
             if logging_conf is not None:
                 logging.config.fileConfig(logging_conf)
             else:

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -28,6 +28,7 @@ from helpers import unittest
 from luigi import six
 
 import luigi
+import luigi.cmdline
 from luigi.mock import MockTarget
 
 
@@ -152,6 +153,33 @@ class CmdlineTest(unittest.TestCase):
     @mock.patch('argparse.ArgumentParser.print_usage')
     def test_no_task(self, print_usage):
         self.assertRaises(SystemExit, luigi.run, ['--local-scheduler', '--no-lock'])
+
+    def test_luigid_logging_conf(self):
+        with mock.patch('luigi.server.run') as server_run, \
+                mock.patch('logging.config.fileConfig') as fileConfig:
+            luigi.cmdline.luigid([])
+            self.assertTrue(server_run.called)
+            # the default test configuration specifies a logging conf file
+            fileConfig.assert_called_with("test/testconfig/logging.cfg")
+
+    def test_luigid_no_configure_logging(self):
+        with mock.patch('luigi.server.run') as server_run, \
+                mock.patch('logging.basicConfig') as basicConfig, \
+                mock.patch('luigi.configuration.get_config') as get_config:
+            get_config.return_value.getboolean.return_value = True  # no_configure_logging=True
+            luigi.cmdline.luigid([])
+            self.assertTrue(server_run.called)
+            self.assertTrue(basicConfig.called)
+
+    def test_luigid_no_logging_conf(self):
+        with mock.patch('luigi.server.run') as server_run, \
+                mock.patch('logging.basicConfig') as basicConfig, \
+                mock.patch('luigi.configuration.get_config') as get_config:
+            get_config.return_value.getboolean.return_value = False  # no_configure_logging=False
+            get_config.return_value.get.return_value = None  # logging_conf_file=None
+            luigi.cmdline.luigid([])
+            self.assertTrue(server_run.called)
+            self.assertTrue(basicConfig.called)
 
 
 class InvokeOverCmdlineTest(unittest.TestCase):

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -181,6 +181,16 @@ class CmdlineTest(unittest.TestCase):
             self.assertTrue(server_run.called)
             self.assertTrue(basicConfig.called)
 
+    def test_luigid_missing_logging_conf(self):
+        with mock.patch('luigi.server.run') as server_run, \
+                mock.patch('logging.basicConfig') as basicConfig, \
+                mock.patch('luigi.configuration.get_config') as get_config:
+            get_config.return_value.getboolean.return_value = False  # no_configure_logging=False
+            get_config.return_value.get.return_value = "nonexistent.cfg"  # logging_conf_file=None
+            self.assertRaises(Exception, luigi.cmdline.luigid, [])
+            self.assertFalse(server_run.called)
+            self.assertFalse(basicConfig.called)
+
 
 class InvokeOverCmdlineTest(unittest.TestCase):
 


### PR DESCRIPTION
….conf file specified in luigi.cfg.

Although the luigi configuration file has an option to specify a logging conf file, this option currently only applies to the workers, not the central scheduler, which AFAICT ignores any logging configuration and starts up with a basic configuration. I poked around and didn't see any way to configure the central scheduler's logging other than hacking on its entry point; hence this PR.