### PR TITLE
Caches get_autoconfig_client on a per-thread basis

### DIFF
--- a/luigi/contrib/hdfs/clients.py
+++ b/luigi/contrib/hdfs/clients.py
@@ -19,33 +19,42 @@
 The implementations of the hdfs clients. The hadoop cli client and the
 snakebite client.
 """
-
+import logging
+import threading
 
 from luigi.contrib.hdfs import config as hdfs_config
 from luigi.contrib.hdfs import snakebite_client as hdfs_snakebite_client
 from luigi.contrib.hdfs import webhdfs_client as hdfs_webhdfs_client
 from luigi.contrib.hdfs import hadoopcli_clients as hdfs_hadoopcli_clients
 import luigi.contrib.target
-import logging
 
 logger = logging.getLogger('luigi-interface')
 
+_AUTOCONFIG_CLIENT = threading.local()
 
-def get_autoconfig_client():
+
+def get_autoconfig_client(client_cache=_AUTOCONFIG_CLIENT):
     """
     Creates the client as specified in the `luigi.cfg` configuration.
     """
-    configured_client = hdfs_config.get_configured_hdfs_client()
-    if configured_client == "webhdfs":
-        return hdfs_webhdfs_client.WebHdfsClient()
-    if configured_client == "snakebite":
-        return hdfs_snakebite_client.SnakebiteHdfsClient()
-    if configured_client == "snakebite_with_hadoopcli_fallback":
-        return luigi.contrib.target.CascadingClient([hdfs_snakebite_client.SnakebiteHdfsClient(),
-                                                     hdfs_hadoopcli_clients.create_hadoopcli_client()])
-    if configured_client == "hadoopcli":
-        return hdfs_hadoopcli_clients.create_hadoopcli_client()
-    raise Exception("Unknown hdfs client " + configured_client)
+    try:
+        return client_cache.client
+    except AttributeError:
+        configured_client = hdfs_config.get_configured_hdfs_client()
+        if configured_client == "webhdfs":
+            client_cache.client = hdfs_webhdfs_client.WebHdfsClient()
+        elif configured_client == "snakebite":
+            client_cache.client = hdfs_snakebite_client.SnakebiteHdfsClient()
+        elif configured_client == "snakebite_with_hadoopcli_fallback":
+            client_cache.client = luigi.contrib.target.CascadingClient([
+                hdfs_snakebite_client.SnakebiteHdfsClient(),
+                hdfs_hadoopcli_clients.create_hadoopcli_client(),
+            ])
+        elif configured_client == "hadoopcli":
+            client_cache.client = hdfs_hadoopcli_clients.create_hadoopcli_client()
+        else:
+            raise Exception("Unknown hdfs client " + configured_client)
+        return client_cache.client
 
 
 def _with_ac(method_name):

--- a/test/hdfs_client_test.py
+++ b/test/hdfs_client_test.py
@@ -1,0 +1,28 @@
+import itertools
+import threading
+import unittest
+
+from luigi.contrib.hdfs import get_autoconfig_client
+
+
+class HdfsClientTest(unittest.TestCase):
+    def test_get_autoconfig_client_cached(self):
+        original_client = get_autoconfig_client()
+        for _ in range(100):
+            self.assertIs(original_client, get_autoconfig_client())
+
+    def test_threaded_clients_different(self):
+        clients = []
+
+        def add_client():
+            clients.append(get_autoconfig_client())
+
+        # run a bunch of threads to get new clients in them
+        threads = [threading.Thread(target=add_client) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        for client1, client2 in itertools.combinations(clients, 2):
+            self.assertIsNot(client1, client2)


### PR DESCRIPTION
## Motivation and Context
If too many different autoconfig clients are open at the same time, it can
create too many open files for the operating system to handle. To avoid
this issue, we can simply cache the autoconfig client to ensure that the
same one is being used every time. However, the autoconfig client is not
thread safe so we must have a different one for each thread.

This resolves #1740

## Have you tested this? If so, how?
I added unit tests and ran the minimal HdfsTarget example in #1740. Both pass.