### PR TITLE
Fix exist method for ftp server

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -131,14 +131,12 @@ class RemoteFileSystem(luigi.target.FileSystem):
         return exists
 
     def _ftp_exists(self, path, mtime):
-        path_parts = path.split('/')
-        path = '/'.join(path_parts[:-1])
-        fn = path_parts[-1]
+        dirname, fn = os.path.split(path)
 
-        files = self.conn.nlst(path)
+        files = self.conn.nlst(dirname)
 
         exists = False
-        if fn in files:
+        if path in files or fn in files:
             if mtime:
                 mdtm = self.conn.sendcmd('MDTM ' + path)
                 modified = datetime.datetime.strptime(mdtm[4:], "%Y%m%d%H%M%S")


### PR DESCRIPTION
## Description
Ftp exists method can now handle FTP servers which return fully qualified name or strictly the filename in question.

## Motivation and Context
Resolves PR #1710 (orphaned PR)

## Have you tested this? If so, how?
Works for me.

