### PR TITLE
Remove abstract Scheduler class

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -29,7 +29,7 @@ from luigi.six.moves.urllib.request import urlopen
 from luigi.six.moves.urllib.error import URLError
 
 from luigi import configuration
-from luigi.scheduler import Scheduler, RPC_METHODS
+from luigi.scheduler import RPC_METHODS
 
 HAS_UNIX_SOCKET = True
 HAS_REQUESTS = True
@@ -87,7 +87,7 @@ class RequestsFetcher(object):
         return resp.text
 
 
-class RemoteScheduler(Scheduler):
+class RemoteScheduler(object):
     """
     Scheduler proxy object. Talks to a RemoteSchedulerResponder.
     """

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -47,16 +47,6 @@ from luigi.task import Config
 logger = logging.getLogger(__name__)
 
 
-class Scheduler(object):
-    """
-    Abstract base class.
-
-    Note that the methods all take string arguments, not Task objects...
-    """""
-    add_task = NotImplemented
-    get_work = NotImplemented
-    ping = NotImplemented
-
 UPSTREAM_RUNNING = 'UPSTREAM_RUNNING'
 UPSTREAM_MISSING_INPUT = 'UPSTREAM_MISSING_INPUT'
 UPSTREAM_FAILED = 'UPSTREAM_FAILED'
@@ -508,7 +498,7 @@ class SimpleTaskState(object):
             self.get_worker(worker).disabled = True
 
 
-class CentralPlannerScheduler(Scheduler):
+class CentralPlannerScheduler(object):
     """
     Async scheduler that can handle multiple workers, etc.
 


### PR DESCRIPTION
## Description

Remove abstract Scheduler class.

This is an internal refactoring. The purpose is just to remove code and
complexity.

## Have you tested this? If so, how?

No, I rely on existing unittests run by Travis.
