### PR TITLE
Can yield (not return) a list of tasks.

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -156,7 +156,7 @@ Sometimes you might not know exactly what other tasks to depend on until runtime
 In that case, Luigi provides a mechanism to specify dynamic dependencies.
 If you yield another :class:`~luigi.task.Task` in the Task.run_ method,
 the current task will be suspended and the other task will be run.
-You can also return a list of tasks.
+You can also yield a list of tasks.
 
 .. code:: python
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Returning tasks from run(), even in a list, does not add dependencies.  yield does.

## Description
<!--- Describe your changes -->
Clarifying the documentation to specify the proper mechanism by which to add dynamic dependencies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The documentation is incorrect.
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I tested with the following cases.  TestYieldTask performs as desired.  TestRunTask does not.
```
class TestYieldTask(DoDynDepTestTask):

    def run(_s):
        yield [ DynDepBTestTask(), DynDepCTestTask(), ]
        super().run()
```
```
class TestRunTask(DoDynDepTestTask):

    def run(_s):
        super().run()
        return [ DynDepBTestTask(), DynDepCTestTask(), ]
```