### PR TITLE
Enables worker timeouts with only one worker

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -778,16 +778,16 @@ class Worker(object):
     def _run_task(self, task_id):
         task = self._scheduled_tasks[task_id]
 
-        p = self._create_task_process(task)
+        task_process = self._create_task_process(task)
 
-        self._running_tasks[task_id] = p
+        self._running_tasks[task_id] = task_process
 
-        if p.random_seed:
+        if task_process.random_seed:
             with fork_lock:
-                p.start()
+                task_process.start()
         else:
             # Run in the same process
-            p.run()
+            task_process.run()
 
     def _create_task_process(self, task):
         def update_tracking_url(tracking_url):

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1220,6 +1220,9 @@ class MultipleWorkersTest(unittest.TestCase):
     def test_time_out_hung_worker(self):
         luigi.build([HangTheWorkerTask(0.1)], workers=2, local_scheduler=True)
 
+    def test_time_out_hung_single_worker(self):
+        luigi.build([HangTheWorkerTask(0.1)], workers=1, local_scheduler=True)
+
     @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/72953986')
     @mock.patch('luigi.worker.time')
     def test_purge_hung_worker_default_timeout_time(self, mock_time):


### PR DESCRIPTION
## Description
Always runs tasks with timeouts in a separate process.

## Motivation and Context
Worker timeouts rely on running the task in a separate process. In order to get them to work with a single worker, we need to run tasks that have timeouts in separate processes. This change does that while still allowing tasks that don't have a timeout set to run in the main process.

## Have you tested this? If so, how?
I have included unit tests and tried it with some simple test jobs. I've also deployed it to production and I no longer see jobs running forever on single workers.