### PR TITLE
Remove tracking url callback hack

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -47,7 +47,6 @@ import threading
 import time
 import traceback
 import types
-import warnings
 
 from luigi import six
 
@@ -113,20 +112,7 @@ class TaskProcess(multiprocessing.Process):
         self.task.set_tracking_url = self.tracking_url_callback
         self.task.set_status_message = self.status_message_callback
 
-        def deprecated_tracking_url_callback(*args, **kwargs):
-            warnings.warn("tracking_url_callback in run() args is deprecated, use "
-                          "set_tracking_url instead.", DeprecationWarning)
-            self.tracking_url_callback(*args, **kwargs)
-
-        run_again = False
-        try:
-            task_gen = self.task.run(tracking_url_callback=deprecated_tracking_url_callback)
-        except TypeError as ex:
-            if 'unexpected keyword argument' not in str(ex):
-                raise
-            run_again = True
-        if run_again:
-            task_gen = self.task.run()
+        task_gen = self.task.run()
 
         self.task.set_tracking_url = None
         self.task.set_status_message = None

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -267,27 +267,6 @@ class WorkerTest(unittest.TestCase):
         self.assertFalse(a.has_run)
         self.assertFalse(b.has_run)
 
-    def test_tracking_url_deprecated(self):
-        tracking_url = 'http://test_url.com/'
-
-        class A(Task):
-            has_run = False
-
-            def complete(self):
-                return self.has_run
-
-            def run(self, tracking_url_callback=None):
-                if tracking_url_callback is not None:
-                    tracking_url_callback(tracking_url)
-                self.has_run = True
-
-        a = A()
-        self.assertTrue(self.w.add(a))
-        self.assertTrue(self.w.run())
-        tasks = self.sch.task_list('DONE', '')
-        self.assertEqual(1, len(tasks))
-        self.assertEqual(tracking_url, tasks[a.task_id]['tracking_url'])
-
     def test_type_error_in_tracking_run_deprecated(self):
         class A(Task):
             num_runs = 0


### PR DESCRIPTION
I removed the deprecated tracking_url_callback hack in worker.py and its associated test.

As explained in https://github.com/spotify/luigi/issues/1707, the `if 'unexpected keyword argument' not in str(ex):` doesn't play well with cython, so we agreed that it should be removed.

I ran the fast tests, namely flake8, py27-nonhdfs and visualiser. I also cythonized my application and made sure I can call luigi without problem. I don't know much about luigi, but afaik it's pretty safe.

As requested, I'll add a branch on my github account with my cython test, in case somebody wants to play with it.