### PR TITLE
Fix bug with GCSFlagTarget __init__

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -465,7 +465,7 @@ class GCSFlagTarget(GCSTarget):
         if path[-1] != "/":
             raise ValueError("GCSFlagTarget requires the path to be to a "
                              "directory.  It must end with a slash ( / ).")
-        super(GCSFlagTarget, self).__init__(path)
+        super(GCSFlagTarget, self).__init__(path, format=format, client=client)
         self.format = format
         self.fs = client or GCSClient()
         self.flag = flag


### PR DESCRIPTION
A single line fix to GCSFlagTarget __init__ that passes along kwargs properly.

## Description

Change __init__ to pass along kwargs (`format` and `client`)

## Motivation and Context

Was initializing a `GCSFlagTarget` with a GCSClient that was created with a json key file, rather than the default auth via environment variable. There wasn't a way to get the GCSFlagTarget to pick this up since it ignored the `client` kwarg.

## Have you tested this? If so, how?

"I ran my jobs with this code and it works for me."
