### PR TITLE
dataproc import just warns and doesn't fails if google credentials do…

### DIFF
--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -14,9 +14,13 @@ try:
     import oauth2client.client
     from googleapiclient import discovery
     from googleapiclient.errors import HttpError
-
-    DEFAULT_CREDENTIALS = oauth2client.client.GoogleCredentials.get_application_default()
-    _dataproc_client = discovery.build('dataproc', 'v1', credentials=DEFAULT_CREDENTIALS, http=httplib2.Http())
+    try:
+        DEFAULT_CREDENTIALS = oauth2client.client.GoogleCredentials.get_application_default()
+        _dataproc_client = discovery.build('dataproc', 'v1', credentials=DEFAULT_CREDENTIALS, http=httplib2.Http())
+    except oauth2client.client.ApplicationDefaultCredentialsError as err:
+        logger.warning("Error loading default application credentials."
+                       " This will crash at runtime if Dataproc functionality is used. " +
+                       str(err))
 except ImportError:
     logger.warning("Loading Dataproc module without the python packages googleapiclient & oauth2client. \
         This will crash at runtime if Dataproc functionality is used.")

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -11,9 +11,12 @@ try:
     from luigi.contrib import dataproc
     from googleapiclient import discovery
 
-    default_credentials = oauth2client.client.GoogleCredentials.get_application_default()
-    default_client = discovery.build('dataproc', 'v1', credentials=default_credentials, http=httplib2.Http())
-    dataproc.set_dataproc_client(default_client)
+    try:
+        default_credentials = oauth2client.client.GoogleCredentials.get_application_default()
+        default_client = discovery.build('dataproc', 'v1', credentials=default_credentials, http=httplib2.Http())
+        dataproc.set_dataproc_client(default_client)
+    except oauth2client.client.ApplicationDefaultCredentialsError:
+        raise unittest.SkipTest('No default credentials to run dataproc tests')
 except ImportError:
     raise unittest.SkipTest('Unable to load google cloud dependencies')
 

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -41,7 +41,11 @@ PROJECT_ID = os.environ.get('GCS_TEST_PROJECT_ID', 'your_project_id_here')
 BUCKET_NAME = os.environ.get('GCS_TEST_BUCKET', 'your_test_bucket_here')
 TEST_FOLDER = os.environ.get('TRAVIS_BUILD_ID', 'gcs_test_folder')
 
-CREDENTIALS = oauth2client.client.GoogleCredentials.get_application_default()
+try:
+    CREDENTIALS = oauth2client.client.GoogleCredentials.get_application_default()
+except oauth2client.client.ApplicationDefaultCredentialsError:
+    raise unittest.SkipTest('No default credentials to run GCS tests')
+
 ATTEMPTED_BUCKET_CREATE = False
 
 


### PR DESCRIPTION
This pull-request fixes the Issue #1768 . 

I haven't set up any Google cloud default credentials so I got odd errors in import tests and other places that don't really test the dataproc functionality but just import the module for one reason or another.
