### PR TITLE
Sends an error message to the scheduler upon failing to load tasks

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -768,7 +768,7 @@ class Worker(object):
                 error_message = notifications.wrap_traceback(ex)
                 notifications.send_error_email(subject, error_message)
                 self._add_task(worker=self._id, task_id=task_id, status=FAILED, runnable=False,
-                               assistant=self._assistant)
+                               assistant=self._assistant, expl=error_message)
                 task_id = None
                 self.run_succeeded = False
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1322,6 +1322,17 @@ class UnimportedTask(luigi.Task):
             self.assertTrue(self.assistant.run())
             self.assertEqual(list(self.sch.task_list('DONE', '').keys()), [task.task_id])
 
+    def test_unimported_job_sends_failure_message(self):
+        class NotInAssistantTask(luigi.Task):
+            task_family = 'Unknown'
+            task_module = None
+
+        task = NotInAssistantTask()
+        self.w.add(task)
+        self.assertFalse(self.assistant.run())
+        self.assertEqual(list(self.sch.task_list('FAILED', '').keys()), [task.task_id])
+        self.assertTrue(self.sch.fetch_error(task.task_id)['error'])
+
 
 class ForkBombTask(luigi.Task):
     depth = luigi.IntParameter()


### PR DESCRIPTION
## Description
Adds the traceback to add_task when updating a task status to FAILED after failing to load it from a task id in the worker.

## Motivation and Context
Since moving to an assistant-based workflow, assistants often pick up tasks that users are developing in their own branches. As assistants have no way of running these, we get a fair amount of failures. Unfortunately, the scheduler never receives the reason for these failures, leaving many
people confused as to what exactly happened. Luckily, there's an easy fix for this by simply adding the traceback when informing the scheduler of the failure.

## Have you tested this? If so, how?
I have included unit tests.