### PR TITLE
Prevents batched tasks from all getting marked RUNNING

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -532,7 +532,7 @@ class SimpleTaskState(object):
             elif task.scheduler_disable_time is not None and new_status != DISABLED:
                 return
 
-        if task.status == RUNNING and task.batch_id is not None:
+        if task.status == RUNNING and task.batch_id is not None and new_status != RUNNING:
             for batch_task in self.get_batch_running_tasks(task.batch_id):
                 self.set_status(batch_task, new_status, config)
                 batch_task.batch_id = None

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -413,6 +413,26 @@ class SchedulerApiTest(unittest.TestCase):
             self.sch.add_task(
                 worker=WORKER, task_id=task_id, task_family='A', params=params, batch_id=batch_id,
                 status='RUNNING')
+            return batch_id, task_id, params
+
+    def test_set_batch_runner_retry(self):
+        batch_id, task_id, params = self._start_simple_batch()
+        self.sch.add_task(
+            worker=WORKER, task_id=task_id, task_family='A', params=params, batch_id=batch_id,
+            status='RUNNING'
+        )
+        self.assertEqual({task_id}, set(self.sch.task_list('RUNNING', '').keys()))
+        self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(BATCH_RUNNING, '').keys()))
+
+    def test_set_batch_runner_multiple_retries(self):
+        batch_id, task_id, params = self._start_simple_batch()
+        for _ in range(3):
+            self.sch.add_task(
+                worker=WORKER, task_id=task_id, task_family='A', params=params, batch_id=batch_id,
+                status='RUNNING'
+            )
+        self.assertEqual({task_id}, set(self.sch.task_list('RUNNING', '').keys()))
+        self.assertEqual({'A_1', 'A_2'}, set(self.sch.task_list(BATCH_RUNNING, '').keys()))
 
     def test_batch_fail(self):
         self._start_simple_batch()


### PR DESCRIPTION
## Description
Adjusts SimpleTaskState.set_status to not set batched tasks to RUNNING when setting an already running batch task to RUNNING again.

## Motivation and Context
I've recently seen some of my workers simultaneously running multiple tasks from the same batchable class, when the should all be running together as a single batch. Furthermore, these tasks exceeded both resource constraints and the number of workers supposed to be running at the same time.

After checking the logs, I saw that the worker would actually run these one at a time upon receiving each one from the scheduler. My best guess after looking into it for a week is that the worker does not receive a response from the scheduler after marking the batch runner as RUNNING, and the scheduler updates the entire batch's status on the retry. I verified that this is indeed a possibility with a unit test and have patched that bug here.

## Have you tested this? If so, how?
I have included unit tests.