### PR TITLE
Added assert_passed_params classmethod for luigi.Task 

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -274,6 +274,17 @@ class Task(object):
         # Sort it by the correct order and make a list
         return [(param_name, list_to_tuple(result[param_name])) for param_name, param_obj in params]
 
+    @classmethod
+    def assert_passed_params(cls, kwargs, include_significant=True):
+        """
+        Checks if all the expected parameters passed onto the task class.
+
+        :param kwargs: keyword arguments.
+        :param include_significant: include significant parameters or not
+        """
+        not_passed = set(cls.get_param_names(include_significant)) - set(kwargs.keys())
+        assert len(not_passed) == 0, "{} expected params not passed to {}".format(not_passed, cls)
+
     def __init__(self, *args, **kwargs):
         params = self.get_params()
         param_values = self.get_param_values(params, args, kwargs)


### PR DESCRIPTION
## Description

Added a simple classmethod that raises assert error when not all expected kwargs passed on to a luigi.Task.
## Motivation and Context

I find it useful when we want to be sure that the upper tasks is passing on all expected/needed parameters to the required subtasks.
I ran my jobs with this code and it works for me.
