### PR TITLE
Remove the confusing "dummy_test_module" directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [report]
 omit =
     luigi/mrrunner.py
+    test/_test_time_generated_module*.py
     */python?.?/*
     */site-packages/nose/*
     *__init__*
@@ -9,7 +10,6 @@ omit =
     */.tox/*
     */setup.py
     */bin/luigidc
-    */dummy_test_module/*
     sitecustomize.py
     hadoop_test.py
     minicluster.py

--- a/dummy_test_module/not_imported.py
+++ b/dummy_test_module/not_imported.py
@@ -1,6 +1,0 @@
-import luigi
-
-
-class UnimportedTask(luigi.Task):
-    def complete(self):
-        return False

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -17,6 +17,9 @@
 
 import functools
 import itertools
+import tempfile
+import re
+from contextlib import contextmanager
 
 import luigi
 import luigi.task_register
@@ -184,3 +187,21 @@ class parsing(object):
 def in_parse(cmds, deferred_computation):
     with CmdlineParser.global_instance(cmds) as cp:
         deferred_computation(cp.get_task_obj())
+
+
+@contextmanager
+def temporary_unloaded_module(python_file_contents):
+    """ Create an importable module
+
+    Return the name of importable module name given its file contents (source
+    code) """
+    with tempfile.NamedTemporaryFile(
+            dir='test/',
+            prefix="_test_time_generated_module",
+            suffix='.py') as temp_module_file:
+        temp_module_file.file.write(python_file_contents)
+        temp_module_file.file.flush()
+        temp_module_path = temp_module_file.name
+        temp_module_name = re.search(r'/(_test_time_generated_module.*).py',
+                                     temp_module_path).group(1)
+        yield temp_module_name


### PR DESCRIPTION
## Description
Remove the confusing "dummy_test_module" directory

## Motivation and Context
The purpose is simply to remove a confusing module from the luigi root
directory. It was only used from tests but it couldn't be put in the
test module for whatever technical reasons.

## Have you tested this? If so, how?
This is only affecting tests. If tests pass it should be OK.