### PR TITLE
Checks for proper email configuration before sending error emails

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -373,7 +373,8 @@ def _prefix(subject):
     If the config has a special prefix for emails then this function adds
     this prefix.
     """
-    if email().prefix is not None:
+    prefix = email().prefix
+    if prefix is not None and prefix != '':
         return "{} {}".format(email().prefix, subject)
     else:
         return subject

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -34,6 +34,8 @@ import textwrap
 
 import luigi.task
 import luigi.parameter
+import luigi.configuration
+
 
 logger = logging.getLogger("luigi-interface")
 DEFAULT_CLIENT_EMAIL = 'luigi-client@%s' % socket.gethostname()
@@ -343,6 +345,19 @@ def send_error_email(subject, message, additional_recipients=None):
     """
     Sends an email to the configured error email, if it's configured.
     """
+    # Check if email settings are configured before sending error email
+    config = luigi.configuration.get_config()
+    section = "email"
+    if not config.has_section(section):
+        logger.warning("No error email sent because email is not configured on this system.  " +
+                       "See http://luigi.readthedocs.io/en/stable/configuration.html#email for more details")
+        return
+
+    if not config.has_option(section, "receiver"):
+        logger.warning("No error email sent because there is no 'receiver' option in the 'email' configuration.  " +
+                       "See http://luigi.readthedocs.io/en/stable/configuration.html#email for more details")
+        return
+
     recipients = _email_recipients(additional_recipients)
     sender = email().sender
     send_email(

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -358,8 +358,7 @@ def _prefix(subject):
     If the config has a special prefix for emails then this function adds
     this prefix.
     """
-    prefix = email().prefix
-    if prefix is not None and prefix != '':
+    if email().prefix:
         return "{} {}".format(email().prefix, subject)
     else:
         return subject


### PR DESCRIPTION
## Description
Currently, if a user did not configure email in the `client.cfg` or isn't pointing luigi to a config file at all, whenever a task runs that throws an error, a warning about a None parameter is shown:
`/Users/steven/source/github/luigi/luigi/parameter.py:261: UserWarning: Parameter value None is not of type string.
  warnings.warn("Parameter value {0} is not of type string.".format(str(x)))`

I was able to track down this warning to the `email` config task in `luigi.notifications`.  Since the `prefix` and `receiver` tasks default to `None`, this warning is thrown when the email is instantiated and the parameter values are serialized.

Instead of changing the warning or email task directly, I decided to add code in `luigi.notifications.send_error_email` which checks to make sure that email is configured properly before attempting to send an error email in any context.

## Motivation and Context
I believe that given a default use-case with no custom configs, luigi should not be throwing ambiguous warnings.  This can confuse users, potentially creating the misconception that there is something wrong with a user's task or pipeline, when in fact it's an internal task that is throwing the warning.

## Have you tested this? If so, how?
I created a task that always throws an error:
```
class TaskC(luigi.Task):

    def run(self):
        raise Exception("TEST")

    def complete(self):
        return False
```
Then I ran `luigi TaskA --local-scheduler` and saw the new warnings regarding the invalid configuration instead of an ambiguous parameter warning.
