### PR TITLE
Reponse #1746 : Add mention of conda-forge build to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ For the bleeding edge code, ``pip install
 git+https://github.com/spotify/luigi.git``. Bleeding edge documentation can be
 found `here <https://luigi.readthedocs.io/en/latest/>`__.
 
+For those using conda package management system you can install the latest community supported luigi version by running the following ``conda install -c conda-forge luigi``
 Background
 ----------
 


### PR DESCRIPTION
## Description
A user requested this be mentioned in the documentation so that anyone using the conda package managent service can get a more up to date version of luigi.

## Motivation and Context

1. Keep scientific community users more in line with current documentation / releases of luigi.
2. Demonstrate to community members doing a PR like this is a few seconds :-)

## Have you tested this? If so, how?
No unit tests. Ran command on MacOs 10.11.5 worked fine.
Testing
Tested command. No test coverage added.