### PR TITLE
Removes comment from NOQA in util.py

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -224,7 +224,7 @@ from luigi import six
 
 from luigi import task
 from luigi import parameter
-from luigi.deprecate_kwarg import deprecate_kwarg  # NOQA: removing this breaks code
+from luigi.deprecate_kwarg import deprecate_kwarg  # NOQA
 
 if six.PY3:
     xrange = range

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
   nosetests -v --tests=test/visualiser
 
 [testenv:flake8]
-deps = flake8
+deps = flake8==3.0.2
 commands = flake8 --max-line-length=160 --exclude=doc,luigi/six.py,.tox
   flake8 --max-line-length=100 --ignore=E265 doc
 


### PR DESCRIPTION
Corrects the flake8 failures on CI and sets a specific flake8 version in tox.ini so that it won't break again without at least a code change.
