### PR TITLE
[MRG+2] Reset terminal colors in external_program ENVIRONMENT print

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -160,6 +160,8 @@ class ExternalProgramRunError(RuntimeError):
         if self.env:
             env_string = ' '.join(['='.join([k, '\'{}\''.format(v)]) for k, v in self.env.items()])
         info += '\nENVIRONMENT: {}'.format(env_string or '[empty]')
+        # reset terminal color in case the ENVIRONMENT changes colors
+        info += '\033[m'
         return info
 
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When an `ExternalProgramRunError` is printed and there are color values in the `ENVIRONMENT`, the terminal colors are permanently changed.  I have noticed this when a `PySparkTask` fails on AWS EMR.  Annoyingly, in EMR, the terminal color is switched to a hard-to-read light blue.  

## Have you tested this? If so, how?
Yeah, it is a one-line change that works fine.

