### PR TITLE
Rename move copy functions added to FileSystem and FileSystemTarget child classes

### DIFF
--- a/luigi/file.py
+++ b/luigi/file.py
@@ -156,12 +156,7 @@ class LocalTarget(FileSystemTarget):
         self.fs.remove(self.path)
 
     def copy(self, new_path, raise_if_exists=False):
-        if raise_if_exists and os.path.exists(new_path):
-            raise RuntimeError('Destination exists: %s' % new_path)
-        tmp = LocalTarget(new_path + '-luigi-tmp-%09d' % random.randrange(0, 1e10), is_tmp=True)
-        tmp.makedirs()
-        shutil.copy(self.path, tmp.fn)
-        tmp.move(new_path)
+        self.fs.copy(self.path, new_path, raise_if_exists)
 
     @property
     def fn(self):

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -91,12 +91,6 @@ class LocalFileSystem(FileSystem):
         else:
             os.remove(path)
 
-    def rename(self, *args, **kwargs):
-        """
-        Calls ``move()``
-        """
-        self.move(*args, **kwargs)
-
     def move(self, old_path, new_path, raise_if_exists=False):
         if raise_if_exists and os.path.exists(new_path):
             raise RuntimeError('Destination exists: %s' % new_path)

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -49,6 +49,14 @@ class LocalFileSystem(FileSystem):
     Work in progress - add things as needed.
     """
 
+    def copy(self, old_path, new_path, raise_if_exists=False):
+        if raise_if_exists and os.path.exists(new_path):
+            raise RuntimeError('Destination exists: %s' % new_path)
+        d = os.path.dirname(new_path)
+        if d and not os.path.exists(d):
+            self.mkdir(d)
+        shutil.copy(old_path, new_path)
+
     def exists(self, path):
         return os.path.exists(path)
 
@@ -82,6 +90,12 @@ class LocalFileSystem(FileSystem):
             shutil.rmtree(path)
         else:
             os.remove(path)
+
+    def rename(self, *args, **kwargs):
+        """
+        Calls ``move()``
+        """
+        self.move(*args, **kwargs)
 
     def move(self, old_path, new_path, raise_if_exists=False):
         if raise_if_exists and os.path.exists(new_path):

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -81,12 +81,6 @@ class MockFileSystem(target.FileSystem):
         contents = self.get_all_data().pop(path)
         self.get_all_data()[dest] = contents
 
-    def rename(self, *args, **kwargs):
-        """
-        Calls Move to perform rename operation
-        """
-        self.move(*args, **kwargs)
-
     def listdir(self, path):
         """
         listdir does a prefix match of self.get_all_data(), but doesn't yet support globs.

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -72,12 +72,6 @@ class MockFileSystem(target.FileSystem):
         else:
             self.get_all_data().pop(path)
 
-    def rename(self, *args, **kwargs):
-        """
-        Calls Move to perform rename operation
-        """
-        self.move(*args, **kwargs)
-
     def move(self, path, dest, raise_if_exists=False):
         """
         Moves a single file from path to dest
@@ -86,6 +80,12 @@ class MockFileSystem(target.FileSystem):
             raise RuntimeError('Destination exists: %s' % path)
         contents = self.get_all_data().pop(path)
         self.get_all_data()[dest] = contents
+
+    def rename(self, *args, **kwargs):
+        """
+        Calls Move to perform rename operation
+        """
+        self.move(*args, **kwargs)
 
     def listdir(self, path):
         """
@@ -125,17 +125,17 @@ class MockTarget(target.FileSystemTarget):
     def exists(self,):
         return self._fn in self.fs.get_all_data()
 
-    def rename(self, path, raise_if_exists=False):
-        if raise_if_exists and path in self.fs.get_all_data():
-            raise RuntimeError('Destination exists: %s' % path)
-        contents = self.fs.get_all_data().pop(self._fn)
-        self.fs.get_all_data()[path] = contents
+    def move(self, path, raise_if_exists=False):
+        """
+        Call MockFileSystem's move command
+        """
+        self.fs.move(self._fn, path, raise_if_exists)
 
-    def move(self, *args, **kwargs):
+    def rename(self, *args, **kwargs):
         """
-        Call rename to move self
+        Call move to rename self
         """
