### PR TITLE
Rename CentralPlannerScheduler to Scheduler

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -131,7 +131,7 @@ class core(task.Config):
 class _WorkerSchedulerFactory(object):
 
     def create_local_scheduler(self):
-        return scheduler.CentralPlannerScheduler(prune_on_get_work=True, record_task_history=False)
+        return scheduler.Scheduler(prune_on_get_work=True, record_task_history=False)
 
     def create_remote_scheduler(self, url):
         return rpc.RemoteScheduler(url)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -498,7 +498,7 @@ class SimpleTaskState(object):
             self.get_worker(worker).disabled = True
 
 
-class CentralPlannerScheduler(object):
+class Scheduler(object):
     """
     Async scheduler that can handle multiple workers, etc.
 

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -16,7 +16,7 @@
 #
 """
 Simple REST server that takes commands in a JSON payload
-Interface to the :py:class:`~luigi.scheduler.CentralPlannerScheduler` class.
+Interface to the :py:class:`~luigi.scheduler.Scheduler` class.
 See :doc:`/central_scheduler` for more info.
 """
 #
@@ -53,7 +53,7 @@ import tornado.ioloop
 import tornado.netutil
 import tornado.web
 
-from luigi.scheduler import CentralPlannerScheduler, RPC_METHODS
+from luigi.scheduler import Scheduler, RPC_METHODS
 
 logger = logging.getLogger("luigi.server")
 
@@ -247,7 +247,7 @@ def run(api_port=8082, address=None, unix_socket=None, scheduler=None, responder
     Runs one instance of the API server.
     """
     if scheduler is None:
-        scheduler = CentralPlannerScheduler()
+        scheduler = Scheduler()
 
     # load scheduler state
     scheduler.load()

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -20,7 +20,7 @@ The worker communicates with the scheduler and does two things:
 1. Sends all tasks that has to be run
 2. Gets tasks from the scheduler that should be run
 
-When running in local mode, the worker talks directly to a :py:class:`~luigi.scheduler.CentralPlannerScheduler` instance.
+When running in local mode, the worker talks directly to a :py:class:`~luigi.scheduler.Scheduler` instance.
 When you run a central server, the worker will talk to the scheduler using a :py:class:`~luigi.rpc.RemoteScheduler` instance.
 
 Everything in this module is private to luigi and may change in incompatible
@@ -53,7 +53,7 @@ from luigi import six
 from luigi import notifications
 from luigi.event import Event
 from luigi.task_register import load_task
-from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, CentralPlannerScheduler
+from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler
 from luigi.target import Target
 from luigi.task import Task, flatten, getpaths, Config
 from luigi.task_register import TaskClassException
@@ -364,7 +364,7 @@ class Worker(object):
 
     def __init__(self, scheduler=None, worker_id=None, worker_processes=1, assistant=False, **kwargs):
         if scheduler is None:
-            scheduler = CentralPlannerScheduler()
+            scheduler = Scheduler()
 
         self.worker_processes = int(worker_processes)
         self._worker_info = self._generate_worker_info()

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -41,7 +41,7 @@ class DummyTask(luigi.Task):
         self.has_run = True
 
 
-class CustomizedLocalScheduler(luigi.scheduler.CentralPlannerScheduler):
+class CustomizedLocalScheduler(luigi.scheduler.Scheduler):
 
     def __init__(self, *args, **kwargs):
         super(CustomizedLocalScheduler, self).__init__(*args, **kwargs)

--- a/test/execution_summary_test.py
+++ b/test/execution_summary_test.py
@@ -30,7 +30,7 @@ class ExecutionSummaryTest(LuigiTestCase):
 
     def setUp(self):
         super(ExecutionSummaryTest, self).setUp()
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler(prune_on_get_work=False)
+        self.scheduler = luigi.scheduler.Scheduler(prune_on_get_work=False)
         self.worker = luigi.worker.Worker(scheduler=self.scheduler)
 
     def run_task(self, task):
@@ -154,7 +154,7 @@ class ExecutionSummaryTest(LuigiTestCase):
         def new_func(*args, **kwargs):
             return None
 
-        with mock.patch('luigi.scheduler.CentralPlannerScheduler.add_task', new_func):
+        with mock.patch('luigi.scheduler.Scheduler.add_task', new_func):
             self.run_task(Foo())
 
         d = self.summary_dict()
