### PR TITLE
Make status_message optional in task serialization.

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -865,7 +865,7 @@ class CentralPlannerScheduler(Scheduler):
             'priority': task.priority,
             'resources': task.resources,
             'tracking_url': getattr(task, "tracking_url", None),
-            'status_message': task.status_message
+            'status_message': getattr(task, "status_message", None)
         }
         if task.status == DISABLED:
             ret['re_enable_able'] = task.scheduler_disable_time is not None


### PR DESCRIPTION
This PR fixes an issue mentioned [here](https://github.com/spotify/luigi/pull/1625#discussion-diff-59153908).

When scheduler tasks are serialized, their ``status_message`` might not be present when using old state files. Just like ``tracking_url``, the presence of this member is now optional.