### PR TITLE
Handles errors when loading batch tasks from multiple ids

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -141,14 +141,18 @@ class RunOnceTask(luigi.Task):
 class LuigiTestCase(unittest.TestCase):
     """
     Tasks registred within a test case will get unregistered in a finalizer
+
+    Instance caches are cleared before and after all runs
     """
     def setUp(self):
         super(LuigiTestCase, self).setUp()
         self._stashed_reg = luigi.task_register.Register._get_reg()
+        luigi.task_register.Register.clear_instance_cache()
 
     def tearDown(self):
         luigi.task_register.Register._set_reg(self._stashed_reg)
         super(LuigiTestCase, self).tearDown()
+        luigi.task_register.Register.clear_instance_cache()
 
     def run_locally(self, args):
         """ Helper for running tests testing more of the stack, the command

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1358,6 +1358,17 @@ class UnimportedTask(luigi.Task):
             self.assertTrue(self.assistant.run())
             self.assertEqual(list(self.sch.task_list('DONE', '').keys()), [task.task_id])
 
+    def test_unimported_job_sends_failure_message(self):
+        class NotInAssistantTask(luigi.Task):
+            task_family = 'Unknown'
+            task_module = None
+
+        task = NotInAssistantTask()
+        self.w.add(task)
+        self.assertFalse(self.assistant.run())
+        self.assertEqual(list(self.sch.task_list('FAILED', '').keys()), [task.task_id])
+        self.assertTrue(self.sch.fetch_error(task.task_id)['error'])
+
 
 class ForkBombTask(luigi.Task):
     depth = luigi.IntParameter()

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -119,7 +119,7 @@ class DummyErrorTask(Task):
         raise Exception("Retry index is %s for %s" % (self.retry_index, self.task_family))
 
 
-class WorkerTest(unittest.TestCase):
+class WorkerTest(LuigiTestCase):
 
     def run(self, result=None):
         self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
@@ -131,14 +131,6 @@ class WorkerTest(unittest.TestCase):
 
         if time.time != self.time:
             time.time = self.time
-
-    def setUp(self):
-        # ensure that other tests don't leak information into these via the task register
-        luigi.task_register.Register.clear_instance_cache()
-
-    def tearDown(self):
-        # ensure these tasks don't leak into others via the task register
-        luigi.task_register.Register.clear_instance_cache()
 
     def setTime(self, t):
         time.time = lambda: t


### PR DESCRIPTION
## Description
Catches and handles exceptions when loading batch tasks from multiple batch ids.

## Motivation and Context
I ran into an error when I used `operator.add` as a batch_method. This fails because operator.add has the wrong signature. The problem is that this failure kills the worker rather than just failing that particular job. In order to allow the rest of the pipeline to continue, we trap the error just like when we fail loading a single task.

## Have you tested this? If so, how?
I have included unit tests.