### PR TITLE
Moves error messages in the task list to a popup

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -231,16 +231,6 @@
                 {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name={{displayName}}><i class="fa fa-comment"></i></button>{{/statusMessage}}
             </div>
         </script>
-        <script type="text/template" name="rowDetailsTemplate">
-          <table cellpadding="5" cellspacing="0" border="0" style="padding-left:50px;">
-          {{#error}}
-            <tr>
-              <td>Exception:</td>
-              <td class="error-trace"></td>
-            </tr>
-          {{ /error }}
-          </table>
-        </script>
         <script type="text/template" name="errorTemplate">
           <div class="modal-dialog">
             <div class="modal-content">

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -911,26 +911,9 @@ function visualiserApp(luigi) {
             var tr = $(this).closest('tr');
             var row = dt.row( tr );
             var data = row.data();
-
-            if ( row.child.isShown() ) {
-                // This row is already open - close it
-                row.child.hide();
-            }
-            else {
-                // Open this row
-                row.child(Mustache.render(templates['rowDetailsTemplate'], data)).show();
-
-                // If error state is present retrieve the error
-                if (data.error) {
-                    errorTrace = row.child().find('.error-trace');
-                    luigi.getErrorTrace(data.taskId, function(error) {
-                        errorTrace.html('<pre class="pre-scrollable">'+decodeError(error.error)+'</pre>');
-                    });
-                }
-
-
-            }
-
+            luigi.getErrorTrace(data.taskId, function(error) {
+                showErrorTrace(error);
+            });
         } );
 
         $('#taskTable tbody').on('click', 'td.details-control .re-enable-button', function () {


### PR DESCRIPTION
## Description
Displays error messages in the task list using a popup like in the graph view rather than inline in the table rows.

## Motivation and Context
When error messages with long lines appear in the task list data table, they can stretch the table width beyond that of the window. Horizontal scrolling is impossible, hiding both the error message and the action buttons needed for hiding the error message or showing others.

As the error message popup works well in the graph, this is easily solved by just using the same popup for displaying error messages in the task list. This popup has a fixed size and allows horizontal scrolling when lines exceed it.

## Have you tested this? If so, how?
I'm using it in production now. It works much better than before.

Before:
![image](https://cloud.githubusercontent.com/assets/2091885/17980049/724ed5d2-6ab2-11e6-848e-cf9b8fb4a321.png)

After:
![image](https://cloud.githubusercontent.com/assets/2091885/17980093/a0fb43de-6ab2-11e6-8800-ccaa60ae1cfa.png)
![image](https://cloud.githubusercontent.com/assets/2091885/17980255/3a78d03a-6ab3-11e6-8368-e8207a58c159.png)
