### PR TITLE
Allows clients to specify max_shown_tasks in task_list

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1121,7 +1121,8 @@ class Scheduler(object):
             task_id, dep_func=lambda t: inverse_graph[t.id], include_done=include_done)
 
     @rpc_method()
-    def task_list(self, status='', upstream_status='', limit=True, search=None, **kwargs):
+    def task_list(self, status='', upstream_status='', limit=True, search=None, max_shown_tasks=None,
+                  **kwargs):
         """
         Query for a subset of tasks by status.
         """
@@ -1140,7 +1141,7 @@ class Scheduler(object):
             if task.status != PENDING or not upstream_status or upstream_status == self._upstream_status(task.id, upstream_status_table):
                 serialized = self._serialize_task(task.id, False)
                 result[task.id] = serialized
-        if limit and len(result) > self._config.max_shown_tasks:
+        if limit and len(result) > (max_shown_tasks or self._config.max_shown_tasks):
             return {'num_tasks': len(result)}
         return result
 

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1260,6 +1260,19 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(set('EFG'), set(sch.task_list('PENDING', '').keys()))
         self.assertEqual({'num_tasks': 4}, sch.task_list('DONE', ''))
 
+    def test_dynamic_shown_tasks_in_task_list(self):
+        sch = Scheduler(max_shown_tasks=3)
+        for task_id in 'ABCD':
+            sch.add_task(worker=WORKER, task_id=task_id, status=DONE)
+        for task_id in 'EFG':
+            sch.add_task(worker=WORKER, task_id=task_id)
+
+        self.assertEqual(set('EFG'), set(sch.task_list('PENDING', '').keys()))
+        self.assertEqual({'num_tasks': 3}, sch.task_list('PENDING', '', max_shown_tasks=2))
+
+        self.assertEqual({'num_tasks': 4}, sch.task_list('DONE', ''))
+        self.assertEqual(set('ABCD'), set(sch.task_list('DONE', '', max_shown_tasks=4).keys()))
+
     def add_task(self, family, **params):
         task_id = str(hash((family, str(params))))  # use an unhelpful task id
         self.sch.add_task(worker=WORKER, family=family, params=params, task_id=task_id)


### PR DESCRIPTION
## Description
Adds an optional max_shown_tasks argument to task_list to override the server-configured value.

## Motivation and Context
I have some scripts that process task_list for reporting. When the response length goes beyond the maximum shown tasks, the scripts all break. In order to allow the scripts to keep reporting as things get backed up, this adds an optional argument to override the config's max shown tasks in task_list, while keeping the configured default for the visualizer.

This could also potentially be used in the visualizer to make the number of tasks shown configurable by users.

## Have you tested this? If so, how?
I included a unit test and I've been using this in production for about 3 months.