### PR TITLE
Disables siginterrupt for SIGUSR1

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -404,6 +404,7 @@ class Worker(object):
         if not self._config.no_install_shutdown_handler:
             try:
                 signal.signal(signal.SIGUSR1, self.handle_interrupt)
+                signal.siginterrupt(signal.SIGUSR1, False)
             except AttributeError:
                 pass
 


### PR DESCRIPTION
## Description
Sets siginterrupt to False for SIGUSR1 when installing the shutdown handler.

## Motivation and Context
I've recently started using SIGUSR1 to stop old workers on deploy and each deploy has resulted in all MapReduce tasks dying with `IOError: [Errno 4] Interrupted system call`. To avoid this, we want the SIGUSR1 signal to not interrupt system calls.

## Have you tested this? If so, how?
I wrote some unit tests and tested it heavily in production both by sending lots of SIGUSR1 signals to running MRs and by seeing the regular stream of errors during deploys stop.
