### PR TITLE
Disable codecov comments on GitHub PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# First just blindly copy paste what is default values from the docs page
+# https://github.com/codecov/support/wiki/codecov.yml
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        if_no_uploads: error
+
+    patch:
+      default:
+        if_no_uploads: error
+
+    changes: true
+
+# But for luigi we do not want any comments
+comment: false


### PR DESCRIPTION
The codecov bot have been spamming PRs with incorrect coverage data. As
We don't know how to fix it for now, lets try to disable it at least.
See spotify/luigi#1693.