### PR TITLE
Compression atomic local file

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -324,7 +324,7 @@ class AtomicFtpFile(luigi.target.AtomicLocalFile):
     Also cleans up the temp file if close is not invoked.
     """
 
-    def __init__(self, fs, path):
+    def __init__(self, fs, path, compressed=False):
         """
         Initializes an AtomicFtpfile instance.
         :param fs:
@@ -332,7 +332,7 @@ class AtomicFtpFile(luigi.target.AtomicLocalFile):
         :type path: str
         """
         self._fs = fs
-        super(AtomicFtpFile, self).__init__(path)
+        super(AtomicFtpFile, self).__init__(path, compressed)
 
     def move_to_final_destination(self):
         self._fs.put(self.tmp_path, self.path)

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -398,9 +398,9 @@ class AtomicGCSFile(luigi.target.AtomicLocalFile):
     A GCS file that writes to a temp file and put to GCS on close.
     """
 
-    def __init__(self, path, gcs_client):
+    def __init__(self, path, gcs_client, compressed=False):
         self.gcs_client = gcs_client
-        super(AtomicGCSFile, self).__init__(path)
+        super(AtomicGCSFile, self).__init__(path, compressed)
 
     def move_to_final_destination(self):
         self.gcs_client.put(self.tmp_path, self.path)

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -104,9 +104,9 @@ class AtomicWebHdfsFile(AtomicLocalFile):
     An Hdfs file that writes to a temp file and put to WebHdfs on close.
     """
 
-    def __init__(self, path, client):
+    def __init__(self, path, client, compressed=False):
         self.client = client
-        super(AtomicWebHdfsFile, self).__init__(path)
+        super(AtomicWebHdfsFile, self).__init__(path, compressed)
 
     def move_to_final_destination(self):
         if not self.client.exists(self.path):

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -103,7 +103,7 @@ class LocalFileSystem(FileSystem):
 class LocalTarget(FileSystemTarget):
     fs = LocalFileSystem()
 
-    def __init__(self, path=None, format=None, is_tmp=False):
+    def __init__(self, path=None, format=None, is_tmp=False, compressed=False):
         if format is None:
             format = get_default_format()
 
@@ -113,6 +113,7 @@ class LocalTarget(FileSystemTarget):
             path = os.path.join(tempfile.gettempdir(), 'luigi-tmp-%09d' % random.randint(0, 999999999))
         super(LocalTarget, self).__init__(path)
         self.format = format
+        self.compressed = compressed
         self.is_tmp = is_tmp
 
     def makedirs(self):
@@ -131,7 +132,7 @@ class LocalTarget(FileSystemTarget):
         rwmode = mode.replace('b', '').replace('t', '')
         if rwmode == 'w':
             self.makedirs()
-            return self.format.pipe_writer(atomic_file(self.path))
+            return self.format.pipe_writer(atomic_file(self.path, self.compressed))
 
         elif rwmode == 'r':
             fileobj = FileWrapper(io.BufferedReader(io.FileIO(self.path, mode)))

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -557,9 +557,9 @@ class AtomicS3File(AtomicLocalFile):
     :param kwargs: Keyword arguments are passed to the boto function `initiate_multipart_upload`
     """
 
-    def __init__(self, path, s3_client, **kwargs):
+    def __init__(self, path, s3_client, compressed=False, **kwargs):
         self.s3_client = s3_client
-        super(AtomicS3File, self).__init__(path)
+        super(AtomicS3File, self).__init__(path, compressed)
         self.s3_options = kwargs
 
     def move_to_final_destination(self):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -280,11 +280,10 @@ class AtomicLocalFile(io.BufferedWriter):
         self.path = path
         self.compressed = compressed
   
+        f = io.FileIO(self.__tmp_path, 'w')
         if self.compressed:
           import gzip
-          f = gzip.open(self.__tmp_path, 'w')
-        else:
-          f = io.FileIO(self.__tmp_path, 'w')
+          f = gzip.GzipFile(fileobj=f)
 
         super(AtomicLocalFile, self).__init__(f)
 

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -275,10 +275,18 @@ class AtomicLocalFile(io.BufferedWriter):
     :class:`luigi.file.LocalTarget` for example
     """
 
-    def __init__(self, path):
+    def __init__(self, path, compressed=False):
         self.__tmp_path = self.generate_tmp_path(path)
         self.path = path
-        super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, 'w'))
+        self.compressed = compressed
+  
+        if self.compressed:
+          import gzip
+          f = gzip.open(self.__tmp_path, 'w')
+        else:
+          f = io.FileIO(self.__tmp_path, 'w')
+
+        super(AtomicLocalFile, self).__init__(f)
 
     def close(self):
         super(AtomicLocalFile, self).close()


### PR DESCRIPTION
## Description

This Pull Request is meant to add a compressed boolean option to AtomicLocalFile to compress data when writing to the file. This particular pull request isn't necessarily the final code, but meant to start a conversation on whether or not this is the right direction to go. One alternative is to explicitly create an AtomicCompressedLocalFile (and associated inherited classes)
## Motivation and Context

In my particular use case, I'd like to compress CSV data (using the csv module) when writing to S3 using the AtomicS3LocalFile. The method I used beforehand was to use zlib to compress data before writing the content to a file - however, it ends up being a little bulky/cumbersome if you want to use the python csv.writer. In particular, with the csv module, I would write to a stringio w/ csv.writer to format the data before then compressing the contents of the stringio when writing to the final atomic file. The usage of AtomicLocalFile with compression=True would be then be similar to using GzipFile.
## Have you tested this? If so, how?

Ran this code with my jobs - specifically, I have only run this with AtomicS3File
