### PR TITLE
Include FAILED and UPSTREAM_FAILED tasks in count_pending

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -363,17 +363,19 @@ class Worker(object):
         if self.last_active + config.worker_disconnect_delay < time.time():
             return True
 
-    def get_pending_tasks(self, state):
+    def get_pending_tasks(self, state, include_failed=False):
         """
         Get PENDING (and RUNNING) tasks for this worker.
 
         You have to pass in the state for optimization reasons.
         """
         if len(self.tasks) < state.num_pending_tasks():
-            return six.moves.filter(lambda task: task.status in [PENDING, RUNNING],
-                                    self.tasks)
+            statuses = [PENDING, RUNNING]
+            if include_failed:
+                statuses.append(FAILED)
+            return six.moves.filter(lambda task: task.status in statuses, self.tasks)
         else:
-            return six.moves.filter(lambda task: self.id in task.workers, state.get_pending_tasks())
+            return six.moves.filter(lambda task: self.id in task.workers, state.get_pending_tasks(include_failed))
 
     def is_trivial_worker(self, state):
         """
@@ -474,9 +476,12 @@ class SimpleTaskState(object):
     def get_running_tasks(self):
         return six.itervalues(self._status_tasks[RUNNING])
 
-    def get_pending_tasks(self):
+    def get_pending_tasks(self, include_failed=False):
+        statuses = [PENDING, RUNNING]
+        if include_failed:
+            statuses.append(FAILED)
         return itertools.chain.from_iterable(six.itervalues(self._status_tasks[status])
-                                             for status in [PENDING, RUNNING])
+                                             for status in statuses)
 
     def set_batcher(self, worker_id, family, batcher_args, max_batch_size):
         self._task_batchers.setdefault(worker_id, {})
@@ -906,7 +911,7 @@ class Scheduler(object):
         running_tasks = []
 
         upstream_status_table = {}
-        for task in worker.get_pending_tasks(self._state):
+        for task in worker.get_pending_tasks(self._state, include_failed=True):
             if self._upstream_status(task.id, upstream_status_table) == UPSTREAM_DISABLED:
                 continue
             if task.status == RUNNING:
@@ -917,7 +922,7 @@ class Scheduler(object):
                     more_info = {'task_id': task.id, 'worker': str(other_worker)}
                     more_info.update(other_worker.info)
                     running_tasks.append(more_info)
-            elif task.status == PENDING:
+            elif task.status in (PENDING, FAILED):
                 num_pending += 1
                 num_unique_pending += int(len(task.workers) == 1)
                 num_pending_last_scheduled += int(task.workers.peek(last=True) == worker_id)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1102,8 +1102,9 @@ class Scheduler(object):
                     elif upstream_status_table[dep_id] == '' and dep.deps:
                         # This is the postorder update step when we set the
                         # status based on the previously calculated child elements
-                        upstream_severities = list(upstream_status_table.get(a_task_id) for a_task_id in dep.deps if a_task_id in upstream_status_table) or ['']
-                        status = min(upstream_severities, key=UPSTREAM_SEVERITY_KEY)
+                        status = max((upstream_status_table.get(a_task_id, '')
+                                      for a_task_id in dep.deps),
+                                     key=UPSTREAM_SEVERITY_KEY)
                         upstream_status_table[dep_id] = status
             return upstream_status_table[dep_id]
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -363,19 +363,13 @@ class Worker(object):
         if self.last_active + config.worker_disconnect_delay < time.time():
             return True
 
-    def get_pending_tasks(self, state, include_failed=False):
-        """
-        Get PENDING (and RUNNING) tasks for this worker.
-
-        You have to pass in the state for optimization reasons.
-        """
-        if len(self.tasks) < state.num_pending_tasks():
-            statuses = [PENDING, RUNNING]
-            if include_failed:
-                statuses.append(FAILED)
+    def get_tasks(self, state, *statuses):
+        num_self_tasks = len(self.tasks)
+        num_state_tasks = sum(len(state._status_tasks[status]) for status in statuses)
+        if num_self_tasks < num_state_tasks:
             return six.moves.filter(lambda task: task.status in statuses, self.tasks)
         else:
-            return six.moves.filter(lambda task: self.id in task.workers, state.get_pending_tasks(include_failed))
+            return six.moves.filter(lambda task: self.id in task.workers, state.get_active_tasks_by_status(*statuses))
 
     def is_trivial_worker(self, state):
         """
