### PR TITLE
Enables running with 0 workers to support assistants

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -193,8 +193,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
         for t in tasks:
             success &= worker.add(t, env_params.parallel_scheduling)
         logger.info('Done scheduling tasks')
-        if env_params.workers != 0:
-            success &= worker.run()
+        success &= worker.run()
     logger.info(execution_summary.summary(worker))
     return dict(success=success, worker=worker)
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -867,7 +867,7 @@ class Scheduler(object):
     def count_pending(self, worker):
         worker_id, worker = worker, self._state.get_worker(worker)
 
-        num_pending, num_unique_pending, num_last_scheduled = 0, 0, 0
+        num_pending, num_unique_pending, num_pending_last_scheduled = 0, 0, 0
         running_tasks = []
 
         upstream_status_table = {}
@@ -885,11 +885,11 @@ class Scheduler(object):
             elif task.status == PENDING:
                 num_pending += 1
                 num_unique_pending += int(len(task.workers) == 1)
-                num_last_scheduled += int(task.workers[-1] == worker_id)
+                num_pending_last_scheduled += int(task.workers[-1] == worker_id)
         return {
             'n_pending_tasks': num_pending,
             'n_unique_pending': num_unique_pending,
-            'n_pending_last_scheduled': num_last_scheduled,
+            'n_pending_last_scheduled': num_pending_last_scheduled,
             'worker_state': worker.state,
             'running_tasks': running_tasks,
         }

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -267,6 +267,7 @@ class OrderedSet(collections.MutableSet):
             return len(self) == len(other) and list(self) == list(other)
         return set(self) == set(other)
 
+
 class Task(object):
     def __init__(self, task_id, status, deps, resources=None, priority=0, family='', module=None,
                  params=None, tracking_url=None, status_message=None, retry_policy='notoptional'):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -100,7 +100,7 @@ GetWorkResponse = collections.namedtuple('GetWorkResponse', (
     'n_pending_tasks',
     'n_unique_pending',
     'n_pending_last_scheduled',
-    'worker_state'
+    'worker_state',
 ))
 
 
@@ -802,9 +802,6 @@ class Worker(object):
                 self._scheduled_tasks.get(batch_id) for batch_id in r['batch_task_ids']])
             self._batch_running_tasks[task_id] = batch_tasks
 
-        r.setdefault('worker_state', WORKER_STATE_ACTIVE)
-        r.setdefault('n_pending_last_scheduled', 0)
-
         return GetWorkResponse(
             task_id=task_id,
             running_tasks=running_tasks,
@@ -814,7 +811,7 @@ class Worker(object):
             # TODO: For a tiny amount of time (a month?) we'll keep forwards compatibility
             #  That is you can user a newer client than server (Sep 2016)
             n_pending_last_scheduled=r.get('n_pending_last_scheduled', 0),
-            worker_state=r.get('worker_state', 0),
+            worker_state=r.get('worker_state', WORKER_STATE_ACTIVE),
         )
 
     def _run_task(self, task_id):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -94,6 +94,16 @@ class TaskException(Exception):
     pass
 
 
