### PR TITLE
[bigquery] point out Avro support

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -50,6 +50,7 @@ class QueryMode(object):
 
 
 class SourceFormat(object):
+    AVRO = 'AVRO'
     CSV = 'CSV'
     DATASTORE_BACKUP = 'DATASTORE_BACKUP'
     NEWLINE_DELIMITED_JSON = 'NEWLINE_DELIMITED_JSON'
@@ -441,7 +442,7 @@ class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
     def schema(self):
         """Schema in the format defined at https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.schema.
 
-        If the value is falsy, it is omitted and inferred by BigQuery, which only works for CSV inputs."""
+        If the value is falsy, it is omitted and inferred by BigQuery, which only works for AVRO and CSV inputs."""
         return []
 
     @property


### PR DESCRIPTION
Google recently introduced Avro support in the BigQuery load API. It is also nice with automatic table schema inference.

We have tested that `'AVRO'` is a valid `source_format` value and it does what it says.