@@ -385,7 +385,7 @@ class ExecutionSummaryTest(LuigiTestCase):
 
         other_worker = luigi.worker.Worker(scheduler=self.scheduler, worker_id="other_worker")
         other_worker.add(AlreadyRunningTask())  # This also registers this worker
-        old_func = luigi.scheduler.CentralPlannerScheduler.get_work
+        old_func = luigi.scheduler.Scheduler.get_work
 
         def new_func(*args, **kwargs):
             new_kwargs = kwargs.copy()
@@ -393,7 +393,7 @@ class ExecutionSummaryTest(LuigiTestCase):
             old_func(*args, **new_kwargs)
             return old_func(*args, **kwargs)
 
-        with mock.patch('luigi.scheduler.CentralPlannerScheduler.get_work', new_func):
+        with mock.patch('luigi.scheduler.Scheduler.get_work', new_func):
             self.run_task(AlreadyRunningTask())
 
         d = self.summary_dict()
@@ -409,14 +409,14 @@ class ExecutionSummaryTest(LuigiTestCase):
 
         other_worker = luigi.worker.Worker(scheduler=self.scheduler, worker_id="other_worker")
         other_worker.add(AlreadyRunningTask())  # This also registers this worker
-        old_func = luigi.scheduler.CentralPlannerScheduler.get_work
+        old_func = luigi.scheduler.Scheduler.get_work
 
         def new_func(*args, **kwargs):
             kwargs['current_tasks'] = None
             old_func(*args, **kwargs)
             return old_func(*args, **kwargs)
 
-        with mock.patch('luigi.scheduler.CentralPlannerScheduler.get_work', new_func):
+        with mock.patch('luigi.scheduler.Scheduler.get_work', new_func):
             self.run_task(AlreadyRunningTask())
 
         d = self.summary_dict()

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -22,7 +22,7 @@ import sys
 from helpers import with_config
 from luigi import notifications
 from luigi import configuration
-from luigi.scheduler import CentralPlannerScheduler
+from luigi.scheduler import Scheduler
 from luigi.worker import Worker
 from luigi import six
 import luigi
@@ -69,7 +69,7 @@ class FailRunTask(TestTask):
 class ExceptionFormatTest(unittest.TestCase):
 
     def setUp(self):
-        self.sch = CentralPlannerScheduler()
+        self.sch = Scheduler()
 
     def test_fail_run(self):
         task = FailRunTask(foo='foo', bar='bar')

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -54,7 +54,7 @@ class RetcodesTest(LuigiTestCase):
             def run(self):
                 pass
 
-        old_func = luigi.scheduler.CentralPlannerScheduler.get_work
+        old_func = luigi.scheduler.Scheduler.get_work
 
         def new_func(*args, **kwargs):
             kwargs['current_tasks'] = None
@@ -63,7 +63,7 @@ class RetcodesTest(LuigiTestCase):
             res['running_tasks'][0]['worker'] = "not me :)"  # Otherwise it will be filtered
             return res
 
-        with mock.patch('luigi.scheduler.CentralPlannerScheduler.get_work', new_func):
+        with mock.patch('luigi.scheduler.Scheduler.get_work', new_func):
             self.run_and_expect('AlreadyRunningTask', 0)  # Test default value to be 0
             self.run_and_expect('AlreadyRunningTask --retcode-already-running 5', 5)
             self.run_with_config(dict(already_running='3'), 'AlreadyRunningTask', 3)
@@ -167,6 +167,6 @@ class RetcodesTest(LuigiTestCase):
         def new_func(*args, **kwargs):
             return None
 
-        with mock.patch('luigi.scheduler.CentralPlannerScheduler.add_task', new_func):
+        with mock.patch('luigi.scheduler.Scheduler.add_task', new_func):
             self.run_and_expect('RequiringTask', 0)
             self.run_and_expect('RequiringTask --retcode-not-run 5', 5)

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -22,8 +22,8 @@ except ImportError:
     import mock
 
 import luigi.rpc
-from luigi.scheduler import CentralPlannerScheduler
-import central_planner_test
+from luigi.scheduler import Scheduler
+import scheduler_api_test
 import luigi.server
 from server_test import ServerTestBase
 import time
@@ -88,11 +88,11 @@ class RemoteSchedulerTest(unittest.TestCase):
         self.assertRaises(luigi.rpc.RPCError, self.get_work, fetch_results)
 
 
