### PR TITLE
Fixes backward compatibility with disable-num-failures

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -126,7 +126,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable_failures'))
+                                         config_path=dict(section='scheduler', name='disable-num-failures'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,


### PR DESCRIPTION
## Description
Changes the name `disable_failures` to `disable-num-failures` in the scheduler config backward compatibility check.

## Motivation and Context
I recently noticed that tasks don't get disabled anymore in my scheduler since updating luigi. After digging into it a bit, I found that my `retry_count` was set to the default value of 999999999. For backward compatibility, it checks `disable_failures`, but my config contains `disable-num-failures`. Some people may be using `disable_num_failures` (which I think was also valid before this change) but I don't know how we can support both cases.

## Have you tested this? If so, how?
I ran a test scheduler with my config and a job set to fail in its run. It disabled appropriately again.