### PR TITLE
Raise Queue.Empty for get() on empty queue

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -271,7 +271,10 @@ class DequeQueue(collections.deque):
         return self.append(obj)
 
     def get(self, block=None, timeout=None):
-        return self.pop()
+        try:
+            return self.pop()
+        except IndexError:
+            raise Queue.Empty
 
 
 class AsyncCompletionException(Exception):


### PR DESCRIPTION
Worker._handle_next_task() expects get() on an empty queue to raise Queue.Empty, but the dummy implementation DequeQueue raises IndexError instead. It probaly only shows up if you create custom workers that derive from Worker, but it is still inconsistent with multiprocessing.Queue.