### PR TITLE
Lets use Text type for value column of TaskParameter table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+.python-version

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -196,7 +196,7 @@ class TaskParameter(Base):
     __tablename__ = 'task_parameters'
     task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'), primary_key=True)
     name = sqlalchemy.Column(sqlalchemy.String(128), primary_key=True)
-    value = sqlalchemy.Column(sqlalchemy.String(256))
+    value = sqlalchemy.Column(sqlalchemy.Text)
 
     def __repr__(self):
         return "TaskParameter(task_id=%d, name=%s, value=%s)" % (self.task_id, self.name, self.value)


### PR DESCRIPTION
## Description

Change `value` column type from `string(256)` to `text` because of the issues on insert to task parameters table.

[error](https://gist.github.com/oivoodoo/0fb78f5a041bb08939f30f4af10c00c6) 
## Motivation and Context

Found this issue from the log file in our production system.
## Have you tested this? If so, how?

Going to test on 17.10.2016 in the next our deploy.
