### PR TITLE
Add the archive parameters to HadoopJobRunner

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -400,8 +400,8 @@ class HadoopJobRunner(JobRunner):
 
     def __init__(self, streaming_jar, modules=None, streaming_args=None,
                  libjars=None, libjars_in_hdfs=None, jobconfs=None,
-                 archives=None, input_format=None, output_format=None,
-                 end_job_with_atomic_move_dir=True):
+                 input_format=None, output_format=None,
+                 end_job_with_atomic_move_dir=True, archives=None):
         def get(x, default):
             return x is not None and x or default
         self.streaming_jar = streaming_jar
@@ -480,10 +480,8 @@ class HadoopJobRunner(JobRunner):
             arglist += ['-libjars', ','.join(libjars)]
 
         # 'archives' is also a generic option
-        archives = [archive for archive in self.archives]
-
-        if archives:
-            arglist += ['-archives', ','.join(archives)]
+        if self.archives:
+            arglist += ['-archives', ','.join(self.archives)]
 
         # Add static files and directories
         extra_files = get_extra_files(job.extra_files())

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -400,7 +400,7 @@ class HadoopJobRunner(JobRunner):
 
     def __init__(self, streaming_jar, modules=None, streaming_args=None,
                  libjars=None, libjars_in_hdfs=None, jobconfs=None,
-                 input_format=None, output_format=None,
+                 archives=None, input_format=None, output_format=None,
                  end_job_with_atomic_move_dir=True):
         def get(x, default):
             return x is not None and x or default
@@ -409,6 +409,7 @@ class HadoopJobRunner(JobRunner):
         self.streaming_args = get(streaming_args, [])
         self.libjars = get(libjars, [])
         self.libjars_in_hdfs = get(libjars_in_hdfs, [])
+        self.archives = get(archives, [])
         self.jobconfs = get(jobconfs, {})
         self.input_format = input_format
         self.output_format = output_format
@@ -477,6 +478,12 @@ class HadoopJobRunner(JobRunner):
 
         if libjars:
             arglist += ['-libjars', ','.join(libjars)]
+
+        # 'archives' is also a generic option
+        archives = [archive for archive in self.archives]
+
+        if archives:
+            arglist += ['-archives', ','.join(archives)]
 
         # Add static files and directories
         extra_files = get_extra_files(job.extra_files())


### PR DESCRIPTION
This PR add an additional parameter of archives. This is helpful in particular when running python task and you want them to be run inside a virtual environment. See this gist for an example of how it could be used. 

https://gist.github.com/mfcabrera/63136e233e8eb36392b1ce33cf4e5a06