### PR TITLE
Extended inherits/requires decorators support multiple parents

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -298,6 +298,54 @@ class inherits(object):
         return Wrapped
 
 
+class multiple_inherits(object):
+    """
+    Task inheritance.
+
+    Usage:
+
+    .. code-block:: python
+
+        class TaskPathA(luigi.Task):
+            a = luigi.IntParameter()
+            # ...
+
+        class TaskPathB(luigi.Task):
+            b = luigi.IntParameter()
+
+        @multiple_inherits(TaskPathA, TaskPathB):
+        class MyTask(luigi.Task):
+            def requires(self):
+               return self.clone_parent()
+
+            def run(self):
+               print self.a # this will be defined
+               print self.b # this will also be defined
+               # ...
+    """
+
+    def __init__(self, *tasks_to_inherit):
+        super(multiple_inherits, self).__init__()
+        self.tasks_to_inherit = tasks_to_inherit
+
+    def __call__(self, task_that_inherits):
+        tasks_to_inherit = self.tasks_to_inherit
+        for task_to_inherit in tasks_to_inherit:
+            for param_name, param_obj in task_to_inherit.get_params():
+                if not hasattr(task_that_inherits, param_name):
+                    setattr(task_that_inherits, param_name, param_obj)
+
+        # Modify task_that_inherits by subclassing it and adding methods
+        @luigi.util.task_wraps(task_that_inherits)
+        class Wrapped(task_that_inherits):
+            def clone_parent(self, **args):
+                task = self.clone(cls=tasks_to_inherit[0])
+                for additional_task in tasks_to_inherit[1:]:
+                    task = task.clone(cls=additional_task, **args)
+                return task
+        return Wrapped
+
+
 class requires(object):
     """
     Same as @inherits, but also auto-defines the requires method.
@@ -317,6 +365,28 @@ class requires(object):
             def requires(_self):
                 return _self.clone_parent()
 
+        return Wrapped
+
+
+class multiple_requires(object):
+    """
+    Same as @multiple_inherits, but also auto-defines the requires method.
+    """
+
+    def __init__(self, *tasks_to_require):
+        super(multiple_requires, self).__init__()
+        self.inherit_decorator = multiple_inherits(*tasks_to_require)
+        self.tasks_to_require = tasks_to_require
+
+    def __call__(self, task_that_requires):
+        task_that_requires = self.inherit_decorator(task_that_requires)
+        tasks_to_require = self.tasks_to_require
+
+        # Modify task_that_requires by subclassing it and adding methods
+        @luigi.util.task_wraps(task_that_requires)
+        class Wrapped(task_that_requires):
+            def requires(self):
+                return (self.clone(x) for x in tasks_to_require)
         return Wrapped
 
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

These decorators simplify creating more complicated dependency graphs where one task either depends on or inherits characteristics from more than one parent task.

Technically, you could replace `@requires` and `@inherits` entirely with these versions, as they support singular input. If you want me to do that, I can change the PR.
## Have you tested this? If so, how?

<!--- Valid responses are "I have included unit tests." or --> 

<!--- "I ran my jobs with this code and it works for me." -->

I have not produced unit tests for this yet, but it works within my own code base. It is a fairly simple logical extension of the base versions of these decorators.
