### PR TITLE
Fixes logging error caused by PR #1624

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -40,12 +40,12 @@ from luigi import execution_summary
 from luigi.cmdline_parser import CmdlineParser
 
 
-def setup_interface_logging(conf_file=None):
+def setup_interface_logging(conf_file=''):
     # use a variable in the function object to determine if it has run before
     if getattr(setup_interface_logging, "has_run", False):
         return
 
-    if conf_file is None:
+    if conf_file == '':
         logger = logging.getLogger('luigi-interface')
         logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Set default conf_file value to empty string within function setup_interface_logging such that logging will not try to using a logging.conf file which doesn't exist.

link to pr #1624