### PR TITLE
Added passthrough for PySFTP Connection keyword arguments to RemoteTarget constructor

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -45,13 +45,15 @@ logger = logging.getLogger('luigi-interface')
 
 class RemoteFileSystem(luigi.target.FileSystem):
 
-    def __init__(self, host, username=None, password=None, port=None, tls=False, timeout=60, sftp=False):
+    def __init__(self, host, username=None, password=None, port=None,
+                 tls=False, timeout=60, sftp=False, pysftp_conn_kwargs=None):
         self.host = host
         self.username = username
         self.password = password
         self.tls = tls
         self.timeout = timeout
         self.sftp = sftp
+        self.pysftp_conn_kwargs = pysftp_conn_kwargs
 
         if port is None:
             if self.sftp:
@@ -76,7 +78,8 @@ class RemoteFileSystem(luigi.target.FileSystem):
         except ImportError:
             logger.warning('Please install pysftp to use SFTP.')
 
-        self.conn = pysftp.Connection(self.host, username=self.username, password=self.password, port=self.port)
+        self.conn = pysftp.Connection(self.host, username=self.username, password=self.password,
+                                      port=self.port, **self.pysftp_conn_kwargs)
 
     def _ftp_connect(self):
         if self.tls:

--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -353,7 +353,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
     def __init__(
         self, path, host, format=None, username=None,
         password=None, port=None, mtime=None, tls=False,
-        timeout=60, sftp=False
+            timeout=60, sftp=False, pysftp_conn_kwargs=None
     ):
         if format is None:
             format = luigi.format.get_default_format()
@@ -364,7 +364,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
         self.tls = tls
         self.timeout = timeout
         self.sftp = sftp
-        self._fs = RemoteFileSystem(host, username, password, port, tls, timeout, sftp)
+        self._fs = RemoteFileSystem(host, username, password, port, tls, timeout, sftp, pysftp_conn_kwargs)
 
     @property
     def fs(self):


### PR DESCRIPTION
## Description
This is simply a passthrough to enable the RemoteTarget to be used in cases 
where the SFTP connection is made using a private key instead of a password.
However, since PySFTP is the underlying SFTP module in use, I reason that there
is no need to continue adding the Connection options piecemeal as people decide
they need them. It is sufficient at this point to maintain the existing username,password
interface of RemoteTarget while allowing users to supplement these with any other
valid PySFTP Connection() constructor arguments that are useful to them. 

This doesn't alter the interface for existing users - it simply
allows users who know that PySFTP is the underlying implementation
to pass additional keyword arguments to the creation of the PySFTP
Connection.

## Motivation and Context
My usage of Luigi requires uploading a file to an SFTP server, to which I authenticate with a username and private key.

## Have you tested this? If so, how?
I have not tested this except for my own usage, but I anticipate it will pass all existing tests, and the implementation is a simple use of standard Python kwargs semantics.