-class RPCTest(central_planner_test.CentralPlannerTest, ServerTestBase):
+class RPCTest(scheduler_api_test.SchedulerApiTest, ServerTestBase):
 
     def get_app(self):
         conf = self.get_scheduler_config()
-        sch = CentralPlannerScheduler(**conf)
+        sch = Scheduler(**conf)
         return luigi.server.app(sch)
 
     def setUp(self):

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -102,7 +102,7 @@ class OddFibTask(luigi.Task):
 class SchedulerVisualisationTest(unittest.TestCase):
 
     def setUp(self):
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler()
+        self.scheduler = luigi.scheduler.Scheduler()
 
     def tearDown(self):
         pass
@@ -160,7 +160,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         root_task = LinearTask(100)
 
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler(max_graph_nodes=10)
+        self.scheduler = luigi.scheduler.Scheduler(max_graph_nodes=10)
         self._build([root_task])
 
         graph = self.scheduler.dep_graph(root_task.task_id)
@@ -181,7 +181,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         root_task = LinearTask(100)
 
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler(max_graph_nodes=10)
+        self.scheduler = luigi.scheduler.Scheduler(max_graph_nodes=10)
         self._build([root_task])
 
         graph = self.scheduler.inverse_dep_graph(LinearTask(0).task_id)
@@ -199,7 +199,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         root_task = BinaryTreeTask(1)
 
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler(max_graph_nodes=10)
+        self.scheduler = luigi.scheduler.Scheduler(max_graph_nodes=10)
         self._build([root_task])
 
         graph = self.scheduler.dep_graph(root_task.task_id)
@@ -221,7 +221,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
         root_task = LinearTask(100)
 
-        self.scheduler = luigi.scheduler.CentralPlannerScheduler(max_graph_nodes=10)
+        self.scheduler = luigi.scheduler.Scheduler(max_graph_nodes=10)
         self._build([root_task])
 
         graph = self.scheduler.dep_graph(root_task.task_id)

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -25,7 +25,7 @@ from helpers import unittest, skipOnTravis
 import luigi.rpc
 import luigi.server
 import luigi.cmdline
-from luigi.scheduler import CentralPlannerScheduler
+from luigi.scheduler import Scheduler
 from luigi.six.moves.urllib.parse import (
     urlencode, ParseResult, quote as urlquote
 )
@@ -58,7 +58,7 @@ def _is_running_from_main_thread():
 class ServerTestBase(AsyncHTTPTestCase):
 
     def get_app(self):
-        return luigi.server.app(CentralPlannerScheduler())
+        return luigi.server.app(Scheduler())
 
     def setUp(self):
         super(ServerTestBase, self).setUp()

--- a/test/task_history_test.py
+++ b/test/task_history_test.py
@@ -44,7 +44,7 @@ class TaskHistoryTest(LuigiTestCase):
 
     def test_run(self):
         th = SimpleTaskHistory()
-        sch = luigi.scheduler.CentralPlannerScheduler(task_history_impl=th)
+        sch = luigi.scheduler.Scheduler(task_history_impl=th)
         with luigi.worker.Worker(scheduler=sch) as w:
             class MyTask(luigi.Task):
                 pass

--- a/test/task_status_message_test.py
+++ b/test/task_status_message_test.py
@@ -28,7 +28,7 @@ class TaskStatusMessageTest(LuigiTestCase):
 
     def test_run(self):
         message = "test message"
-        sch = luigi.scheduler.CentralPlannerScheduler()
+        sch = luigi.scheduler.Scheduler()
         with luigi.worker.Worker(scheduler=sch) as w:
             class MyTask(luigi.Task):
                 def run(self):

--- a/test/worker_external_task_test.py
+++ b/test/worker_external_task_test.py
@@ -14,7 +14,7 @@
 
 import luigi
 from luigi.file import LocalTarget
-from luigi.scheduler import CentralPlannerScheduler
+from luigi.scheduler import Scheduler
 import luigi.server
 import luigi.worker
 import luigi.task
@@ -92,7 +92,7 @@ class WorkerExternalTaskTest(unittest.TestCase):
             w.run()
 
     def _make_worker(self):
