### PR TITLE
Scheduler: don't give tasks to disabled assistants

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -322,6 +322,17 @@ class Worker(object):
     def assistant(self):
         return self.info.get('assistant', False)
 
+    @property
+    def enabled(self):
+        return not self.disabled
+
+    @property
+    def state(self):
+        if self.enabled:
+            return WORKER_STATE_ACTIVE
+        else:
+            return WORKER_STATE_DISABLED
+
     def __str__(self):
         return self.id
 
@@ -530,7 +541,7 @@ class SimpleTaskState(object):
         for worker in six.itervalues(self._active_workers):
             if last_active_lt is not None and worker.last_active >= last_active_lt:
                 continue
-            last_get_work = getattr(worker, 'last_get_work', None)
+            last_get_work = worker.last_get_work
             if last_get_work_gt is not None and (
                             last_get_work is None or last_get_work <= last_get_work_gt):
                 continue
@@ -557,10 +568,10 @@ class SimpleTaskState(object):
                 task.stakeholders.difference_update(workers)
             task.workers.difference_update(workers)
 
-    def disable_workers(self, workers):
-        self._remove_workers_from_tasks(workers, remove_stakeholders=False)
-        for worker in workers:
-            self.get_worker(worker).disabled = True
+    def disable_workers(self, worker_ids):
+        self._remove_workers_from_tasks(worker_ids, remove_stakeholders=False)
+        for worker_id in worker_ids:
+            self.get_worker(worker_id).disabled = True
 
 
 class Scheduler(object):
@@ -626,13 +637,12 @@ class Scheduler(object):
 
         self._state.inactivate_tasks(remove_tasks)
 
-    def update(self, worker_id, worker_reference=None, get_work=False):
-        """
-        Keep track of whenever the worker was last active.
-        """
+    def _update_worker(self, worker_id, worker_reference=None, get_work=False):
+        # Keep track of whenever the worker was last active.
+        # For convenience also return the worker object.
         worker = self._state.get_worker(worker_id)
         worker.update(worker_reference, get_work=get_work)
-        return not getattr(worker, 'disabled', False)
+        return worker
 
     def _update_priority(self, task, prio, worker):
         """
@@ -666,10 +676,10 @@ class Scheduler(object):
         """
         assert worker is not None
         worker_id = worker
-        worker_enabled = self.update(worker_id)
+        worker = self._update_worker(worker_id)
         retry_policy = self._generate_retry_policy(retry_policy_dict)
 
-        if worker_enabled:
+        if worker.enabled:
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
                 priority=priority, family=family, module=module, params=params,
@@ -679,7 +689,7 @@ class Scheduler(object):
 
         task = self._state.get_task(task_id, setdefault=_default_task)
 
-        if task is None or (task.status != RUNNING and not worker_enabled):
+        if task is None or (task.status != RUNNING and not worker.enabled):
             return
 
         # for setting priority, we'll sometimes create tasks with unset family and params
@@ -731,7 +741,7 @@ class Scheduler(object):
         if resources is not None:
             task.resources = resources
 
-        if worker_enabled and not assistant:
+        if worker.enabled and not assistant:
             task.stakeholders.add(worker_id)
 
             # Task dependencies might not exist yet. Let's create dummy tasks for them for now.
@@ -746,7 +756,7 @@ class Scheduler(object):
         # before we know their retry_policy, we always set it here
         task.retry_policy = retry_policy
 
-        if runnable and status != FAILED and worker_enabled:
+        if runnable and status != FAILED and worker.enabled:
             task.workers.add(worker_id)
             self._state.get_worker(worker_id).tasks.add(task)
             task.runnable = runnable
@@ -840,20 +850,19 @@ class Scheduler(object):
 
         assert worker is not None
         worker_id = worker
-        worker_enabled = self.update(
+        worker = self._update_worker(
             worker_id,
             worker_reference={'host': host},
             get_work=True)
-        if not worker_enabled:
+        if not worker.enabled:
             reply = {'n_pending_tasks': 0,
                      'running_tasks': 0,
                      'task_id': None,
                      'n_unique_pending': 0,
-                     'worker_state': WORKER_STATE_DISABLED,
+                     'worker_state': worker.state,
                      }
             return reply
 
-        self.update(worker_id, {'host': host}, get_work=True)
         if assistant:
             self.add_worker(worker_id, [('assistant', assistant)])
 
@@ -958,7 +967,7 @@ class Scheduler(object):
                  'running_tasks': running_tasks,
                  'task_id': None,
                  'n_unique_pending': n_unique_pending,
-                 'worker_state': WORKER_STATE_ACTIVE
+                 'worker_state': worker.state,
                  }
 
         if len(batched_tasks) > 1:
@@ -993,7 +1002,7 @@ class Scheduler(object):
     @rpc_method(attempts=1)
     def ping(self, **kwargs):
         worker_id = kwargs['worker']
-        self.update(worker_id)
+        self._update_worker(worker_id)
 
     def _upstream_status(self, task_id, upstream_status_table):
         if task_id in upstream_status_table:
@@ -1159,7 +1168,7 @@ class Scheduler(object):
                 return all(term in t.pretty_id for term in terms)
         for task in filter(filter_func, self._state.get_active_tasks(status)):
             if task.status != PENDING or not upstream_status or upstream_status == self._upstream_status(task.id, upstream_status_table):
-                serialized = self._serialize_task(task.id, False)
+                serialized = self._serialize_task(task.id, include_deps=False)
                 result[task.id] = serialized
         if limit and len(result) > (max_shown_tasks or self._config.max_shown_tasks):
             return {'num_tasks': len(result)}
@@ -1179,7 +1188,8 @@ class Scheduler(object):
             dict(
                 name=worker.id,
                 last_active=worker.last_active,
-                started=getattr(worker, 'started', None),
+                started=worker.started,
+                state=worker.state,
                 first_task_display_name=self._first_task_display_name(worker),
                 **worker.info
             ) for worker in self._state.get_active_workers()]
@@ -1190,7 +1200,7 @@ class Scheduler(object):
             num_uniques = collections.defaultdict(int)
             for task in self._state.get_pending_tasks():
                 if task.status == RUNNING and task.worker_running:
-                    running[task.worker_running][task.id] = self._serialize_task(task.id, False)
+                    running[task.worker_running][task.id] = self._serialize_task(task.id, include_deps=False)
                 elif task.status == PENDING:
                     for worker in task.workers:
                         num_pending[worker] += 1
@@ -1221,7 +1231,7 @@ class Scheduler(object):
             for task in self._state.get_running_tasks():
                 if task.status == RUNNING and task.resources:
                     for resource, amount in six.iteritems(task.resources):
-                        consumers[resource][task.id] = self._serialize_task(task.id, False)
+                        consumers[resource][task.id] = self._serialize_task(task.id, include_deps=False)
             for resource in resources:
                 tasks = consumers[resource['name']]
                 resource['num_consumer'] = len(tasks)
@@ -1252,7 +1262,7 @@ class Scheduler(object):
         result = collections.defaultdict(dict)
         for task in self._state.get_active_tasks():
             if task.id.find(task_str) != -1:
-                serialized = self._serialize_task(task.id, False)
+                serialized = self._serialize_task(task.id, include_deps=False)
                 result[task.status][task.id] = serialized
         return result
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -69,6 +69,9 @@ STATUS_TO_UPSTREAM_MAP = {
     DISABLED: UPSTREAM_DISABLED,
 }
 
+WORKER_STATE_DISABLED = 'disabled'
+WORKER_STATE_ACTIVE = 'active'
+
 TASK_FAMILY_RE = re.compile(r'([^(_]+)[(_]')
 
 RPC_METHODS = {}
@@ -845,7 +848,9 @@ class Scheduler(object):
             reply = {'n_pending_tasks': 0,
                      'running_tasks': 0,
                      'task_id': None,
-                     'n_unique_pending': 0}
+                     'n_unique_pending': 0,
+                     'worker_state': WORKER_STATE_DISABLED,
+                     }
             return reply
 
         self.update(worker_id, {'host': host}, get_work=True)
