### PR TITLE
Assistants: Don't affect longevity of tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -444,11 +444,12 @@ class SimpleTaskState(object):
 
     def update_status(self, task, config):
         # Mark tasks with no remaining active stakeholders for deletion
-        if not task.stakeholders:
-            if task.remove is None:
-                logger.debug("Task %r has stakeholders %r but none remain connected -> might remove "
-                             "task in %s seconds", task.id, task.stakeholders, config.remove_delay)
-                task.remove = time.time() + config.remove_delay
+        if (not task.stakeholders) and (task.remove is None) and (task.status != RUNNING):
+            # We don't check for the RUNNING case, because that is already handled
+            # by the fail_dead_worker_task function.
+            logger.debug("Task %r has no stakeholders anymore -> might remove "
+                         "task in %s seconds", task.id, config.remove_delay)
+            task.remove = time.time() + config.remove_delay
 
         # Re-enable task after the disable time expires
         if task.status == DISABLED and task.scheduler_disable_time is not None:
@@ -505,15 +506,6 @@ class SimpleTaskState(object):
         self._remove_workers_from_tasks(workers, remove_stakeholders=False)
         for worker in workers:
             self.get_worker(worker).disabled = True
-
-    def get_necessary_tasks(self):
-        necessary_tasks = set()
-        for task in self.get_active_tasks():
-            if task.status not in (DONE, DISABLED, UNKNOWN) or \
-                    task.scheduler_disable_time is not None:
-                necessary_tasks.update(task.deps)
-                necessary_tasks.add(task.id)
-        return necessary_tasks
 
 
 class CentralPlannerScheduler(Scheduler):
@@ -573,15 +565,10 @@ class CentralPlannerScheduler(Scheduler):
         assistant_ids = set(w.id for w in self._state.get_assistants())
         remove_tasks = []
 
-        if assistant_ids:
-            necessary_tasks = self._state.get_necessary_tasks()
-        else:
-            necessary_tasks = ()
-
         for task in self._state.get_active_tasks():
             self._state.fail_dead_worker_task(task, self._config, assistant_ids)
             self._state.update_status(task, self._config)
-            if self._state.may_prune(task) and task.id not in necessary_tasks:
+            if self._state.may_prune(task):
                 logger.info("Removing task %r", task.id)
                 remove_tasks.append(task.id)
 


### PR DESCRIPTION
## Motivation and Context

When assistants where introduced, we imagined that one worker would
run tasks (the assistant) and one would upload them.  In order to ensure
that the tasks don't get pruned before tasks get completed, we added
a what we now consider an "antifeature" that made tasks not getting
pruned while assistants where alive.

Real world use have showed that it wasn't a good feature. It have
caused bugs like spotify/luigi@736c0f1, but worst, it's a feature that
makes luigid change behavior for all tasks if you just submit 1
assistant. I didn't expect that the first time I tested assistants.

There's an email thread where it was discussed to remove this feature.
In there one can also read about how to get something similar to the old
behavior.

https://groups.google.com/forum/#!topic/luigi-user/b7Acym0n-g4

## Have you tested this? If so, how?

In addition to the modified tests, I'll try to test this in production for a few days. I'll report back.