### PR TITLE
Scheduler keeps resources for each worker

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -70,6 +70,11 @@ function visualiserApp(luigi) {
             time_running = task.time_running;
             displayTime += " | " + minutes_running + " minutes";
         }
+        if(task.status == 'RUNNING'){
+            r = task.resources[task.worker_running]
+        }else{
+            r = task.resources
+        }
         return {
             taskId: task.taskId,
             encodedTaskId: encodeURIComponent(task.taskId),
@@ -77,7 +82,7 @@ function visualiserApp(luigi) {
             taskParams: taskParams,
             displayName: task.display_name,
             priority: task.priority,
-            resources: JSON.stringify(task.resources).replace(/,"/g, ', "'),
+            resources: JSON.stringify(r).replace(/,"/g, ', "'),
             displayTime: displayTime,
             displayTimestamp: task.last_updated,
             timeRunning: time_running,


### PR DESCRIPTION
Scheduler keeps resources for each worker

## Description
  Change the scheduler's behavior so that it keeps the resources for
  each worker.
  The change provide dynamically scheduling of resources.

## Motivation and Context
  Conventional implementation cannot support Dynamic resource allocation.
  Users strongly wish the feature.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.