### PR TITLE
improve ecs task

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps=
   nose<2.0
   unittest2<2.0
   boto<3.0
+  boto3==1.3.1
   sqlalchemy<2.0
   elasticsearch<2.0.0
   psutil<4.0


### PR DESCRIPTION
## Improve ECSTask

1. Replacing manual waiters by boto waiters
2. Replacing arn by family_tag
3. Allowing to use different cluster
4, Allowing to specify timeout

## Motivation and Context
- Less code to maintain
- More options
- Easier to use

## Have you tested this? If so, how?
I did  `tox -e flake8`, but I did not succeed to run `tox -e py27-nonhdfs test/contrib/ecs_test.py`. I got this message: NoRegionError: You must specify a region. How do you test it ?
Note: I already use it on my jobs and it works for me.

