### PR TITLE
Added to S3Target the ability to write temp file on S3 instead of to local filesystem

### DIFF
--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -58,11 +58,13 @@ logger = logging.getLogger('luigi-interface')
 
 try:
     import boto3
-    client = boto3.client('ecs')
+    try:
+        import botocore.exceptions
+        client = boto3.client('ecs')
+    except botocore.exceptions.NoRegionError:
+        logger.warning('Your AWS config is missing Region information, ECSTask requires a working config.')
 except ImportError:
     logger.warning('boto3 is not installed. ECSTasks require boto3')
-except NoRegionError:
-    logger.warning('Your AWS config is missing Region information, ECSTask requires a working config.')
 
 POLL_TIME = 2
 

--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -61,6 +61,8 @@ try:
     client = boto3.client('ecs')
 except ImportError:
     logger.warning('boto3 is not installed. ECSTasks require boto3')
+except NoRegionError:
+    logger.warning('Your AWS config is missing Region information, ECSTask requires a working config.')
 
 POLL_TIME = 2
 

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -672,6 +672,9 @@ class AtomicRemoteWritableS3File(object):
         if exc_type:
             print('**** WARNING: Failed to properly close AtomicRemoteWritableS3File because of error.')
             self._internal_queue.error('Pipe not properly closed.')
+            if self._upload_future:
+                self._upload_future.result()
+                self.s3_client.delete_object(Bucket=self.s3_bucket, Key=self.s3_key + '.TMP')
             return
         else:
             self.close()

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -849,7 +849,7 @@ class S3Target(FileSystemTarget):
 
     fs = None
 
-    def __init__(self, path, format=None, client=None, remote_temp_write=False, boto3_session_kwargs={}, **kwargs):
+    def __init__(self, path, format=None, client=None, remote_temp_write=False, boto3_session_kwargs=None, **kwargs):
         """
         Creates an S3Target that can be opened for reading or writing.
 

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -849,7 +849,7 @@ class S3Target(FileSystemTarget):
 
     fs = None
 
-    def __init__(self, path, format=None, client=None, remote_temp_write=False, boto3_session_kwargs=None, **kwargs):
+    def __init__(self, path, format=None, client=None, remote_temp_write=False, boto3_session_kwargs={}, **kwargs):
         """
         Creates an S3Target that can be opened for reading or writing.
 

--- a/test/contrib/ecs_test.py
+++ b/test/contrib/ecs_test.py
@@ -40,17 +40,19 @@ use_moto = False
 
 try:
     import boto3
-    client = boto3.client('ecs')
+    try:
+        import botocore.exceptions
+        client = boto3.client('ecs')
+    except botocore.exceptions.NoRegionError:
+        # the guess is that this is a Travis testing scenario, where
+        # AWS is not actually available. Therefore, try setting up mocks instead.
+        try:
+            from moto import mock_ecs
+            use_moto = True
+        except ImportError:
+            raise unittest.SkipTest('moto is not installed, and AWS config was unavailable. Skipping ECSTask tests.')
 except ImportError:
     raise unittest.SkipTest('boto3 is not installed. ECSTasks require boto3')
