### PR TITLE
tests: Fix warning in remote_scheduler_test.py

### DIFF
--- a/test/remote_scheduler_test.py
+++ b/test/remote_scheduler_test.py
@@ -17,7 +17,6 @@
 
 import os
 import tempfile
-import unittest
 
 import luigi.server
 import server_test
@@ -26,7 +25,7 @@ tempdir = tempfile.mkdtemp()
 
 
 class DummyTask(luigi.Task):
-    id = luigi.Parameter()
+    id = luigi.IntParameter()
 
     def run(self):
         f = self.output().open('w')
@@ -51,7 +50,3 @@ class RemoteSchedulerTest(server_test.ServerTestBase):
 
     def test_multiple_workers(self):
         self._test_run(workers=10)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
## Description

When you run the test, we get a warning about using an int for a string parameter
