### PR TITLE
Filters tasks in second branch of Worker.get_pending_tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -301,7 +301,7 @@ class Worker(object):
             return six.moves.filter(lambda task: task.status in [PENDING, RUNNING],
                                     self.tasks)
         else:
-            return state.get_pending_tasks()
+            return six.moves.filter(lambda task: self.id in task.workers, state.get_pending_tasks())
 
     def is_trivial_worker(self, state):
         """


### PR DESCRIPTION
## Description
Filters the results of worker.get_pending_tasks to only those containing the worker id in its workers list.

## Motivation and Context
When a worker has many DONE tasks, get_pending_tasks may switch to using state.get_pending_tasks in order to speed up the process. This can include pending tasks not owned by the worker, invalidating the result and causing functions like is_trivial_worker to return erroneous results.

To fix this, we simply filter the results of state.get_pending_tasks to
remove any tasks that don't include this worker.

## Have you tested this? If so, how?
I've included unit tests.
