### PR TITLE
tests: Disable server_test.test_404

### DIFF
--- a/test/server_test.py
+++ b/test/server_test.py
@@ -153,6 +153,7 @@ class _ServerTest(unittest.TestCase):
     def test_raw_ping_extended(self):
         self.sch._request('/api/ping', {'worker': 'xyz', 'foo': 'bar'})
 
+    @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/166833694')
     def test_404(self):
         with self.assertRaises(luigi.rpc.RPCError):
             self.sch._request('/api/fdsfds', {'dummy': 1})


### PR DESCRIPTION
There was a sporadic failure happening. Last time it bothered us in spotify/luigi#1878.