### PR TITLE
Cleanup code by removing `if __name__ == '__main__'` pattern

### DIFF
--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -1,4 +1,4 @@
-.. highlight:: bash
+.. _CommandLine:
 
 Running from the Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/elasticsearch_index.py
+++ b/examples/elasticsearch_index.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import datetime
 import json
 

--- a/examples/foo.py
+++ b/examples/foo.py
@@ -14,10 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+You can run this example like this:
+
+    .. code:: console
+
+            $ rm -rf '/tmp/bar'
+            $ luigi --module examples.foo examples.Foo --workers 2 --local-scheduler
+
+"""
 
 from __future__ import print_function
-import os
-import shutil
 import time
 
 import luigi
@@ -51,10 +58,3 @@ class Bar(luigi.Task):
         """
         time.sleep(1)
         return luigi.LocalTarget('/tmp/bar/%d' % self.num)
-
-
-if __name__ == "__main__":
-    if os.path.exists('/tmp/bar'):
-        shutil.rmtree('/tmp/bar')
-
-    luigi.run(['examples.Foo', '--workers', '2', '--local-scheduler'])

--- a/examples/foo_complex.py
+++ b/examples/foo_complex.py
@@ -14,9 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+You can run this example like this:
 
-import os
-import shutil
+    .. code:: console
+
+            $ rm -rf '/tmp/bar'
+            $ luigi --module examples.foo_complex examples.Foo --workers 2 --local-scheduler
+
+"""
 import time
 import random
 
@@ -67,10 +73,3 @@ class Bar(luigi.Task):
        """
         time.sleep(1)
         return luigi.LocalTarget('/tmp/bar/%d' % self.num)
-
-
-if __name__ == "__main__":
-    if os.path.exists('/tmp/bar'):
-        shutil.rmtree('/tmp/bar')
-
-    luigi.run(['examples.Foo', '--workers', '2', '--local-scheduler'])

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,3 +1,12 @@
+"""
+You can run this example like this:
+
+    .. code:: console
+
+            $ luigi --module examples.hello_world examples.HelloWorldTask --local-scheduler
+
+If that does not work, see :ref:`CommandLine`.
+"""
 import luigi
 
 

--- a/examples/ssh_remote_execution.py
+++ b/examples/ssh_remote_execution.py
@@ -97,7 +97,3 @@ class ProcessRemoteData(luigi.Task):
         :rtype: object (:py:class:`~luigi.target.Target`)
         """
         return MockFile("output", mirror_on_stderr=True)
-
-
-if __name__ == "__main__":
-    luigi.run()

--- a/examples/terasort.py
+++ b/examples/terasort.py
@@ -110,7 +110,3 @@ class TeraSort(luigi.contrib.hadoop_jar.HadoopJarJobTask):
 
     def args(self):
         return [self.input(), self.output()]
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -315,7 +315,3 @@ class TestHiveTarget(unittest.TestCase):
         target = luigi.contrib.hive.HivePartitionTarget(database='db', table='foo', partition='bar', client=client)
         target.exists()
         client.table_exists.assert_called_with('foo', 'db', 'bar')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/contrib/sge_test.py
+++ b/test/contrib/sge_test.py
@@ -100,7 +100,3 @@ class TestSGEJob(unittest.TestCase):
                 os.remove(fpath)
             except OSError:
                 pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -354,7 +354,3 @@ class SubtaskTest(unittest.TestCase):
         # the same name
         from luigi.task import Register
         self.assertEqual(Register.get_task_cls('SubtaskDelegator'), SubtaskDelegator)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from helpers import unittest
-
 import luigi
 import luigi.date_interval
 import luigi.notifications
@@ -95,7 +93,3 @@ class InterfaceTest(LuigiTestCase):
 
     def _run_interface(self):
         return luigi.interface.build([self.task_a, self.task_b], worker_scheduler_factory=self.worker_scheduler_factory)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/set_task_name_test.py
+++ b/test/set_task_name_test.py
@@ -42,7 +42,3 @@ class SetTaskNameTest(unittest.TestCase):
 
     def test_set_task_name(self):
         luigi.run(['--local-scheduler', '--no-lock', 'MyNewTask'])
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -103,7 +103,3 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(tracking_url, 'http://test.luigi.com/')
         message = task.set_status_message('message')
         self.assertEqual(message, 'message')
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/worker_multiprocess_test.py
+++ b/test/worker_multiprocess_test.py
@@ -106,7 +106,3 @@ class MultiprocessWorkerTest(unittest.TestCase):
                                                     self.gw_res(0, None)])
 
         self.assertFalse(self.worker.run())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/worker_parallel_scheduling_test.py
+++ b/test/worker_parallel_scheduling_test.py
@@ -166,7 +166,3 @@ class ParallelSchedulingTest(unittest.TestCase):
         send.check_called_once()
         self.assertEqual(UNKNOWN, self.sch.add_task.call_args[1]['status'])
         self.assertFalse(self.sch.add_task.call_args[1]['runnable'])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/wrap_test.py
+++ b/test/wrap_test.py
@@ -101,7 +101,3 @@ class WrapperTest(unittest.TestCase):
 
 class WrapperWithMultipleWorkersTest(WrapperTest):
     workers = 7
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
   nosetests -v --tests=test/visualiser
 
 [testenv:flake8]
-deps = flake8>=3.0.2
+deps = flake8>=3.2.0
 commands = flake8 --max-line-length=160 --exclude=doc,luigi/six.py,.tox
   flake8 --max-line-length=100 --ignore=E265 doc
 


### PR DESCRIPTION
This patch started out as fixing the red in the current travis flake8
step.  As most occurrences was about simply removing the over-(mis)-used
`if __name__ == "__main__"` pattern that was way to prevalent in the luigi
code base.

This is kind of analogous to the other time flake8 suddenly got more
sensitive. See spotify/luigi#1786