### PR TITLE
worker.py: Remove old and not useful comment

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -31,7 +31,7 @@ ways between versions. The exception is the exception types and the
 import collections
 import getpass
 import logging
-import multiprocessing  # Note: this seems to have some stability issues: https://github.com/spotify/luigi/pull/438
+import multiprocessing
 import os
 import signal
 import subprocess


### PR DESCRIPTION
It was introduced in spotify/luigi#438. Would that bug be reintroduced I'm think that (1) we have tests nowadays for it and (2) this comment doesn't help any more.
