### PR TITLE
Allow port reuse for central scheduler server

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -234,7 +234,7 @@ def _init_api(scheduler, responder=None, api_port=None, address=None, unix_socke
     if unix_socket is not None:
         api_sockets = [tornado.netutil.bind_unix_socket(unix_socket)]
     else:
-        api_sockets = tornado.netutil.bind_sockets(api_port, address=address)
+        api_sockets = tornado.netutil.bind_sockets(api_port, address=address, reuse_port=True)
     server = tornado.httpserver.HTTPServer(api_app)
     server.add_sockets(api_sockets)
 


### PR DESCRIPTION
## Description

Allows port reuse for the central scheduler server.
## Motivation and Context

Otherwise it is impossible to restart the scheduler. For a minute or more startup fails with:

```
Traceback (most recent call last):
  File "/usr/bin/luigid", line 11, in <module>
    sys.exit(luigid())
  File "/usr/lib/python3.5/site-packages/luigi/cmdline.py", line 56, in luigid
    luigi.server.run(api_port=opts.port, address=opts.address, unix_socket=opts.unix_socket)
  File "/usr/lib/python3.5/site-packages/luigi/server.py", line 260, in run
    unix_socket=unix_socket,
  File "/usr/lib/python3.5/site-packages/luigi/server.py", line 237, in _init_api
    api_sockets = tornado.netutil.bind_sockets(api_port, address=address)
  File "/usr/lib64/python3.5/site-packages/tornado/netutil.py", line 194, in bind_sockets
    sock.bind(sockaddr)
OSError: [Errno 98] Address already in use
```
## Have you tested this? If so, how?

Manually tried restarting it after this change. Works okay now.
