### PR TITLE
Added tests for hashing parameters except ListParameter

### DIFF
--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -286,6 +286,85 @@ class ParameterTest(LuigiTestCase):
         self.assertEqual(b_tuple, a.parse(a.serialize(b_tuple)))
 
 
+class TestParametersHashability(LuigiTestCase):
+    def test_date(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.DateParameter()
+        p = luigi.parameter.DateParameter()
+        self.assertEqual(hash(Foo(args=datetime.date(2000, 1, 1)).args), hash(p.parse('2000-1-1')))
+
+    def test_dateminute(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.DateMinuteParameter()
+        p = luigi.parameter.DateMinuteParameter()
+        self.assertEqual(hash(Foo(args=datetime.datetime(2000, 1, 1, 12, 0)).args), hash(p.parse('2000-1-1T1200')))
+
+    def test_dateinterval(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.DateIntervalParameter()
+        p = luigi.parameter.DateIntervalParameter()
+        di = luigi.date_interval.Custom(datetime.date(2000, 1, 1), datetime.date(2000, 2, 12))
+        self.assertEqual(hash(Foo(args=di).args), hash(p.parse('2000-01-01-2000-02-12')))
+
+    def test_timedelta(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.TimeDeltaParameter()
+        p = luigi.parameter.TimeDeltaParameter()
+        self.assertEqual(hash(Foo(args=datetime.timedelta(days=2, hours=3, minutes=2)).args), hash(p.parse('P2DT3H2M')))
+
+    def test_boolean(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.BoolParameter()
+
+        p = luigi.parameter.BoolParameter()
+        self.assertEqual(hash(Foo(args=True).args), hash(p.parse('true')))
+
+    def test_int(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.IntParameter()
+
+        p = luigi.parameter.IntParameter()
+        self.assertEqual(hash(Foo(args=1).args), hash(p.parse('1')))
+
+    def test_float(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.FloatParameter()
+
+        p = luigi.parameter.FloatParameter()
+        self.assertEqual(hash(Foo(args=1.0).args), hash(p.parse('1')))
+
+    def test_enum(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.EnumParameter(enum=MyEnum)
+
+        p = luigi.parameter.EnumParameter(enum=MyEnum)
+        self.assertEqual(hash(Foo(args=MyEnum.A).args), hash(p.parse('A')))
+
+    def test_dict(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.DictParameter()
+
+        p = luigi.parameter.DictParameter()
+        self.assertEqual(hash(Foo(args=dict(foo=1, bar="hello")).args), hash(p.parse('{"foo":1,"bar":"hello"}')))
+
+    def test_tuple(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.TupleParameter()
+
+        p = luigi.parameter.TupleParameter()
+        self.assertEqual(hash(Foo(args=(1, "hello")).args), hash(p.parse('(1,"hello")')))
+
+    def test_task(self):
+        class Bar(luigi.Task):
+            pass
+
+        class Foo(luigi.Task):
+            args = luigi.parameter.TaskParameter()
+
+        p = luigi.parameter.TaskParameter()
+        self.assertEqual(hash(Foo(args=Bar).args), hash(p.parse('Bar')))
+
+
 class TestNewStyleGlobalParameters(LuigiTestCase):
 
     def setUp(self):


### PR DESCRIPTION
ListParameter cannot be hashed. This may or may not be a problem.

Meant to add this for the other PR. Lists can't be hashed of course. Not sure what should be done wrt that.

I realize the tests are a bit repetitive, but it seems that many of the parameter tests are similar in this respect.

The reason I went through the trouble of actually instantiating a task is due to the distinction between how the parsing of the string handles the creation of the value for the parameter and that the actual instantiation logic only invokes the normalization code. This is what caused the two separate ways that errors showed up for DictParameters in the execution summary.

@Tarrasch 