### PR TITLE
Pass through parameters on Range tasks to of tasks

### DIFF
--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -102,10 +102,17 @@ and stop (exclusive) parameters specified:
 Propagating parameters with Range
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When your recurring task has a parameter, you'll at first notice that the Range
-tasks do not recognize or propagate parameters passed to them. The easiest
-solution is to set the parameter at the task family level as described
-:ref:`here <Parameter-class-level-parameters>`.
+Some tasks you want to recur may include additional parameters which need to be configured.
+The Range classes provide a parameter which accepts a :class:`~luigi.params.DictParameter`
+and passes any parameters onwards for this purpose.
+
+.. code-block:: console
+
+	luigi RangeDaily --of MyTask --start 2014-10-31 --of-param '{"my-param": 123}'
+
+Alternatively, you can specify parameters at the task family level (as described :ref:`here <Parameter-class-level-parameters>`),
+however these will not appear in the task name for the upstream Range task which
+can have implications in how the scheduler and visualizer handle task instances.
 
 .. code-block:: console
 

--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -103,7 +103,7 @@ Propagating parameters with Range
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some tasks you want to recur may include additional parameters which need to be configured.
-The Range classes provide a parameter which accepts a :class:`~luigi.params.DictParameter`
+The Range classes provide a parameter which accepts a :class:`~luigi.parameter.DictParameter`
 and passes any parameters onwards for this purpose.
 
 .. code-block:: console

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -186,7 +186,10 @@ class RangeBase(luigi.WrapperTask):
 
     @property
     def _param_name(self):
-        return self.of.get_params()[0][0] if self.param_name is None else self.param_name
+        if self.param_name is None:
+            return next(x[0] for x in self.of.get_params() if x[1].positional)
+        else:
+            return self.param_name
 
     def _task_parameters(self, param):
         kwargs = dict(**self.of_params)

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -88,6 +88,7 @@ class RangeBase(luigi.WrapperTask):
     # TODO lift the single parameter constraint by passing unknown parameters through WrapperTask?
     of = luigi.TaskParameter(
         description="task name to be completed. The task must take a single datetime parameter")
+    of_params = luigi.DictParameter(default=dict(),description="Arguments to be provided to the 'of' class when instantiating")
     # The common parameters 'start' and 'stop' have type (e.g. DateParameter,
     # DateHourParameter) dependent on the concrete subclass, cumbersome to
     # define here generically without dark magic. Refer to the overrides.
@@ -175,9 +176,10 @@ class RangeBase(luigi.WrapperTask):
 
     def _instantiate_task_cls(self, param):
         if self.param_name is None:
-            return self.of_cls(param)
+            return self.of_cls(param,**self.of_params)
         else:
-            kwargs = {self.param_name: param}
+            kwargs = self.of_params.copy()
+            kwargs[self.param_name] = param
             return self.of_cls(**kwargs)
 
     def requires(self):

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -128,9 +128,15 @@ class RangeBase(luigi.WrapperTask):
         raise NotImplementedError
 
     def datetime_to_parameters(self, dt):
+        """
+        Given a date-time, will produce a dictionary of of-params combined with the ranged task parameter
+        """
         raise NotImplementedError
 
     def parameters_to_datetime(self, p):
+        """
+        Given a dictionary of parameters, will extract the ranged task parameter value
+        """
         raise NotImplementedError
 
     def moving_start(self, now):
@@ -299,9 +305,15 @@ class RangeDailyBase(RangeBase):
         return datetime(p.year, p.month, p.day)
 
     def datetime_to_parameters(self, dt):
+        """
+        Given a date-time, will produce a dictionary of of-params combined with the ranged task parameter
+        """
         return self._task_parameters(dt.date())
 
     def parameters_to_datetime(self, p):
+        """
+        Given a dictionary of parameters, will extract the ranged task parameter value
+        """
         dt = p[self._param_name]
         return datetime(dt.year, dt.month, dt.day)
 
@@ -356,9 +368,15 @@ class RangeHourlyBase(RangeBase):
         return p
 
     def datetime_to_parameters(self, dt):
+        """
+        Given a date-time, will produce a dictionary of of-params combined with the ranged task parameter
+        """
         return self._task_parameters(dt)
 
     def parameters_to_datetime(self, p):
+        """
+        Given a dictionary of parameters, will extract the ranged task parameter value
+        """
         return p[self._param_name]
 
     def moving_start(self, now):

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -88,7 +88,7 @@ class RangeBase(luigi.WrapperTask):
     # TODO lift the single parameter constraint by passing unknown parameters through WrapperTask?
     of = luigi.TaskParameter(
         description="task name to be completed. The task must take a single datetime parameter")
-    of_params = luigi.DictParameter(default=dict(),description="Arguments to be provided to the 'of' class when instantiating")
+    of_params = luigi.DictParameter(default=dict(), description="Arguments to be provided to the 'of' class when instantiating")
     # The common parameters 'start' and 'stop' have type (e.g. DateParameter,
     # DateHourParameter) dependent on the concrete subclass, cumbersome to
     # define here generically without dark magic. Refer to the overrides.
@@ -176,7 +176,7 @@ class RangeBase(luigi.WrapperTask):
 
     def _instantiate_task_cls(self, param):
         if self.param_name is None:
