### PR TITLE
Tries using path for non-hdfs targets in hadoop_jar

### DIFF
--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -52,7 +52,12 @@ def fix_paths(job):
                 logger.info('Using temp path: %s for path %s', y.path, x.path)
                 args.append(y.path)
         else:
-            args.append(str(x))
+            try:
+                # hopefully the target has a path to use
+                args.append(x.path)
+            except AttributeError:
+                # if there's no path then hope converting it to a string will work
+                args.append(str(x))
 
     return (tmp_files, args)
 

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -19,8 +19,8 @@ import luigi
 import tempfile
 import shlex
 from helpers import unittest
-from luigi.contrib.hadoop_jar import HadoopJarJobError, HadoopJarJobTask
-from mock import patch
+from luigi.contrib.hadoop_jar import HadoopJarJobError, HadoopJarJobTask, fix_paths
+from mock import patch, Mock
 
 
 class TestHadoopJarJob(HadoopJarJobTask):
@@ -46,6 +46,21 @@ class TestRemoteMissingJarJob(TestHadoopJarJob):
 
 class TestRemoteHadoopJarTwoParamJob(TestRemoteHadoopJarJob):
     param2 = luigi.Parameter()
+
+
+class FixPathsTest(unittest.TestCase):
+    def test_fix_paths_non_hdfs_target_path(self):
+        mock_job = Mock()
+        mock_arg = Mock()
+        mock_job.args.return_value = [mock_arg]
+        mock_arg.path = 'right_path'
+        self.assertEqual(([], ['right_path']), fix_paths(mock_job))
+
+    def test_fix_paths_non_hdfs_target_str(self):
+        mock_job = Mock()
+        mock_arg = Mock(spec=[])
+        mock_job.args.return_value = [mock_arg]
+        self.assertEqual(([], [str(mock_arg)]), fix_paths(mock_job))
 
 
 class HadoopJarJobTaskTest(unittest.TestCase):


### PR DESCRIPTION
## Description
Tries using the path attribute of arguments in fix_paths before resorting to str.

## Motivation and Context
When writing a map-reduce job that takes S3 inputs, I found that the arguments were incorrect. As S3Target does not inherit from HdfsTarget, the code goes to the base case of calling str.

## Have you tested this? If so, how?
I've been running this code a while and have unit tests.
