### PR TITLE
Added note in documentation about underscore in parameter names

### DIFF
--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -29,3 +29,10 @@ Or alternatively like this:
 .. code-block:: console
 
         $ python -m luigi --module my_module MyTask --x 100 --local-scheduler
+
+Note that if a parameter name contains '_', it should be replaced by '-'.
+For example, if MyTask had a parameter called 'my_parameter':
+
+.. code-block:: console
+
+        $ luigi --module my_module MyTask --my-parameter 100 --local-scheduler


### PR DESCRIPTION
## Description
Add a note in the documentation to clarify how to call parameters with '_' from the command line.

## Motivation and Context
This patch improves documentation to address #1728

## Have you tested this? If so, how?
The preview of the file in GitHub seems correct.

