### PR TITLE
docs: Install sphinx 1.4.4 in setup.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ autoclass_content = 'both'
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.4.4'
+needs_sphinx = '1.4.4'  # Value mirrored in doc/conf.py
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.append('sqlalchemy')
     # readthedocs don't like python-daemon, see #1342
     install_requires.remove('python-daemon<3.0')
+    install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 setup(
     name='luigi',


### PR DESCRIPTION
## Motivation and Context
This should unbreak the readthedocs build

https://readthedocs.org/projects/luigi/builds/4193162/

## Have you tested this? If so, how?
I tested by:

 1. Create and source a `virtualenv`
 1. `python setup.py install`
 1. `sphinx-build -T -E -b readthedocs -d _build/doctrees-readthedocs -D language=en doc _build/html`

While it fails "somewhere", it still reports to have used sphinx 1.4.4. As expected.