### PR TITLE
Truncates long streaming job confs

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -764,6 +764,7 @@ DataInterchange = {
 
 
 class JobTask(BaseHadoopJobTask):
+    jobconf_truncate = 20000
     n_reduce_tasks = 25
     reducer = NotImplemented
 
@@ -773,6 +774,8 @@ class JobTask(BaseHadoopJobTask):
             jcs.append('mapred.reduce.tasks=0')
         else:
             jcs.append('mapred.reduce.tasks=%s' % self.n_reduce_tasks)
+        if self.jobconf_truncate >= 0:
+            jcs.append('stream.jobconf.truncate.limit=%i' % self.jobconf_truncate)
         return jcs
 
     def init_mapper(self):


### PR DESCRIPTION
## Description
Adds `stream.jobconf.truncate.limit=20000` to jobconfs of streaming jobs. The 20000 number is configurable via the `jobconf_truncate` task property.

## Motivation and Context
When running a streaming job with lots of inputs, the job conf gets passed to
each mapper. This can cause an exception from passing too many arguments to the
mapper. This job conf is not actually, needed, so it's safe to truncate. 20000
is recommended as a safe value for this truncation in
http://aajisaka.github.io/hadoop-project/hadoop-streaming/HadoopStreaming.html#What_do_I_do_if_I_get_a_error7_Argument_list_too_long

## Have you tested this? If so, how?
Ran a MR job that failed without this. It now runs fine.