### PR TITLE
Allows breaking resource strings on commas in visualizer

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -77,7 +77,7 @@ function visualiserApp(luigi) {
             taskParams: taskParams,
             displayName: task.display_name,
             priority: task.priority,
-            resources: JSON.stringify(task.resources),
+            resources: JSON.stringify(task.resources).replace(/,"/g, ', "'),
             displayTime: displayTime,
             displayTimestamp: task.last_updated,
             timeRunning: time_running,


### PR DESCRIPTION
## Description
Adds a space after comma separators when converting the resources dict to a string for the visualizer.

## Motivation and Context
Using JSON.stringify produces a compact string with no spaces between separators. When used with a longer resources dict, it can cause the cell in the task list datatable to become too wide and push the edge of the table off of the screen. By adding a space after the comma separators, the resources dict can be broken up and everything fits comfortably within my laptop's smaller window size again.

## Have you tested this? If so, how?
I'm using this now in production and I can finally view the whole data table without having to use my browser's zoom out function.

Before:
![image](https://cloud.githubusercontent.com/assets/2091885/17979952/f19a6b68-6ab1-11e6-8401-91ade40e9278.png)

After:
![image](https://cloud.githubusercontent.com/assets/2091885/17979895/bf34071a-6ab1-11e6-9572-9d8ad8680aa3.png)