### PR TITLE
Allow GCSTarget's as input and GCSFlagTarget's as output for Hadoop jobs

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -457,9 +457,11 @@ class HadoopJobRunner(JobRunner):
         output_final = job.output().path
         # atomic output: replace output with a temporary work directory
         if self.end_job_with_atomic_move_dir:
-            if isinstance(job.output(), luigi.s3.S3FlagTarget):
+            illegal_targets = (
+                luigi.s3.S3FlagTarget, luigi.contrib.gcs.GCSFlagTarget)
+            if isinstance(job.output(), illegal_targets):
                 raise TypeError("end_job_with_atomic_move_dir is not supported"
-                                " for S3FlagTarget")
+                                " for {}".format(illegal_targets))
             output_hadoop = '{output}-temp-{time}'.format(
                 output=output_final,
                 time=datetime.datetime.now().isoformat().replace(':', '-'))


### PR DESCRIPTION
This PR allows `GCSTarget()`'s to be valid input and `GCSFlagTarget()`'s to be valid output for Hadoop `JobTask()`'s just like `S3Target()`'s.

Looking at the tests in `test/contrib/hadoop_teset.py` I don't see the `s3` functionality tested anywhere, so this PR does not introduce any new tests, but I am happy to add some with a bit of guidance.

When running a Hadoop job on Google Compute Engine Google Cloud Storage can be used as HDFS, so `gs://bucket/path/to/resource` URL's are valid in addition to normal HDFS paths.

Also like `S3FlagTarget()`, an exception is raised if `end_job_with_atomic_move_dir=True` and the output is a `GCSFlagTarget()`.  I'm not 100% positive this is the correct behavior, but when I tried to run a test job with atomic move a `UserWarning` was issued stating the client doesn't support atomic move, and the job ultimately failed.  I'm on the fence about this portion of the PR and feel like I don't necessarily have enough information to confidently implement this, so I'm happy to remove it, but unfortunately I don't have time to investigate if the atomic move is possible on GCS.  We found that it was prohibitively slow anyway.

```
/usr/local/lib/python2.7/dist-packages/luigi/target.py:182: UserWarning: File system HdfsClient client doesn't support atomic mv.
  warnings.warn("File system {} client doesn't support atomic mv.".format(self.__class__.__name__))
DEBUG:luigi-interface:Running file existence check: hadoop fs -stat gs://bucket/scratch/kevin/hadoop-gcs/
Traceback (most recent call last):
  File "gcs_hadoop.py", line 209, in <module>
    task.run()
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 707, in run
    self.job_runner().run_job(self)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hadoop.py", line 552, in run_job
    luigi.contrib.hdfs.HdfsTarget(output_hadoop).move_dir(output_final)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hdfs/target.py", line 150, in move_dir
    self.fs.rename_dont_move(self.path, path)
  File "/usr/local/lib/python2.7/dist-packages/luigi/contrib/hdfs/abstract_client.py", line 55, in rename_dont_move
    return super(HdfsFileSystem, self).rename_dont_move(path, dest)
  File "/usr/local/lib/python2.7/dist-packages/luigi/target.py", line 184, in rename_dont_move
    raise FileAlreadyExists()
luigi.target.FileAlreadyExists
DEBUG:luigi-interface:Removing directory /tmp/tmp31ZxPX
```