-            return self.of_cls(param,**self.of_params)
+            return self.of_cls(param, **self.of_params)
         else:
             kwargs = self.of_params.copy()
             kwargs[self.param_name] = param

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -745,19 +745,19 @@ class RangeInstantiationTest(LuigiTestCase):
             arbitrary_integer_param = luigi.IntParameter(default=10)
             date_param = luigi.DateParameter()
 
-            def output(self):
-                return MockTarget("{0}-{1}-{2}".format(date_param,arbitrary_param,arbitrary_integer_param))
+            def complete(self):
+                return False
 
         range_task_1 = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
-                                of=MyTask,
-                                start=datetime.date(2015, 12, 1),
-                                stop=datetime.date(2015, 12, 2))
+                                  of=MyTask,
+                                  start=datetime.date(2015, 12, 1),
+                                  stop=datetime.date(2015, 12, 2))
         range_task_2 = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
-                                of=MyTask,
-                                of_params=dict(arbitrary_param="bar",abitrary_integer_param=2),
-                                start=datetime.date(2015, 12, 1),
-                                stop=datetime.date(2015, 12, 2))
-        self.assertNotEqual(range_task_1.task_id,range_task_2.task_id)
+                                  of=MyTask,
+                                  of_params=dict(arbitrary_param="bar", abitrary_integer_param=2),
+                                  start=datetime.date(2015, 12, 1),
+                                  stop=datetime.date(2015, 12, 2))
+        self.assertNotEqual(range_task_1.task_id, range_task_2.task_id)
 
     def test_of_param_commandline(self):
         class MyTask(luigi.Task):
@@ -765,19 +765,17 @@ class RangeInstantiationTest(LuigiTestCase):
             date_param = luigi.DateParameter()
             arbitrary_param = luigi.Parameter(default='foo')
             arbitrary_integer_param = luigi.IntParameter(default=10)
-            state = (None,None)
+            state = (None, None)
             comp = False
-
-            def output(self):
-                return MockTarget("{0}-{1}-{2}".format(date_param,arbitrary_param,arbitrary_integer_param))
 
             def complete(self):
                 return self.comp
 
             def run(self):
                 self.comp = True
-                MyTask.state = (self.arbitrary_param,self.arbitrary_integer_param)
+                MyTask.state = (self.arbitrary_param, self.arbitrary_integer_param)
 
         now = str(int(datetime_to_epoch(datetime.datetime(2015, 12, 2))))
-        self.run_locally(['RangeDailyBase','--of','wohoo.MyTask','--of-params','{"arbitrary_param":"bar","arbitrary_integer_param":5}','--now','{0}'.format(now),'--start','2015-12-01','--stop','2015-12-02'])
-        self.assertEqual(MyTask.state,('bar',5))
+        self.run_locally(['RangeDailyBase', '--of', 'wohoo.MyTask', '--of-params', '{"arbitrary_param":"bar","arbitrary_integer_param":5}',
+                          '--now', '{0}'.format(now), '--start', '2015-12-01', '--stop', '2015-12-02'])
+        self.assertEqual(MyTask.state, ('bar', 5))

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -738,3 +738,46 @@ class RangeInstantiationTest(LuigiTestCase):
                                 param_name='date_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
         self.assertEqual(expected_task, list(range_task._requires())[0])
+
+    def test_of_param_distinction(self):
+        class MyTask(luigi.Task):
+            arbitrary_param = luigi.Parameter(default='foo')
+            arbitrary_integer_param = luigi.IntParameter(default=10)
+            date_param = luigi.DateParameter()
+
+            def output(self):
+                return MockTarget("{0}-{1}-{2}".format(date_param,arbitrary_param,arbitrary_integer_param))
+
+        range_task_1 = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
+                                of=MyTask,
+                                start=datetime.date(2015, 12, 1),
+                                stop=datetime.date(2015, 12, 2))
+        range_task_2 = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
+                                of=MyTask,
+                                of_params=dict(arbitrary_param="bar",abitrary_integer_param=2),
+                                start=datetime.date(2015, 12, 1),
+                                stop=datetime.date(2015, 12, 2))
+        self.assertNotEqual(range_task_1.task_id,range_task_2.task_id)
+
+    def test_of_param_commandline(self):
+        class MyTask(luigi.Task):
+            task_namespace = "wohoo"
+            date_param = luigi.DateParameter()
+            arbitrary_param = luigi.Parameter(default='foo')
+            arbitrary_integer_param = luigi.IntParameter(default=10)
+            state = (None,None)
+            comp = False
+
+            def output(self):
+                return MockTarget("{0}-{1}-{2}".format(date_param,arbitrary_param,arbitrary_integer_param))
+
+            def complete(self):
+                return self.comp
+
+            def run(self):
+                self.comp = True
+                MyTask.state = (self.arbitrary_param,self.arbitrary_integer_param)
+
+        now = str(int(datetime_to_epoch(datetime.datetime(2015, 12, 2))))
+        self.run_locally(['RangeDailyBase','--of','wohoo.MyTask','--of-params','{"arbitrary_param":"bar","arbitrary_integer_param":5}','--now','{0}'.format(now),'--start','2015-12-01','--stop','2015-12-02'])
+        self.assertEqual(MyTask.state,('bar',5))


### PR DESCRIPTION
## Description
I've added "of_params" as an additional parameter on the RangeBase class. The approach is based on discussion with @Tarrasch 

## Motivation and Context
Please see issue from #1627 

## Have you tested this? If so, how?
I have included unit tests.

I have not yet tested this in our system, but I will do so if the maintainers think the approach used is fine and report back on the behavior.