### PR TITLE
Reduce number of get_params calls in common_params.

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -240,10 +240,11 @@ def common_params(task_instance, task_cls):
         raise TypeError("task_cls must be an uninstantiated Task")
 
     task_instance_param_names = dict(task_instance.get_params()).keys()
-    task_cls_param_names = dict(task_cls.get_params()).keys()
-    common_param_names = list(set.intersection(set(task_instance_param_names), set(task_cls_param_names)))
-    common_param_vals = [(key, dict(task_cls.get_params())[key]) for key in common_param_names]
-    common_kwargs = dict([(key, task_instance.param_kwargs[key]) for key in common_param_names])
+    task_cls_params_dict = dict(task_cls.get_params())
+    task_cls_param_names = task_cls_params_dict.keys()
+    common_param_names = set(task_instance_param_names).intersection(set(task_cls_param_names))
+    common_param_vals = [(key, task_cls_params_dict[key]) for key in common_param_names]
+    common_kwargs = dict((key, task_instance.param_kwargs[key]) for key in common_param_names)
     vals = dict(task_instance.get_param_values(common_param_vals, [], common_kwargs))
     return vals
 


### PR DESCRIPTION
This PR addresses #1736.

It saves the intermediate result ``dict(task_cls.get_params())`` to reduce the number of calls to ``task.get_params()``.

