### PR TITLE
Bug fix for spark task can not be pickled

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -944,7 +944,7 @@ class JobTask(BaseHadoopJobTask):
         """
         Dump instance to file.
         """
-        with self._without_unpicklable_properties():
+        with self.no_unpicklable_properties():
             file_name = os.path.join(directory, 'job-instance.pickle')
             if self.__module__ == '__main__':
                 d = pickle.dumps(self)

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -944,23 +944,16 @@ class JobTask(BaseHadoopJobTask):
         """
         Dump instance to file.
         """
-        _set_tracking_url = self.set_tracking_url
-        self.set_tracking_url = None
-        _set_status_message = self.set_status_message
-        self.set_status_message = None
+        with self._without_unpicklable_properties():
+            file_name = os.path.join(directory, 'job-instance.pickle')
+            if self.__module__ == '__main__':
+                d = pickle.dumps(self)
+                module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
+                d = d.replace(b'(c__main__', "(c" + module_name)
+                open(file_name, "wb").write(d)
 
-        file_name = os.path.join(directory, 'job-instance.pickle')
-        if self.__module__ == '__main__':
-            d = pickle.dumps(self)
-            module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-            d = d.replace(b'(c__main__', "(c" + module_name)
-            open(file_name, "wb").write(d)
-
-        else:
-            pickle.dump(self, open(file_name, "wb"))
-
-        self.set_tracking_url = _set_tracking_url
-        self.set_status_message = _set_status_message
+            else:
+                pickle.dump(self, open(file_name, "wb"))
 
     def _map_input(self, input_stream):
         """

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -203,6 +203,7 @@ class SGEJobTask(luigi.Task):
         description="don't tarball (and extract) the luigi project files")
 
     def __init__(self, *args, **kwargs):
+        super(SGEJobTask, self).__init__(*args, **kwargs)
         if self.job_name:
             # use explicitly provided job name
             pass
@@ -270,15 +271,15 @@ class SGEJobTask(luigi.Task):
 
     def _dump(self, out_dir=''):
         """Dump instance to file."""
-        self.job_file = os.path.join(out_dir, 'job-instance.pickle')
-        if self.__module__ == '__main__':
-            d = pickle.dumps(self)
-            module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-            d = d.replace('(c__main__', "(c" + module_name)
-            open(self.job_file, "w").write(d)
-
-        else:
-            pickle.dump(self, open(self.job_file, "w"))
+        with self._without_unpicklable_properties():
+            self.job_file = os.path.join(out_dir, 'job-instance.pickle')
+            if self.__module__ == '__main__':
+                d = pickle.dumps(self)
+                module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
+                d = d.replace('(c__main__', "(c" + module_name)
+                open(self.job_file, "w").write(d)
+            else:
+                pickle.dump(self, open(self.job_file, "w"))
 
     def _run_job(self):
 

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -271,7 +271,7 @@ class SGEJobTask(luigi.Task):
 
     def _dump(self, out_dir=''):
         """Dump instance to file."""
-        with self._without_unpicklable_properties():
+        with self.no_unpicklable_properties():
             self.job_file = os.path.join(out_dir, 'job-instance.pickle')
             if self.__module__ == '__main__':
                 d = pickle.dumps(self)

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -285,6 +285,13 @@ class PySparkTask(SparkSubmitTask):
             shutil.rmtree(self.run_path)
 
     def _dump(self, fd):
+        # set_tracking_url and set_status_message is not picklable
+        # ignore them before dump and resume them after dump
+        _set_tracking_url = self.set_tracking_url
+        self.set_tracking_url = None
+        _set_status_message = self.set_status_message
+        self.set_status_message = None
+
         if self.__module__ == '__main__':
             d = pickle.dumps(self)
             module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
@@ -292,6 +299,9 @@ class PySparkTask(SparkSubmitTask):
             fd.write(d)
         else:
             pickle.dump(self, fd)
+
+        self.set_tracking_url = _set_tracking_url
+        self.set_status_message = _set_status_message
 
     def _setup_packages(self, sc):
         """

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -285,7 +285,7 @@ class PySparkTask(SparkSubmitTask):
             shutil.rmtree(self.run_path)
 
     def _dump(self, fd):
-        with self._without_unpicklable_properties():
+        with self.no_unpicklable_properties():
             if self.__module__ == '__main__':
                 d = pickle.dumps(self)
                 module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -285,23 +285,14 @@ class PySparkTask(SparkSubmitTask):
             shutil.rmtree(self.run_path)
 
     def _dump(self, fd):
