### PR TITLE
Fix bug in LocalFileSystem.move

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -88,7 +88,7 @@ class LocalFileSystem(FileSystem):
             raise RuntimeError('Destination exists: %s' % new_path)
         d = os.path.dirname(new_path)
         if d and not os.path.exists(d):
-            self.fs.mkdir(d)
+            self.mkdir(d)
         os.rename(old_path, new_path)
 
 

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -299,6 +299,15 @@ class FileSystemTest(unittest.TestCase):
             pass
         self.assertTrue([self.path + '/file'], list(self.fs.listdir(self.path + '/')))
 
+    def test_move_to_new_dir(self):
+        # Regression test for a bug in LocalFileSystem.move
+        src = os.path.join(self.path, 'src.txt')
+        dest = os.path.join(self.path, 'newdir', 'dest.txt')
+
+        LocalTarget(src).open('w').close()
+        self.fs.move(src, dest)
+        self.assertTrue(os.path.exists(dest))
+
 
 class TestImportFile(unittest.TestCase):
 


### PR DESCRIPTION
0bdb009aedf6307fcd066c73f19e8bf96876a183 refactored the implementation of `move` from `LocalTarget` to `LocalFileSystem` but didn't repoint `self.fs.mkdir` to `self.mkdir`. This causes code like ```LocalTarget(src).move(dest)``` to fail if `dest` is in a nonexistent directory.

This adds a fix + regression test