### PR TITLE
Made creating a tarball of luigi optional to reduce I/O overhead of r…

### DIFF
--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -171,6 +171,9 @@ class SGEJobTask(luigi.Task):
     - run_locally: Run locally instead of on the cluster.
     - poll_time: the length of time to wait in order to poll qstat
     - dont_remove_tmp_dir: Instead of deleting the temporary directory, keep it.
+    - no_tarball: Don't create a tarball of the luigi project directory.  Can be
+        useful to reduce I/O requirements when the luigi directory is accessible
+        from cluster nodes already.
 
     """
 
@@ -186,6 +189,9 @@ class SGEJobTask(luigi.Task):
     dont_remove_tmp_dir = luigi.BoolParameter(
         significant=False,
         description="don't delete the temporary directory used (for debugging)")
+    no_tarball = luigi.BoolParameter(
+        significant=False,
+        description="don't tarball (and extract) the luigi project files")
 
     def _fetch_task_failures(self):
         if not os.path.exists(self.errfile):
@@ -215,11 +221,13 @@ class SGEJobTask(luigi.Task):
         logging.debug("Dumping pickled class")
         self._dump(self.tmp_dir)
 
-        # Make sure that all the class's dependencies are tarred and available
-        logging.debug("Tarballing dependencies")
-        # Grab luigi and the module containing the code to be run
-        packages = [luigi] + [__import__(self.__module__, None, None, 'dummy')]
-        luigi.hadoop.create_packages_archive(packages, os.path.join(self.tmp_dir, "packages.tar"))
+        if not self.no_tarball:
+            # Make sure that all the class's dependencies are tarred and available
+            # This is not necessary if luigi is importable from the cluster node
+            logging.debug("Tarballing dependencies")
+            # Grab luigi and the module containing the code to be run
+            packages = [luigi] + [__import__(self.__module__, None, None, 'dummy')]
+            luigi.hadoop.create_packages_archive(packages, os.path.join(self.tmp_dir, "packages.tar"))
 
     def run(self):
         if self.run_locally:
@@ -259,6 +267,8 @@ class SGEJobTask(luigi.Task):
             runner_path = runner_path[:-3] + "py"
         job_str = 'python {0} "{1}" "{2}"'.format(
             runner_path, self.tmp_dir, os.getcwd())  # enclose tmp_dir in quotes to protect from special escape chars
+        if self.no_tarball:
+            job_str += ' "--no-tarball"'
 
         # Build qsub submit command
         self.outfile = os.path.join(self.tmp_dir, 'job.out')

--- a/luigi/contrib/sge_runner.py
+++ b/luigi/contrib/sge_runner.py
@@ -42,10 +42,13 @@ import logging
 import tarfile
 
 
-def _do_work_on_compute_node(work_dir):
+def _do_work_on_compute_node(work_dir, tarball=True):
 
-    # Extract the necessary dependencies
-    _extract_packages_archive(work_dir)
+    if tarball:
+        # Extract the necessary dependencies
+        # This can create a lot of I/O overhead when running many SGEJobTasks,
+        # so is optional if the luigi project is accessible from the cluster node
+        _extract_packages_archive(work_dir)
 
     # Open up the pickle file with the work to be done
     os.chdir(work_dir)
@@ -78,13 +81,14 @@ def main(args=sys.argv):
     """Run the work() method from the class instance in the file "job-instance.pickle".
     """
     try:
+        tarball = "--no-tarball" not in args
         # Set up logging.
         logging.basicConfig(level=logging.WARN)
         work_dir = args[1]
         assert os.path.exists(work_dir), "First argument to sge_runner.py must be a directory that exists"
         project_dir = args[2]
         sys.path.append(project_dir)
-        _do_work_on_compute_node(work_dir)
+        _do_work_on_compute_node(work_dir, tarball)
     except Exception as e:
         # Dump encoded data that we will try to fetch using mechanize
         print(e)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Creating luigi tarball and extracting it in an SGE job is now optional.

## Motivation and Context
This change is helpful when running many SGEJobTasks on a cluster sharing drives.  People I work with have been running hundreds of these Tasks at the same time, each of which required copying the luigi directory structure; for us, this is simply unnecessary and added a lot of startup overhead to every job we were running.

## Have you tested this? If so, how?
We've been using the change I made here successfully for about a week without issues.