### PR TITLE
Update salesforce http header for Requests update

### DIFF
--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -474,7 +474,7 @@ class SalesforceAPI(object):
             raise Exception("Can not create a batch without a valid job_id and an active session.")
 
         headers = self._get_create_batch_content_headers(file_type)
-        headers['Content-Length'] = len(data)
+        headers['Content-Length'] = str(len(data))
 
         response = requests.post(self._get_create_batch_url(job_id),
                                  headers=headers,


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
With the release of Requests 2.11, headers were strictly required to contain string-only components. This requires the casting of `Content-Length` to the string equivalent of the length of the data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix error caused by method `check_header_validity` in `requests/utils.py` (`InvalidHeader: Header value 65 must be of type str or bytes, not <type 'int'>`).

[Requests Issue discussion](https://github.com/kennethreitz/requests/issues/3477)

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Runs my jobs without error.

