### PR TITLE
Correct docs for Range.of-params

### DIFF
--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -108,7 +108,7 @@ and passes any parameters onwards for this purpose.
 
 .. code-block:: console
 
-	luigi RangeDaily --of MyTask --start 2014-10-31 --of-param '{"my-param": 123}'
+	luigi RangeDaily --of MyTask --start 2014-10-31 --of-params '{"my_string_param": "123", "my_int_param": 123}'
 
 Alternatively, you can specify parameters at the task family level (as described :ref:`here <Parameter-class-level-parameters>`),
 however these will not appear in the task name for the upstream Range task which


### PR DESCRIPTION
This is a fix up for #1675

I used this as reference https://github.com/spotify/luigi/pull/1675/files#diff-bcfedf11b58a3378d447759fcaf6c843R837