### PR TITLE
Uses task name instead of task_id as job identifier for MR

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -678,7 +678,7 @@ class BaseHadoopJobTask(luigi.Task):
 
     def jobconfs(self):
         jcs = []
-        jcs.append('mapred.job.name=%s' % self.task_id)
+        jcs.append('mapred.job.name=%s' % self)
         if self.mr_priority != NotImplemented:
             jcs.append('mapred.job.priority=%s' % self.mr_priority())
         pool = self._get_pool()

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -99,7 +99,7 @@ class HadoopJarJobTaskTest(unittest.TestCase):
                             raise AssertionError
 
             task = TestRemoteHadoopJarTwoParamJob(temp_file.name, 'test')
-            mock_job.side_effect = lambda x, _: check_space(x, task.task_id)
+            mock_job.side_effect = lambda x, _: check_space(x, str(task))
             task.run()
 
     @patch('luigi.contrib.hadoop.run_and_track_hadoop_job')


### PR DESCRIPTION
## Description
Uses task name instead of task_id as job identifier for MR

## Motivation and Context
It's much more useful to see MyTask(param=value) in the job tracker rather than MyTask_value_abf1238eb238eb1832, especially when the latter form usually removes most of the useful information for figuring out which task is which. Since changing the task id format, we're no longer intending for task ids to be human-readable, and this is a context where we want something human-readable.

## Have you tested this? If so, how?
I updated the unit tests and ran MRs with this code to validate that their names are now human-readable.