### PR TITLE
Added InputFileParameter and OutputFileParameter classes.

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -35,7 +35,8 @@ from luigi.parameter import (
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter, DateSecondParameter,
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BooleanParameter, BoolParameter,
-    TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter
+    TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter,
+    InputFileParameter, OutputFileParameter
 )
 
 from luigi import configuration
@@ -57,5 +58,6 @@ __all__ = [
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
     'FloatParameter', 'BooleanParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
-    'configuration', 'interface', 'file', 'run', 'build', 'event', 'Event'
+    'configuration', 'interface', 'file', 'run', 'build', 'event', 'Event',
+    'InputFileParameter', 'OutputFileParameter'
 ]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -961,6 +961,7 @@ class TupleParameter(Parameter):
         """
         return json.dumps(x)
 
+
 class InputFileParameter(Parameter):
     """
     Paramater whose value is an existing file.
@@ -974,6 +975,7 @@ class InputFileParameter(Parameter):
             return os.path.realpath(s)
         else:
             raise OSError("{s} does not exist".format(s=s))
+
 
 class OutputFileParameter(Parameter):
     """

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -29,6 +29,7 @@ from collections import OrderedDict, Mapping
 import operator
 import functools
 from ast import literal_eval
+import os
 
 try:
     from ConfigParser import NoOptionError, NoSectionError
@@ -959,3 +960,36 @@ class TupleParameter(Parameter):
         :param x: the value to serialize.
         """
         return json.dumps(x)
+
+class InputFileParameter(Parameter):
+    """
+    Paramater whose value is an existing file.
+    """
+
+    def parse(self, s):
+        """
+        Returns the real path to the file from the string if it exists.
+        """
+        if os.path.isfile(s):
+            return os.path.realpath(s)
+        else:
+            raise OSError("{s} does not exist".format(s=s))
+
+class OutputFileParameter(Parameter):
+    """
+    Parameter whose value is an output file to be created.
+    """
+
+    def parse(self, s):
+        """
+        Returns the real path to the file and attempts to create any directories
+        needed.
+        """
+        s = os.path.realpath(s)
+        if not os.path.isdir(os.path.dirname(s)):
+            try:
+                os.makedirs(os.path.dirname(s))
+            except OSError:
+                raise OSError("could not make parent directories for {s}".format(
+                    s=s))
+        return s


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Added class, InputFileParameter, that parses to the real path of the parameter if it's a file, and raises an OSError otherwise.
2. Added class, OutputFileParameter, that parses to the real path of the parameter if it's a valid file path, creates the required output directories if necessary, and raises an OSError if it can't do this successfully.

## Motivation and Context
I commonly create luigi Tasks that take input and output file parameters.  It is helpful to me, and I expect to others, to restrict a parameter to existing files/valid paths (for output files).  This also has the benefit of converting a given relative path to the absolute path, which is useful in my experience when the working directory changes, as it does with, for example, SGEJobTasks.

## Have you tested this? If so, how?
I have been using these two classes successfully for several weeks.