### PR TITLE
Add current directory to python path

### DIFF
--- a/doc/example_top_artists.rst
+++ b/doc/example_top_artists.rst
@@ -77,11 +77,11 @@ Try running this using eg.
     $ cd examples
     $ luigi --module top_artists AggregateArtists --local-scheduler --date-interval 2012-06
 
-Note that  *AggregateArtists* needs to be in your PYTHONPATH, or else this can produce an error (*ImportError: No module named AggregateArtists*). Add the current working directory to the command PYTHONPATH with:
+Note that  *top_artists* needs to be in your PYTHONPATH, or else this can produce an error (*ImportError: No module named top_artists*). Add the current working directory to the command PYTHONPATH with:
 
 .. code-block:: console
 
-    $ PYTHONPATH='' luigi --module top_artists AggregateArtists --local-scheduler --date-interval 2012-06
+    $ PYTHONPATH='.' luigi --module top_artists AggregateArtists --local-scheduler --date-interval 2012-06
 
 You can also try to view the manual using `--help` which will give you an
 overview of the options.


### PR DESCRIPTION
## Description
The directions for adding the current working directory did not work for me until I changed '' to '.'.  Also it had the task name instead of the module name in the text.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.