### PR TITLE
#1685 Add support for multiple results in salesforce batch jobs

### DIFF
--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -181,14 +181,14 @@ class QuerySalesforce(Task):
                 # If there's only one result, just download it, otherwise we need to merge the resulting downloads
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
-                    with open(self.output().fn, 'w') as outfile:
+                    with open(self.output().path, 'w') as outfile:
                         outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
                     # Preferring to do it this way so as to minimize memory consumption.
                     for i, result_id in enumerate(result_ids):
                         logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
-                        with open("%s.%d" % (self.output().fn, i), 'w') as outfile:
+                        with open("%s.%d" % (self.output().path, i), 'w') as outfile:
                             outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
 
                     logger.info("Merging results of batch %s" % batch_id)
@@ -202,7 +202,7 @@ class QuerySalesforce(Task):
             data_file = sf.query_all(self.soql)
 
             reader = csv.reader(data_file)
-            with open(self.output().fn, 'w') as outfile:
+            with open(self.output().path, 'w') as outfile:
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
@@ -211,11 +211,11 @@ class QuerySalesforce(Task):
         """
         Merges the resulting files of a multi-result batch bulk query.
         """
-        outfile = open(self.output().fn, 'w')
+        outfile = open(self.output().path, 'w')
 
         if self.content_type == 'CSV':
             for i, result_id in enumerate(result_ids):
-                with open("%s.%d" % (self.output().fn, i), 'r') as f:
+                with open("%s.%d" % (self.output().path, i), 'r') as f:
                     header = f.readline()
                     if i == 0:
                         outfile.write(header)

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -175,6 +175,7 @@ class QuerySalesforce(Task):
 
                 with open(self.output().fn, 'w') as outfile:
                     for result_id in result_ids:
+                        logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
                         data = sf.get_batch_result(job_id, batch_id, result_id)
                         outfile.write(data)
         finally:

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -140,6 +140,11 @@ class QuerySalesforce(Task):
         """Override to True if soql property is a file path."""
         return False
 
+    @property
+    def content_type(self):
+        """Override to use a different content type. (e.g. XML)"""
+        return "CSV"
+
     def run(self):
         if self.use_sandbox and not self.sandbox_name:
             raise Exception("Parameter sf_sandbox_name must be provided when uploading to a Salesforce Sandbox")
@@ -173,11 +178,21 @@ class QuerySalesforce(Task):
             else:
                 result_ids = sf.get_batch_result_ids(job_id, batch_id)
 
-                with open(self.output().fn, 'w') as outfile:
-                    for result_id in result_ids:
-                        logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
-                        data = sf.get_batch_result(job_id, batch_id, result_id)
+                # If there's only one result, just download it, otherwise we need to merge the resulting downloads
+                if len(result_ids) == 1:
+                    data = sf.get_batch_result(job_id, batch_id, result_ids[0])
+                    with open(self.output().fn, 'w') as outfile:
                         outfile.write(data)
+                else:
+                    # Download each file to disk, and then merge into one.
+                    # Preferring to do it this way so as to minimize memory consumption.
+                    for i, result_id in enumerate(result_ids):
+                        logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
+                        with open("%s.%d" % (self.output().fn, i), 'w') as outfile:
+                            outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
+
+                    logger.info("Merging results of batch %s" % batch_id)
+                    self.merge_batch_results(result_ids)
         finally:
             logger.info("Closing job %s" % job_id)
             sf.close_job(job_id)
@@ -191,6 +206,25 @@ class QuerySalesforce(Task):
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
+
+    def merge_batch_results(self, result_ids):
+        """
+        Merges the resulting files of a multi-result batch bulk query.
+        """
+        outfile = open(self.output().fn, 'w')
+
+        if self.content_type == 'CSV':
+            for i, result_id in enumerate(result_ids):
+                with open("%s.%d" % (self.output().fn, i), 'r') as f:
+                    header = f.readline()
+                    if i == 0:
+                        outfile.write(header)
+                    for line in f:
+                        outfile.write(line)
+        else:
+            raise Exception("Batch result merging not implemented for %s" % self.content_type)
+
+        outfile.close()
 
 
 class SalesforceAPI(object):
@@ -356,15 +390,17 @@ class SalesforceAPI(object):
         else:
             return json_result
 
-    def create_operation_job(self, operation, obj, external_id_field_name=None, content_type='CSV'):
+    def create_operation_job(self, operation, obj, external_id_field_name=None, content_type=None):
         """
         Creates a new SF job that for doing any operation (insert, upsert, update, delete, query)
 
         :param operation: delete, insert, query, upsert, update, hardDelete. Must be lowercase.
         :param obj: Parent SF object
         :param external_id_field_name: Optional.
-        :param content_type: XML, CSV, ZIP_CSV, or ZIP_XML. Defaults to CSV
         """
+        if content_type is None:
+            content_type = self.content_type
+
         if not self.has_active_session():
             self.start_session()
 
@@ -422,7 +458,7 @@ class SalesforceAPI(object):
 
         return response
 
-    def create_batch(self, job_id, data, file_type='csv'):
+    def create_batch(self, job_id, data, file_type=None):
         """
         Creates a batch with either a string of data or a file containing data.
 
@@ -432,12 +468,14 @@ class SalesforceAPI(object):
 
         :param job_id: job_id as returned by 'create_operation_job(...)'
         :param data:
-        :param file_type:
 
         :return: Returns batch_id
         """
         if not job_id or not self.has_active_session():
             raise Exception("Can not create a batch without a valid job_id and an active session.")
+
+        if file_type is None:
+            file_type = self.content_type.lower()
 
         headers = self._get_create_batch_content_headers(file_type)
         headers['Content-Length'] = len(data)

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -135,10 +135,6 @@ class MockTarget(target.FileSystemTarget):
     def path(self):
         return self._fn
 
