### PR TITLE
README: Remove monthly downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,6 @@
 .. image:: https://landscape.io/github/spotify/luigi/master/landscape.svg?style=flat
    :target: https://landscape.io/github/spotify/luigi/master
 
-.. image:: https://img.shields.io/pypi/dm/luigi.svg?style=flat
-   :target: https://pypi.python.org/pypi/luigi
-
 .. image:: https://img.shields.io/pypi/v/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 


### PR DESCRIPTION
## Description

README: Remove monthly downloads badge

## Motivation and Context

The fact that there's only 4 downloads per month is not something we can really brag about. Let's just remove this bag. A historic note is that at some point that number fell from the tens of thousands downloads per month to just a handful. I suppose pypi fixed a bug on their side.