### PR TITLE
Uses more thorough pid check for locking

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -42,7 +42,7 @@ def getpcmd(pid):
                 _, val = lines
                 return val
     else:
-        cmd = 'ps -o pid,args'
+        cmd = 'ps -xo pid,args'
         with os.popen(cmd, 'r') as p:
             # Skip the column titles
             p.readline()


### PR DESCRIPTION
## Description
Adds `-x` to the `ps` command used in lock.py for checking the command used to run the current process.

## Motivation and Context
I was recently having issues where my jobs started failing once I scheduled them in cron jobs on an osx machine. After investigating, I eventually found that the PID wasn't being found using the standard `ps` command. Adding `-x` includes processes that don't have a controlling terminal, fixing my issue.

## Have you tested this? If so, how?
I ran this on the machine that was having trouble and it fixed my problems. I also verified that the `-x` option is available on my Ubuntu machines. Not sure how to check its universality though.