### PR TITLE
Properly use Python3's buffer interface.

### DIFF
--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -145,8 +145,9 @@ class PigJobTask(luigi.Task):
                         line = proc.stderr.readline().decode('utf8')
                         err_lines.append(line)
                     if fd == proc.stdout.fileno():
-                        line = proc.stdout.readline().decode('utf8')
-                        temp_stdout.write(line)
+                        line_bytes = proc.stdout.readline()
+                        temp_stdout.write(line_bytes)
+                        line = line_bytes.decode('utf8')
 
                 err_line = line.lower()
                 if err_line.find('More information at:') != -1:

--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -127,7 +127,7 @@ class PigJobTask(luigi.Task):
             self.track_and_progress(cmd)
 
     def track_and_progress(self, cmd):
-        temp_stdout = tempfile.TemporaryFile()
+        temp_stdout = tempfile.TemporaryFile('wb')
         env = os.environ.copy()
         env['PIG_HOME'] = self.pig_home()
         for k, v in six.iteritems(self.pig_env_vars()):

--- a/test/contrib/pig_test.py
+++ b/test/contrib/pig_test.py
@@ -173,11 +173,19 @@ def _get_fake_Popen(arglist_result, return_code, *args, **kwargs):
         arglist_result.append(arglist)
 
         class P(object):
+            number_of_process_polls = 5
+
+            def __init__(self):
+                self._process_polls_left = self.number_of_process_polls 
 
             def wait(self):
                 pass
 
             def poll(self):
+                if self._process_polls_left:
+                    self._process_polls_left -= 1
+                    return None
+
                 return 0
 
             def communicate(self):

--- a/test/contrib/pig_test.py
+++ b/test/contrib/pig_test.py
@@ -176,7 +176,7 @@ def _get_fake_Popen(arglist_result, return_code, *args, **kwargs):
             number_of_process_polls = 5
 
             def __init__(self):
-                self._process_polls_left = self.number_of_process_polls 
+                self._process_polls_left = self.number_of_process_polls
 
             def wait(self):
                 pass


### PR DESCRIPTION
## Description
When using `luigi` with Python 3 there is issue running PigTask. Because output in `track_and_progress` is both read to unicode string and copied to temporary file, it failed as conversion to string happens before writing to file. I simply moved decoding after writing to temporary file.

## Motivation and Context
Without this change, running PigTask ended with following error:

>   File "/projects/big-data/luigi-tasks/libs/pig_task.py", line 57, in on_execute
>    PigTask.run(self)
>  File "/home/etl/.projects/big-data/lib/python3.4/site-packages/luigi/contrib/pig.py", line 127, in run
>    self.track_and_progress(cmd)
>  File "/home/etl/.projects/big-data/lib/python3.4/site-packages/luigi/contrib/pig.py", line 149, in >track_and_progress
>    temp_stdout.write(line)
>TypeError: 'str' does not support the buffer interface

And while Pig script finished successfully, `luigi` marked it as failed.

## Have you tested this? If so, how?
After making this change locally our Pig scripts run without issues using Python3.4