### PR TITLE
Include sys.argv in error emails

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -315,7 +315,7 @@ def _prefix(subject):
     return subject
 
 
-def format_task_error(headline, task, formatted_exception=None):
+def format_task_error(headline, task, command, formatted_exception=None):
     """
     Format a message body for an error email related to a luigi.task.Task
 
@@ -348,6 +348,11 @@ def format_task_error(headline, task, formatted_exception=None):
         </table>
         </pre>
 
+        <h2>Command line</h2>
+        <pre>
+        {command}
+        </pre>
+
         <h2>Traceback</h2>
         {traceback}
         </body>
@@ -357,7 +362,7 @@ def format_task_error(headline, task, formatted_exception=None):
         str_params = task.to_str_params()
         params = '\n'.join('<tr><th>{}</th><td>{}</td></tr>'.format(*items) for items in str_params.items())
         body = msg_template.format(headline=headline, name=task.task_family, param_rows=params,
-                                   traceback=formatted_exception)
+                                   command=command, traceback=formatted_exception)
     else:
         msg_template = textwrap.dedent('''\
         {headline}
@@ -367,6 +372,9 @@ def format_task_error(headline, task, formatted_exception=None):
         Parameters:
         {params}
 
+        Command line:
+          {command}
+
         {traceback}
         ''')
 
@@ -374,6 +382,6 @@ def format_task_error(headline, task, formatted_exception=None):
         max_width = max([0] + [len(x) for x in str_params.keys()])
         params = '\n'.join('  {:{width}}: {}'.format(*items, width=max_width) for items in str_params.items())
         body = msg_template.format(headline=headline, name=task.task_family, params=params,
-                                   traceback=formatted_exception)
+                                   command=command, traceback=formatted_exception)
 
     return body

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -34,6 +34,7 @@ import logging
 import multiprocessing  # Note: this seems to have some stability issues: https://github.com/spotify/luigi/pull/438
 import os
 import signal
+import subprocess
 import sys
 
 try:
@@ -510,7 +511,7 @@ class Worker(object):
 
     def _email_error(self, task, formatted_traceback, subject, headline):
         formatted_subject = subject.format(task=task, host=self.host)
-        command = ' '.join("'{}'".format(arg) for arg in sys.argv)
+        command = subprocess.list2cmdline(sys.argv)
         message = notifications.format_task_error(headline, task, command, formatted_traceback)
         notifications.send_error_email(formatted_subject, message, task.owner_email)
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -34,6 +34,7 @@ import logging
 import multiprocessing  # Note: this seems to have some stability issues: https://github.com/spotify/luigi/pull/438
 import os
 import signal
+import sys
 
 try:
     import Queue
@@ -509,7 +510,8 @@ class Worker(object):
 
     def _email_error(self, task, formatted_traceback, subject, headline):
         formatted_subject = subject.format(task=task, host=self.host)
-        message = notifications.format_task_error(headline, task, formatted_traceback)
+        command = ' '.join("'{}'".format(arg) for arg in sys.argv)
+        message = notifications.format_task_error(headline, task, command, formatted_traceback)
         notifications.send_error_email(formatted_subject, message, task.owner_email)
 
     def add(self, task, multiprocess=False):


### PR DESCRIPTION
Sometimes my team shares base tasks. When we get an error email, it's sometimes unclear which upstream task requires() the one that failed.

Following @Tarrasch's suggestion of adding command line arguments to address this.