### PR TITLE
Update call to iteritems in luigi/tools/deps: deprecated in Python 3

### DIFF
--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -117,7 +117,7 @@ def main():
         task_output = task.output()
 
         if isinstance(task_output, dict):
-            output_descriptions = [get_task_output_description(output) for label, output in task_output.iteritems()]
+            output_descriptions = [get_task_output_description(output) for label, output in task_output.items()]
         elif isinstance(task_output, collections.Iterable):
             output_descriptions = [get_task_output_description(output) for output in task_output]
         else:


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
dict.iteritems() is deprecated in Python 3 (PEP 3106), was replaced with dict.items()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running luigi-deps to get a list of all upstream outputs returned the following error: `AttributeError: 'dict' object has no attribute 'iteritems'`

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
The change worked for me (Python 3.5.0)
