### PR TITLE
Use deps instead of requires.

### DIFF
--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -77,7 +77,7 @@ def _depth_first_search(set_tasks, current_task, visited):
         upstream_missing_dependency = False
         upstream_run_by_other_worker = False
         upstream_scheduling_error = False
-        for task in current_task._requires():
+        for task in current_task.deps():
             if task not in visited:
                 _depth_first_search(set_tasks, task, visited)
             if task in set_tasks["failed"] or task in set_tasks["upstream_failure"]:

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -440,10 +440,12 @@ class Task(object):
         provide consistent end-user experience), yet need to introduce
         (non-input) dependencies.
 
-        Must return an iterable which among others contains the _requires() of
-        the superclass.
+        Must return a structure of Tasks which among others contains
+        the _requires() of the superclass. The return value can be a single
+        Task, a list of Task instances, or a dict whose values are
+        Task instances.
         """
-        return flatten(self.requires())  # base impl
+        return self.requires()  # base impl
 
     def process_resources(self):
         """
@@ -459,10 +461,11 @@ class Task(object):
 
         See :ref:`Task.input`
 
-        :return: a list of :py:class:`Target` objects which are specified as
-                 outputs of all required Tasks.
+        :return: a structure of :py:class:`Target` objects which are specified
+                 as outputs of all required Tasks. Normally, the structure is
+                 the same as that returned by :py:meth:`requires`.
         """
-        return getpaths(self.requires())
+        return getpaths(self._requires())
 
     def deps(self):
         """
@@ -559,7 +562,7 @@ class WrapperTask(Task):
     """
 
     def complete(self):
-        return all(r.complete() for r in flatten(self.requires()))
+        return all(r.complete() for r in self.deps())
 
 
 class Config(Task):
@@ -636,6 +639,6 @@ def flatten_output(task):
     """
     r = flatten(task.output())
     if not r:
-        for dep in flatten(task.requires()):
+        for dep in flatten(task.deps()):
             r += flatten_output(dep)
     return r


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
## Description

Replace calls to _self.requires()_ with _self.deps()_ in the task module.
Handling of dependencies gets inconsistent when one redefines method __requires_.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We have workflow of a daily task with a whole tree of dependencies.  Now, we have just discovered an issue with the task _A_ in the middle of the tree of deps.  We need to recompute it and all of its successors but we want not to touch other fine tasks.

We solved it by the daily job having a taskParameter "startAt" to limit the dependency tree only up to task _A_.  The implementation is in the redefined method __requires_.

<!--- If it fixes an open issue, please link to the issue here. -->
## Have you tested this? If so, how?

<!--- Valid responses are "I have included unit tests." or --> 

<!--- "I ran my jobs with this code and it works for me." -->

We run our jobs with overwritten methods _complete_.