-        # set_tracking_url and set_status_message is not picklable
-        # ignore them before dump and resume them after dump
-        _set_tracking_url = self.set_tracking_url
-        self.set_tracking_url = None
-        _set_status_message = self.set_status_message
-        self.set_status_message = None
-
-        if self.__module__ == '__main__':
-            d = pickle.dumps(self)
-            module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-            d = d.replace(b'(c__main__', "(c" + module_name)
-            fd.write(d)
-        else:
-            pickle.dump(self, fd)
-
-        self.set_tracking_url = _set_tracking_url
-        self.set_status_message = _set_status_message
+        with self._without_unpicklable_properties():
+            if self.__module__ == '__main__':
+                d = pickle.dumps(self)
+                module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
+                d = d.replace(b'(c__main__', "(c" + module_name)
+                fd.write(d)
+            else:
+                pickle.dump(self, fd)
 
     def _setup_packages(self, sc):
         """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -571,12 +571,11 @@ class Task(object):
 
         """
         unpicklable_properties = ('set_tracking_url', 'set_status_message')
-        placeholder_during_pickling = None
         reserved_properties = {}
         for property_name in unpicklable_properties:
             if hasattr(self, property_name):
                 reserved_properties[property_name] = getattr(self, property_name)
-                setattr(self, property_name, placeholder_during_pickling)
+                setattr(self, property_name, 'placeholder_during_pickling')
 
         yield
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -552,7 +552,7 @@ class Task(object):
         pass
 
     @contextmanager
-    def _without_unpicklable_properties(self):
+    def no_unpicklable_properties(self):
         """
         Remove unpicklable properties before dump task and resume them after.
 
@@ -566,16 +566,17 @@ class Task(object):
             class DummyTask(luigi):
 
                 def _dump(self):
-                    with self._without_unpicklable_properties():
+                    with self.no_unpicklable_properties():
                         pickle.dumps(self)
 
         """
         unpicklable_properties = ('set_tracking_url', 'set_status_message')
+        placeholder_during_pickling = None
         reserved_properties = {}
         for property_name in unpicklable_properties:
             if hasattr(self, property_name):
                 reserved_properties[property_name] = getattr(self, property_name)
-                setattr(self, property_name, None)
+                setattr(self, property_name, placeholder_during_pickling)
 
         yield
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -579,7 +579,7 @@ class Task(object):
 
         yield
 
-        for property_name, value in reserved_properties.iteritems():
+        for property_name, value in six.iteritems(reserved_properties):
             setattr(self, property_name, value)
 
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -24,6 +24,7 @@ try:
     from itertools import imap as map
 except ImportError:
     pass
+from contextlib import contextmanager
 import logging
 import traceback
 import warnings
