### PR TITLE
Ensure DictParameter's are normalized to FrozenOrderedDict

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -786,6 +786,12 @@ class DictParameter(Parameter):
                 return obj.get_wrapped()
             return json.JSONEncoder.default(self, obj)
 
+    def normalize(self,value):
+        """
+        Ensure that dictionary parameter is converted to a FrozenOrderedDict so it can be JSON serialized.
+        """
+        return FrozenOrderedDict(value)
+
     def parse(self, s):
         """
         Parses an immutable and ordered ``dict`` from a JSON string using standard JSON library.

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -786,9 +786,9 @@ class DictParameter(Parameter):
                 return obj.get_wrapped()
             return json.JSONEncoder.default(self, obj)
 
-    def normalize(self,value):
+    def normalize(self, value):
         """
-        Ensure that dictionary parameter is converted to a FrozenOrderedDict so it can be JSON serialized.
+        Ensure that dictionary parameter is converted to a FrozenOrderedDict so it can be hashed.
         """
         return FrozenOrderedDict(value)
 


### PR DESCRIPTION
## Description
I normalized dict parameters to instances of Frozen Ordered Dict's

## Motivation and Context
There was an outstanding bug

## Have you tested this? If so, how?
I have included unit tests

Closes #1657