-    @property
-    def fn(self):
-        return self._fn
-
     def open(self, mode):
         fn = self._fn
         mock_target = self

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -135,6 +135,10 @@ class MockTarget(target.FileSystemTarget):
     def path(self):
         return self._fn
 
+    @property
+    def fn(self):
+        return self._fn
+
     def open(self, mode):
         fn = self._fn
         mock_target = self

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -114,4 +114,4 @@ class TestSalesforceQuery(unittest.TestCase):
         qsf = TestQuerySalesforce()
 
         qsf.merge_batch_results(self.result_ids)
-        self.assertEqual(MockTarget(qsf.output().fn).open('r').read(), self.all_lines)
+        self.assertEqual(MockTarget(qsf.output().path).open('r').read(), self.all_lines)

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Simply Measured
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# This method will be used by the mock to replace requests.get
+
+"""
+Unit test for the Salesforce contrib package
+"""
+
+import luigi
+from luigi.contrib.salesforce import SalesforceAPI
+
+from helpers import unittest
+import mock
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, body, status_code):
+            self.body = body
+            self.status_code = status_code
+
+        @property
+        def text(self):
+            return self.body
+
+        def raise_for_status(self):
+            return None
+
+    return MockResponse('<result-list xmlns="http://www.force.com/2009/06/asyncapi/dataload"><result>1234</result><result>1235</result><result>1236</result></result-list>', 200)
+
+class TestSalesforceAPI(unittest.TestCase):
+    # We patch 'requests.get' with our own method. The mock object is passed in to our test case method.
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    def test_deprecated_results(self, mock_get):
+        sf = SalesforceAPI('xx', 'xx', 'xx')
+        result_id = sf.get_batch_results('job_id', 'batch_id')
+        self.assertEqual('1234', result_id)
+
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    def test_result_ids(self, mock_get):
+        sf = SalesforceAPI('xx', 'xx', 'xx')
+        result_ids = sf.get_batch_result_ids('job_id', 'batch_id')
+        self.assertEqual(['1234', '1235', '1236'], result_ids)

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -24,9 +24,9 @@ from luigi.contrib.salesforce import SalesforceAPI, QuerySalesforce
 
 from helpers import unittest
 import mock
-import re
-import sys
 from luigi.mock import MockTarget
+from luigi.six import PY3
+import re
 
 
 def mocked_requests_get(*args, **kwargs):
@@ -90,7 +90,7 @@ class TestQuerySalesforce(QuerySalesforce):
 
 class TestSalesforceQuery(unittest.TestCase):
     patch_name = '__builtin__.open'
-    if sys.version_info.major > 2:
+    if PY3:
         patch_name = 'builtins.open'
 
     @mock.patch(patch_name, side_effect=mocked_open)

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -109,5 +109,4 @@ class TestSalesforceQuery(unittest.TestCase):
         qsf = TestQuerySalesforce()
 
         qsf.merge_batch_results(self.result_ids)
-        print qsf.output().fn
         self.assertEqual(MockTarget(qsf.output().fn).open('r').read(), self.all_lines)

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -25,6 +25,7 @@ from luigi.contrib.salesforce import SalesforceAPI, QuerySalesforce
 from helpers import unittest
 import mock
 import re
+import sys
 from luigi.mock import MockTarget
 
 
@@ -88,7 +89,11 @@ class TestQuerySalesforce(QuerySalesforce):
 
 
 class TestSalesforceQuery(unittest.TestCase):
-    @mock.patch('__builtin__.open', side_effect=mocked_open)
+    patch_name = '__builtin__.open'
+    if sys.version_info.major > 2:
+        patch_name = 'builtins.open'
+
+    @mock.patch(patch_name, side_effect=mocked_open)
     def setUp(self, mock_open):
         MockTarget.fs.clear()
         self.result_ids = ['a', 'b', 'c']
@@ -104,7 +109,7 @@ class TestSalesforceQuery(unittest.TestCase):
                 self.all_lines += line+"\n"
                 counter += 2
 
-    @mock.patch('__builtin__.open', side_effect=mocked_open)
+    @mock.patch(patch_name, side_effect=mocked_open)
     def test_multi_csv_download(self, mock_open):
         qsf = TestQuerySalesforce()
 

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -20,11 +20,11 @@
 Unit test for the Salesforce contrib package
 """
 
-import luigi
 from luigi.contrib.salesforce import SalesforceAPI
 
 from helpers import unittest
 import mock
+
 
 def mocked_requests_get(*args, **kwargs):
     class MockResponse:
@@ -39,7 +39,13 @@ def mocked_requests_get(*args, **kwargs):
         def raise_for_status(self):
             return None
 
-    return MockResponse('<result-list xmlns="http://www.force.com/2009/06/asyncapi/dataload"><result>1234</result><result>1235</result><result>1236</result></result-list>', 200)
+    result_list = (
+        '<result-list xmlns="http://www.force.com/2009/06/asyncapi/dataload">'
+        '<result>1234</result><result>1235</result><result>1236</result>'
+        '</result-list>'
+    )
+    return MockResponse(result_list, 200)
+
 
 class TestSalesforceAPI(unittest.TestCase):
     # We patch 'requests.get' with our own method. The mock object is passed in to our test case method.


### PR DESCRIPTION
Addresses #1685 by adding support to fetch multiple results from a single Salesforce batch job.

## Open Items

- [x] Merge downloaded files

## Description
- New `get_batch_result_ids` method that is more accurately documented
- Backwards compatible `get_batch_results` method, including warning message
- Small set of tests for the changes

## Motivation and Context
Fixes #1685 

## Have you tested this? If so, how?
Included unit tests as well as verified locally.