### PR TITLE
Fails batch_running tasks if worker dies early

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -484,7 +484,7 @@ class SimpleTaskState(object):
 
     def fail_dead_worker_task(self, task, config, assistants):
         # If a running worker disconnects, tag all its jobs as FAILED and subject it to the same retry logic
-        if task.status == RUNNING and task.worker_running and task.worker_running not in task.stakeholders | assistants:
+        if task.status in (BATCH_RUNNING, RUNNING) and task.worker_running and task.worker_running not in task.stakeholders | assistants:
             logger.info("Task %r is marked as running by disconnected worker %r -> marking as "
                         "FAILED with retry delay of %rs", task.id, task.worker_running,
                         config.retry_delay)

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -330,18 +330,20 @@ class SchedulerApiTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id='A_2', status=DONE)
         self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(DONE, '').keys()))
 
-    def _start_simple_batch(self, use_max=False):
+    def _start_simple_batch(self, use_max=False, mark_running=True):
         self.sch.add_task_batcher(worker=WORKER, task_family='A', batched_args=['a'])
         self.sch.add_task(worker=WORKER, task_id='A_1', family='A', params={'a': '1'},
                           batchable=True)
         self.sch.add_task(worker=WORKER, task_id='A_2', family='A', params={'a': '2'},
                           batchable=True)
         response = self.sch.get_work(worker=WORKER)
-        batch_id = response['batch_id']
-        task_id, params = ('A_2', {'a': '2'}) if use_max else ('A_1_2', {'a': '1,2'})
-        self.sch.add_task(
-            worker=WORKER, task_id=task_id, task_family='A', params=params, batch_id=batch_id,
-            status='RUNNING')
+        if mark_running:
+            batch_id = response['batch_id']
+            task_id, params = ('A_2', {'a': '2'}) if use_max else ('A_1_2', {'a': '1,2'})
+
+            self.sch.add_task(
+                worker=WORKER, task_id=task_id, task_family='A', params=params, batch_id=batch_id,
+                status='RUNNING')
 
     def test_batch_fail(self):
         self._start_simple_batch()
@@ -366,15 +368,20 @@ class SchedulerApiTest(unittest.TestCase):
     def test_batch_fail_from_dead_worker(self):
         self.setTime(1)
         self._start_simple_batch()
-        self.setTime(10000)
-        self.sch.prune()
-        self.setTime(10001)
+        self.setTime(601)
         self.sch.prune()
         self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(FAILED, '').keys()))
 
     def test_batch_fail_max_from_dead_worker(self):
         self.setTime(1)
         self._start_simple_batch(use_max=True)
+        self.setTime(601)
+        self.sch.prune()
+        self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(FAILED, '').keys()))
+
+    def test_batch_fail_from_dead_worker_without_running(self):
+        self.setTime(1)
+        self._start_simple_batch(mark_running=False)
         self.setTime(601)
         self.sch.prune()
         self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(FAILED, '').keys()))


### PR DESCRIPTION
## Description
Compares task.status to both BATCH_RUNNING and RUNNING in fail_dead_worker_task instead of just to RUNNING.

## Motivation and Context
If a worker were to die between receiving batch tasks and responding with the task that will run them, we want the tasks to fail. Our existing methods to fail batch tasks don't work in this case, so I've extended the method for failing RUNNING tasks to also work for BATCH_RUNNING in order to handle this extra case.

## Have you tested this? If so, how?
I have included tests.