### PR TITLE
[fix] BigqueryLoadTask#run() source_uris method call error

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -503,7 +503,7 @@ class BigqueryLoadTask(MixinBigqueryBulkComplete, luigi.Task):
 
         bq_client = output.client
 
-        source_uris = self.source_uris()
+        source_uris = self.source_uris
         assert all(x.startswith('gs://') for x in source_uris)
 
         job = {


### PR DESCRIPTION
Fix BigqueryLoadTask run method.

## Motivation and Context
If BigqueryLoadTask#run() execute, cause Error.
Error is "list is not called". Because "BigqueryLoadTask#source_uris" is property and return list.

## Have you tested this? If so, how?
Yes, "BigqueryLoadTask#run" execute.  After, table exists and exists data.
