### PR TITLE
S3 list with key object

### DIFF
--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -449,13 +449,14 @@ class S3Client(FileSystem):
         self.copy(source_path, destination_path, **kwargs)
         self.remove(source_path)
 
-    def listdir(self, path, start_time=None, end_time=None):
+    def listdir(self, path, start_time=None, end_time=None, return_key=False):
         """
         Get an iterable with S3 folder contents.
         Iterable contains paths relative to queried path.
 
         :param start_time: Optional argument to copy files with modified dates after start_time
         :param end_time: Optional argument to copy files with modified dates before end_time
+        :param return_key: Optional argument, when set to True will return a boto.s3.key.Key (instead of the filename)
         """
         (bucket, key) = self._path_to_bucket_and_key(path)
 
@@ -472,12 +473,18 @@ class S3Client(FileSystem):
                     (not start_time and end_time and last_modified_date < end_time) or  # end defined, prior to end
                     (start_time and end_time and start_time < last_modified_date < end_time)  # both defined, between
                ):
-                yield self._add_path_delimiter(path) + item.key[key_path_len:]
+                if return_key:
+                    yield item
+                else:
+                    yield self._add_path_delimiter(path) + item.key[key_path_len:]
 
-    def list(self, path, start_time=None, end_time=None):  # backwards compat
+    def list(self, path, start_time=None, end_time=None, return_key=False):  # backwards compat
         key_path_len = len(self._add_path_delimiter(path))
-        for item in self.listdir(path, start_time=start_time, end_time=end_time):
-            yield item[key_path_len:]
+        for item in self.listdir(path, start_time=start_time, end_time=end_time, return_key=return_key):
+            if return_key:
+                yield item
+            else:
+                yield item[key_path_len:]
 
     def isdir(self, path):
         """

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -345,12 +345,36 @@ class TestS3Client(unittest.TestCase):
 
         self.assertEqual(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
                          list(s3_client.listdir('s3://mybucket/hello')))
-        self.assertEqual(['s3://mybucket/hello/frank', 's3://mybucket/hello/world'],
-                         list(s3_client.listdir('s3://mybucket/hello/')))
+
+    def test_list(self):
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.s3.create_bucket('mybucket')
+
+        s3_client.put_string("", 's3://mybucket/hello/frank')
+        s3_client.put_string("", 's3://mybucket/hello/world')
+
         self.assertEqual(['frank', 'world'],
                          list(s3_client.list('s3://mybucket/hello')))
-        self.assertEqual(['frank', 'world'],
-                         list(s3_client.list('s3://mybucket/hello/')))
+
+    def test_listdir_key(self):
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.s3.create_bucket('mybucket')
+
+        s3_client.put_string("", 's3://mybucket/hello/frank')
+        s3_client.put_string("", 's3://mybucket/hello/world')
+
+        self.assertEqual([True, True],
+                         [x.exists() for x in s3_client.listdir('s3://mybucket/hello', return_key=True)])
+
+    def test_list_key(self):
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        s3_client.s3.create_bucket('mybucket')
+
+        s3_client.put_string("", 's3://mybucket/hello/frank')
+        s3_client.put_string("", 's3://mybucket/hello/world')
+
+        self.assertEqual([True, True],
+                         [x.exists() for x in s3_client.list('s3://mybucket/hello', return_key=True)])
 
     def test_remove(self):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)


### PR DESCRIPTION
## Description
Updated `S3Client.copy()` such that when copying a directory of files, the number and total size of files will be returned. To accomplish this, the `list()` and `listdir()` now have an optional parameter `return_key` which when set `True` will return the `boto.s3.key.Key` objects rather than the string filenames.

Module should remain backwards compatible.

## Motivation and Context
I need to perform a few dynamic calculations based on the number and size of copied files. To accomplish this, `S3Client.copy()` needs to return the number and size of files copied.

## Have you tested this? If so, how?
Tests are included.
