### PR TITLE
Fixing task.flatten to allow for custom Targets inheriting from dict/MutableMapping

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -34,6 +34,7 @@ import re
 from luigi import six
 
 from luigi import parameter
+from luigi.target import Target
 from luigi.task_register import Register
 
 Parameter = parameter.Parameter
@@ -609,6 +610,8 @@ def flatten(struct):
     """
     if struct is None:
         return []
+    if isinstance(struct, Target):
+        return [struct]
     flat = []
     if isinstance(struct, dict):
         for _, result in six.iteritems(struct):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -43,6 +43,10 @@ class DefaultInsignificantParamTask(luigi.Task):
     necessary_param = luigi.Parameter(significant=False)
 
 
+class DummyListTarget(luigi.Target, list):
+    pass
+
+
 class TaskTest(unittest.TestCase):
 
     def test_tasks_doctest(self):
@@ -84,6 +88,10 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(flatten('foo'), ['foo'])
         self.assertEqual(flatten(42), [42])
         self.assertEqual(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+
+        dummy_list_target = DummyListTarget()
+        self.assertEqual(flatten(dummy_list_target), [dummy_list_target])
+
         self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
 
     def test_externalized_task_picklable(self):


### PR DESCRIPTION
## Description
I added a conditional short-circuit `return` in `task.flatten`.
This adds a dependency for the `task` module to the `target` module.

## Motivation and Context
This allows for `dict`-like and iterable custom `Target` classes.

## Have you tested this? If so, how?
I have included a unit test.
