### PR TITLE
Make RunAnywayTarget compatible with python 2.7

### DIFF
--- a/luigi/contrib/simulate.py
+++ b/luigi/contrib/simulate.py
@@ -101,5 +101,8 @@ class RunAnywayTarget(luigi.Target):
         logger.info('Marking %s as done', self)
 
         fn = self.get_path()
-        os.makedirs(os.path.dirname(fn), exist_ok=True)
+        try:
+            os.makedirs(os.path.dirname(fn))
+        except OSError:
+            pass
         open(fn, 'w').close()

--- a/test/simulate_test.py
+++ b/test/simulate_test.py
@@ -33,7 +33,10 @@ def is_writable():
     fn = os.path.join(d, 'luigi-simulate-write-test')
     exists = True
     try:
-        os.makedirs(d, exist_ok=True)
+        try:
+            os.makedirs(d)
+        except OSError:
+            pass
         open(fn, 'w').close()
         os.remove(fn)
     except:
@@ -50,7 +53,10 @@ class TaskA(luigi.Task):
 
     def run(self):
         fn = os.path.join(temp_dir(), 'luigi-simulate-test.tmp')
-        os.makedirs(os.path.dirname(fn), exist_ok=True)
+        try:
+            os.makedirs(os.path.dirname(fn))
+        except OSError:
+            pass
 
         with open(fn, 'a') as f:
             f.write('{0}={1}\n'.format(self.__class__.__name__, self.i))


### PR DESCRIPTION
## Description
Make `RunAnywayTarget` compatible with python 2.7

## Motivation and Context
`exist_ok` parameter doesn't exist for function `os.makedirs` in python 2.7.12

## Have you tested this? If so, how?
I tested it locally with my existing pipeline (can add unit tests if necessary).
