### PR TITLE
Add scheduled tasks to error emails

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -509,7 +509,8 @@ class Worker(object):
 
     def _email_error(self, task, formatted_traceback, subject, headline):
         formatted_subject = subject.format(task=task, host=self.host)
-        message = notifications.format_task_error(headline, task, formatted_traceback)
+        scheduled_tasks = sorted(self._scheduled_tasks.itervalues(), key=lambda t: t.task_id)
+        message = notifications.format_task_error(headline, task, formatted_traceback, scheduled_tasks)
         notifications.send_error_email(formatted_subject, message, task.owner_email)
 
     def add(self, task, multiprocess=False):


### PR DESCRIPTION
Request for comments

Sometimes my team shares base tasks.  When we get an error email, it's sometimes unclear which upstream task requires() the one that failed. In order to address this, I'm proposing adding the worker's scheduled tasks to the error email.

Some things to consider:

- Is one worker's view on scheduled tasks wide enough to capture all the relevant incomplete tasks?
- Is sorting by task_id meaningful?
- Is there a more general way to show the task tree (ex. execution_summary.summary?)


For my proof-of-concept:

```
import luigi

class SubTask(luigi.Task):
    p = luigi.Parameter()
    def run(self):
        raise Exception('I meant to do that...')

class TestTask(luigi.Task):
    def requires(self):
        yield SubTask('some option')

if __name__ == '__main__':
    luigi.run(main_task_cls=TestTask, local_scheduler=True)
```

produces a plain-text email body:

```
Name: SubTask

Parameters:
  p: some option

Scheduled tasks:
- SubTask(p=some option)
- TestTask()

Runtime error:
Traceback (most recent call last):
  File "/home/nisaac/code/luigi/luigi/worker.py", line 171, in run
    new_deps = self._run_get_new_deps()
  File "/home/nisaac/code/luigi/luigi/worker.py", line 113, in _run_get_new_deps
    task_gen = self.task.run()
  File "testtask.py", line 9, in run
    raise Exception('I meant to do that...')
Exception: I meant to do that...
```