### PR TITLE
Add the extra_arguments to easily pass additional arguments to streaming jobs

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -509,6 +509,12 @@ class HadoopJobRunner(JobRunner):
         for conf in jobconfs:
             arglist += ['-D', conf]
 
+        extra_arguments = job.extra_arguments()
+        for (arg, value) in extra_arguments:
+            if not arg.startswith('-'):  # safety first
+                arg = '-' + arg
+            arglist += [arg, value]
+
         arglist += self.streaming_args
 
         arglist += ['-mapper', map_cmd]
@@ -751,6 +757,13 @@ class BaseHadoopJobTask(luigi.Task):
       """.format(message=exception.message, stdout=exception.out, stderr=exception.err)
         else:
             return super(BaseHadoopJobTask, self).on_failure(exception)
+
+    def extra_arguments(self):
+        """
+        Extra arguments to Hadoop command line.
+        Return here a list of (parameter, value) tuples.
+        """
+        return []  # can be overridden in subclass
 
 
 DataInterchange = {

--- a/test/contrib/streaming_test.py
+++ b/test/contrib/streaming_test.py
@@ -77,6 +77,6 @@ class StreamingRunTest(unittest.TestCase):
 
         self.assertEqual(1, rath_job.call_count)
         mr_args = rath_job.call_args[0][0]
-        mr_args_pairs = zip(mr_args, mr_args[1:])
+        mr_args_pairs = list(zip(mr_args, mr_args[1:]))
         self.assertIn(('-myargument', '/path/to/coolvalue'), mr_args_pairs)
         self.assertIn(('-archives', '/path/to/myarchive.zip,/path/to/other_archive.zip'), mr_args_pairs)

--- a/test/contrib/streaming_test.py
+++ b/test/contrib/streaming_test.py
@@ -21,8 +21,11 @@ class MockStreamingJob(JobTask):
 class MockStreamingJobWithExtraArguments(JobTask):
     package_binary = Parameter(default=None)
 
-    def extra_arguments(self,):
+    def extra_streaming_arguments(self):
         return [('myargument', '/path/to/coolvalue')]
+
+    def extra_archives(self):
+        return ['/path/to/myarchive.zip', '/path/to/other_archive.zip']
 
     def output(self):
         rv = mock.MagicMock(HdfsTarget)
@@ -76,3 +79,4 @@ class StreamingRunTest(unittest.TestCase):
         mr_args = rath_job.call_args[0][0]
         mr_args_pairs = zip(mr_args, mr_args[1:])
         self.assertIn(('-myargument', '/path/to/coolvalue'), mr_args_pairs)
+        self.assertIn(('-archives', '/path/to/myarchive.zip,/path/to/other_archive.zip'), mr_args_pairs)


### PR DESCRIPTION
## Description
Added the `extra_straming_arguments` methods to `BaseHadoopJobTask`. This method should return a list of tuples containing additional arguments to the hadoop streaming job. I also added the method `extra_archives` (archives is generic option) so it any subclass overriding this method can make the JobRunner to add extra archives. 

## Motivation and Context
Adding additional/non-supported hadoop streaming parameters requires both modifying `JobTask` and implementing a custom `HadoopJobRunner`  that pass pass that parameter to its parent. See http://mfcabrera.com/python/2016/04/25/python-streaming-blog-org.html for an example. 

I believe this way is a more flxible way of adding parameters and something like this was  proposed by @erikbern  in #1895 . Actually this PR supersedes  #1895 . 

## Have you tested this? If so, how?
I have added a unit test and I have tested on my own. 

