### PR TITLE
Use ps command that prints full command lines without errors

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -42,7 +42,7 @@ def getpcmd(pid):
                 _, val = lines
                 return val
     else:
-        cmd = 'ps -xo pid,args'
+        cmd = 'ps x -wwo pid,args'
         with os.popen(cmd, 'r') as p:
             # Skip the column titles
             p.readline()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Based on errors with the existing command, this should behave correctly

## Motivation and Context
Fixes #1808

## Have you tested this? If so, how?
Tested on colleagues machine. Tested command on our machine. Would need external validation about behavior with ps on more operating systems/versions.

