### PR TITLE
HiveQueryTask needs support for LocalTarget

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -366,7 +366,10 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                     arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
 
             logger.info(arglist)
-            return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url)
+            result = luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url)
+            if job.output():
+                job.output().open("w").close()
+            return result
 
 
 class HiveTableTarget(luigi.Target):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

I'm not certain this patch will work for all scenarios, however it has fixed the issue for my scenario where I have a HiveQueryTask with a LocalTarget in the output.

<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes -->

Consider the following task:
`

```
class MyHiveTask(luigi.contrib.hive.HiveQueryTask):
   def query(self):
        return 'select * from foo;'
   def output(self):
        return luigi.LocalTarget('/tmp/{1}/{0}'.format(type(self).__name__, self.tablename))
```

`
The patch ensures the local target is touched upon successful completion of the hive session.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Without the patch, HiveQueryTask with LocalTarget was not touched. There was no place to write the logic for touching the local target file.
`job.output().open("w").close()`
Without touching the file, the luigi session will retry the task and then eventually error out because the target was not written and it is assumed the task was not complete.

<!--- If it fixes an open issue, please link to the issue here. -->
## Have you tested this? If so, how?

<!--- Valid responses are "I have included unit tests." or --> 

I ran my jobs with this code and it worked for me.

<!--- "I ran my jobs with this code and it works for me." -->
