### PR TITLE
Fixes Sphinx version for docs to 1.3b1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,7 @@ except ImportError:
     pass
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, node, *args, **kwargs):
     """
     Mute warnings that are like ``WARNING: nonlocal image URI found: https://img. ...``
 
@@ -62,7 +62,7 @@ def _warn_node(self, msg, node):
     http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
     """
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        self._warnfunc(msg, '%s:%s' % get_source_line(node), *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands = isort -w 120 -rc luigi test examples bin
 # Call this using `tox -e docs`.
 deps =
   sqlalchemy
-  Sphinx>=1.3b1
+  Sphinx==1.3b1
   sphinx_rtd_theme
 commands =
     # build API docs


### PR DESCRIPTION
## Description
Changes Sphinx requirement for docs from `Sphinx>=1.3b1` to `Sphinx==1.3b1` and updates the sphinx warn_node override to better match the function signature in newer versions.

## Motivation and Context
The docs test is currently broken because it's incompatible with the latest version of Sphinx. By fixing Sphinx to an exact version number, we avoid picking up a newer version that breaks everything. By also fixing the bug that broke the newer version, we can use a newer version if we choose.

## Have you tested this? If so, how?
I ran the doc test and it succeeded with the lower version with and without the bugfix and with the latest version with the bug fix.