@@ -386,7 +380,7 @@ class Worker(object):
         """
         if self.assistant:
             return False
-        return all(not task.resources for task in self.get_pending_tasks(state))
+        return all(not task.resources for task in self.get_tasks(state, PENDING))
 
     @property
     def assistant(self):
@@ -458,30 +452,18 @@ class SimpleTaskState(object):
         else:
             logger.info("No prior state file exists at %s. Starting with empty state", self._state_path)
 
-    def get_active_tasks(self, status=None):
-        if status:
-            for task in six.itervalues(self._status_tasks[status]):
-                yield task
-        else:
-            for task in six.itervalues(self._tasks):
-                yield task
+    def get_active_tasks(self):
+        return six.itervalues(self._tasks)
+
+    def get_active_tasks_by_status(self, *statuses):
+        return itertools.chain.from_iterable(six.itervalues(self._status_tasks[status]) for status in statuses)
 
     def get_batch_running_tasks(self, batch_id):
         assert batch_id is not None
         return [
-            task for task in self.get_active_tasks(BATCH_RUNNING)
+            task for task in self.get_active_tasks_by_status(BATCH_RUNNING)
             if task.batch_id == batch_id
         ]
-
-    def get_running_tasks(self):
-        return six.itervalues(self._status_tasks[RUNNING])
-
-    def get_pending_tasks(self, include_failed=False):
-        statuses = [PENDING, RUNNING]
-        if include_failed:
-            statuses.append(FAILED)
-        return itertools.chain.from_iterable(six.itervalues(self._status_tasks[status])
-                                             for status in statuses)
 
     def set_batcher(self, worker_id, family, batcher_args, max_batch_size):
         self._task_batchers.setdefault(worker_id, {})
@@ -866,7 +848,7 @@ class Scheduler(object):
     def _used_resources(self):
         used_resources = collections.defaultdict(int)
         if self._resources is not None:
-            for task in self._state.get_active_tasks(status=RUNNING):
+            for task in self._state.get_active_tasks_by_status(RUNNING):
                 if task.resources:
                     for resource, amount in six.iteritems(task.resources):
                         used_resources[resource] += amount
@@ -893,11 +875,11 @@ class Scheduler(object):
     def _reset_orphaned_batch_running_tasks(self, worker_id):
         running_batch_ids = {
             task.batch_id
-            for task in self._state.get_running_tasks()
+            for task in self._state.get_active_tasks_by_status(RUNNING)
             if task.worker_running == worker_id
         }
         orphaned_tasks = [
-            task for task in self._state.get_active_tasks(BATCH_RUNNING)
+            task for task in self._state.get_active_tasks_by_status(BATCH_RUNNING)
             if task.worker_running == worker_id and task.batch_id not in running_batch_ids
         ]
         for task in orphaned_tasks:
@@ -911,21 +893,24 @@ class Scheduler(object):
         running_tasks = []
 
         upstream_status_table = {}
-        for task in worker.get_pending_tasks(self._state, include_failed=True):
+        for task in worker.get_tasks(self._state, RUNNING):
             if self._upstream_status(task.id, upstream_status_table) == UPSTREAM_DISABLED:
                 continue
-            if task.status == RUNNING:
-                # Return a list of currently running tasks to the client,
-                # makes it easier to troubleshoot
-                other_worker = self._state.get_worker(task.worker_running)
-                if other_worker is not None:
-                    more_info = {'task_id': task.id, 'worker': str(other_worker)}
-                    more_info.update(other_worker.info)
-                    running_tasks.append(more_info)
-            elif task.status in (PENDING, FAILED):
-                num_pending += 1
-                num_unique_pending += int(len(task.workers) == 1)
-                num_pending_last_scheduled += int(task.workers.peek(last=True) == worker_id)
+            # Return a list of currently running tasks to the client,
+            # makes it easier to troubleshoot
+            other_worker = self._state.get_worker(task.worker_running)
+            if other_worker is not None:
+                more_info = {'task_id': task.id, 'worker': str(other_worker)}
+                more_info.update(other_worker.info)
+                running_tasks.append(more_info)
+
+        for task in worker.get_tasks(self._state, PENDING, FAILED):
+            if self._upstream_status(task.id, upstream_status_table) == UPSTREAM_DISABLED:
+                continue
+            num_pending += 1
+            num_unique_pending += int(len(task.workers) == 1)
+            num_pending_last_scheduled += int(task.workers.peek(last=True) == worker_id)
+
         return {
             'n_pending_tasks': num_pending,
             'n_unique_pending': num_unique_pending,
@@ -974,7 +959,7 @@ class Scheduler(object):
         best_task = None
         if current_tasks is not None:
             ct_set = set(current_tasks)
-            for task in sorted(self._state.get_running_tasks(), key=self._rank):
+            for task in sorted(self._state.get_active_tasks_by_status(RUNNING), key=self._rank):
                 if task.worker_running == worker_id and task.id not in ct_set:
                     best_task = task
 
@@ -986,11 +971,11 @@ class Scheduler(object):
 
         worker = self._state.get_worker(worker_id)
         if worker.is_trivial_worker(self._state):
-            relevant_tasks = worker.get_pending_tasks(self._state)
+            relevant_tasks = worker.get_tasks(self._state, PENDING, RUNNING)
             used_resources = collections.defaultdict(int)
             greedy_workers = dict()  # If there's no resources, then they can grab any task
         else:
-            relevant_tasks = self._state.get_pending_tasks()
+            relevant_tasks = self._state.get_active_tasks_by_status(PENDING, RUNNING)
             used_resources = self._used_resources()
             activity_limit = time.time() - self._config.worker_disconnect_delay
             active_workers = self._state.get_active_workers(last_get_work_gt=activity_limit)
@@ -1248,7 +1233,9 @@ class Scheduler(object):
 
             def filter_func(t):
                 return all(term in t.pretty_id for term in terms)
-        for task in filter(filter_func, self._state.get_active_tasks(status)):
+
+        tasks = self._state.get_active_tasks_by_status(status) if status else self._state.get_active_tasks()
+        for task in filter(filter_func, tasks):
             if task.status != PENDING or not upstream_status or upstream_status == self._upstream_status(task.id, upstream_status_table):
                 serialized = self._serialize_task(task.id, include_deps=False)
                 result[task.id] = serialized
@@ -1278,16 +1265,18 @@ class Scheduler(object):
         workers.sort(key=lambda worker: worker['started'], reverse=True)
         if include_running:
             running = collections.defaultdict(dict)
+            for task in self._state.get_active_tasks_by_status(RUNNING):
+                if task.worker_running:
+                    running[task.worker_running][task.id] = self._serialize_task(task.id, include_deps=False)
+
             num_pending = collections.defaultdict(int)
             num_uniques = collections.defaultdict(int)
-            for task in self._state.get_pending_tasks():
-                if task.status == RUNNING and task.worker_running:
-                    running[task.worker_running][task.id] = self._serialize_task(task.id, include_deps=False)
-                elif task.status == PENDING:
-                    for worker in task.workers:
-                        num_pending[worker] += 1
-                    if len(task.workers) == 1:
-                        num_uniques[list(task.workers)[0]] += 1
+            for task in self._state.get_active_tasks_by_status(PENDING):
+                for worker in task.workers:
+                    num_pending[worker] += 1
+                if len(task.workers) == 1:
+                    num_uniques[list(task.workers)[0]] += 1
+
             for worker in workers:
                 tasks = running[worker['name']]
                 worker['num_running'] = len(tasks)
@@ -1310,7 +1299,7 @@ class Scheduler(object):
             ) for resource, r_dict in six.iteritems(self.resources())]
         if self._resources is not None:
             consumers = collections.defaultdict(dict)
-            for task in self._state.get_running_tasks():
+            for task in self._state.get_active_tasks_by_status(RUNNING):
                 if task.status == RUNNING and task.resources:
                     for resource, amount in six.iteritems(task.resources):
                         consumers[resource][task.id] = self._serialize_task(task.id, include_deps=False)

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -868,6 +868,61 @@ class SchedulerApiTest(unittest.TestCase):
             }
             self.assertEqual(expected, self.sch.count_pending(WORKER))
 
+    def test_count_pending_include_failures(self):
+        for num_tasks in range(1, 20):
+            # must be scheduled as pending before failed to ensure WORKER is in the task's workers
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks), status=PENDING)
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks), status=FAILED)
+            expected = {
+                'n_pending_tasks': num_tasks,
+                'n_unique_pending': num_tasks,
+                'n_pending_last_scheduled': num_tasks,
+                'running_tasks': [],
+                'worker_state': 'active',
+            }
+            self.assertEqual(expected, self.sch.count_pending(WORKER))
+
+    def test_count_pending_do_not_include_done_or_disabled(self):
+        for num_tasks in range(1, 20, 2):
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks), status=PENDING)
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks + 1), status=PENDING)
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks), status=DONE)
+            self.sch.add_task(worker=WORKER, task_id=str(num_tasks + 1), status=DISABLED)
+        expected = {
+            'n_pending_tasks': 0,
+            'n_unique_pending': 0,
+            'n_pending_last_scheduled': 0,
+            'running_tasks': [],
+            'worker_state': 'active',
+        }
+        self.assertEqual(expected, self.sch.count_pending(WORKER))
+
+    def test_count_pending_do_not_count_upstream_disabled(self):
+        self.sch.add_task(worker=WORKER, task_id='A', status=PENDING)
+        self.sch.add_task(worker=WORKER, task_id='B', status=DISABLED)
+        self.sch.add_task(worker=WORKER, task_id='C', status=PENDING, deps=['A', 'B'])
+        expected = {
+            'n_pending_tasks': 1,
+            'n_unique_pending': 1,
+            'n_pending_last_scheduled': 1,
+            'running_tasks': [],
+            'worker_state': 'active',
+        }
+        self.assertEqual(expected, self.sch.count_pending(WORKER))
+
+    def test_count_pending_count_upstream_failed(self):
+        self.sch.add_task(worker=WORKER, task_id='A', status=PENDING)
+        self.sch.add_task(worker=WORKER, task_id='A', status=FAILED)
+        self.sch.add_task(worker=WORKER, task_id='B', status=PENDING, deps=['A'])
+        expected = {
+            'n_pending_tasks': 2,
+            'n_unique_pending': 2,
+            'n_pending_last_scheduled': 2,
+            'running_tasks': [],
+            'worker_state': 'active',
+        }
+        self.assertEqual(expected, self.sch.count_pending(WORKER))
+
     def test_count_pending_missing_worker(self):
         self.sch.add_task(worker=WORKER, task_id='A', status=PENDING)
         expected = {

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -227,7 +227,7 @@ class SchedulerIoTest(unittest.TestCase):
 
 class SchedulerWorkerTest(unittest.TestCase):
     def get_pending_ids(self, worker, state):
-        return {task.id for task in worker.get_pending_tasks(state)}
+        return {task.id for task in worker.get_tasks(state, 'PENDING')}
 
     def test_get_pending_tasks_with_many_done_tasks(self):
         sch = luigi.scheduler.Scheduler()

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -423,7 +423,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(db['status'], 'DONE')
 
         missing_input = remote.task_list('PENDING', 'UPSTREAM_MISSING_INPUT')
-        self.assertEqual(len(missing_input), 3)
+        self.assertEqual(len(missing_input), 2)
 
         pa = missing_input.get(A().task_id)
         self.assertEqual(pa['status'], 'PENDING')
@@ -433,15 +433,14 @@ class SchedulerVisualisationTest(unittest.TestCase):
         self.assertEqual(pc['status'], 'PENDING')
         self.assertEqual(remote._upstream_status(C().task_id, {}), 'UPSTREAM_MISSING_INPUT')
 
-        pe = missing_input.get(E().task_id)
-        self.assertEqual(pe['status'], 'PENDING')
-        self.assertEqual(remote._upstream_status(E().task_id, {}), 'UPSTREAM_MISSING_INPUT')
-
         upstream_failed = remote.task_list('PENDING', 'UPSTREAM_FAILED')
-        self.assertEqual(len(upstream_failed), 1)
+        self.assertEqual(len(upstream_failed), 2)
+        pe = upstream_failed.get(E().task_id)
+        self.assertEqual(pe['status'], 'PENDING')
+        self.assertEqual(remote._upstream_status(E().task_id, {}), 'UPSTREAM_FAILED')
 
-        pd = upstream_failed.get(D().task_id)
-        self.assertEqual(pd['status'], 'PENDING')
+        pe = upstream_failed.get(D().task_id)
+        self.assertEqual(pe['status'], 'PENDING')
         self.assertEqual(remote._upstream_status(D().task_id, {}), 'UPSTREAM_FAILED')
 
         pending = dict(missing_input)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -784,7 +784,7 @@ class WorkerTest(LuigiTestCase):
 
         self.assertFalse(any(task.complete() for task in all_tasks))
 
-        worker = Worker(scheduler=self.sch, keep_alive=True)
+        worker = Worker(scheduler=Scheduler(retry_count=1), keep_alive=True)
 
         for task in all_tasks:
             self.assertTrue(worker.add(task))
@@ -814,7 +814,7 @@ class WorkerKeepAliveTests(LuigiTestCase):
         self.sch = Scheduler()
         super(WorkerKeepAliveTests, self).setUp()
 
-    def _worker_keep_alive_test(self, first_should_live, second_should_live, **worker_args):
+    def _worker_keep_alive_test(self, first_should_live, second_should_live, task_status=None, **worker_args):
         worker_args.update({
             'scheduler': self.sch,
             'worker_processes': 0,
@@ -831,6 +831,9 @@ class WorkerKeepAliveTests(LuigiTestCase):
             worker2.add(DummyTask())
             t2 = threading.Thread(target=worker2.run)
             t2.start()
+
+            if task_status:
+                self.sch.add_task(worker='DummyWorker', task_id=DummyTask().task_id, status=task_status)
 
             # allow workers to run their get work loops a few times
             time.sleep(0.1)
@@ -872,6 +875,22 @@ class WorkerKeepAliveTests(LuigiTestCase):
             second_should_live=True,
             keep_alive=True,
             count_last_scheduled=True,
+        )
+
+    def test_keep_alive_through_failure(self):
+        self._worker_keep_alive_test(
+            first_should_live=True,
+            second_should_live=True,
+            keep_alive=True,
+            task_status='FAILED',
+        )
+
+    def test_do_not_keep_alive_through_disable(self):
+        self._worker_keep_alive_test(
+            first_should_live=False,
+            second_should_live=False,
+            keep_alive=True,
+            task_status='DISABLED',
         )
 
 
@@ -1692,7 +1711,7 @@ class PerTaskRetryPolicyBehaviorTest(LuigiTestCase):
 
                     self.assertFalse(w3.run())
                     self.assertFalse(w2.run())
-                    self.assertFalse(w1.run())
+                    self.assertTrue(w1.run())
 
                     self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
 
@@ -1774,7 +1793,7 @@ class PerTaskRetryPolicyBehaviorTest(LuigiTestCase):
 
                     self.assertTrue(w3.run())
                     self.assertFalse(w2.run())
-                    self.assertFalse(w1.run())
+                    self.assertTrue(w1.run())
 
                     self.assertEqual([wt.task_id], list(self.sch.task_list('PENDING', 'UPSTREAM_DISABLED').keys()))
                     self.assertEqual([e1.task_id], list(self.sch.task_list('DISABLED', '').keys()))


### PR DESCRIPTION
## Description
Reverts #1789 and replaces it by counting FAILED tasks in count_pending

## Motivation and Context
#1789 was meant to allow workers to stay alive in order to keep working on FAILED tasks after they become PENDING again. The approach in that PR didn't really work well, as it missed cases where the root task is failed or where all leaf tasks are failed. Instead, we just directly count FAILED tasks as part of the pending count, as well as counting UPSTREAM_FAILED tasks as PENDING. UPSTREAM_DISABLED tasks are still not counted, even if only one dependency is DISABLED.

## Have you tested this? If so, how?
I have included unit tests.