### PR TITLE
Limits resource usage bar fill to 100%

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -247,6 +247,7 @@ function visualiserApp(luigi) {
         resource.percent_used = 100 * resource.num_used / resource.num_total;
         if (resource.percent_used >= 100) {
             resource.bar_type = 'danger';
+            resource.percent_used = 100;
         } else if (resource.percent_used > 50) {
             resource.bar_type = 'warning';
         } else {


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Limits the resource percent used to 100 in the visualiser Resources tab.

## Motivation and Context
If more than the maximum amount of a resource is in use (say, after decreasing the maximum amount of a resource) the bar fill can exceed 100%. This pushes the bar-centered label way out, so we simply limit the bar fill to 100 to fix the display issue.

## Have you tested this? If so, how?
I've been using this for about 5 months now, just forgot to make a PR until I was merging the latest back to my fork and saw this wasn't in yet.