### PR TITLE
Per Task Retry-Policy

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -209,6 +209,7 @@ smtp_timeout
   Optionally sets the number of seconds after which smtp attempts should
   time out.
 
+.. _worker-config:
 
 [worker]
 --------
@@ -742,33 +743,35 @@ Luigi also supports defining retry-policy per task.
 
     class GenerateWordsFromHdfs(luigi.Task):
 
-       retry_count = 5
+       retry_count = 2
 
         ...
 
     class GenerateWordsFromRDBM(luigi.Task):
 
-       retry_count = 3
+       retry_count = 5
 
         ...
 
     class CountLetters(luigi.Task):
 
         def requires(self):
-            return [GenerateWordsFromHdfs(),GenerateWordsFromRDBM()]
+            return [GenerateWordsFromHdfs()]
+
+        def run():
+            yield GenerateWordsFromRDBM()
 
         ...
 
-Supported Configurations
-************************
-The configurations below are also definable in luigi config file. Check :ref:`scheduler-config`
+If none of retry-policy fields is defined per task, the field value will be **default** value which is defined in luigi config file. 
 
-+------------------------+-----------+
-| Config                 | Section   |
-+========================+===========+
-| retry_count            | scheduler |
-+------------------------+-----------+
-| disable_hard_timeout   | scheduler |
-+------------------------+-----------+
-| disable_window_seconds | scheduler |
-+------------------------+-----------+
+To make luigi sticks to the given retry-policy, be sure you run luigi worker with `keep_alive` config. Please check ``keep_alive`` config in :ref:`worker-config` section.
+
+Retry-Policy Fields
+-------------------
+
+The fields below are in retry-policy and they can be defined per task.
+
+* retry_count
+* disable_hard_timeout
+* disable_window_seconds

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -269,7 +269,7 @@ retry_external_tasks
   This means that if external dependencies are satisfied after a workflow has
   started, any tasks dependent on that resource will be eligible for running.
   Note: Every time the task remains incomplete, it will count as FAILED, so
-  normal retry logic applies (see: `disable-num-failures` and `retry-delay`).
+  normal retry logic applies (see: `retry_count` and `retry-delay`).
   This setting works best with `worker-keep-alive: true`.
   If false, external tasks will only be evaluated when Luigi is first invoked.
   In this case, Luigi will not check whether external dependencies are
@@ -550,10 +550,10 @@ disable-hard-timeout
   **again** after this amount of time. E.g. if this was set to 600
   (i.e. 10 minutes), and the task first failed at 10:00am, the task would
   be disabled if it failed again any time after 10:10am. Note: This setting
-  does not consider the values of the `disable-num-failures` or
+  does not consider the values of the `retry_count` or
   `disable-window-seconds` settings.
 
-disable-num-failures
+retry_count
   Number of times a task can fail within disable-window-seconds before
   the scheduler will automatically disable it. If not set, the scheduler
   will not automatically disable jobs.
@@ -563,7 +563,7 @@ disable-persist-seconds
   Defaults to 86400 (1 day).
 
 disable-window-seconds
-  Number of seconds during which disable-num-failures failures must
+  Number of seconds during which retry_count failures must
   occur in order for an automatic disable by the scheduler. The
   scheduler forgets about disables that have occurred longer ago than
   this amount of time. Defaults to 3600 (1 hour).
@@ -731,3 +731,44 @@ user
   Perform file system operations as the specified user instead of $USER.  Since
   this parameter is not honored by any of the other hdfs clients, you should
   think twice before setting this parameter.
+
+
+Per Task Retry-Policy
+---------------------
+
+Luigi also supports defining retry-policy per task.
+
+.. code-block:: python
+
+    class GenerateWordsFromHdfs(luigi.Task):
+
+       retry_count = 5
+
+        ...
+
+    class GenerateWordsFromRDBM(luigi.Task):
+
+       retry_count = 3
+
+        ...
+
+    class CountLetters(luigi.Task):
+
+        def requires(self):
+            return [GenerateWordsFromHdfs(),GenerateWordsFromRDBM()]
+
+        ...
+
+Supported Configurations
+************************
+The configurations below are also definable in luigi config file. Check :ref:`scheduler-config`
+
++------------------------+-----------+
+| Config                 | Section   |
++========================+===========+
+| retry_count            | scheduler |
++------------------------+-----------+
+| disable_hard_timeout   | scheduler |
++------------------------+-----------+
+| disable_window_seconds | scheduler |
++------------------------+-----------+

--- a/examples/per_task_retry_policy.py
+++ b/examples/per_task_retry_policy.py
@@ -13,41 +13,47 @@ You can run this example like this:
             ...
             DEBUG: ErrorTask1__99914b932b task num failures is 1 and limit is 5
             DEBUG: ErrorTask2__99914b932b task num failures is 1 and limit is 2
-            DEBUG: ErrorTask2__99914b932b task num failures limit(2) is exceeded
+            DEBUG: DynamicErrorTask1__99914b932b task num failures is 1 and limit is 3
             DEBUG: ErrorTask1__99914b932b task num failures is 2 and limit is 5
             DEBUG: ErrorTask2__99914b932b task num failures is 2 and limit is 2
+            DEBUG: ErrorTask2__99914b932b task num failures limit(2) is exceeded
+            DEBUG: DynamicErrorTask1__99914b932b task num failures is 2 and limit is 3
             DEBUG: ErrorTask1__99914b932b task num failures is 3 and limit is 5
+            DEBUG: DynamicErrorTask1__99914b932b task num failures is 3 and limit is 3
+            DEBUG: DynamicErrorTask1__99914b932b task num failures limit(3) is exceeded
             DEBUG: ErrorTask1__99914b932b task num failures is 4 and limit is 5
             DEBUG: ErrorTask1__99914b932b task num failures is 5 and limit is 5
             DEBUG: ErrorTask1__99914b932b task num failures limit(5) is exceeded
             INFO:
             ===== Luigi Execution Summary =====
 
-            Scheduled 5 tasks of which:
+            Scheduled 8 tasks of which:
             * 2 ran successfully:
                 - 1 SuccessSubTask1()
                 - 1 SuccessTask1()
-            * 2 failed:
+            * 3 failed:
+                - 1 DynamicErrorTask1()
                 - 1 ErrorTask1()
                 - 1 ErrorTask2()
-            * 1 were left pending, among these:
+            * 3 were left pending, among these:
+                * 1 were missing external dependencies:
+                    - 1 DynamicErrorTaskSubmitter()
                 * 1 had failed dependencies:
                     - 1 examples.PerTaskRetryPolicy()
