### PR TITLE
Remove decode utf-8 function in external_program.py to avoid encoding errors

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -83,7 +83,7 @@ class ExternalProgramTask(luigi.Task):
 
     def _clean_output_file(self, file_object):
         file_object.seek(0)
-        return ''.join(map(lambda s: s.decode('utf-8'), file_object.readlines()))
+        return file_object.read()
 
     def run(self):
         args = list(map(str, self.program_args()))


### PR DESCRIPTION
## Description
Remove the decode('utf-8') function in _clean_output_file to avoid encoding errors.

## Motivation and Context
In the `ExternalProgramTask` class the `run` function has such code

    logger.info('Program stdout:\n{}'.format(stdout))

The `stdout` is unicode object after decoded in the ` _clean_output_file` function. And the python`format` function here will convert it to ascii code first. If we have an character not in the ascii range, an exception will occur. Unfortunately, we have some chinese character. And we got this exception:
```
Traceback (most recent call last):
  File "/opt/tiger/ss_lib/python_package/lib/python2.7/site-packages/luigi/worker.py", line 181, in run
    new_deps = self._run_get_new_deps()
  File "/opt/tiger/ss_lib/python_package/lib/python2.7/site-packages/luigi/worker.py", line 119, in _run_get_new_deps
    task_gen = self.task.run()
  File "/opt/tiger/ss_lib/python_package/lib/python2.7/site-packages/luigi/contrib/spark.py", line 283, in run
    super(PySparkTask, self).run()
  File "/opt/tiger/ss_lib/python_package/lib/python2.7/site-packages/luigi/contrib/external_program.py", line 110, in run
    logger.info('Program stdout:\n{}'.format(stdout))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1689-1690: ordinal not in range(128)
```
I have use some other solutions to fix this bug in the product environment
* `logger.info(u'Program stdout:\n{}'.format(stdout))`
* `logger.info('Program stdout:\n{}'.format(stdout.encode('utf-8')))`

But I finally remove the decode function here, because seems we don't need to do the "decode-encode" work at all

## Have you tested this? If so, how?
I ran the code in the production environment, and it works fine

