### PR TITLE
Fix formatting of example configuration snippet

### DIFF
--- a/doc/central_scheduler.rst
+++ b/doc/central_scheduler.rst
@@ -60,6 +60,7 @@ When starting up,
 <http://docs.sqlalchemy.org/en/rel_0_9/core/metadata.html#sqlalchemy.schema.MetaData.create_all>`_.
 
 Example configuration
+
 .. code:: ini
 
     [scheduler]


### PR DESCRIPTION
Code formatting keyword had no effect:

http://luigi.readthedocs.io/en/stable/central_scheduler.html#enabling-task-history