### PR TITLE
Excludes .tox from flake8 to prevent checking third-party libraries

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --max-line-length=160 --exclude=doc,luigi/six.py
+commands = flake8 --max-line-length=160 --exclude=doc,luigi/six.py,.tox
   flake8 --max-line-length=100 --ignore=E265 doc
 
 [testenv:autopep8]


### PR DESCRIPTION
## Description
Ads .tox to the exclude list in flake8 commands

## Motivation and Context
flake8 is failing in the CI due to errors found in the .tox directory. Since these have nothing to do with our code, they can be safely ignored.

## Have you tested this? If so, how?
We'll see if it passes CI. Since other stuff is currently broken, we'll have to check the flake8 test in particular.
