### PR TITLE
Add status message endpoints to RPC handler list.

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -85,6 +85,8 @@ class RPCHandler(tornado.web.RequestHandler):
             'task_search',
             'update_resources',
             'worker_list',
+            'set_task_status_message',
+            'get_task_status_message',
         ]:
             self.send_error(404)
             return


### PR DESCRIPTION
This PR fixes a bug resulting from the interference of PR #1625 (Task status messages) and PR #1631 (Add explicit whitelist of RPC commands for luigid) task status messages.

I wasn't aware of the new white-listing. The ci tests of #1625 still succeeded as the two PRs were fairly parallel.

To fix this, I simply added ``set_task_status_message`` and ``get_task_status_message`` to the white-listing.