### PR TITLE
make elasticsearch example run out of the box

### DIFF
--- a/examples/elasticsearch_index.py
+++ b/examples/elasticsearch_index.py
@@ -112,4 +112,4 @@ class IndexDocuments(CopyToIndex):
         return FakeDocuments()
 
 if __name__ == "__main__":
-    luigi.run(['--task', 'IndexDocuments'])
+    luigi.run(['IndexDocuments', '--local-scheduler'])


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes -->

Change parameters to `luigi.run` in elasticsearch indexing example.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

The `--task` parameter seems obsolete now.

> error: unrecognized arguments: --task

Also, I tested the example with the latest elasticsearch release [5.0.0](https://www.elastic.co/v5) - it works.
## Have you tested this? If so, how?

<!--- Valid responses are "I have included unit tests." or --> 

<!--- "I ran my jobs with this code and it works for me." -->

Tested locally:

```
$ brew install elasticsearch
$ elasticsearch --daemonize
$ python examples/elasticsearch_index.py
...
This progress looks :)
```
