### PR TITLE
Adds BATCH_RUNNING to the visualiser

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -490,6 +490,16 @@
                   </div>
 
                   <div class="col-md-3 col-sm-6 col-xs-12">
+                    <div class="info-box status-info" data-color='purple' data-category='BATCH_RUNNING' id="BATCH_RUNNING_info">
+                      <span class="info-box-icon bg-purple"><i class="fa fa-spinner fa-pulse"></i></span>
+                      <div class="info-box-content">
+                        <span class="info-box-text">Batch Running Tasks</span>
+                        <span class="info-box-number">?</span>
+                      </div><!-- /.info-box-content -->
+                    </div><!-- /.info-box -->
+                  </div>
+
+                  <div class="col-md-3 col-sm-6 col-xs-12">
                     <div class="info-box status-info" data-color='green' data-category='DONE' id="DONE_info">
                       <span class="info-box-icon bg-green"><i class="fa fa-spinner fa-pulse"></i></span>
                       <div class="info-box-content">

--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -2,6 +2,7 @@ Graph = (function() {
     var statusColors = {
         "FAILED":"#DD0000",
         "RUNNING":"#0044DD",
+        "BATCH_RUNNING":"#BB00BB",
         "PENDING":"#EEBB00",
         "DONE":"#00DD00",
         "DISABLED":"#808080",
@@ -22,6 +23,8 @@ Graph = (function() {
     var legendMaxY = (function () {
         return Object.keys(statusColors).length * legendLineHeight + ( legendLineHeight / 2 )
     })();
+
+    var legendWidth = 110;
 
     function nodeFromTask(task) {
         var deps = task.deps;
@@ -230,7 +233,7 @@ Graph = (function() {
         $(svgElement("rect"))
             .attr("x", -1)
             .attr("y", -1)
-            .attr("width", "100px")
+            .attr("width", legendWidth + "px")
             .attr("height", legendMaxY + "px")
             .attr("fill", "#FFF")
             .attr("stroke", "#DDD")
@@ -247,7 +250,7 @@ Graph = (function() {
                 .appendTo(legend)
 
             $(svgElement("text"))
-                .text(key.charAt(0).toUpperCase() + key.substring(1).toLowerCase())
+                .text(key.charAt(0).toUpperCase() + key.substring(1).toLowerCase().replace(/_./gi, function (x) { return " " + x[1].toUpperCase(); }))
                 .attr("x", legendLineHeight + 14)
                 .attr("y", legendLineHeight+(x*legendLineHeight))
                 .appendTo(legend);

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -99,6 +99,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getBatchRunningTaskList = function(callback) {
+        return jsonRPC(this.urlRoot + "/task_list", {status: "BATCH_RUNNING", upstream_status: "", search: searchTerm()}, function(response) {
+            callback(flatten(response.response));
+        });
+    };
+
     LuigiAPI.prototype.getPendingTaskList = function(callback) {
         return jsonRPC(this.urlRoot + "/task_list", {status: "PENDING", upstream_status: "", search: searchTerm()}, function(response) {
             callback(flatten(response.response));

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -14,6 +14,7 @@ function visualiserApp(luigi) {
     var taskIcons = {
         PENDING: 'pause',
         RUNNING: 'play',
+        BATCH_RUNNING: 'play',
         DONE: 'check',
         FAILED: 'times',
         UPSTREAM_FAILED: 'warning',
@@ -101,6 +102,10 @@ function visualiserApp(luigi) {
             case 'RUNNING':
                 iconClass = 'fa-play';
                 iconColor = 'aqua';
+                break;
+            case 'BATCH_RUNNING':
+                iconClass = 'fa-play';
+                iconColor = 'purple';
                 break;
             case 'DONE':
                 iconClass = 'fa-check';
@@ -630,6 +635,7 @@ function visualiserApp(luigi) {
         var mostImportantCategory = function (cat1, cat2) {
             var priorities = [
                 'RUNNING',
+                'BATCH_RUNNING',
                 'DONE',
                 'PENDING',
                 'UPSTREAM_DISABLED',
@@ -733,31 +739,35 @@ function visualiserApp(luigi) {
             updateTaskCategory(dt, 'RUNNING', runningTasks);
         });
 
-        var ajax2 = luigi.getFailedTaskList(function(failedTasks) {
+        var ajax2 = luigi.getBatchRunningTaskList(function(batchRunningTasks) {
+            updateTaskCategory(dt, 'BATCH_RUNNING', batchRunningTasks);
+        });
+
+        var ajax3 = luigi.getFailedTaskList(function(failedTasks) {
             updateTaskCategory(dt, 'FAILED', failedTasks);
         });
 
-        var ajax3 = luigi.getUpstreamFailedTaskList(function(upstreamFailedTasks) {
+        var ajax4 = luigi.getUpstreamFailedTaskList(function(upstreamFailedTasks) {
             updateTaskCategory(dt, 'UPSTREAM_FAILED', upstreamFailedTasks);
         });
 
-        var ajax4 = luigi.getDisabledTaskList(function(disabledTasks) {
+        var ajax5 = luigi.getDisabledTaskList(function(disabledTasks) {
             updateTaskCategory(dt, 'DISABLED', disabledTasks);
         });
 
-        var ajax5 = luigi.getUpstreamDisabledTaskList(function(upstreamDisabledTasks) {
+        var ajax6 = luigi.getUpstreamDisabledTaskList(function(upstreamDisabledTasks) {
             updateTaskCategory(dt, 'UPSTREAM_DISABLED', upstreamDisabledTasks);
         });
 
-        var ajax6 = luigi.getPendingTaskList(function(pendingTasks) {
+        var ajax7 = luigi.getPendingTaskList(function(pendingTasks) {
             updateTaskCategory(dt, 'PENDING', pendingTasks);
         });
 
-        var ajax7 = luigi.getDoneTaskList(function(doneTasks) {
+        var ajax8 = luigi.getDoneTaskList(function(doneTasks) {
             updateTaskCategory(dt, 'DONE', doneTasks);
         });
 
-        $.when(ajax1, ajax2, ajax3, ajax4, ajax5, ajax6, ajax7).done(function () {
+        $.when(ajax1, ajax2, ajax3, ajax4, ajax5, ajax6, ajax7, ajax8).done(function () {
             dt.draw();
 
             $('.sidebar').html(renderSidebar(dt.column(1).data()));


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
In the earlier batching PR, I left out any visualiser elements. This
adds BATCH_RUNNING to the Task List selectors and Dependency Graph
legend. The legend needed to be widened a bit to accomodate the longer
name, and I replace commas with spaces while capitalizing the first
letter of each word in the legend.

## Motivation and Context
I realized while working to merge the latest trunk with my fork that my visualizer code was left out.

## Have you tested this? If so, how?
I've been using this for a few months now with the batch running backend from the dropped PR. This part should be the same, as it's just about the statuses.