### PR TITLE
Fix inherits decorator docs.

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -158,7 +158,7 @@ inheritance.
         param_b = luigi.Parameter()
 
         def requires(self):
-            t = self.clone(TaskB)
+            t = self.clone(TaskA)  # or t = self.clone_parent()
 
             # Wait... whats this clone thingy do?
             #


### PR DESCRIPTION
## Description
Just a simple change to the description of how to use the `inherits` decorator. I think there was a bug in the class that's supplied as the argument to `clone` in the example used as the motivation for the `inherits`.

## Have you tested this? If so, how?
No tests required, since it's just the docs fix.

