### PR TITLE
Adding release step for Debian packages.

### DIFF
--- a/RELEASE-PROCESS.rst
+++ b/RELEASE-PROCESS.rst
@@ -1,9 +1,11 @@
 For maintainers of luigi, who have push access to pypi. Here's how you upload
 luigi to pypi.
 
-     1. Update version number in setup.py, if needed. Commit and push.
-     2. pypi (Executing ``python setup.py sdist upload``)
-     3. Add tag on github (https://github.com/spotify/luigi/releases), including changelog
+     1. Update version number in setup.py, if needed.
+     2. Update version number in debian/changelog
+     3. Commit and push.
+     4. pypi (Executing ``python setup.py sdist upload``)
+     5. Add tag on github (https://github.com/spotify/luigi/releases), including changelog
 
 If you know a better way, please say so! I'm (arash) not used to releasing code
 to pypi!


### PR DESCRIPTION
Debian packages build with the version number in the debian/changelog
file.  The 2.1.1 release and probably others have a version number of
0.0 in that file, so if you grab the release and do a "debuild" you get
a package of version 0.0.