@@ -549,6 +550,37 @@ class Task(object):
 
         Default behavior is to send an None value"""
         pass
+
+    @contextmanager
+    def _without_unpicklable_properties(self):
+        """
+        Remove unpicklable properties before dump task and resume them after.
+
+        This method could be called in subtask's dump method, to ensure unpicklable
+        properties won't break dump.
+
+        This method is a context-manager which can be called as below:
+
+        .. code-block: python
+
+            class DummyTask(luigi):
+
+                def _dump(self):
+                    with self._without_unpicklable_properties():
+                        pickle.dumps(self)
+
+        """
+        unpicklable_properties = ('set_tracking_url', 'set_status_message')
+        reserved_properties = {}
+        for property_name in unpicklable_properties:
+            if hasattr(self, property_name):
+                reserved_properties[property_name] = getattr(self, property_name)
+                setattr(self, property_name, None)
+
+        yield
+
+        for property_name, value in reserved_properties.iteritems():
+            setattr(self, property_name, value)
 
 
 class MixinNaiveBulkComplete(object):

--- a/test/contrib/sge_test.py
+++ b/test/contrib/sge_test.py
@@ -21,9 +21,10 @@ import os.path
 from glob import glob
 import unittest
 import logging
+from mock import patch
 
 import luigi
-from luigi.contrib.sge import SGEJobTask, _parse_qstat_state, _clean_task_id
+from luigi.contrib.sge import SGEJobTask, _parse_qstat_state
 
 DEFAULT_HOME = '/home'
 
@@ -56,11 +57,6 @@ class TestSGEWrappers(unittest.TestCase):
         self.assertEqual(_parse_qstat_state('', 1), 'u')
         self.assertEqual(_parse_qstat_state('', 4), 'u')
 
-    def test_clean_task_id(self):
-        task_id = 'SomeTask(param_1=0, param_2=/path/to/file)'
-        cleaned_id = 'SomeTask-param_1-0--param_2--path-to-file-'
-        self.assertEqual(_clean_task_id(task_id), cleaned_id)
-
 
 class TestJobTask(SGEJobTask):
 
@@ -87,6 +83,16 @@ class TestSGEJob(unittest.TestCase):
             tasks = [TestJobTask(i=str(i), n_cpu=1) for i in range(3)]
             luigi.build(tasks, local_scheduler=True, workers=3)
             self.assertTrue(os.path.exists(outfile))
+
+    @patch('subprocess.check_output')
+    def test_run_job_with_dump(self, mock_check_output):
+        mock_check_output.side_effect = [
+            'Your job 12345 ("test_job") has been submitted',
+            ''
+        ]
+        task = TestJobTask(i=1, n_cpu=1, shared_tmp_dir='/tmp')
+        luigi.build([task], local_scheduler=True)
+        self.assertEqual(mock_check_output.call_count, 2)
 
     def tearDown(self):
         for fpath in glob(os.path.join(DEFAULT_HOME, 'test_file_*')):

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -197,6 +197,18 @@ class PySparkTaskTest(unittest.TestCase):
         self.assertTrue(os.path.exists(proc_arg_list[7]))
         self.assertTrue(proc_arg_list[8].endswith('TestPySparkTask.pickle'))
 
+    @with_config({'spark': {'spark-submit': ss, 'master': "spark://host:7077"}})
+    @patch('luigi.contrib.external_program.subprocess.Popen')
+    def test_run_with_pickle_dump(self, proc):
+        setup_run_process(proc)
+        job = TestPySparkTask()
+        luigi.build([job], local_scheduler=True)
+        self.assertEqual(proc.call_count, 1)
+        proc_arg_list = proc.call_args[0][0]
+        self.assertEqual(proc_arg_list[0:7], ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'client', '--name', 'TestPySparkTask'])
+        self.assertTrue(os.path.exists(proc_arg_list[7]))
+        self.assertTrue(proc_arg_list[8].endswith('TestPySparkTask.pickle'))
+
     @patch.dict('sys.modules', {'pyspark': MagicMock()})
     @patch('pyspark.SparkContext')
     def test_pyspark_runner(self, spark_context):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -91,11 +91,11 @@ class TaskTest(unittest.TestCase):
         pickled_task = pickle.dumps(task)
         self.assertEqual(task, pickle.loads(pickled_task))
 
-    def test_without_unpicklable_properties(self):
+    def test_no_unpicklable_properties(self):
         task = luigi.Task()
         task.set_tracking_url = lambda tracking_url: tracking_url
         task.set_status_message = lambda message: message
-        with task._without_unpicklable_properties():
+        with task.no_unpicklable_properties():
             pickle.dumps(task)
         self.assertIsNotNone(task.set_tracking_url)
         self.assertIsNotNone(task.set_status_message)

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -91,6 +91,19 @@ class TaskTest(unittest.TestCase):
         pickled_task = pickle.dumps(task)
         self.assertEqual(task, pickle.loads(pickled_task))
 
+    def test_without_unpicklable_properties(self):
+        task = luigi.Task()
+        task.set_tracking_url = lambda tracking_url: tracking_url
+        task.set_status_message = lambda message: message
+        with task._without_unpicklable_properties():
+            pickle.dumps(task)
+        self.assertIsNotNone(task.set_tracking_url)
+        self.assertIsNotNone(task.set_status_message)
+        tracking_url = task.set_tracking_url('http://test.luigi.com/')
+        self.assertEqual(tracking_url, 'http://test.luigi.com/')
+        message = task.set_status_message('message')
+        self.assertEqual(message, 'message')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR is addressing https://github.com/spotify/luigi/issues/1765 

## Description
The change of this PR is trying to set problematic methods to None before dump and resume them
after dump which is consistent to the behavior of hadoop job which you can find [here](https://github.com/spotify/luigi/blob/master/luigi/contrib/hadoop.py#L947)

## Motivation and Context
https://github.com/spotify/luigi/issues/1765 

## Have you tested this? If so, how?
I ran this code with my own job and it works, also travis build is passed you can find it here https://travis-ci.org/ivannotes/luigi/builds/152888222

let me know it you need more information.

