### PR TITLE
Bug Fix for Removing Temporary Directory on an NFS

### DIFF
--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -262,7 +262,7 @@ class SGEJobTask(luigi.Task):
         # Now delete the temporaries, if they're there.
         if self.tmp_dir and os.path.exists(self.tmp_dir):
             logger.info('Removing temporary directory %s' % self.tmp_dir)
-            shutil.rmtree(self.tmp_dir)
+            subprocess.call(["rm", "-rf", self.tmp_dir])
 
     def _track_job(self):
         while True:

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -94,7 +94,6 @@ import time
 import sys
 import logging
 import random
-import shutil
 try:
     import cPickle as pickle
 except ImportError:


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The only difference is changing an shutil.rmtree() call to subprocess.call(["rm", "-rf", ...]).

## Motivation and Context
shutil.rmtree() was used for portability with Windows, but the SGE cluster runs on Unix OSes, so is not actually an advantage.  shutil.rmtree() can time out when deleting on an NFS, causing jobs to fail unnecessarily.  See issue #1665.

## Have you tested this? If so, how?
I (and others I work with) have run SGEJobTasks for several months after I made this change on our local copy with no failures.