### PR TITLE
Aws session token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,6 @@ or held presentations about Luigi:
 * `enbrite.ly <http://enbrite.ly/>`_
 * `Dow Jones / The Wall Street Journal <http://wsj.com>`_
 * `Hotels.com <https://hotels.com>`_
-* `Simulmedia <http://www.simulmedia.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 

--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,7 @@ or held presentations about Luigi:
 * `enbrite.ly <http://enbrite.ly/>`_
 * `Dow Jones / The Wall Street Journal <http://wsj.com>`_
 * `Hotels.com <https://hotels.com>`_
+* `Simulmedia <http://www.simulmedia.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION
## Description
I added the ability to optionally set a [session token parameter](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) when loading an S3 file into a Redshift table, similar to how one can set the `aws_access_key_id` and the `aws_secret_access_key`.

## Motivation and Context
I was not able to use the `S3CopyToTable` or `S3CopyJSONToTable` because my credentials require an AWS session token.

In both the above classes I added a function `aws_session_token` and changed the credentials string. If `aws_session_token` is set, then `;token=<aws session token>` is appended to the credentials string. If not, then the string will stay the same as it was before.

## Have you tested this? If so, how?
I ran this locally and it worked for me.
