### PR TITLE
Prevents batch tasks from running before their dependencies

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -894,7 +894,8 @@ class Scheduler(object):
 
             if (best_task and batched_params and task.family == best_task.family and
                     len(batched_tasks) < max_batch_size and task.is_batchable() and all(
-                    task.params.get(name) == value for name, value in unbatched_params.items())):
+                    task.params.get(name) == value for name, value in unbatched_params.items()) and
+                    self._schedulable(task)):
                 for name, params in batched_params.items():
                     params.append(task.params.get(name))
                 batched_tasks.append(task)


### PR DESCRIPTION
## Description
Checks whether batch tasks are schedulable before adding them to a batch in get_work.

Note that even though self._schedulable(task) gets called twice in the get_work loop, they fall under different branches of whether best_task is defined, so this shouldn't slow get_work down much.

## Motivation and Context
When adding tasks to an existing batch in get_work, we neglected to check whether the tasks were schedulable. This meant that in production I found my pipelines running batches that included jobs with PENDING dependencies. In order to fix this, we simply add a check that the task is schedulable.

## Have you tested this? If so, how?
I have included unit tests.