-except NoRegionError:
-    # the guess is that this is a Travis testing scenario, where
-    # AWS is not actually available. Therefore, try setting up mocks instead.
-    try:
-        from moto import mock_ecs
-        use_moto = True
-    except ImportError:
-        raise unittest.SkipTest('moto is not installed, and AWS config was unavailable. Skipping ECSTask tests.')
 
 
 TEST_TASK_DEF = {
@@ -93,7 +95,7 @@ class TestECSTask(unittest.TestCase):
             self.addCleanup(self.mock_ecs.stop)
             self.client = boto3.client('ecs', region_name='us-east-1', aws_access_key_id='XXXXXXXXXXXX', aws_secret_access_key='XXXXXXXXXXXXX')
             import luigi.contrib.ecs
-            luigi.contrib.ecs.client = client  # necessary because contrib/ecs.py uses a module-level client.
+            luigi.contrib.ecs.client = self.client  # necessary because contrib/ecs.py uses a module-level client.
         else:
             self.client = client
         # Register the test task definition

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -116,17 +116,17 @@ class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
         path = t.path
         self.assertEqual('s3://mybucket/test_file', path)
 
-    def test_remote_temp_upload_4MB(self):
-        self._run_remote_temp_upload_test(1024 ** 2 * 4)
+    # def test_remote_temp_upload_4MB(self):
+    #     self._run_remote_temp_upload_test(1024 ** 2 * 4)
 
-    def test_remote_temp_upload_6MB(self):
-        self._run_remote_temp_upload_test(1024 ** 2 * 6)
+    # def test_remote_temp_upload_6MB(self):
+    #     self._run_remote_temp_upload_test(1024 ** 2 * 6)
 
-    def test_remote_temp_upload_10MB(self):
-        self._run_remote_temp_upload_test(1024 ** 2 * 10)
+    # def test_remote_temp_upload_10MB(self):
+    #     self._run_remote_temp_upload_test(1024 ** 2 * 10)
 
-    def test_remote_temp_upload_20MB(self):
-        self._run_remote_temp_upload_test(1024 ** 2 * 20)
+    # def test_remote_temp_upload_20MB(self):
+    #     self._run_remote_temp_upload_test(1024 ** 2 * 20)
 
     def _run_remote_temp_upload_test(self, file_size):
         file_contents = b"a" * file_size
@@ -328,7 +328,7 @@ class TestS3Client(unittest.TestCase):
         tmp_file_path = tmp_file.name
 
         s3_client.get('s3://mybucket/putMe', tmp_file_path)
-        self.assertEquals(tmp_file.read(), self.tempFileContents)
+        self.assertEqual(tmp_file.read(), self.tempFileContents)
 
         tmp_file.close()
 
@@ -340,7 +340,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe')
 
-        self.assertEquals(contents, self.tempFileContents)
+        self.assertEqual(contents, self.tempFileContents)
 
     def test_get_key(self):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -28,8 +28,6 @@ from boto.s3 import key
 from moto import mock_s3
 from moto import mock_sts
 
-import boto3  # remote temp file on S3Target write
-
 from luigi import configuration
 from luigi.s3 import FileNotFoundException, InvalidDeleteException, S3Client, S3Target
 from luigi.target import MissingParentDirectory

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -140,7 +140,7 @@ class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
         s3_client.s3.create_bucket('mybucket')
 
         s3_path = 's3://mybucket/remote_test_file'
-        t = S3Target(s3_path, remote_temp_write=True)
+        t = S3Target(s3_path, client=s3_client, remote_temp_write=True)
         with open(tmp_file_path, 'rb') as source_file:
             with t.open('w') as write_file:
                 for line in source_file:

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -28,6 +28,8 @@ from boto.s3 import key
 from moto import mock_s3
 from moto import mock_sts
 
+import boto3  # remote temp file on S3Target write
+
 from luigi import configuration
 from luigi.s3 import FileNotFoundException, InvalidDeleteException, S3Client, S3Target
 from luigi.target import MissingParentDirectory

--- a/test/s3_test.py
+++ b/test/s3_test.py
@@ -140,7 +140,10 @@ class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
         s3_client.s3.create_bucket('mybucket')
 
         s3_path = 's3://mybucket/remote_test_file'
-        t = S3Target(s3_path, client=s3_client, remote_temp_write=True)
+        t = S3Target(s3_path, client=s3_client, remote_temp_write=True,
+                     boto3_session_kwargs={'region_name': 'us-east-1',
+                                           'aws_access_key_id': AWS_ACCESS_KEY,
+                                           'aws_secret_access_key': AWS_SECRET_KEY})
         with open(tmp_file_path, 'rb') as source_file:
             with t.open('w') as write_file:
                 for line in source_file:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps=
   nose<2.0
   unittest2<2.0
   boto<3.0
+  boto3<1.4.0
   sqlalchemy<2.0
   elasticsearch<2.0.0
   psutil<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps=
   nose<2.0
   unittest2<2.0
   boto<3.0
-  boto3>=1.4.0
-  s3transfer>=0.1.2
+  # boto3>=1.4.0
+  # s3transfer>=0.1.2
   sqlalchemy<2.0
   elasticsearch<2.0.0
   psutil<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ deps=
   nose<2.0
   unittest2<2.0
   boto<3.0
-  boto3<1.4.0
+  boto3>=1.4.0
+  s3transfer>=0.1.2
   sqlalchemy<2.0
   elasticsearch<2.0.0
   psutil<4.0


### PR DESCRIPTION
## Description

Added to S3Target the ability to write temp file on S3 instead of to local file system. This requires boto3 >= 1.4.0, but is only enabled if requested by the caller, so it should not affect current users at all.
## Motivation and Context

When working with very large files, it is impractical (or impossible) to write an entire file to a local filesystem. S3 is much more scalable, and it makes more sense to write the temporary/in-progress file there instead of locally. This significantly increases the flexibility of working with S3Target for my use cases, and I imagine it will come in handy for others as well. 
## Have you tested this? If so, how?

I have tested this thoroughly with my own code and it works well. I have not included unit tests, but can write some if someone can point me to an example set of tests for the AtomicS3File. The particular issues that need to be tested in a formal test are small files vs large files. Because boto3 handles these differently (because of S3 rules about multipart upload sizes), it was necessary to write some logic to intelligently buffer to meet boto3's expectations. The file sizes to test would be files < 5MB, files < 8MB, files <16MB, and files >16MB.
