### PR TITLE
[WIP] Add docker image build task

### DIFF
--- a/examples/docker_build.py
+++ b/examples/docker_build.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+import luigi
+import luigi.contrib
+import luigi.contrib.docker
+import os
+
+
+class Dockerfile(luigi.Task):
+    context_path = luigi.Parameter(default='.')
+
+    def run(self):
+        if not os.path.exists(self.context_path):
+            os.makedirs(self.context_path)
+        with self.output().open('w') as f:
+            f.write('FROM alpine\n')
+            f.write('RUN apk update && apk add git\n')
+
+    def output(self):
+        return luigi.LocalTarget('%s/Dockerfile' % self.context_path)
+
+
+class BuildImage(luigi.contrib.docker.DockerImageBuildTask):
+    def requires(self):
+        return [Dockerfile(context_path=self.path)]
+
+if __name__ == '__main__':
+    luigi.build([BuildImage(name='luigi-built-image', path='build/context')], local_scheduler=True)

--- a/examples/docker_run.py
+++ b/examples/docker_run.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import luigi
+import luigi.contrib
+import luigi.contrib.docker
+
+
+class DockerHelloWorld(luigi.contrib.docker.DockerTask):
+
+    @property
+    def command(self):
+        return [{
+            'command': ['echo', 'hello world'],
+        }]
+
+if __name__ == '__main__':
+    luigi.build([DockerHelloWorld(image='alpine:3.1', remove=True, remove_volumes=True)], local_scheduler=True)

