### PR TITLE
Added image_version support to Dataproc

### DIFF
--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -195,7 +195,9 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
                     "numInstances": self.worker_preemptible_count,
                     "isPreemptible": True
                 },
-                "imageVersion": self.image_version 
+                "softwareConfig": {
+                    "imageVersion": self.image_version
+                }
             }
         }
 

--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -144,7 +144,7 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
     worker_disk_size = luigi.Parameter(default="100")
     worker_normal_count = luigi.Parameter(default="2")
     worker_preemptible_count = luigi.Parameter(default="0")
-    image_version = luigi.Parameter(default="1.1")
+    image_version = luigi.Parameter(default="")
 
     def _get_cluster_status(self):
         return self.dataproc_client.projects().regions().clusters()\
@@ -163,6 +163,11 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
 
     def run(self):
         base_uri = "https://www.googleapis.com/compute/v1/projects/{}".format(self.gcloud_project_id)
+        software_config = {}
+
+        if self.image_version:
+            software_config["imageVersion"] = self.image_version
+
         cluster_conf = {
             "clusterName": self.dataproc_cluster_name,
             "projectId": self.gcloud_project_id,
@@ -195,9 +200,7 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
                     "numInstances": self.worker_preemptible_count,
                     "isPreemptible": True
                 },
-                "softwareConfig": {
-                    "imageVersion": self.image_version
-                }
+                "softwareConfig": software_config
             }
         }
 

--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -163,7 +163,7 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
 
     def run(self):
         base_uri = "https://www.googleapis.com/compute/v1/projects/{}".format(self.gcloud_project_id)
-        software_config = { "imageVersion": self.image_version } if self.image_version else {}
+        software_config = {"imageVersion": self.image_version} if self.image_version else {}
 
         cluster_conf = {
             "clusterName": self.dataproc_cluster_name,

--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -144,6 +144,7 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
     worker_disk_size = luigi.Parameter(default="100")
     worker_normal_count = luigi.Parameter(default="2")
     worker_preemptible_count = luigi.Parameter(default="0")
+    image_version = luigi.Parameter(default="1.1")
 
     def _get_cluster_status(self):
         return self.dataproc_client.projects().regions().clusters()\
@@ -193,7 +194,8 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
                 "secondaryWorkerConfig": {
                     "numInstances": self.worker_preemptible_count,
                     "isPreemptible": True
-                }
+                },
+                "imageVersion": self.image_version 
             }
         }
 

--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -163,10 +163,7 @@ class CreateDataprocClusterTask(_DataprocBaseTask):
 
     def run(self):
         base_uri = "https://www.googleapis.com/compute/v1/projects/{}".format(self.gcloud_project_id)
-        software_config = {}
-
-        if self.image_version:
-            software_config["imageVersion"] = self.image_version
+        software_config = { "imageVersion": self.image_version } if self.image_version else {}
 
         cluster_conf = {
             "clusterName": self.dataproc_cluster_name,

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -27,7 +27,7 @@ from nose.plugins.attrib import attr
 PROJECT_ID = os.environ.get('DATAPROC_TEST_PROJECT_ID', 'your_project_id_here')
 CLUSTER_NAME = os.environ.get('DATAPROC_TEST_CLUSTER', 'unit-test-cluster')
 REGION = os.environ.get('DATAPROC_REGION', 'global')
-
+IMAGE_VERSION = '1.0'
 
 class _DataprocBaseTestCase(unittest.TestCase):
 
@@ -139,11 +139,19 @@ class DataprocTaskTest(_DataprocBaseTestCase):
         self.assertTrue(success)
         self.assertLess(time.time() - job_start, 3)
 
-    def test_8_create_cluster_1_0(self):
+    def test_8_create_cluster_image_version(self):
         success = luigi.run(['--local-scheduler',
                              '--no-lock',
                              'CreateDataprocClusterTask',
                              '--gcloud-project-id=' + PROJECT_ID,
-                             '--dataproc-cluster-name=' + CLUSTER_NAME,
+                             '--dataproc-cluster-name=' + CLUSTER_NAME + '-' + IMAGE_VERSION,
                              '--image-version=1.0'])
+        self.assertTrue(success)
+
+    def test_9_delete_cluster_image_version(self):
+        success = luigi.run(['--local-scheduler',
+                             '--no-lock',
+                             'DeleteDataprocClusterTask',
+                             '--gcloud-project-id=' + PROJECT_ID,
+                             '--dataproc-cluster-name=' + CLUSTER_NAME + '-' + IMAGE_VERSION])
         self.assertTrue(success)

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -138,3 +138,12 @@ class DataprocTaskTest(_DataprocBaseTestCase):
                              '--dataproc-cluster-name=' + CLUSTER_NAME])
         self.assertTrue(success)
         self.assertLess(time.time() - job_start, 3)
+
+    def test_8_create_cluster_1_0(self):
+        success = luigi.run(['--local-scheduler',
+                             '--no-lock',
+                             'CreateDataprocClusterTask',
+                             '--gcloud-project-id=' + PROJECT_ID,
+                             '--dataproc-cluster-name=' + CLUSTER_NAME,
+                             '--image-version=1.0'])
+        self.assertTrue(success)

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -29,6 +29,7 @@ CLUSTER_NAME = os.environ.get('DATAPROC_TEST_CLUSTER', 'unit-test-cluster')
 REGION = os.environ.get('DATAPROC_REGION', 'global')
 IMAGE_VERSION = '1.0'
 
+
 class _DataprocBaseTestCase(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adds the `image_version` parameter. [Version list](https://cloud.google.com/dataproc/docs/concepts/dataproc-versions)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Relates to issue [Dataproc image-version param not supported](https://github.com/spotify/luigi/issues/1831)

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Manually tested against Google Dataproc. Both 1.0 and 1.1 cluster creation worked.