+                * 1 had missing external dependencies:
+                    - 1 examples.PerTaskRetryPolicy()
+                * 1 was not granted run permission by the scheduler:
+                    - 1 DynamicErrorTaskSubmitter()
 
             This progress looks :( because there were failed tasks
 
             ===== Luigi Execution Summary =====
-
-
-As it seems, While ``ErrorTask1`` is retried 5 times (Exception: Test Exception. Retry Index 5 for ErrorTask1),
-``ErrorTask2`` is retried 2 times (Exception: Test Exception. Retry Index 2 for ErrorTask2). Luigi keeps retrying
-while keep-alive mode is active.
 """
 
 import luigi
 
 
-class PerTaskRetryPolicy(luigi.WrapperTask):
+class PerTaskRetryPolicy(luigi.Task):
     """
         Wrapper class for some error and success tasks. Worker won't be shutdown unless there is
         pending tasks or failed tasks which will be retried. While keep-alive is active, workers
@@ -58,7 +64,7 @@ class PerTaskRetryPolicy(luigi.WrapperTask):
     task_namespace = 'examples'
 
     def requires(self):
-        return [ErrorTask1(), ErrorTask2(), SuccessTask1()]
+        return [ErrorTask1(), ErrorTask2(), SuccessTask1(), DynamicErrorTaskSubmitter()]
 
     def output(self):
         return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
@@ -89,6 +95,37 @@ class ErrorTask2(luigi.Task):
     retry = 0
 
     retry_count = 2
+
+    def run(self):
+        self.retry += 1
+        raise Exception('Test Exception. Retry Index %s for %s' % (self.retry, self.task_family))
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class DynamicErrorTaskSubmitter(luigi.Task):
+    target = None
+
+    def run(self):
+        target = yield DynamicErrorTask1()
+
+        if target.exists():
+            with self.output().open('w') as output:
+                output.write('SUCCESS DynamicErrorTaskSubmitter\n')
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class DynamicErrorTask1(luigi.Task):
+    """
+        This dynamic error task raises error to retry the task. retry-count for this task is 3
+    """
+
+    retry = 0
+
+    retry_count = 3
 
     def run(self):
         self.retry += 1

--- a/examples/per_task_retry_policy.py
+++ b/examples/per_task_retry_policy.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+"""
+You can run this example like this:
+
+    .. code:: console
+
+            $ luigi --module examples.per_task_retry_policy examples.PerTaskRetryPolicy --worker-keep-alive \
+            --local-scheduler --scheduler-retry-delay 5  --logging-conf-file test/testconfig/logging.cfg
+
+            ...
+            ... lots of spammy output
+            ...
+            DEBUG: ErrorTask1__99914b932b task num failures is 1 and limit is 5
+            DEBUG: ErrorTask2__99914b932b task num failures is 1 and limit is 2
+            DEBUG: ErrorTask2__99914b932b task num failures limit(2) is exceeded
+            DEBUG: ErrorTask1__99914b932b task num failures is 2 and limit is 5
+            DEBUG: ErrorTask2__99914b932b task num failures is 2 and limit is 2
+            DEBUG: ErrorTask1__99914b932b task num failures is 3 and limit is 5
+            DEBUG: ErrorTask1__99914b932b task num failures is 4 and limit is 5
+            DEBUG: ErrorTask1__99914b932b task num failures is 5 and limit is 5
+            DEBUG: ErrorTask1__99914b932b task num failures limit(5) is exceeded
+            INFO:
+            ===== Luigi Execution Summary =====
+
+            Scheduled 5 tasks of which:
+            * 2 ran successfully:
+                - 1 SuccessSubTask1()
+                - 1 SuccessTask1()
+            * 2 failed:
+                - 1 ErrorTask1()
+                - 1 ErrorTask2()
+            * 1 were left pending, among these:
+                * 1 had failed dependencies:
+                    - 1 examples.PerTaskRetryPolicy()
+
+            This progress looks :( because there were failed tasks
+
+            ===== Luigi Execution Summary =====
+
+
+As it seems, While ``ErrorTask1`` is retried 5 times (Exception: Test Exception. Retry Index 5 for ErrorTask1),
+``ErrorTask2`` is retried 2 times (Exception: Test Exception. Retry Index 2 for ErrorTask2). Luigi keeps retrying
+while keep-alive mode is active.
+"""
+
+import luigi
+
+
+class PerTaskRetryPolicy(luigi.WrapperTask):
+    """
+        Wrapper class for some error and success tasks. Worker won't be shutdown unless there is
+        pending tasks or failed tasks which will be retried. While keep-alive is active, workers
+        are not shutdown while there is/are some pending task(s).
+
+    """
+
+    task_namespace = 'examples'
+
+    def requires(self):
+        return [ErrorTask1(), ErrorTask2(), SuccessTask1()]
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class ErrorTask1(luigi.Task):
+    """
+        This error class raises error to retry the task. retry-count for this task is 5. It can be seen on
+    """
+
+    retry = 0
+
+    retry_count = 5
+
+    def run(self):
+        self.retry += 1
+        raise Exception('Test Exception. Retry Index %s for %s' % (self.retry, self.task_family))
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class ErrorTask2(luigi.Task):
+    """
+        This error class raises error to retry the task. retry-count for this task is 2
+    """
+
+    retry = 0
+
+    retry_count = 2
+
+    def run(self):
+        self.retry += 1
+        raise Exception('Test Exception. Retry Index %s for %s' % (self.retry, self.task_family))
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class SuccessTask1(luigi.Task):
+    def requires(self):
+        return [SuccessSubTask1()]
+
+    def run(self):
+        with self.output().open('w') as output:
+            output.write('SUCCESS Test Task 4\n')
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)
+
+
+class SuccessSubTask1(luigi.Task):
+    """
+        This success task sleeps for a while and then it is completed successfully.
+    """
+
+    def run(self):
+        with self.output().open('w') as output:
+            output.write('SUCCESS Test Task 4.1\n')
+
+    def output(self):
+        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.task_id)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -862,9 +862,8 @@ class Scheduler(object):
                     elif upstream_status_table[dep_id] == '' and dep.deps:
                         # This is the postorder update step when we set the
                         # status based on the previously calculated child elements
