### PR TITLE
Correctly escape query used with Redshift UNLOAD

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -637,7 +637,7 @@ class RedshiftUnloadTask(postgres.PostgresQuery):
             self.aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
 
         unload_query = self.unload_query.format(
-            query=self.query().replace("'", "\'"),
+            query=self.query().replace("'", r"\'"),
             s3_unload_path=self.s3_unload_path,
             unload_options=self.unload_options,
             s3_access_key=self.aws_access_key_id,

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -232,7 +232,7 @@ class TestRedshiftUnloadTask(unittest.TestCase):
 
         # Check the Unload query.
         mock_cursor.execute.assert_called_with(
-            "UNLOAD ( 'SELECT \'a\' as col_a, current_date as col_b' ) TO 's3://bucket/key' "
+            "UNLOAD ( 'SELECT \\'a\\' as col_a, current_date as col_b' ) TO 's3://bucket/key' "
             "credentials 'aws_access_key_id=AWS_ACCESS_KEY;aws_secret_access_key=AWS_SECRET_KEY' "
             "DELIMITER ',' ADDQUOTES GZIP ALLOWOVERWRITE PARALLEL OFF;"
         )


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
SQL queries used in the context of the UNLOAD command in Redshift need to have any single quotes escaped.

This change fixes a little bug which didn't correctly add the backslashes to the query string.

## Have you tested this? If so, how?

While creating some jobs that use RedshiftUnloadTask earlier today, I noticed the issue. This PR fixes it.