### PR TITLE
docs: Set minimum versions for sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ autoclass_content = 'both'
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.4.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands = isort -w 120 -rc luigi test examples bin
 # Call this using `tox -e docs`.
 deps =
   sqlalchemy
-  Sphinx==1.4.2
+  Sphinx>=1.4.4<1.5
   sphinx_rtd_theme
 commands =
     # build API docs


### PR DESCRIPTION
I saw that the readthedocs build was failing, hence this is my attempt to fix it,
altough I don't know how to test this before merging it.
See https://readthedocs.org/projects/luigi/builds/4189801/

Unfortunately I couldn't find a way to connect a webhook between GitHub
PRs and readthedocs: https://github.com/rtfd/readthedocs.org/issues/1340

The reason I believe a version bump would fix it is because I see
exactly the same error as in sphinx-doc/sphinx#2465 and readthedocs
seem to use 1.3.5, causing the pdf docs to be outdated.