@@ -952,7 +957,9 @@ class Scheduler(object):
         reply = {'n_pending_tasks': locally_pending_tasks,
                  'running_tasks': running_tasks,
                  'task_id': None,
-                 'n_unique_pending': n_unique_pending}
+                 'n_unique_pending': n_unique_pending,
+                 'worker_state': WORKER_STATE_ACTIVE
+                 }
 
         if len(batched_tasks) > 1:
             batch_string = '|'.join(task.id for task in batched_tasks)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -856,7 +856,7 @@ class Scheduler(object):
             get_work=True)
         if not worker.enabled:
             reply = {'n_pending_tasks': 0,
-                     'running_tasks': 0,
+                     'running_tasks': [],
                      'task_id': None,
                      'n_unique_pending': 0,
                      'worker_state': worker.state,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -837,7 +837,17 @@ class Scheduler(object):
 
         assert worker is not None
         worker_id = worker
-        # Return remaining tasks that have no FAILED descendants
+        worker_enabled = self.update(
+            worker_id,
+            worker_reference={'host': host},
+            get_work=True)
+        if not worker_enabled:
+            reply = {'n_pending_tasks': 0,
+                     'running_tasks': 0,
+                     'task_id': None,
+                     'n_unique_pending': 0}
+            return reply
+
         self.update(worker_id, {'host': host}, get_work=True)
         if assistant:
             self.add_worker(worker_id, [('assistant', assistant)])

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -283,22 +283,22 @@
               </div>
             </div>
             {{#workers}}
-            {{#num_pending}}
-            <div class="box">
-            {{/num_pending}}
-            {{^num_pending}}
+            {{#is_disabled}}
             <div class="box box-solid box-default">
-            {{/num_pending}}
+            {{/is_disabled}}
+            {{^is_disabled}}
+            <div class="box">
+            {{/is_disabled}}
                 <div class="box-header with-border">
                     <h3 class="box-title">{{name}}</h3>
                     <div class="box-tools pull-right">
-                      {{#num_pending}}
+                      {{^is_disabled}}
                       <div class="button-tooltip" data-toggle="tooltip" title="Disable Worker">
                         <button type="button" class="btn btn-danger btn-disable-worker" data-toggle="modal" data-target="#disableWorkerModal" data-worker="{{name}}">
                           <i class="fa fa-fire-extinguisher"></i>
                         </button>
                       </div>
-                      {{/num_pending}}
+                      {{/is_disabled}}
                     </div>
                 </div>
                 <div class="box-body">

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -274,6 +274,9 @@
                   </div>
                   <div class="modal-body">
                     Are you sure you want to disable this worker?
+                    <p>
+                        A disabled worker will finish its existing tasks but not start new ones.
+                    </p>
                   </div>
                   <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -308,6 +311,9 @@
                     Running: {{num_running}}<br>
                     Pending: {{num_pending}}<br>
                     Unique Pending: {{num_uniques}}<br>
+                    {{#is_disabled}}
+                    This worker is <b>disabled</b>. It will not start on new tasks.<br>
+                    {{/is_disabled}}
 
                     {{#num_running}}
                     <hr>

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -312,7 +312,7 @@
                     Pending: {{num_pending}}<br>
                     Unique Pending: {{num_uniques}}<br>
                     {{#is_disabled}}
-                    This worker is <b>disabled</b>. It will not start on new tasks.<br>
+                    This worker is <b>disabled</b>. It will not start new tasks.<br>
                     {{/is_disabled}}
 
                     {{#num_running}}

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -240,6 +240,7 @@ function visualiserApp(luigi) {
         worker.tasks.sort(function(task1, task2) { return task1.timeRunning - task2.timeRunning; });
         worker.start_time = new Date(worker.started * 1000).toLocaleString();
         worker.active = new Date(worker.last_active * 1000).toLocaleString();
+        worker.is_disabled = worker.state === 'disabled';
         return worker;
     }
 

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1305,6 +1305,15 @@ class SchedulerApiTest(unittest.TestCase):
     def test_disable_worker_stays_disabled_on_new_deps(self):
         self._test_disable_worker_helper(new_status='PENDING', new_deps=['B', 'C'])
 
+    def test_disable_worker_assistant_gets_no_task(self):
+        self.setTime(0)
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_worker('assistant', [('assistant', True)])
+        self.sch.ping(worker='assistant')
+        self.sch.disable_worker('assistant')
+        self.assertIsNone(self.sch.get_work(worker='assistant', assistant=True)['task_id'])
+        self.assertIsNotNone(self.sch.get_work(worker=WORKER)['task_id'])
+
     def test_prune_worker(self):
         self.setTime(1)
         self.sch.add_worker(worker=WORKER, info={})

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -532,6 +532,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(0, worker['num_pending'])
         self.assertEqual(0, worker['num_uniques'])
         self.assertEqual(0, worker['num_running'])
+        self.assertEqual('active', worker['state'])
         self.assertEqual(1, worker['workers'])
 
     def test_worker_list_pending_uniques(self):
@@ -583,6 +584,17 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(1, worker['num_pending'])
         self.assertEqual(1, worker['num_uniques'])
 
+    def test_worker_list_disabled_worker(self):
+        class X(luigi.Task):
+            pass
 
-if __name__ == '__main__':
-    unittest.main()
+        with luigi.worker.Worker(worker_id='w', scheduler=self.scheduler) as w:
+            w.add(X())  #
+            workers = self._remote().worker_list()
+            self.assertEqual(1, len(workers))
+            self.assertEqual('active', workers[0]['state'])
+            self.scheduler.disable_worker('w')
+            workers = self._remote().worker_list()
+            self.assertEqual(1, len(workers))
+            self.assertEqual(1, len(workers))
+            self.assertEqual('disabled', workers[0]['state'])

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -164,65 +164,6 @@ class WorkerTest(unittest.TestCase):
         self.assertTrue(a.has_run)
         self.assertTrue(b.has_run)
 
-    def test_stop_getting_new_work(self):
-        d = DummyTask()
-        self.w.add(d)
-
-        self.assertFalse(d.complete())
-        try:
-            self.w.handle_interrupt(signal.SIGUSR1, None)
-        except AttributeError:
-            raise unittest.SkipTest('signal.SIGUSR1 not found on this system')
-        self.w.run()
-        self.assertFalse(d.complete())
-
-    @mock.patch('luigi.worker.signal')
-    def test_signal_interrupt_disabled(self, worker_signal):
-        w = Worker(scheduler=self.sch)
-        worker_signal.signal.assert_called_once_with(worker_signal.SIGUSR1, w.handle_interrupt)
-        worker_signal.siginterrupt.assert_called_once_with(worker_signal.SIGUSR1, False)
-
-    @mock.patch('luigi.worker.signal')
-    def test_signal_interrupt_not_disabled_without_shutdown_handler(self, worker_signal):
-        Worker(scheduler=self.sch, no_install_shutdown_handler=True)
-        self.assertEqual(0, worker_signal.signal.call_count)
-        self.assertEqual(0, worker_signal.siginterrupt.call_count)
-
-    @mock.patch('luigi.worker.signal')
-    def test_signal_interrupt_ok_to_not_exist(self, worker_signal):
-        worker_signal.siginterrupt.side_effect = AttributeError
-        w = Worker(scheduler=self.sch)  # may fail due to the AttributeError
-
-        # we still register the handler when the siginterrupt disable fails
-        worker_signal.signal.assert_called_once_with(worker_signal.SIGUSR1, w.handle_interrupt)
-
-    def test_disabled_shutdown_hook(self):
-        w = Worker(scheduler=self.sch, keep_alive=True, no_install_shutdown_handler=True)
-        with w:
-            try:
-                # try to kill the worker!
-                os.kill(os.getpid(), signal.SIGUSR1)
-            except AttributeError:
-                raise unittest.SkipTest('signal.SIGUSR1 not found on this system')
-            # try to kill the worker... AGAIN!
-            t = SuicidalWorker(signal.SIGUSR1)
-            w.add(t)
-            w.run()
-            # task should have stepped away from the ledge, and completed successfully despite all the SIGUSR1 signals
-            self.assertEqual(list(self.sch.task_list('DONE', '').keys()), [t.task_id])
-
-    @with_config({"worker": {"no_install_shutdown_handler": "True"}})
-    def test_can_run_luigi_in_thread(self):
-        class A(DummyTask):
-            pass
-        task = A()
-        # Note that ``signal.signal(signal.SIGUSR1, fn)`` can only be called in the main thread.
-        # So if we do not disable the shutdown handler, this would fail.
-        t = threading.Thread(target=lambda: luigi.build([task], local_scheduler=True))
-        t.start()
-        t.join()
-        self.assertTrue(task.complete())
-
     def test_external_dep(self):
         class A(ExternalTask):
 
@@ -832,6 +773,56 @@ class WorkerTest(unittest.TestCase):
         self.assertEqual({task.task_id for task in tasks}, set(self.sch.task_list('FAILED', '')))
 
 
+class WorkerInterruptedTest(unittest.TestCase):
+    def setUp(self):
+        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+
+    requiring_sigusr = unittest.skipUnless(hasattr(signal, 'SIGUSR1'),
+                                           'signal.SIGUSR1 not found on this system')
+
+    def _test_stop_getting_new_work(self, worker):
+        d = DummyTask()
+        with worker:
+            worker.add(d)  # For assistant its ok that other tasks add it
+            self.assertFalse(d.complete())
+            worker.handle_interrupt(signal.SIGUSR1, None)
+            worker.run()
+            self.assertFalse(d.complete())
+
+    @requiring_sigusr
+    def test_stop_getting_new_work(self):
+        self._test_stop_getting_new_work(
+            Worker(scheduler=self.sch))
+
+    @requiring_sigusr
+    def test_stop_getting_new_work_assistant(self):
+        self._test_stop_getting_new_work(
+            Worker(scheduler=self.sch, keep_alive=False, assistant=True))
+
+    @requiring_sigusr
+    def test_stop_getting_new_work_assistant_keep_alive(self):
+        self._test_stop_getting_new_work(
+            Worker(scheduler=self.sch, keep_alive=True, assistant=True))
+
+    def test_existence_of_disabling_option(self):
+        # any code equivalent of `os.kill(os.getpid(), signal.SIGUSR1)`
+        # seem to give some sort of a "InvocationError"
+        Worker(no_install_shutdown_handler=True)
+
+    @with_config({"worker": {"no_install_shutdown_handler": "True"}})
+    def test_can_run_luigi_in_thread(self):
+        class A(DummyTask):
+            pass
+        task = A()
+        # Note that ``signal.signal(signal.SIGUSR1, fn)`` can only be called in the main thread.
+        # So if we do not disable the shutdown handler, this would fail.
+        t = threading.Thread(target=lambda: luigi.build([task], local_scheduler=True))
+        t.start()
+        t.join()
+        self.assertTrue(task.complete())
+
+
+
 class DynamicDependenciesTest(unittest.TestCase):
     n_workers = 1
     timeout = float('inf')
@@ -1024,7 +1015,7 @@ class WorkerEmailTest(LuigiTestCase):
 
     @email_patch
     def test_task_process_dies(self, emails):
-        a = SuicidalWorker(signal.SIGKILL)
+        a = SendSignalTask(signal.SIGKILL)
         luigi.build([a], workers=2, local_scheduler=True)
         self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
         self.assertTrue(emails[0].find("died unexpectedly with exit code -9") != -1)
@@ -1084,7 +1075,7 @@ class RaiseSystemExit(luigi.Task):
         raise SystemExit("System exit!!")
 
 
-class SuicidalWorker(luigi.Task):
+class SendSignalTask(luigi.Task):
     signal = luigi.IntParameter()
 
     def run(self):
@@ -1135,15 +1126,15 @@ class MultipleWorkersTest(unittest.TestCase):
         luigi.build([RaiseSystemExit()], workers=2, local_scheduler=True)
 
     def test_term_worker(self):
-        luigi.build([SuicidalWorker(signal.SIGTERM)], workers=2, local_scheduler=True)
+        luigi.build([SendSignalTask(signal.SIGTERM)], workers=2, local_scheduler=True)
 
     def test_kill_worker(self):
-        luigi.build([SuicidalWorker(signal.SIGKILL)], workers=2, local_scheduler=True)
+        luigi.build([SendSignalTask(signal.SIGKILL)], workers=2, local_scheduler=True)
 
     def test_purge_multiple_workers(self):
         w = Worker(worker_processes=2, wait_interval=0.01)
-        t1 = SuicidalWorker(signal.SIGTERM)
-        t2 = SuicidalWorker(signal.SIGKILL)
+        t1 = SendSignalTask(signal.SIGTERM)
+        t2 = SendSignalTask(signal.SIGKILL)
         w.add(t1)
         w.add(t2)
 


### PR DESCRIPTION
## Description

Previously assistants would keep getting tasks and never stop. Despite
that a user have clicked "disable worker" in the WebUI.

## Motivation and Context

This is a bugfix.

## Have you tested this? If so, how?

I have included unit tests. I have yet to test in production environment.