### PR TITLE
Only validate S3 buckets if checking for the root path

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -121,7 +121,7 @@ class S3Client(FileSystem):
         (bucket, key) = self._path_to_bucket_and_key(path)
 
         # grab and validate the bucket
-        s3_bucket = self.s3.get_bucket(bucket, validate=True)
+        s3_bucket = self.s3.get_bucket(bucket, validate=self._is_root(key))
 
         # root always exists
         if self._is_root(key):


### PR DESCRIPTION
With the current behaviour, even if Luigi only needs to check the existence of some object in a bucket, it will actually validate twice, unnecessarily: once with `validate=True` on the bucket, and then again when getting the key from the bucket object (since `validate=True` is the default for the `get_key()` call).

This is not only unnecessary from a performance standpoint, it actually causes problems with IAM permissions. It's common for a policy to restrict `LIST` access on the bucket root but still allow read/write on some sub-path. With the way things are now, you _need_ to have read access to the root bucket even if Luigi only ever accesses a subpath, since that first validation on the bucket will fail with a 403.

With this fix, if you're calling `.exists()` on a bucket root, nothing changes, everything works as before. But if you call it on a non-root path, it will skip validation on bucket creation and only validate the key. If the bucket happens to not exist (which is what `.get_bucket(validate=True)` is meant to check for) then it will still fail on `.get_key()`. If it does exist, then we've avoided an unnecessary API call and permission issue.

**Testing results**: Incoming