+GetWorkResponse = collections.namedtuple('GetWorkResponse', (
+    'task_id',
+    'running_tasks',
+    'n_pending_tasks',
+    'n_unique_pending',
+    'n_pending_last_scheduled',
+    'worker_state'
+))
+
+
 class TaskProcess(multiprocessing.Process):
 
     """ Wrap all task execution in this class.
@@ -310,6 +320,10 @@ class worker(Config):
                                   description='worker-count-uniques means that we will keep a '
                                   'worker alive only if it has a unique pending task, as '
                                   'well as having keep-alive true')
+    count_last_scheduled = BoolParameter(default=False,
+                                         description='Keep a worker alive only if there are '
+                                                     'pending tasks which it was the last to '
+                                                     'schedule.')
     wait_interval = FloatParameter(default=1.0,
                                    config_path=dict(section='core', name='worker-wait-interval'))
     wait_jitter = FloatParameter(default=5.0)
@@ -698,19 +712,27 @@ class Worker(object):
         self._worker_info.append(('first_task', self._first_task))
         self._scheduler.add_worker(self._id, self._worker_info)
 
-    def _log_remote_tasks(self, running_tasks, n_pending_tasks, n_unique_pending):
+    def _log_remote_tasks(self, get_work_response):
         logger.debug("Done")
         logger.debug("There are no more tasks to run at this time")
-        if running_tasks:
-            for r in running_tasks:
+        if get_work_response.running_tasks:
+            for r in get_work_response.running_tasks:
                 logger.debug('%s is currently run by worker %s', r['task_id'], r['worker'])
-        elif n_pending_tasks:
-            logger.debug("There are %s pending tasks possibly being run by other workers", n_pending_tasks)
-            if n_unique_pending:
-                logger.debug("There are %i pending tasks unique to this worker", n_unique_pending)
+        elif get_work_response.n_pending_tasks:
+            logger.debug(
+                "There are %s pending tasks possibly being run by other workers",
+                get_work_response.n_pending_tasks)
+            if get_work_response.n_unique_pending:
+                logger.debug(
+                    "There are %i pending tasks unique to this worker",
+                    get_work_response.n_unique_pending)
+            if get_work_response.n_pending_last_scheduled:
+                logger.debug(
+                    "There are %i pending tasks last scheduled by this worker",
+                    get_work_response.n_pending_last_scheduled)
 
     def _get_work_task_id(self, get_work_response):
-        if get_work_response['task_id'] is not None:
+        if get_work_response.get('task_id') is not None:
             return get_work_response['task_id']
         elif 'batch_id' in get_work_response:
             task = load_task(
@@ -728,10 +750,12 @@ class Worker(object):
                 batch_id=get_work_response['batch_id'],
             )
             return task.task_id
+        else:
+            return None
 
     def _get_work(self):
         if self._stop_requesting_work:
-            return None, 0, 0, 0, WORKER_STATE_DISABLED
+            return GetWorkResponse(None, 0, 0, 0, 0, WORKER_STATE_DISABLED)
 
         if self.worker_processes > 0:
             logger.debug("Asking scheduler for work...")
@@ -741,28 +765,17 @@ class Worker(object):
                 assistant=self._assistant,
                 current_tasks=list(self._running_tasks.keys()),
             )
-            n_pending_tasks = r['n_pending_tasks']
-            running_tasks = r['running_tasks']
-            n_unique_pending = r['n_unique_pending']
-            # TODO: For a tiny amount of time (a month?) we'll keep forwards compatibility
-            # That is you can user a newer client than server (Sep 2016)
-            worker_state = r.get('worker_state', WORKER_STATE_ACTIVE)  # state according to server!
-            task_id = self._get_work_task_id(r)
-
-            self._get_work_response_history.append({
-                'task_id': task_id,
-                'running_tasks': running_tasks,
-            })
-
-        # Just keeping tasks alive for assistants
         else:
             logger.debug("Checking if tasks are still pending")
             r = self._scheduler.count_pending(worker=self._id)
-            n_pending_tasks = r['n_pending_tasks']
-            running_tasks = 0
-            n_unique_pending = r['n_pending_last_scheduled']
-            worker_state = r['worker_state']
-            task_id = None
+
+        running_tasks = r['running_tasks']
+        task_id = self._get_work_task_id(r)
+
+        self._get_work_response_history.append({
+            'task_id': task_id,
+            'running_tasks': running_tasks,
+        })
 
         if task_id is not None and task_id not in self._scheduled_tasks:
             logger.info('Did not schedule %s, will load it dynamically', task_id)
@@ -789,7 +802,20 @@ class Worker(object):
                 self._scheduled_tasks.get(batch_id) for batch_id in r['batch_task_ids']])
             self._batch_running_tasks[task_id] = batch_tasks
 
-        return task_id, running_tasks, n_pending_tasks, n_unique_pending, worker_state
+        r.setdefault('worker_state', WORKER_STATE_ACTIVE)
+        r.setdefault('n_pending_last_scheduled', 0)
+
+        return GetWorkResponse(
+            task_id=task_id,
+            running_tasks=running_tasks,
+            n_pending_tasks=r['n_pending_tasks'],
+            n_unique_pending=r['n_unique_pending'],
+
+            # TODO: For a tiny amount of time (a month?) we'll keep forwards compatibility
+            #  That is you can user a newer client than server (Sep 2016)
+            n_pending_last_scheduled=r.get('n_pending_last_scheduled', 0),
+            worker_state=r.get('worker_state', 0),
+        )
 
     def _run_task(self, task_id):
         task = self._scheduled_tasks[task_id]
@@ -920,7 +946,7 @@ class Worker(object):
             time.sleep(wait_interval)
             yield
 
-    def _keep_alive(self, n_pending_tasks, n_unique_pending):
+    def _keep_alive(self, get_work_response):
         """
         Returns true if a worker should stay alive given.
 
@@ -935,8 +961,12 @@ class Worker(object):
             return False
         elif self._assistant:
             return True
+        elif self._config.count_last_scheduled:
+            return get_work_response.n_pending_last_scheduled > 0
+        elif self._config.count_uniques:
+            return get_work_response.n_unique_pending > 0
         else:
