### PR TITLE
Added processing_time to task FAILURE

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -160,6 +160,7 @@ class TaskProcess(multiprocessing.Process):
             # Need to have different random seeds if running in separate processes
             random.seed((os.getpid(), time.time()))
 
+        t0 = time.time() # Failed task start time
         status = FAILED
         expl = ''
         missing = []
@@ -208,6 +209,8 @@ class TaskProcess(multiprocessing.Process):
             raise
         except BaseException as ex:
             status = FAILED
+            self.task.trigger_event(
+                Event.PROCESSING_TIME, self.task, time.time() - t0)
             logger.exception("[pid %s] Worker %s failed    %s", os.getpid(), self.worker_id, self.task)
             self.task.trigger_event(Event.FAILURE, self.task, ex)
             raw_error_message = self.task.on_failure(ex)

--- a/test/event_callbacks_test.py
+++ b/test/event_callbacks_test.py
@@ -147,8 +147,11 @@ class TestEventCallbacks(unittest.TestCase):
         self.assertEqual(time, 42.0)
 
     def test_processing_time_handler_failure(self):
-        t, result = self._run_processing_time_handler(True)
-        self.assertEqual(result, [])
+        t, result = self._run_processing_time_handler(False)
+        self.assertEqual(len(result), 1)
+        task, time = result[0]
+        self.assertTrue(task is t)
+        self.assertEqual(time, 42.0)
 
 
 #        A


### PR DESCRIPTION
Added processing time to FAILURE tasks

## Description
Added line 211 and 212 to assign processing_time to failed tasks

## Motivation and Context
If no processing time assigned to failed tasks, initialized value will be logged as processing time. If user initializes processing_time as None, they will get "None" as processing time, which creates problem if they are pushing the log data to a sql database with field type as decimal numbers.
https://github.com/spotify/luigi/issues/1924

## Have you tested this? If so, how?
I have included unit test, and unit tests passed.

Signed-off-by: Shayne Wang <shaynexwang@gmail.com>