--- a/luigi/contrib/docker.py
+++ b/luigi/contrib/docker.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Thibault JAMET
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Docker build library.
+
+Allow having docker image build tasks within luigi.
+This contrib uses the official python docker client to be installed
+with `pip install docker-py`
+
+:class:`DockerClient` is meant to provide a docker client
+to sub classes through the `client` attribute
+
+:class:`DockerImageTarget` is meant to provide a target ensuring
+that <image_name> is available on the docker_host
+
+:class:`DockerImageBuildTask` is meant to provide a task being responsible
+for building a docker image
+
+
+.. _docker-cli: https://docs.docker.com/engine/reference/commandline/cli/
+.. _docker-py: http://docker-py.readthedocs.io/en/stable/api/
+.. _docker-py-create-container: http://docker-py.readthedocs.io/en/stable/api/#create_container
+"""
+
+from __future__ import absolute_import
+
+import logging
+import luigi
+import luigi.target
+
+logger = logging.getLogger('luigi-interface')
+
+try:
+    import docker
+    import docker.errors
+    import docker.utils
+except ImportError:
+    logger.warning('docker-py is not installed. Please run `pip install docker-py` to run Docker tasks')
+
+
+class DockerClient(object):
+    """
+    A base class to provide shared docker client definition
+    """
+
+    @property
+    def client(self):
+        """
+        An instance of docker client matching docker-py_ interface
+
+        """
+        params = docker.utils.kwargs_from_env(assert_hostname=False)
+        host = self.docker_host
+
+        if host:
+            params['base_url'] = host
+        try:
+            self._client
+        except AttributeError:
+            self._client = docker.Client(**params)
+        return self._client
+
+
+class DockerImageTarget(DockerClient, luigi.target.Target):
+    """
+    Target for a docker image
+    """
+
+    def __init__(self, name, tag='latest', registry=None, docker_host=None):
+        """
+        :param name: (str) Base name of the image to be built
+        :param tag: (str) Tag applied to the image (defaults to 0)
+        :param registry: (str) Registry where the image is hosted (defaults to None)
+        :param docker_host: (str) Address of the docker socket
+            Note: neither TLS nor version selection are supported yet
+            See docker-cli_
+            and docker-py_
+            for more information
+
+        """
+        self.docker_host = docker_host
+        self.name = name
+        self.tag = tag
+        self.registry = registry
+
+    @property
+    def image_name(self):
+        if self.registry:
+            return "%s/%s:%s" % (self.registry, self.name, self.tag)
+        else:
+            return "%s:%s" % (self.name, self.tag)
+
+    def exists(self):
+        """
+        Checks the existence of the image on the docker host
+        """
+        try:
+            self.client.inspect_image(self.image_name)
+            return True
+        except docker.errors.NotFound:
+            return False
+
+
+class DockerImageBuildTask(DockerClient, luigi.Task):
+    """
+    Task building a docker image
+    
+    :param name:
+        The name of the built image without
+        registry and tag.
+    
+    :param tag:
+        The image tag to be built.
+    
+    :param registry:
+        The registry on which the image should
+        be tagged.
+    
+    :param dockerfile:
+        Path of the Dockerfile within the build context.
+        It is the `Dockerfile.mine` of 
+        `docker build -t <...> -f Dockerfile.mine .`
+    
+    :param path:
+        Path of the build context.
+        It is the `.` of `docker build -t <...> .`
+
+    :param docker_host: the address of the docker socket
+        defaults to None to use docker defaults
+        example::
+
+            tcp://localhost:2375
+    """
+    name = luigi.Parameter()
+    tag = luigi.Parameter(default='latest')
+    registry = luigi.Parameter(default='')
+    dockerfile = luigi.Parameter(default='Dockerfile')
+    path = luigi.Parameter(default='.')
+    docker_host = luigi.Parameter(default=None)
+
+    def output(self):
+        return DockerImageTarget(self.name, tag=self.tag, registry=self.registry)
+
+    def run(self):
+        kwds = docker.utils.kwargs_from_env(assert_hostname=False)
+        client = docker.Client(**kwds)
+        client.build(
+            path=self.path,
+            tag=self.output().image_name,
+            dockerfile=self.dockerfile
+        )

--- a/test/contrib/docker_test.py
+++ b/test/contrib/docker_test.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Thibault JAMET
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for the Luigi Docker wrapper.
+
+Requires:
+
+- docker-py package
+"""
+
+import logging
+import mock
+import unittest
+import uuid
+
+import luigi
+from luigi.contrib.docker import DockerImageTarget, DockerImageBuildTask
+
+logger = logging.getLogger('luigi-interface')
+
+try:
+    import docker
+    import docker.utils
+    import docker.errors
+except ImportError:
+    no_docker = True
+    logger.warning("Failed to import docker, will run mocked tests only")
+else:
+    try:
+        client = docker.Client(**docker.utils.kwargs_from_env(assert_hostname=False))
+        no_docker = False
+    except docker.errors.Exception:
+        no_docker = True
+        logger.warning("Failed to connect to docker, will run mocked tests only")
+
+
+class DummyNotFound(Exception):
+    def __init__(self):
+        pass
+
+
+class DockerMocked(object):
+    """
+    Adds some minimal non-regression tests even if
+    no docker host can be reached. In such a case,
+    expect the docker API to behave exactly as desribed
+    in the documentation
+    """
+
+    def setUp(self):
+        self.client = mock.MagicMock()
+        self.docker = mock.MagicMock()
+        self.docker.errors = mock.MagicMock()
+        self.docker.errors.NotFound = DummyNotFound
+        self.docker.utils = mock.MagicMock()
+        self.docker.Client.return_value = self.client
+        self.patches = []
+        self.patches.append(mock.patch.dict('sys.modules', docker=self.docker))
+        for patch in self.patches:
+            patch.start()
+        reload(luigi.contrib.docker)
+
+    def tearDown(self):
+        for patch in self.patches:
+            patch.stop()
+        reload(luigi.contrib.docker)
+
+
+class TestDockerImageTarget(DockerMocked, unittest.TestCase):
+
+    def test_exists(self):
+
+        self.docker.utils.kwargs_from_env.return_value = {}
+        self.client.inspect_image.return_value = {}
+
+        target = luigi.contrib.docker.DockerImageTarget('dummy name')
+        self.assertTrue(target.exists())
+
+        self.client.inspect_image.side_effect = DummyNotFound
+        self.assertFalse(target.exists())
+
+    def test_image_name(self):
+        target = DockerImageTarget("some.name")
+        self.assertEquals(target.image_name, "some.name:latest")
+        target = DockerImageTarget("some.other.name", tag="tagged")
+        self.assertEquals(target.image_name, "some.other.name:tagged")
+
+        target = DockerImageTarget("some.name", registry="my.docker-registry")
+        self.assertEquals(target.image_name, "my.docker-registry/some.name:latest")
+        target = DockerImageTarget("some.other.name", tag="tagged", registry="my.docker-registry")
+        self.assertEquals(target.image_name, "my.docker-registry/some.other.name:tagged")
+
+
+class TestDockerImageBuildTask(DockerMocked, unittest.TestCase):
+
+    def test_run(self):
+        DockerImageBuildTask(name='my.image').run()
+        self.client.build.assert_called_once_with(path='.', tag='my.image:latest', dockerfile='Dockerfile')
+        self.client.build.reset_mock()
+
+        DockerImageBuildTask(name='my.image', dockerfile='other').run()
+        self.client.build.assert_called_once_with(path='.', tag='my.image:latest', dockerfile='other')
+        self.client.build.reset_mock()
+
+        DockerImageBuildTask(name='my.image', dockerfile='other', path='/build-root').run()
+        self.client.build.assert_called_once_with(path='/build-root', tag='my.image:latest', dockerfile='other')
+        self.client.build.reset_mock()
+
+
+@unittest.skipIf(no_docker, "Failed to import/connect to docker")
+class TestDockerImageTargetIntegration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # In case there is no docker client (the default in CI),
+        # tests will be marked as skept but the setup seems sot be
+        # done anyway. Prevent from client not found exception
+        cls.pulled = False
+        if not no_docker:
+            for image in client.images():
+                cls.image_id = image['Id']
+                break
+            else:
+                cls.pulled = True
+                client.pull('alpine:3.1')
+                cls.image_id = client.inspect_image('alpine:3.1')['Id']
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.pulled:
+            client.remove_image(cls.image_id)
+
+    def setUp(self):
+        self.image_name = str(uuid.uuid1())
+        self.registry = str(uuid.uuid1())
+        self.tag = str(uuid.uuid1())
+
+    def tearDown(self):
+        for name in [
+            "%s/%s:%s" % (self.registry, self.image_name, self.tag),
+            "%s:%s" % (self.image_name, self.tag),
+            "%s/%s" % (self.registry, self.image_name),
+            self.image_name,
+        ]:
+            try:
+                client.remove_image(name)
+            except docker.errors.NotFound:
+                pass
+
+    def test_non_existing_image(self):
+        self.assertFalse(DockerImageTarget(self.image_name).exists())
+        self.assertFalse(DockerImageTarget(self.image_name, tag=self.tag).exists())
+        self.assertFalse(DockerImageTarget(self.image_name, registry=self.registry).exists())
+        self.assertFalse(DockerImageTarget(self.image_name, registry=self.registry, tag=self.tag).exists())
+
+    def test_existing_image(self):
+        client.tag(self.image_id, self.image_name)
+        client.tag(self.image_id, self.image_name, self.tag)
+        client.tag(self.image_id, "%s/%s" % (self.registry, self.image_name))
+        client.tag(self.image_id, "%s/%s" % (self.registry, self.image_name), self.tag)
+        self.assertTrue(DockerImageTarget(self.image_name).exists())
+        self.assertTrue(DockerImageTarget(self.image_name, tag=self.tag).exists())
+        self.assertTrue(DockerImageTarget(self.image_name, registry=self.registry).exists())
+        self.assertTrue(DockerImageTarget(self.image_name, registry=self.registry, tag=self.tag).exists())


### PR DESCRIPTION
Add docker support to luigi tasks
## Motivation and Context

As far as I have seen, currently, the only way to run tasks in docker container or build images is to implement it your way.
I think it would be nice to add a native support of such a feature.
Currently, a very first idea is to add a task to build a docker image.
Then, inspired on ssh module, remote file system and task run will be added if the suggestion is encouraged
## Have you tested this? If so, how?

There is currently an example running it.
I will be happy to add unittests as soon as the feature suggestion is encouraged
