### PR TITLE
Addresses Unintended Error caused by PR #1624 when user does not specify a logging_conf_file

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -86,7 +86,7 @@ class core(task.Config):
         description='Port of remote scheduler api process',
         config_path=dict(section='core', name='default-scheduler-port'))
     scheduler_url = parameter.Parameter(
-        default='',
+        default=None,
         description='Full path to remote scheduler',
         config_path=dict(section='core', name='default-scheduler-url'),
     )
@@ -106,10 +106,10 @@ class core(task.Config):
         default=1,
         description='Maximum number of parallel tasks to run')
     logging_conf_file = parameter.Parameter(
-        default='',
+        default=None,
         description='Configuration file for logging')
     module = parameter.Parameter(
-        default='',
+        default=None,
         description='Used for dynamic loading of modules',
         always_in_help=True)
     parallel_scheduling = parameter.BoolParameter(
@@ -158,7 +158,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
     # search for logging configuration path first on the command line, then
     # in the application config file
     logging_conf = env_params.logging_conf_file
-    if logging_conf != '' and not os.path.exists(logging_conf):
+    if logging_conf is not None and not os.path.exists(logging_conf):
         raise Exception(
             "Error: Unable to locate specified logging configuration file!"
         )
@@ -175,7 +175,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
     if env_params.local_scheduler:
         sch = worker_scheduler_factory.create_local_scheduler()
     else:
-        if env_params.scheduler_url != '':
+        if env_params.scheduler_url is not None:
             url = env_params.scheduler_url
         else:
             url = 'http://{host}:{port:d}/'.format(

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -230,7 +230,7 @@ class Parameter(object):
 
         :param x: the value to serialize.
         """
-        if not isinstance(x, six.string_types) and self.__class__ == Parameter:
+        if not isinstance(x, six.string_types) and self.__class__ == Parameter and x is not None:
             warnings.warn("Parameter {0} is not of type string.".format(str(x)))
         return str(x)
 


### PR DESCRIPTION
Revert default config variables to None, rather than empty strings. Don't warn user if Parameter has value of None.