-                        status = max((upstream_status_table.get(a_task_id, '')
-                                      for a_task_id in dep.deps),
-                                     key=UPSTREAM_SEVERITY_KEY)
+                        upstream_severities = list(upstream_status_table.get(a_task_id) for a_task_id in dep.deps if a_task_id in upstream_status_table) or ['']
+                        status = min(upstream_severities, key=UPSTREAM_SEVERITY_KEY)
                         upstream_status_table[dep_id] = status
             return upstream_status_table[dep_id]
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -124,7 +124,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable-num-failures'))
+                                         config_path=dict(section='scheduler', name='disable_failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -46,7 +46,6 @@ from luigi.task import Config
 
 logger = logging.getLogger(__name__)
 
-
 UPSTREAM_RUNNING = 'UPSTREAM_RUNNING'
 UPSTREAM_MISSING_INPUT = 'UPSTREAM_MISSING_INPUT'
 UPSTREAM_FAILED = 'UPSTREAM_FAILED'
@@ -70,6 +69,17 @@ STATUS_TO_UPSTREAM_MAP = {
 TASK_FAMILY_RE = re.compile(r'([^(_]+)[(_]')
 
 RPC_METHODS = {}
+
+_retry_policy_fields = [
+    "retry_count",
+    "disable_hard_timeout",
+    "disable_window",
+]
+RetryPolicy = collections.namedtuple("RetryPolicy", _retry_policy_fields)
+
+
+def _get_empty_retry_policy():
+    return RetryPolicy(*[None] * len(_retry_policy_fields))
 
 
 def rpc_method(**request_args):
@@ -97,6 +107,7 @@ def rpc_method(**request_args):
 
         RPC_METHODS[fn_name] = rpc_func
         return fn
+
     return _rpc_method
 
 
@@ -108,12 +119,12 @@ class scheduler(Config):
     worker_disconnect_delay = parameter.FloatParameter(default=60.0)
     state_path = parameter.Parameter(default='/var/lib/luigi-server/state.pickle')
 
-    # Jobs are disabled if we see more than disable_failures failures in disable_window seconds.
+    # Jobs are disabled if we see more than retry_count failures in disable_window seconds.
     # These disables last for disable_persist seconds.
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
-    disable_failures = parameter.IntParameter(default=999999999,
-                                              config_path=dict(section='scheduler', name='disable-num-failures'))
+    retry_count = parameter.IntParameter(default=999999999,
+                                         config_path=dict(section='scheduler', name='disable-num-failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,
@@ -124,6 +135,9 @@ class scheduler(Config):
     record_task_history = parameter.BoolParameter(default=False)
 
     prune_on_get_work = parameter.BoolParameter(default=False)
+
+    def _get_retry_policy(self):
+        return RetryPolicy(self.retry_count, self.disable_hard_timeout, self.disable_window)
 
 
 class Failures(object):
@@ -181,10 +195,8 @@ def _get_default(x, default):
 
 
 class Task(object):
-
     def __init__(self, task_id, status, deps, resources=None, priority=0, family='', module=None,
-                 params=None, disable_failures=None, disable_window=None, disable_hard_timeout=None,
-                 tracking_url=None, status_message=None):
+                 params=None, tracking_url=None, status_message=None, retry_policy=None):
         self.id = task_id
         self.stakeholders = set()  # workers ids that are somehow related to this task (i.e. don't prune while any of these workers are still active)
         self.workers = set()  # workers ids that can perform task - task is 'BROKEN' if none of these workers are active
@@ -205,9 +217,9 @@ class Task(object):
         self.family = family
         self.module = module
         self.params = _get_default(params, {})
-        self.disable_failures = disable_failures
-        self.disable_hard_timeout = disable_hard_timeout
-        self.failures = Failures(disable_window)
+
+        self.retry_policy = _get_default(retry_policy, _get_empty_retry_policy())
+        self.failures = Failures(self.retry_policy.disable_window)
         self.tracking_url = tracking_url
         self.status_message = status_message
         self.scheduler_disable_time = None
@@ -221,11 +233,12 @@ class Task(object):
 
     def has_excessive_failures(self):
         if self.failures.first_failure_time is not None:
-            if (time.time() >= self.failures.first_failure_time +
-                    self.disable_hard_timeout):
+            if (time.time() >= self.failures.first_failure_time + self.retry_policy.disable_hard_timeout):
                 return True
 
-        if self.failures.num_failures() >= self.disable_failures:
+        logger.debug('%s task num failures is %s and limit is %s', self.id, self.failures.num_failures(), self.retry_policy.retry_count)
+        if self.failures.num_failures() >= self.retry_policy.retry_count:
+            logger.debug('%s task num failures limit(%s) is exceeded', self.id, self.retry_policy.retry_count)
             return True
 
         return False
@@ -408,7 +421,7 @@ class SimpleTaskState(object):
                     'Luigi Scheduler: DISABLED {task} due to excessive failures'.format(task=task.id),
                     '{task} failed {failures} times in the last {window} seconds, so it is being '
                     'disabled for {persist} seconds'.format(
-                        failures=config.disable_failures,
+                        failures=task.retry_policy.retry_count,
                         task=task.id,
                         window=config.disable_window,
                         persist=config.disable_persist,
@@ -467,7 +480,7 @@ class SimpleTaskState(object):
                 continue
             last_get_work = getattr(worker, 'last_get_work', None)
             if last_get_work_gt is not None and (
-                    last_get_work is None or last_get_work <= last_get_work_gt):
+                            last_get_work is None or last_get_work <= last_get_work_gt):
                 continue
             yield worker
 
@@ -523,10 +536,7 @@ class Scheduler(object):
         else:
             self._task_history = history.NopHistory()
         self._resources = resources or configuration.get_config().getintdict('resources')  # TODO: Can we make this a Parameter?
-        self._make_task = functools.partial(
-            Task, disable_failures=self._config.disable_failures,
-            disable_hard_timeout=self._config.disable_hard_timeout,
-            disable_window=self._config.disable_window)
+        self._make_task = functools.partial(Task, retry_policy=self._config._get_retry_policy())
         self._worker_requests = {}
 
     def load(self):
@@ -589,7 +599,8 @@ class Scheduler(object):
     def add_task(self, task_id=None, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
                  priority=0, family='', module=None, params=None,
-                 assistant=False, tracking_url=None, worker=None, **kwargs):
+                 assistant=False, tracking_url=None, worker=None,
+                 retry_policy_dict=None, deps_retry_policy_dicts=None, **kwargs):
         """
         * add task identified by task_id if it doesn't exist
         * if deps is not None, update dependency list
@@ -605,6 +616,7 @@ class Scheduler(object):
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
                 priority=priority, family=family, module=module, params=params,
+                retry_policy=self._generate_retry_policy(retry_policy_dict)
             )
         else:
             _default_task = None
@@ -656,8 +668,11 @@ class Scheduler(object):
 
             # Task dependencies might not exist yet. Let's create dummy tasks for them for now.
             # Otherwise the task dependencies might end up being pruned if scheduling takes a long time
+            deps_retry_policy_dicts = _get_default(deps_retry_policy_dicts, {})
             for dep in task.deps or []:
-                t = self._state.get_task(dep, setdefault=self._make_task(task_id=dep, status=UNKNOWN, deps=None, priority=priority))
+                t = self._state.get_task(dep, setdefault=self._make_task(task_id=dep, status=UNKNOWN, deps=None, priority=priority,
+                                                                         retry_policy=self._generate_retry_policy(
+                                                                             deps_retry_policy_dicts.get(dep))))
                 t.stakeholders.add(worker_id)
 
         self._update_priority(task, priority, worker_id)
@@ -680,6 +695,11 @@ class Scheduler(object):
         if self._resources is None:
             self._resources = {}
         self._resources.update(resources)
+
+    def _generate_retry_policy(self, task_retry_policy_dict):
+        retry_policy_dict = self._config._get_retry_policy()._asdict()
+        retry_policy_dict.update({k: v for k, v in six.iteritems(_get_default(task_retry_policy_dict, {})) if v is not None})
+        return RetryPolicy(**retry_policy_dict)
 
     def _has_resources(self, needed_resources, used_resources):
         if needed_resources is None:
@@ -1002,8 +1022,7 @@ class Scheduler(object):
             def filter_func(t):
                 return all(term in t.pretty_id for term in terms)
         for task in filter(filter_func, self._state.get_active_tasks(status)):
-            if (task.status != PENDING or not upstream_status or
-                    upstream_status == self._upstream_status(task.id, upstream_status_table)):
+            if task.status != PENDING or not upstream_status or upstream_status == self._upstream_status(task.id, upstream_status_table):
                 serialized = self._serialize_task(task.id, False)
                 result[task.id] = serialized
         if limit and len(result) > self._config.max_shown_tasks:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -124,7 +124,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable_failures'))
+                                         config_path=dict(section='scheduler', name='disable-num-failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -124,7 +124,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable-failures'))
+                                         config_path=dict(section='scheduler', name='disable_failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -124,7 +124,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable-num-failures'))
+                                         config_path=dict(section='scheduler', name='disable-failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -147,6 +147,30 @@ class Task(object):
     worker_timeout = None
 
     @property
+    def retry_count(self):
+        """
+        Override this positive integer to have different ``retry_count`` at task level
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
+    def disable_hard_timeout(self):
+        """
+        Override this positive integer to have different ``disable_hard_timeout`` at task level.
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
+    def disable_window_seconds(self):
+        """
+        Override this positive integer to have different ``disable_window_seconds`` at task level.
+        Check :ref:`scheduler-config`
+        """
+        return None
+
+    @property
     def owner_email(self):
         '''
         Override this to send out additional error emails to task owner, in addition to the one

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -53,7 +53,7 @@ from luigi import six
 from luigi import notifications
 from luigi.event import Event
 from luigi.task_register import load_task
-from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler
+from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler, RetryPolicy
 from luigi.target import Target
 from luigi.task import Task, flatten, getpaths, Config
 from luigi.task_register import TaskClassException
@@ -83,6 +83,10 @@ _WAIT_INTERVAL_EPS = 0.00001
 
 def _is_external(task):
     return task.run is None or task.run == NotImplemented
+
+
+def _get_retry_policy_dict(task):
+    return RetryPolicy(task.retry_count, task.disable_hard_timeout, task.disable_window_seconds)._asdict()
 
 
 class TaskException(Exception):
@@ -569,6 +573,7 @@ class Worker(object):
         return self.add_succeeded
 
     def _add(self, task, is_complete):
+        deps_retry_policy_dicts = None
         if self._config.task_limit is not None and len(self._scheduled_tasks) >= self._config.task_limit:
             logger.warning('Will not run %s or any dependencies due to exceeded task-limit of %d', task, self._config.task_limit)
             deps = None
@@ -635,6 +640,7 @@ class Worker(object):
                     task.trigger_event(Event.DEPENDENCY_DISCOVERED, task, d)
                     yield d  # return additional tasks to add
 
+                deps_retry_policy_dicts = {d.task_id: _get_retry_policy_dict(d) for d in deps}
                 deps = [d.task_id for d in deps]
 
         self._scheduled_tasks[task.task_id] = task
@@ -643,7 +649,9 @@ class Worker(object):
                        resources=task.process_resources(),
                        params=task.to_str_params(),
                        family=task.task_family,
-                       module=task.task_module)
+                       module=task.task_module,
+                       retry_policy_dict=_get_retry_policy_dict(task),
+                       deps_retry_policy_dicts=deps_retry_policy_dicts)
 
     def _validate_dependency(self, dependency):
         if isinstance(dependency, Target):

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -93,7 +93,7 @@ class DbTaskHistoryTest(unittest.TestCase):
 
     def run_task(self, task):
         task2 = luigi.scheduler.Task(task.task_id, PENDING, [], family=task.task_family,
-                                     params=task.param_kwargs)
+                                     params=task.param_kwargs, retry_policy=luigi.scheduler._get_empty_retry_policy())
 
         self.history.task_scheduled(task2)
         self.history.task_started(task2, 'hostname')
@@ -133,7 +133,8 @@ class MySQLDbTaskHistoryTest(unittest.TestCase):
 
     def run_task(self, task):
         task2 = luigi.scheduler.Task(task.task_id, PENDING, [],
-                                     family=task.task_family, params=task.param_kwargs)
+                                     family=task.task_family, params=task.param_kwargs,
+                                     retry_policy=luigi.scheduler._get_empty_retry_policy())
 
         self.history.task_scheduled(task2)
         self.history.task_started(task2, 'hostname')

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -42,7 +42,7 @@ class SchedulerApiTest(unittest.TestCase):
             'worker_disconnect_delay': 10,
             'disable_persist': 10,
             'disable_window': 10,
-            'disable_failures': 3,
+            'retry_count': 3,
             'disable_hard_timeout': 60 * 60,
         }
 
@@ -742,7 +742,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(self.sch.get_work(worker=WORKER)['task_id'], 'A')
 
     def test_automatic_re_enable(self):
-        self.sch = Scheduler(disable_failures=2, disable_persist=100)
+        self.sch = Scheduler(retry_count=2, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
@@ -755,7 +755,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(FAILED, self.sch.task_list('', '')['A']['status'])
 
     def test_automatic_re_enable_with_one_failure_allowed(self):
-        self.sch = Scheduler(disable_failures=1, disable_persist=100)
+        self.sch = Scheduler(retry_count=1, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
 
@@ -779,7 +779,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(DISABLED, self.sch.task_list('', '')['A']['status'])
 
     def test_no_automatic_re_enable_after_auto_then_manual_disable(self):
-        self.sch = Scheduler(disable_failures=2, disable_persist=100)
+        self.sch = Scheduler(retry_count=2, disable_persist=100)
         self.setTime(0)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
         self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -54,7 +54,7 @@ class SchedulerIoTest(unittest.TestCase):
 
             self.assertEqual(list(state.get_worker_ids()), [])
 
-    @with_config({'scheduler': {'disable-num-failures': '44', 'worker-disconnect-delay': '55'}})
+    @with_config({'scheduler': {'retry_count': '44', 'worker-disconnect-delay': '55'}})
     def test_scheduler_with_config(self):
         scheduler = luigi.scheduler.Scheduler()
         self.assertEqual(44, scheduler._config.retry_count)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -183,11 +183,9 @@ class SchedulerIoTest(unittest.TestCase):
         self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_6.retry_policy)
 
         cps._state._tasks = {}
-        cps.add_task(worker='test_worker3', task_id='test_task_7', deps=['test_task_8', 'test_task_9'],
-                     deps_retry_policy_dicts={
-                         'test_task_8': luigi.scheduler.RetryPolicy(99, 999, 9999)._asdict(),
-                         'test_task_9': luigi.scheduler.RetryPolicy(11, 111, 1111)._asdict(),
-                     })
+        cps.add_task(worker='test_worker3', task_id='test_task_7', deps=['test_task_8', 'test_task_9'])
+        cps.add_task(worker='test_worker3', task_id='test_task_8', retry_policy_dict=luigi.scheduler.RetryPolicy(99, 999, 9999)._asdict())
+        cps.add_task(worker='test_worker3', task_id='test_task_9', retry_policy_dict=luigi.scheduler.RetryPolicy(11, 111, 1111)._asdict())
 
         tasks = list(cps._state.get_active_tasks())
         self.assertEqual(3, len(tasks))

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -225,7 +225,3 @@ class SchedulerIoTest(unittest.TestCase):
         self.assertFalse(task_9.has_excessive_failures())
         task_9.add_failure()
         self.assertTrue(task_9.has_excessive_failures())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -57,13 +57,13 @@ class SchedulerIoTest(unittest.TestCase):
     @with_config({'scheduler': {'disable-num-failures': '44', 'worker-disconnect-delay': '55'}})
     def test_scheduler_with_config(self):
         scheduler = luigi.scheduler.Scheduler()
-        self.assertEqual(44, scheduler._config.disable_failures)
+        self.assertEqual(44, scheduler._config.retry_count)
         self.assertEqual(55, scheduler._config.worker_disconnect_delay)
 
         # Override
-        scheduler = luigi.scheduler.Scheduler(disable_failures=66,
+        scheduler = luigi.scheduler.Scheduler(retry_count=66,
                                               worker_disconnect_delay=77)
-        self.assertEqual(66, scheduler._config.disable_failures)
+        self.assertEqual(66, scheduler._config.retry_count)
         self.assertEqual(77, scheduler._config.worker_disconnect_delay)
 
     @with_config({'resources': {'a': '100', 'b': '200'}})
@@ -110,3 +110,122 @@ class SchedulerIoTest(unittest.TestCase):
                 self.worker_disconnect_delay = 10
 
         worker.prune(TmpCfg())
+
+    def test_get_empty_retry_policy(self):
+        retry_policy = luigi.scheduler._get_empty_retry_policy()
+        self.assertEqual(3, len(retry_policy))
+        self.assertEqual(["retry_count", "disable_hard_timeout", "disable_window"], list(retry_policy._asdict().keys()))
+        self.assertEqual([None, None, None], list(retry_policy._asdict().values()))
+
+    @with_config({'scheduler': {'retry_count': '9', 'disable_hard_timeout': '99', 'disable_window': '999'}})
+    def test_scheduler_get_retry_policy(self):
+        s = luigi.scheduler.Scheduler()
+        self.assertEqual(luigi.scheduler.RetryPolicy(9, 99, 999), s._config._get_retry_policy())
+
+    @with_config({'scheduler': {'retry_count': '9', 'disable_hard_timeout': '99', 'disable_window': '999'}})
+    def test_generate_retry_policy(self):
+        s = luigi.scheduler.Scheduler()
+
+        try:
+            s._generate_retry_policy({'inexist_attr': True})
+            self.assertFalse(True, "'unexpected keyword argument' error must have been thrown")
+        except TypeError:
+            self.assertTrue(True)
+
+        retry_policy = s._generate_retry_policy({})
+        self.assertEqual(luigi.scheduler.RetryPolicy(9, 99, 999), retry_policy)
+
+        retry_policy = s._generate_retry_policy({'retry_count': 1})
+        self.assertEqual(luigi.scheduler.RetryPolicy(1, 99, 999), retry_policy)
+
+        retry_policy = s._generate_retry_policy({'retry_count': 1, 'disable_hard_timeout': 11, 'disable_window': 111})
+        self.assertEqual(luigi.scheduler.RetryPolicy(1, 11, 111), retry_policy)
+
+    @with_config({'scheduler': {'retry_count': '44'}})
+    def test_per_task_retry_policy(self):
+        cps = luigi.scheduler.Scheduler()
+
+        cps.add_task(worker='test_worker1', task_id='test_task_1', deps=['test_task_2', 'test_task_3'])
+        tasks = list(cps._state.get_active_tasks())
+        self.assertEqual(3, len(tasks))
+
+        tasks = sorted(tasks, key=lambda x: x.id)
+        task_1 = tasks[0]
+        task_2 = tasks[1]
+        task_3 = tasks[2]
+
+        self.assertEqual('test_task_1', task_1.id)
+        self.assertEqual('test_task_2', task_2.id)
+        self.assertEqual('test_task_3', task_3.id)
+
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_1.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_2.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_3.retry_policy)
+
+        cps._state._tasks = {}
+        cps.add_task(worker='test_worker2', task_id='test_task_4', deps=['test_task_5', 'test_task_6'],
+                     retry_policy_dict=luigi.scheduler.RetryPolicy(99, 999, 9999)._asdict())
+
+        tasks = list(cps._state.get_active_tasks())
+        self.assertEqual(3, len(tasks))
+
+        tasks = sorted(tasks, key=lambda x: x.id)
+        task_4 = tasks[0]
+        task_5 = tasks[1]
+        task_6 = tasks[2]
+
+        self.assertEqual('test_task_4', task_4.id)
+        self.assertEqual('test_task_5', task_5.id)
+        self.assertEqual('test_task_6', task_6.id)
+
+        self.assertEqual(luigi.scheduler.RetryPolicy(99, 999, 9999), task_4.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_5.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_6.retry_policy)
+
+        cps._state._tasks = {}
+        cps.add_task(worker='test_worker3', task_id='test_task_7', deps=['test_task_8', 'test_task_9'],
+                     deps_retry_policy_dicts={
+                         'test_task_8': luigi.scheduler.RetryPolicy(99, 999, 9999)._asdict(),
+                         'test_task_9': luigi.scheduler.RetryPolicy(11, 111, 1111)._asdict(),
+                     })
+
+        tasks = list(cps._state.get_active_tasks())
+        self.assertEqual(3, len(tasks))
+
+        tasks = sorted(tasks, key=lambda x: x.id)
+        task_7 = tasks[0]
+        task_8 = tasks[1]
+        task_9 = tasks[2]
+
+        self.assertEqual('test_task_7', task_7.id)
+        self.assertEqual('test_task_8', task_8.id)
+        self.assertEqual('test_task_9', task_9.id)
+
+        self.assertEqual(luigi.scheduler.RetryPolicy(44, 999999999, 3600), task_7.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(99, 999, 9999), task_8.retry_policy)
+        self.assertEqual(luigi.scheduler.RetryPolicy(11, 111, 1111), task_9.retry_policy)
+
+        # Task 7 which is disable-failures 44 and its has_excessive_failures method returns False under 44
+        for i in range(43):
+            task_7.add_failure()
+        self.assertFalse(task_7.has_excessive_failures())
+        task_7.add_failure()
+        self.assertTrue(task_7.has_excessive_failures())
+
+        # Task 8 which is disable-failures 99 and its has_excessive_failures method returns False under 44
+        for i in range(98):
+            task_8.add_failure()
+        self.assertFalse(task_8.has_excessive_failures())
+        task_8.add_failure()
+        self.assertTrue(task_8.has_excessive_failures())
+
+        # Task 9 which is disable-failures 1 and its has_excessive_failures method returns False under 44
+        for i in range(10):
+            task_9.add_failure()
+        self.assertFalse(task_9.has_excessive_failures())
+        task_9.add_failure()
+        self.assertTrue(task_9.has_excessive_failures())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -423,7 +423,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(db['status'], 'DONE')
 
         missing_input = remote.task_list('PENDING', 'UPSTREAM_MISSING_INPUT')
-        self.assertEqual(len(missing_input), 2)
+        self.assertEqual(len(missing_input), 3)
 
         pa = missing_input.get(A().task_id)
         self.assertEqual(pa['status'], 'PENDING')
@@ -433,14 +433,15 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(pc['status'], 'PENDING')
         self.assertEqual(remote._upstream_status(C().task_id, {}), 'UPSTREAM_MISSING_INPUT')
 
-        upstream_failed = remote.task_list('PENDING', 'UPSTREAM_FAILED')
-        self.assertEqual(len(upstream_failed), 2)
-        pe = upstream_failed.get(E().task_id)
+        pe = missing_input.get(E().task_id)
         self.assertEqual(pe['status'], 'PENDING')
-        self.assertEqual(remote._upstream_status(E().task_id, {}), 'UPSTREAM_FAILED')
+        self.assertEqual(remote._upstream_status(E().task_id, {}), 'UPSTREAM_MISSING_INPUT')
 
-        pe = upstream_failed.get(D().task_id)
-        self.assertEqual(pe['status'], 'PENDING')
+        upstream_failed = remote.task_list('PENDING', 'UPSTREAM_FAILED')
+        self.assertEqual(len(upstream_failed), 1)
+
+        pd = upstream_failed.get(D().task_id)
+        self.assertEqual(pd['status'], 'PENDING')
         self.assertEqual(remote._upstream_status(D().task_id, {}), 'UPSTREAM_FAILED')
 
         pending = dict(missing_input)

--- a/test/worker_keep_alive_test.py
+++ b/test/worker_keep_alive_test.py
@@ -33,7 +33,7 @@ class WorkerKeepAliveUpstreamTest(LuigiTestCase):
         """
         Common setup code. Due to the contextmanager cant use normal setup
         """
-        self.sch = Scheduler(retry_delay=0.00000001, disable_failures=2)
+        self.sch = Scheduler(retry_delay=0.00000001, retry_count=2)
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1, wait_jitter=0) as w:
             self.w = w

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1299,6 +1299,7 @@ class WorkerPurgeEventHandlerTest(unittest.TestCase):
 
         self.assertEqual(result, [task])
 
+
 class PerTaskRetryPolicyBehaviorTest(unittest.TestCase):
     def setUp(self):
         self.per_task_retry_count = 2

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -24,7 +24,6 @@ import signal
 import tempfile
 import threading
 import time
-from uuid import uuid4
 
 import psutil
 from helpers import (unittest, with_config, skipOnTravis, LuigiTestCase,
@@ -109,6 +108,14 @@ class DynamicRequiresOtherModule(Task):
 
         with self.output().open('w') as f:
             f.write('Done!')
+
+
+class DummyErrorTask(Task):
+    retry_index = 0
+
+    def run(self):
+        self.retry_index += 1
+        raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
 
 
 class WorkerTest(unittest.TestCase):
@@ -1300,356 +1307,274 @@ class WorkerPurgeEventHandlerTest(unittest.TestCase):
         self.assertEqual(result, [task])
 
 
-class PerTaskRetryPolicyBehaviorTest(unittest.TestCase):
+class PerTaskRetryPolicyBehaviorTest(LuigiTestCase):
     def setUp(self):
+        super(PerTaskRetryPolicyBehaviorTest, self).setUp()
         self.per_task_retry_count = 2
         self.default_retry_count = 1
-        self.sch = Scheduler(retry_delay=0.1, retry_count=self.default_retry_count, prune_on_get_work=True, record_task_history=False)
-
-        self.test_instance_id = str(uuid4())
+        self.sch = Scheduler(retry_delay=0.1, retry_count=self.default_retry_count, prune_on_get_work=True)
 
     def test_with_all_disabled_with_single_worker(self):
         """
-            With this test, a case which has a task (A), requires two another tasks (B,C) which both is failed, is tested.
+            With this test, a case which has a task (TestWrapperTask), requires two another tasks (TestErrorTask1,TestErrorTask1) which both is failed, is
+            tested.
 
-            Task C has default retry_count which is 1, but Task B has retry_count at task level as 2.
+            Task TestErrorTask1 has default retry_count which is 1, but Task TestErrorTask2 has retry_count at task level as 2.
 
             This test is running on single worker
         """
-        class C(luigi.Task):
-            task_namespace = self.test_instance_id
 
-            retry_index = 0
+        class TestErrorTask1(DummyErrorTask):
+            pass
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
+        e1 = TestErrorTask1()
 
-        c = C()
-
-        class B(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask2(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e2 = TestErrorTask2()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        b = B()
-
-        class A(luigi.WrapperTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(luigi.WrapperTask):
             def requires(self):
-                return [b, c]
+                return [e2, e1]
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
-            self.assertTrue(w1.add(a))
+            self.assertTrue(w1.add(wt))
 
             self.assertFalse(w1.run())
 
-            self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+            self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
 
-            self.assertEqual(sorted([b.task_id, c.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
+            self.assertEqual(sorted([e1.task_id, e2.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
 
-            self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(b.task_id).failures.num_failures())
-            self.assertEqual(self.default_retry_count, self.sch._state.get_task(c.task_id).failures.num_failures())
+            self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e2.task_id).failures.num_failures())
+            self.assertEqual(self.default_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())
 
     def test_with_all_disabled_with_multiple_worker(self):
         """
-            With this test, a case which has a task (A), requires two another tasks (B,C) which both is failed, is tested.
+            With this test, a case which has a task (TestWrapperTask), requires two another tasks (TestErrorTask1,TestErrorTask1) which both is failed, is
+            tested.
 
-            Task C has default retry_count which is 1, but Task B has retry_count at task level as 2.
+            Task TestErrorTask1 has default retry_count which is 1, but Task TestErrorTask2 has retry_count at task level as 2.
 
             This test is running on multiple worker
         """
 
-        class C(luigi.Task):
-            task_namespace = self.test_instance_id
+        class TestErrorTask1(DummyErrorTask):
+            pass
 
-            retry_index = 0
+        e1 = TestErrorTask1()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        c = C()
-
-        class B(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask2(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e2 = TestErrorTask2()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        b = B()
-
-        class A(luigi.WrapperTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(luigi.WrapperTask):
             def requires(self):
-                return [b, c]
+                return [e2, e1]
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
             with Worker(scheduler=self.sch, worker_id='Y', keep_alive=True, wait_interval=0.1) as w2:
                 with Worker(scheduler=self.sch, worker_id='Z', keep_alive=True, wait_interval=0.1) as w3:
-                    self.assertTrue(w1.add(a))
-                    self.assertTrue(w2.add(b))
-                    self.assertTrue(w3.add(c))
+                    self.assertTrue(w1.add(wt))
+                    self.assertTrue(w2.add(e2))
+                    self.assertTrue(w3.add(e1))
 
                     self.assertFalse(w3.run())
                     self.assertFalse(w2.run())
                     self.assertFalse(w1.run())
 
-                    self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+                    self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
 
-                    self.assertEqual(sorted([b.task_id, c.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
+                    self.assertEqual(sorted([e1.task_id, e2.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
 
-                    self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-                    self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(b.task_id).failures.num_failures())
-                    self.assertEqual(self.default_retry_count, self.sch._state.get_task(c.task_id).failures.num_failures())
+                    self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+                    self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e2.task_id).failures.num_failures())
+                    self.assertEqual(self.default_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())
 
     def test_with_includes_success_with_single_worker(self):
         """
-            With this test, a case which has a task (A), requires one (B) FAILED and one (C) SUCCESS, is tested.
+            With this test, a case which has a task (TestWrapperTask), requires one (TestErrorTask1) FAILED and one (TestSuccessTask1) SUCCESS, is tested.
 
-            Task C will be DONE successfully, but Task B will be failed and it has retry_count at task level as 2.
+            Task TestSuccessTask1 will be DONE successfully, but Task TestErrorTask1 will be failed and it has retry_count at task level as 2.
 
             This test is running on single worker
         """
 
-        class C(DummyTask):
-            task_namespace = self.test_instance_id
+        class TestSuccessTask1(DummyTask):
+            pass
 
-        c = C()
+        s1 = TestSuccessTask1()
 
-        class B(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask1(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e1 = TestErrorTask1()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        b = B()
-
-        class A(luigi.WrapperTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(luigi.WrapperTask):
             def requires(self):
-                return [b, c]
+                return [e1, s1]
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
-            self.assertTrue(w1.add(a))
+            self.assertTrue(w1.add(wt))
 
             self.assertFalse(w1.run())
 
-            self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
-            self.assertEqual([b.task_id], sorted(self.sch.task_list('DISABLED', '').keys()))
-            self.assertEqual([c.task_id], list(self.sch.task_list('DONE', '').keys()))
+            self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+            self.assertEqual([e1.task_id], list(self.sch.task_list('DISABLED', '').keys()))
+            self.assertEqual([s1.task_id], list(self.sch.task_list('DONE', '').keys()))
 
-            self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(b.task_id).failures.num_failures())
-            self.assertEqual(0, self.sch._state.get_task(c.task_id).failures.num_failures())
+            self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())
+            self.assertEqual(0, self.sch._state.get_task(s1.task_id).failures.num_failures())
 
     def test_with_includes_success_with_multiple_worker(self):
         """
-            With this test, a case which has a task (A), requires one (B) FAILED and one (C) SUCCESS, is tested.
+            With this test, a case which has a task (TestWrapperTask), requires one (TestErrorTask1) FAILED and one (TestSuccessTask1) SUCCESS, is tested.
 
-            Task C will be DONE successfully, but Task B will be failed and it has retry_count at task level as 2.
+            Task TestSuccessTask1 will be DONE successfully, but Task TestErrorTask1 will be failed and it has retry_count at task level as 2.
 
             This test is running on multiple worker
         """
 
-        class C(DummyTask):
-            task_namespace = self.test_instance_id
+        class TestSuccessTask1(DummyTask):
+            pass
 
-        c = C()
+        s1 = TestSuccessTask1()
 
-        class B(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask1(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e1 = TestErrorTask1()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        b = B()
-
-        class A(luigi.WrapperTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(luigi.WrapperTask):
             def requires(self):
-                return [b, c]
+                return [e1, s1]
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
             with Worker(scheduler=self.sch, worker_id='Y', keep_alive=True, wait_interval=0.1) as w2:
                 with Worker(scheduler=self.sch, worker_id='Z', keep_alive=True, wait_interval=0.1) as w3:
-                    self.assertTrue(w1.add(a))
-                    self.assertTrue(w2.add(b))
-                    self.assertTrue(w3.add(c))
+                    self.assertTrue(w1.add(wt))
+                    self.assertTrue(w2.add(e1))
+                    self.assertTrue(w3.add(s1))
 
                     self.assertTrue(w3.run())
                     self.assertFalse(w2.run())
                     self.assertFalse(w1.run())
 
-                    self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
-                    self.assertEqual([b.task_id], sorted(self.sch.task_list('DISABLED', '').keys()))
-                    self.assertEqual([c.task_id], list(self.sch.task_list('DONE', '').keys()))
+                    self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+                    self.assertEqual([e1.task_id], list(self.sch.task_list('DISABLED', '').keys()))
+                    self.assertEqual([s1.task_id], list(self.sch.task_list('DONE', '').keys()))
 
-                    self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-                    self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(b.task_id).failures.num_failures())
-                    self.assertEqual(0, self.sch._state.get_task(c.task_id).failures.num_failures())
+                    self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+                    self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())
+                    self.assertEqual(0, self.sch._state.get_task(s1.task_id).failures.num_failures())
 
     def test_with_dynamic_dependencies_with_single_worker(self):
         """
-            With this test, a case includes dependency tasks(C,D) which both are failed.
+            With this test, a case includes dependency tasks(TestErrorTask1,TestErrorTask2) which both are failed.
 
-            Task D has default retry_count which is 1, but Task C has retry_count at task level as 2.
+            Task TestErrorTask1 has default retry_count which is 1, but Task TestErrorTask2 has retry_count at task level as 2.
 
             This test is running on single worker
         """
 
-        class D(Task):
-            task_namespace = self.test_instance_id
+        class TestErrorTask1(DummyErrorTask):
+            pass
 
-            retry_index = 0
+        e1 = TestErrorTask1()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        d = D()
-
-        class C(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask2(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e2 = TestErrorTask2()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
+        class TestSuccessTask1(DummyTask):
+            pass
 
-        c = C()
+        s1 = TestSuccessTask1()
 
-        class B(DummyTask):
-            task_namespace = self.test_instance_id
-
-        b = B()
-
-        class A(DummyTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(DummyTask):
             def requires(self):
-                return [b]
+                return [s1]
 
             def run(self):
-                super(A, self).run()
-                yield c, d
+                super(TestWrapperTask, self).run()
+                yield e2, e1
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
-            self.assertTrue(w1.add(a))
+            self.assertTrue(w1.add(wt))
 
             self.assertFalse(w1.run())
 
-            self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+            self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
 
-            self.assertEqual(sorted([c.task_id, d.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
+            self.assertEqual(sorted([e1.task_id, e2.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
 
-            self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-            self.assertEqual(0, self.sch._state.get_task(b.task_id).failures.num_failures())
-            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(c.task_id).failures.num_failures())
-            self.assertEqual(self.default_retry_count, self.sch._state.get_task(d.task_id).failures.num_failures())
+            self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+            self.assertEqual(0, self.sch._state.get_task(s1.task_id).failures.num_failures())
+            self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e2.task_id).failures.num_failures())
+            self.assertEqual(self.default_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())
 
     def test_with_dynamic_dependencies_with_multiple_workers(self):
         """
-            With this test, a case includes dependency tasks(C,D) which both are failed.
+            With this test, a case includes dependency tasks(TestErrorTask1,TestErrorTask2) which both are failed.
 
-            Task D has default retry_count which is 1, but Task C has retry_count at task level as 2.
+            Task TestErrorTask1 has default retry_count which is 1, but Task TestErrorTask2 has retry_count at task level as 2.
 
             This test is running on multiple worker
         """
 
-        class D(Task):
-            task_namespace = self.test_instance_id
+        class TestErrorTask1(DummyErrorTask):
+            pass
 
-            retry_index = 0
+        e1 = TestErrorTask1()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
-
-        d = D()
-
-        class C(Task):
-            task_namespace = self.test_instance_id
-
+        class TestErrorTask2(DummyErrorTask):
             retry_count = self.per_task_retry_count
 
-            retry_index = 0
+        e2 = TestErrorTask2()
 
-            def run(self):
-                self.retry_index += 1
-                raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
+        class TestSuccessTask1(DummyTask):
+            pass
 
-        c = C()
+        s1 = TestSuccessTask1()
 
-        class B(DummyTask):
-            task_namespace = self.test_instance_id
-
-        b = B()
-
-        class A(DummyTask):
-            task_namespace = self.test_instance_id
-
+        class TestWrapperTask(DummyTask):
             def requires(self):
-                return [b]
+                return [s1]
 
             def run(self):
-                super(A, self).run()
-                yield c, d
+                super(TestWrapperTask, self).run()
+                yield e2, e1
 
-        a = A()
+        wt = TestWrapperTask()
 
         with Worker(scheduler=self.sch, worker_id='X', keep_alive=True, wait_interval=0.1) as w1:
             with Worker(scheduler=self.sch, worker_id='Y', keep_alive=True, wait_interval=0.1) as w2:
-                self.assertTrue(w1.add(a))
-                self.assertTrue(w2.add(b))
+                self.assertTrue(w1.add(wt))
+                self.assertTrue(w2.add(s1))
 
                 self.assertTrue(w2.run())
                 self.assertFalse(w1.run())
 
-                self.assertEqual([a.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
+                self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
 
-                self.assertEqual(sorted([c.task_id, d.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
+                self.assertEqual(sorted([e1.task_id, e2.task_id]), sorted(self.sch.task_list('DISABLED', '').keys()))
 
-                self.assertEqual(0, self.sch._state.get_task(a.task_id).failures.num_failures())
-                self.assertEqual(0, self.sch._state.get_task(b.task_id).failures.num_failures())
-                self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(c.task_id).failures.num_failures())
-                self.assertEqual(self.default_retry_count, self.sch._state.get_task(d.task_id).failures.num_failures())
+                self.assertEqual(0, self.sch._state.get_task(wt.task_id).failures.num_failures())
+                self.assertEqual(0, self.sch._state.get_task(s1.task_id).failures.num_failures())
+                self.assertEqual(self.per_task_retry_count, self.sch._state.get_task(e2.task_id).failures.num_failures())
+                self.assertEqual(self.default_retry_count, self.sch._state.get_task(e1.task_id).failures.num_failures())


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Defining retry-policy per task as it is defined in #1073 

## Motivation and Context

It may be required to have different retry-policy for different tasks according to their priority and resource usage. Assume that, a task is retrieving data from Hive which responses in long time and other one is retrieving data from RDBM which responses in short time. I may want Hive task not to retry many times and not to drain all my resource again an again. But, retrying RDBM task many times may not be problem for me. Assume that, I have some network issue for a while and I should be able to give its retry-count more than Hive task. So I would need to define retry-policy at task level.

This fixes the issue defined in #1073

## Have you tested this? If so, how?

* Some unit tests are added about the feature.
* Run available tests(Not all of them, I don't know, some of them maybe includes hadoop ones, I couldn't make passed. ) via tox and travis.
* PyCharm Debugging.

## What is added?
* The feature
* Unit tests
* Documentation
* An example