### PR TITLE
Uses a sane default for pysftp_conn_kwargs

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -53,7 +53,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
         self.tls = tls
         self.timeout = timeout
         self.sftp = sftp
-        self.pysftp_conn_kwargs = pysftp_conn_kwargs
+        self.pysftp_conn_kwargs = pysftp_conn_kwargs or {}
 
         if port is None:
             if self.sftp:


### PR DESCRIPTION
## Description
pysftp_conn_kwargs defaults to None, which causes a `TypeError` when passed
with `**` for the kwargs of pysftp.connect. This fixes replaces `None` with `{}` when storing pysftp_conn_kwargs in the RemoteFileSystem.

## Motivation and Context
I found that since updating to the latest luigi yesterday, my sftp tasks have stopped working. There would be an error like `TypeError: type object argument after ** must be a mapping, not NoneType` in the luigi ftp library. I traced it down to the default value for the new optional argument pysftp_conn_kwargs in RemoteFileSystem. By storing `{}` when `None` is passed, the error is fixed.

## Have you tested this? If so, how?
I ran a previously failing job with this code and it succeeded.