-        self.rename(*args, **kwargs)
+        self.move(*args, **kwargs)
 
     @property
     def path(self):

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -37,6 +37,15 @@ class MockFileSystem(target.FileSystem):
     """
     _data = None
 
+    def copy(self, path, dest, raise_if_exists=False):
+        """
+        Copies the contents of a single file path to dest
+        """
+        if raise_if_exists and dest in self.get_all_data():
+            raise RuntimeError('Destination exists: %s' % path)
+        contents = self.get_all_data()[path]
+        self.get_all_data()[dest] = contents
+
     def get_all_data(self):
         # This starts a server in the background, so we don't want to do it in the global scope
         if MockFileSystem._data is None:
@@ -62,6 +71,21 @@ class MockFileSystem(target.FileSystem):
                 self.get_all_data().pop(s)
         else:
             self.get_all_data().pop(path)
+
+    def rename(self, *args, **kwargs):
+        """
+        Calls Move to perform rename operation
+        """
+        self.move(*args, **kwargs)
+
+    def move(self, path, dest, raise_if_exists=False):
+        """
+        Moves a single file from path to dest
+        """
+        if raise_if_exists and dest in self.get_all_data():
+            raise RuntimeError('Destination exists: %s' % path)
+        contents = self.get_all_data().pop(path)
+        self.get_all_data()[dest] = contents
 
     def listdir(self, path):
         """
@@ -106,6 +130,12 @@ class MockTarget(target.FileSystemTarget):
             raise RuntimeError('Destination exists: %s' % path)
         contents = self.fs.get_all_data().pop(self._fn)
         self.fs.get_all_data()[path] = contents
+
+    def move(self, *args, **kwargs):
+        """
+        Call rename to move self
+        """
+        self.rename(*args, **kwargs)
 
     @property
     def path(self):

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -440,12 +440,6 @@ class S3Client(FileSystem):
                 mp.cancel_upload()
             raise
 
-    def rename(self, *args, **kwargs):
-        """
-        Alias for ``move()``
-        """
-        self.move(*args, **kwargs)
-
     def move(self, source_path, destination_path, **kwargs):
         """
         Rename/move an object from one S3 location to another.

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -184,6 +184,21 @@ class FileSystem(object):
             raise FileAlreadyExists()
         self.move(path, dest)
 
+    def rename(self, *args, **kwargs):
+        """
+        Alias for ``move()``
+        """
+        self.move(*args, **kwargs)
+
+    def copy(self, path, dest):
+        """
+        Copy a file or a directory with contents.
+        Currently, LocalFileSystem and MockFileSystem support only single file
+        copying but S3Client copies either a file or a directory as required.
+        """
+        raise NotImplementedError("copy() not implemented on {0}".
+                                  format(self.__class__.__name__))
+
 
 class FileSystemTarget(Target):
     """

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -276,6 +276,15 @@ class FileSystemTest(unittest.TestCase):
     def tearDown(self):
         self.setUp()
 
+    def test_copy(self):
+        src = os.path.join(self.path, 'src.txt')
+        dest = os.path.join(self.path, 'newdir', 'dest.txt')
+
+        LocalTarget(src).open('w').close()
+        self.fs.copy(src, dest)
+        self.assertTrue(os.path.exists(src))
+        self.assertTrue(os.path.exists(dest))
+
     def test_mkdir(self):
         testpath = os.path.join(self.path, 'foo/bar')
 

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -64,8 +64,14 @@ class MockFileSystemTest(unittest.TestCase):
         self.fs.clear()
         self.path = "/tmp/foo"
         self.path2 = "/tmp/bar"
+        self.path3 = "/tmp/foobar"
         self._touch(self.path)
         self._touch(self.path2)
+
+    def test_copy(self):
+        self.fs.copy(self.path, self.path3)
+        self.assertTrue(self.fs.exists(self.path))
+        self.assertTrue(self.fs.exists(self.path3))
 
     def test_exists(self):
         self.assertTrue(self.fs.exists(self.path))
@@ -78,6 +84,11 @@ class MockFileSystemTest(unittest.TestCase):
         self.fs.remove("/tmp", recursive=True)
         self.assertFalse(self.fs.exists(self.path))
         self.assertFalse(self.fs.exists(self.path2))
+
+    def test_rename(self):
+        self.fs.rename(self.path, self.path3)
+        self.assertFalse(self.fs.exists(self.path))
+        self.assertTrue(self.fs.exists(self.path3))
 
     def test_listdir(self):
         self.assertEqual(sorted([self.path, self.path2]), sorted(self.fs.listdir("/tmp")))


### PR DESCRIPTION
## Description
Added/Edited copy, rename and move functions in LocalTarget, LocalFileSystem, MockTarget and MockFileSystem where I felt it would be suitable.

## Motivation and Context
While writing test cases for a rename function which would rename files in S3, I found that MockFileSystem did not have rename or move functions making writing appropriate tests a convoluted and error-prone process, especially when using the OpenerTarget class from luigi.contrib.opener. So, I chose to implement the above functions in file.py and mock.py (s3.py already had support for most functions) in order to present a uniform interface across classes which inherit from FileSystem and FileSystemTarget.

## Have you tested this? If so, how?
I have included 3 unit tests:
file_test.py:
test_copy()
mock_test.py:
test_copy()
test_rename()
All above test cases pass.