### PR TITLE
Add CORS headers to api requests

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -62,6 +62,9 @@ class RPCHandler(tornado.web.RequestHandler):
 
     def initialize(self, scheduler):
         self._scheduler = scheduler
+        self.set_header("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Origin")
+        self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.set_header("Access-Control-Allow-Origin", "*")
 
     def get(self, method):
         if method not in RPC_METHODS:

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -98,6 +98,17 @@ class ServerTest(ServerTestBase):
     def test_api_404(self):
         self._test_404('/api/foo')
 
+    def test_api_cors_headers(self):
+        response = self.fetch('/api/graph')
+        headers = dict(response.headers)
+
+        def _set(name):
+            return set(headers[name].replace(" ", "").split(","))
+
+        self.assertSetEqual(_set("Access-Control-Allow-Headers"), {"Content-Type", "Accept", "Authorization", "Origin"})
+        self.assertSetEqual(_set("Access-Control-Allow-Methods"), {"GET", "OPTIONS"})
+        self.assertEqual(headers["Access-Control-Allow-Origin"], "*")
+
 
 class _ServerTest(unittest.TestCase):
     """


### PR DESCRIPTION

## Description

Add the following headers to API server requests:
* `Access-Control-Allow-Headers:Accept, Authorization, Content-Type, Origin`
* `Access-Control-Allow-Methods:GET, OPTIONS`
* `Access-Control-Allow-Origin:*`

## Motivation and Context

This allows an external application to request data from the api via Javascript. In our specific case, we request JSON data from `/api/graph` and display it in an internal ops dashboard.

## Have you tested this? If so, how?

Ran the server locally and verified that the desired headers show up. Tested out with an AngularJS application that pulls in luigi task data.

Simple test that you can run in a dev console (requires jQuery): `$.get("http://localhost:8082/api/graph", function(data) { console.dir(data.response); })`