-            return n_pending_tasks and (n_unique_pending or not self._config.count_uniques)
+            return get_work_response.n_pending_tasks > 0
 
     def handle_interrupt(self, signum, _):
         """
@@ -969,16 +999,16 @@ class Worker(object):
                 logger.debug('%d running tasks, waiting for next task to finish', len(self._running_tasks))
                 self._handle_next_task()
 
-            task_id, running_tasks, n_pending_tasks, n_unique_pending, worker_state = self._get_work()
+            get_work_response = self._get_work()
 
-            if worker_state == WORKER_STATE_DISABLED:
+            if get_work_response.worker_state == WORKER_STATE_DISABLED:
                 self._start_phasing_out()
 
-            if task_id is None:
+            if get_work_response.task_id is None:
                 if not self._stop_requesting_work:
-                    self._log_remote_tasks(running_tasks, n_pending_tasks, n_unique_pending)
+                    self._log_remote_tasks(get_work_response)
                 if len(self._running_tasks) == 0:
-                    if self._keep_alive(n_pending_tasks, n_unique_pending):
+                    if self._keep_alive(get_work_response):
                         six.next(sleeper)
                         continue
                     else:
@@ -988,8 +1018,8 @@ class Worker(object):
                     continue
 
             # task_id is not None:
-            logger.debug("Pending tasks: %s", n_pending_tasks)
-            self._run_task(task_id)
+            logger.debug("Pending tasks: %s", get_work_response.n_pending_tasks)
+            self._run_task(get_work_response.task_id)
 
         while len(self._running_tasks):
             logger.debug('Shut down Worker, %d more tasks to go', len(self._running_tasks))

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -773,6 +773,72 @@ class WorkerTest(unittest.TestCase):
         self.assertEqual({task.task_id for task in tasks}, set(self.sch.task_list('FAILED', '')))
 
 
+class WorkerKeepAliveTests(LuigiTestCase):
+    def setUp(self):
+        self.sch = Scheduler()
+        super(WorkerKeepAliveTests, self).setUp()
+
+    def _worker_keep_alive_test(self, first_should_live, second_should_live, **worker_args):
+        worker_args.update({
+            'scheduler': self.sch,
+            'worker_processes': 0,
+            'wait_interval': 0.01,
+            'wait_jitter': 0.0,
+        })
+        w1 = Worker(worker_id='w1', **worker_args)
+        w2 = Worker(worker_id='w2', **worker_args)
+        with w1 as worker1, w2 as worker2:
+            worker1.add(DummyTask())
+            t1 = threading.Thread(target=worker1.run)
+            t1.start()
+
+            worker2.add(DummyTask())
+            t2 = threading.Thread(target=worker2.run)
+            t2.start()
+
+            # allow workers to run their get work loops a few times
+            time.sleep(0.1)
+
+            try:
+                self.assertEqual(first_should_live, t1.isAlive())
+                self.assertEqual(second_should_live, t2.isAlive())
+
+            finally:
+                # mark the task done so the worker threads will die
+                self.sch.add_task(worker='DummyWorker', task_id=DummyTask().task_id, status='DONE')
+                t1.join()
+                t2.join()
+
+    def test_no_keep_alive(self):
+        self._worker_keep_alive_test(
+            first_should_live=False,
+            second_should_live=False,
+        )
+
+    def test_keep_alive(self):
+        self._worker_keep_alive_test(
+            first_should_live=True,
+            second_should_live=True,
+            keep_alive=True,
+        )
+
+    def test_keep_alive_count_uniques(self):
+        self._worker_keep_alive_test(
+            first_should_live=False,
+            second_should_live=False,
+            keep_alive=True,
+            count_uniques=True,
+        )
+
+    def test_keep_alive_count_last_scheduled(self):
+        self._worker_keep_alive_test(
+            first_should_live=False,
+            second_should_live=True,
+            keep_alive=True,
+            count_last_scheduled=True,
+        )
+
+
 class WorkerInterruptedTest(unittest.TestCase):
     def setUp(self):
         self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)


### PR DESCRIPTION
## Description
Changes how worker.run works to make it compatible with running 0 workers. This allows scheduler verification of whether the worker needs to stay alive.

## Motivation and Context
In order to allow assistants to take care of running all tasks, we need a
way to run scheduling with 0 workers. This adds a slightly tweaked worker
code path to allow a process with 0 workers to stay alive while skipping
any get_work calls to the scheduler. Instead, the worker makes a
count_pending call to see if it's still necessary.

count_pending returns the pending count and unique count as well as a new
pending last scheduled count, which counts the number of pending tasks
which haven't been scheduled by another worker since the current worker
first scheduled it. This last count is important because it allows enough
workers to stay alive to keep all tasks scheduled. If we use unique counts
to keep workers alive, all workers could die at the same time leaving
nothing running. If we use pending counts, all workers will stay alive,
preventing new tasks from being scheduled via locks.

In order to minimize code changes, the pending last scheduled count is
stored into the same variable used for unique pending counts in standard
workers. This makes slightly misleading messages but that can be fixed
later if it bothers anyone.

These workers should be used with keep_alive and count_uniques both set
to true. I'll add documentation about this to the luigi patterns doc once
I've solved more of the issues I'm having with assistant-based workloads.

## Have you tested this? If so, how?
I have included unit tests and I've been using this in production for about a month.