### PR TITLE
Normalize ListParameter to be Immutable

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -853,6 +853,15 @@ class ListParameter(Parameter):
 
         $ luigi --module my_tasks MyTask --grades '[100,70]'
     """
+    def normalize(self, x):
+        """
+        Ensure that list parameter is converted to a tuple so it can be hashed.
+
+        :param str x: the value to parse.
+        :return: the normalized (hashable/immutable) value.
+        """
+        return tuple(x)
+
     def parse(self, x):
         """
         Parse an individual value from the input.

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -347,6 +347,13 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.DictParameter()
         self.assertEqual(hash(Foo(args=dict(foo=1, bar="hello")).args), hash(p.parse('{"foo":1,"bar":"hello"}')))
 
+    def test_list(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.ListParameter()
+
+        p = luigi.parameter.ListParameter()
+        self.assertEqual(hash(Foo(args=[1, "hello"]).args), hash(p.normalize(p.parse('[1,"hello"]'))))
+
     def test_tuple(self):
         class Foo(luigi.Task):
             args = luigi.parameter.TupleParameter()


### PR DESCRIPTION
Prompted by PR #1719 

## Description
ListParameter was not immutable. `Parameter`'s `normalize()` was overwritten by casting the list to a tuple.

## Motivation and Context
Parameters need to be immutable.

## Have you tested this? If so, how?
Test is included.