### PR TITLE
allow sftp default port 22 to be overridden

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -45,17 +45,21 @@ logger = logging.getLogger('luigi-interface')
 
 class RemoteFileSystem(luigi.target.FileSystem):
 
-    def __init__(self, host, username=None, password=None, port=21, tls=False, timeout=60, sftp=False):
+    def __init__(self, host, username=None, password=None, port=None, tls=False, timeout=60, sftp=False):
         self.host = host
         self.username = username
         self.password = password
-        self.port = port
         self.tls = tls
         self.timeout = timeout
         self.sftp = sftp
 
-        if self.sftp:
-            self.port = 22
+        if port is None:
+            if self.sftp:
+                self.port = 22
+            else:
+                self.port = 21
+        else:
+            self.port = port
 
     def _connect(self):
         """
@@ -347,7 +351,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
 
     def __init__(
         self, path, host, format=None, username=None,
-        password=None, port=21, mtime=None, tls=False,
+        password=None, port=None, mtime=None, tls=False,
         timeout=60, sftp=False
     ):
         if format is None:


### PR DESCRIPTION
## Description
The ftp remote target defaults to port 21 and allows it to be changed.
If sftp is needed, it changes the port to 22 and does not allow it to be changed.

See https://github.com/spotify/luigi/issues/1688

This pull request keeps the intended behavior by defaulting to 21 or 22 but also allows both to be overridden in such a way that it is not a breaking change.

## Motivation
I have to pull files from a non-default sftp port of 522 but cannot.
## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.