-        self.scheduler = CentralPlannerScheduler(prune_on_get_work=True)
+        self.scheduler = Scheduler(prune_on_get_work=True)
         return luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1)
 
     def test_external_dependency_already_complete(self):

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -33,7 +33,7 @@ import luigi.worker
 import mock
 from luigi import ExternalTask, RemoteScheduler, Task, Event
 from luigi.mock import MockTarget, MockFileSystem
-from luigi.scheduler import CentralPlannerScheduler
+from luigi.scheduler import Scheduler
 from luigi.worker import Worker
 from luigi.rpc import RPCError
 from luigi import six
@@ -112,7 +112,7 @@ class DynamicRequiresOtherModule(Task):
 class WorkerTest(unittest.TestCase):
 
     def run(self, result=None):
-        self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         self.time = time.time
         with Worker(scheduler=self.sch, worker_id='X') as w, Worker(scheduler=self.sch, worker_id='Y') as w2:
             self.w = w
@@ -345,7 +345,7 @@ class WorkerTest(unittest.TestCase):
         self.assertFalse(b.has_run)
 
     def test_unknown_dep(self):
-        # see central_planner_test.CentralPlannerTest.test_remove_dep
+        # see related test_remove_dep test (grep for it)
         class A(ExternalTask):
 
             def complete(self):
@@ -511,7 +511,7 @@ class WorkerTest(unittest.TestCase):
         eb = ExternalB()
         self.assertEqual(str(eb), "B()")
 
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id='X') as w, Worker(scheduler=sch, worker_id='Y') as w2:
             self.assertTrue(w.add(b))
             self.assertTrue(w2.add(eb))
@@ -540,7 +540,7 @@ class WorkerTest(unittest.TestCase):
 
         self.assertEqual(str(eb), "B()")
 
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id='X') as w, Worker(scheduler=sch, worker_id='Y') as w2:
             self.assertTrue(w2.add(eb))
             self.assertTrue(w.add(b))
@@ -571,7 +571,7 @@ class WorkerTest(unittest.TestCase):
 
         b = B()
 
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
 
         with Worker(scheduler=sch, worker_id='X', keep_alive=True, count_uniques=True) as w:
             with Worker(scheduler=sch, worker_id='Y', keep_alive=True, count_uniques=True, wait_interval=0.1) as w2:
@@ -605,7 +605,7 @@ class WorkerTest(unittest.TestCase):
 
         b = B()
 
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
 
         with Worker(scheduler=sch, worker_id='X', keep_alive=True, count_uniques=True) as w:
             with Worker(scheduler=sch, worker_id='Y', keep_alive=True, count_uniques=True, wait_interval=0.1) as w2:
@@ -638,7 +638,7 @@ class WorkerTest(unittest.TestCase):
                 return a, c
 
         b = B()
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as w:
             self.assertFalse(w.add(b))
             self.assertTrue(w.run())
@@ -671,7 +671,7 @@ class WorkerTest(unittest.TestCase):
                 return c, a
 
         b = B()
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as w:
             self.assertFalse(w.add(b))
             self.assertTrue(w.run())
@@ -725,7 +725,7 @@ class WorkerPingThreadTests(unittest.TestCase):
 
         Kind of ugly since it uses actual timing with sleep to test the thread
         """
-        sch = CentralPlannerScheduler(
+        sch = Scheduler(
             retry_delay=100,
             remove_delay=1000,
             worker_disconnect_delay=10,
@@ -785,7 +785,7 @@ class WorkerEmailTest(LuigiTestCase):
 
     def run(self, result=None):
         super(WorkerEmailTest, self).setUp()
-        sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as self.worker:
             super(WorkerEmailTest, self).run(result)
 
@@ -1072,7 +1072,7 @@ class Dummy2Task(Task):
 
 class AssistantTest(unittest.TestCase):
     def run(self, result=None):
-        self.sch = CentralPlannerScheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
         self.assistant = Worker(scheduler=self.sch, worker_id='Y', assistant=True)
         with Worker(scheduler=self.sch, worker_id='X') as w:
             self.w = w


### PR DESCRIPTION
## Description

Rename CentralPlannerScheduler to Scheduler

## Motivation and Context

I find very little value in having that complicated name. In particular
it should be clear that the main class of scheduler.py is in fact
the Scheduler() class.

I've also renamed the tests testing the api to
test/scheduler_api_test.py. This should feel more intuitive to have
"scheduler" in the name of the file

## Have you tested this? If so, how?

I rely on Travis for this. I could try this in production before merging to, just in case. :)