### PR TITLE
Fix running nose with xunit.

### DIFF
--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -124,15 +124,13 @@ class MockTarget(target.FileSystemTarget):
                 self.wrapper = wrapper
 
             def write(self, data):
-                if six.PY3:
-                    stderrbytes = sys.stderr.buffer
-                else:
-                    stderrbytes = sys.stderr
-
                 if mock_target._mirror_on_stderr:
                     if self._write_line:
                         sys.stderr.write(fn + ": ")
-                    stderrbytes.write(data)
+                    if six.binary_type:
+                        sys.stderr.write(data.decode('utf8'))
+                    else:
+                        sys.stderr.write(data)
                     if (data[-1]) == '\n':
                         self._write_line = True
                     else:


### PR DESCRIPTION
## Description
When running nosetest with xunit on projects that use luigi (`nosetests tests --with-xunit`), the tests would crash for external using python 3.5 with something similar to:

```
Traceback (most recent call last):
  File "./lib/python3.5/site-packages/luigi/mock.py",
  line 128, in write
      stderrbytes = sys.stderr.buffer
      AttributeError: 'Tee' object has no attribute 'buffer'
```

This is because xunit overrides sys.stderr, and the class it uses does
not have the 'buffer' attribute defined.

Nose source:
  https://github.com/nose-devs/nose/blob/master/nose/plugins/xunit.py#L127-L147

## Motivation and Context
I can't run unit tests with xunit output, on my person projects.

## Have you tested this? If so, how?
I have run the existing unit tests in test_mock.py for python 3.5 and 2.7. Also having this fix in my project passes all existing unit tests.

Note: The original commit that added this is here if needed: https://github.com/spotify/luigi/commit/21f42bc92c23345b10ce61d02688e4c5bedf526f