### PR TITLE
Added pwd to python's path when running on cluster.

### DIFF
--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -243,7 +243,8 @@ class SGEJobTask(luigi.Task):
         runner_path = sge_runner.__file__
         if runner_path.endswith("pyc"):
             runner_path = runner_path[:-3] + "py"
-        job_str = 'python {0} "{1}"'.format(runner_path, self.tmp_dir)  # enclose tmp_dir in quotes to protect from special escape chars
+        job_str = 'python {0} "{1}" "{2}"'.format(
+            runner_path, self.tmp_dir, os.getcwd())  # enclose tmp_dir in quotes to protect from special escape chars
 
         # Build qsub submit command
         self.outfile = os.path.join(self.tmp_dir, 'job.out')

--- a/luigi/contrib/sge_runner.py
+++ b/luigi/contrib/sge_runner.py
@@ -82,6 +82,8 @@ def main(args=sys.argv):
         logging.basicConfig(level=logging.WARN)
         work_dir = args[1]
         assert os.path.exists(work_dir), "First argument to sge_runner.py must be a directory that exists"
+        project_dir = args[2]
+        sys.path.append(project_dir)
         _do_work_on_compute_node(work_dir)
     except Exception as e:
         # Dump encoded data that we will try to fetch using mechanize


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When submitting to the cluster, sge.py now passes the present working directory to sge_runner.py.  sge_runner.py uses this new parameter to append to the python path.

## Motivation and Context
These changes allow the user to properly import scripts in the same directory as the luigi script, even if they're not in the user's normal $PYTHONPATH.  Without these changes, attempting to do this results in an ImportError.

## Have you tested this? If so, how?
I've been using these changes for several months without issue.

