### PR TITLE
Fix RemoteFileSystem._ftp_exists once more

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -131,14 +131,11 @@ class RemoteFileSystem(luigi.target.FileSystem):
         return exists
 
     def _ftp_exists(self, path, mtime):
-        path_parts = path.split('/')
-        path = '/'.join(path_parts[:-1])
-        fn = path_parts[-1]
-
-        files = self.conn.nlst(path)
+        dirname = os.path.dirname(path)
+        files = self.conn.nlst(dirname)
 
         exists = False
-        if fn in files:
+        if path in files:
             if mtime:
                 mdtm = self.conn.sendcmd('MDTM ' + path)
                 modified = datetime.datetime.strptime(mdtm[4:], "%Y%m%d%H%M%S")


### PR DESCRIPTION
## Motivation and Context

Commit bdfd225 from PR  #1602 breaks _ftp_exists. The problem is that nlist(path)
returns a list of paths starting with path.

E.g.

```python
In [40]: conn.nlst()
Out[40]: ['public', 'pub', 'ietf', 'apnic', 'uploads', 'welcome.msg']

In [41]: conn.nlst('pub/stats')
Out[41]:
['pub/stats/lacnic',
 'pub/stats/ripe-ncc',
 'pub/stats/iana',
 'pub/stats/afrinic',
 'pub/stats/apnic',
 'pub/stats/arin']
```

The test `fn in files` will always be false since fn is only the basename of
the path.

Also, conn.sendcmd('MDTM ' + path) will fail if path is a not a regular file.
This is never triggered because the above test always fails.

## Have you tested this? If so, how?

Works for me.
