### PR TITLE
Add "print task tree only" option to luigi

### DIFF
--- a/luigi/tools/deps_tree.py
+++ b/luigi/tools/deps_tree.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+This module parses commands exactly the same as the luigi task runner. You must specify the module, the task and task paramters.
+Instead of executing a task, this module prints the significant paramters and state of the task and its dependencies in a tree format.
+Use this to visualize the execution plan in the terminal.
+
+.. code-block:: none
+
+    $ luigi-deps-tree --module foo_complex examples.Foo
+    ...
+    └─--[Foo-{} (PENDING)]
+       |--[Bar-{'num': '0'} (PENDING)]
+       |  |--[Bar-{'num': '4'} (PENDING)]
+       |  └─--[Bar-{'num': '5'} (PENDING)]
+       |--[Bar-{'num': '1'} (PENDING)]
+       └─--[Bar-{'num': '2'} (PENDING)]
+          └─--[Bar-{'num': '6'} (PENDING)]
+             |--[Bar-{'num': '7'} (PENDING)]
+             |  |--[Bar-{'num': '9'} (PENDING)]
+             |  └─--[Bar-{'num': '10'} (PENDING)]
+             |     └─--[Bar-{'num': '11'} (PENDING)]
+             └─--[Bar-{'num': '8'} (PENDING)]
+                └─--[Bar-{'num': '12'} (PENDING)]
+"""
+
+from luigi.task import flatten
+from luigi.cmdline_parser import CmdlineParser
+import sys
+import warnings
+
+
+class bcolors:
+    '''
+    colored output for task status
+    '''
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    ENDC = '\033[0m'
+
+
+def print_tree(task, indent='', last=True):
+    '''
+    Return a string representation of the tasks, their statuses/parameters in a dependency tree format
+    '''
+    # dont bother printing out warnings about tasks with no output
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete\(\) method')
+        is_task_complete = task.complete()
+    is_complete = (bcolors.OKGREEN + 'COMPLETE' if is_task_complete else bcolors.OKBLUE + 'PENDING') + bcolors.ENDC
+    name = task.__class__.__name__
+    params = task.to_str_params(only_significant=True)
+    result = '\n' + indent
+    if(last):
+        result += '└─--'
+        indent += '   '
+    else:
+        result += '|--'
+        indent += '|  '
+    result += '[{0}-{1} ({2})]'.format(name, params, is_complete)
+    children = flatten(task.requires())
+    for index, child in enumerate(children):
+        result += print_tree(child, indent, (index+1) == len(children))
+    return result
+
+
+def main():
+    cmdline_args = sys.argv[1:]
+    with CmdlineParser.global_instance(cmdline_args) as cp:
+        task = cp.get_task_obj()
+        print(print_tree(task))
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             'luigid = luigi.cmdline:luigid',
             'luigi-grep = luigi.tools.luigi_grep:main',
             'luigi-deps = luigi.tools.deps:main',
+            'luigi-deps-tree = luigi.tools.deps_tree:main',
             'luigi-migrate = luigi.tools.migrate:main'
         ]
     },

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -302,6 +302,16 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         self.assertTrue(stdout.find(b'[FileSystem] data/streams_2015_03_04_faked.tsv') != -1)
         self.assertTrue(stdout.find(b'[DB] localhost') != -1)
 
+    def test_deps_tree_py_script(self):
+        """
+        Test the deps_tree.py script.
+        """
+        args = 'python luigi/tools/deps_tree.py --module examples.top_artists AggregateArtists --date-interval 2012-06'.split()
+        returncode, stdout, stderr = self._run_cmdline(args)
+        self.assertEqual(0, returncode)
+        for i in range(1, 30):
+            self.assertTrue(stdout.find(("-[Streams-{{'date': '2012-06-{0}'}}".format(str(i).zfill(2))).encode('utf-8')) != -1)
+
     def test_bin_mentions_misspelled_task(self):
         """
         Test that the error message is informative when a task is misspelled.


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Consider a debugging/review command-line option to print task dependency trees in a hypothetical run.
Basically, dont run the tasks, just print the current status so I know what will run.

`$ luigi --module dummy Task1 --local-scheduler --param1=foo --print-tree`
`|[Task1-{'param1': 'foo'} (COMPLETE)]`
`|----[Task2-{'param2': 'foo'} (COMPLETE)]`
`|--------[Task3-{'param3': 'foo'} (COMPLETE)]`
`|--------[Task4-{} (COMPLETE)]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
Well this isnt perfect yet. I need some help fitting this in to the proper place in the command line execution. 
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Sometimes when you're developing an ETL you want to view the tasks in a dependency tree and their state before you decide on what to execute.
By adding this --print-tree option, the task does not execute. It outputs the tree instead