### PR TITLE
Parameterized poll_time for SGEJobTask.

### DIFF
--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -169,6 +169,7 @@ class SGEJobTask(luigi.Task):
           this drive. The default is ``/home``, the NFS share location setup
           by StarCluster
     - run_locally: Run locally instead of on the cluster.
+    - poll_time: the length of time to wait in order to poll qstat
 
     """
 
@@ -178,6 +179,9 @@ class SGEJobTask(luigi.Task):
     run_locally = luigi.BoolParameter(
         default=False, significant=False,
         description="run locally instead of on the cluster")
+    poll_time = luigi.IntParameter(
+        significant=False, default=POLL_TIME,
+        description="specify the wait time to poll qstat for the job status")
 
     def _fetch_task_failures(self):
         if not os.path.exists(self.errfile):
@@ -273,7 +277,7 @@ class SGEJobTask(luigi.Task):
     def _track_job(self):
         while True:
             # Sleep for a little bit
-            time.sleep(POLL_TIME)
+            time.sleep(self.poll_time)
 
             # See what the job's up to
             # ASSUMPTION


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added the --poll-time parameter to SGEJobTask.

## Motivation and Context
This change is helpful in my experience because I run into scaling issues with the default of waiting 5 seconds for every SGEJobTask running.  I frequently have hundreds of these tasks running on a cluster, and so raising the wait time for long-running jobs reduces the overhead.

## Have you tested this? If so, how?
I have been using this change for several months on my cluster successfully.  We experience better responsiveness on our head node when adjusting the poll time up when we're running my tasks simultaneously.

