### PR TITLE
print BQTable in a query friendly format

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -96,6 +96,9 @@ class BQTable(collections.namedtuple('BQTable', 'project_id dataset_id table_id'
         return "bq://" + self.project_id + "/" + \
                self.dataset.dataset_id + "/" + self.table_id
 
+    def __str__(self):
+        return "%s:%s.%s" % (self.project_id, self.dataset_id, self.table_id)
+
 
 class BigqueryClient(object):
     """A client for Google BigQuery.


### PR DESCRIPTION
## Description

print BQTable in a query friendly format
## Motivation and Context

enables some neat stuff, like:

``` py
class MyBQTask(BigqueryRunQueryTask):

  def requires(self):
    return { 't1': BQTask1(),
             't2': BQTask2()}

  @property
  def query(self)
    return '''
      SELECT t1.f1, t2.f2
      FROM [{t1}] AS t1
      JOIN [{t2}] AS t2
      ON t1.f3 = t2.f3
    '''.format(**self.input())

  ...
```
## Have you tested this? If so, how?

"I ran my jobs with this code and it works for me."
