### PR TITLE
Add u prefix in the format statement to avoid encoding error

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -107,10 +107,10 @@ class ExternalProgramTask(luigi.Task):
             stderr = self._clean_output_file(tmp_stderr)
 
             if stdout:
-                logger.info('Program stdout:\n{}'.format(stdout))
+                logger.info(u'Program stdout:\n{}'.format(stdout))
             if stderr:
                 if self.always_log_stderr or not success:
-                    logger.info('Program stderr:\n{}'.format(stderr))
+                    logger.info(u'Program stderr:\n{}'.format(stderr))
 
             if not success:
                 raise ExternalProgramRunError(


### PR DESCRIPTION
## Description

Fix encoding error issue
## Motivation and Context

The `stdout` and `stderr` is an unicode object after decoded in the _clean_output_file function
And if we have some character not in ascii range, the python `format` function will return an error. 
## Have you tested this? If so, how?

It works fine in my production environment. python 2.7
