### PR TITLE
Adds time_running to batch running tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -431,6 +431,7 @@ class SimpleTaskState(object):
         self.set_status(task, BATCH_RUNNING)
         task.batch_id = batch_id
         task.worker_running = worker_id
+        task.time_running = time.time()
 
     def set_status(self, task, new_status, config=None):
         if new_status == FAILED:

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -181,6 +181,20 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual({'a': ['1', '2', '3']}, response['task_params'])
         self.assertEqual('A', response['task_family'])
 
+    def test_batch_time_running(self):
+        self.setTime(1234)
+        self.sch.add_task_batcher(worker=WORKER, task_family='A', batched_args=['a'])
+        self.sch.add_task(
+            worker=WORKER, task_id='A_a_1', family='A', params={'a': '1'}, batchable=True)
+        self.sch.add_task(
+            worker=WORKER, task_id='A_a_2', family='A', params={'a': '2'}, batchable=True)
+        self.sch.add_task(
+            worker=WORKER, task_id='A_a_3', family='A', params={'a': '3'}, batchable=True)
+
+        self.sch.get_work(worker=WORKER)
+        for task in self.sch.task_list().values():
+            self.assertEqual(1234, task['time_running'])
+
     def test_batch_ignore_items_not_ready(self):
         self.sch.add_task_batcher(worker=WORKER, task_family='A', batched_args=['a'])
         self.sch.add_task(


### PR DESCRIPTION
## Description
Sets time_running when marking a task as BATCH_RUNNING in the scheduler.

## Motivation and Context
We neglected to set time_running when setting a task as batch_running. By adding it, we get a better view of these tasks in the visualizer.

## Have you tested this? If so, how?
I've been using it in production, and I added a test to verify that the time is set.