### PR TITLE
Add retries when polling for the job status in BigQuery

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -326,7 +326,7 @@ class BigQueryClient(object):
         job_id = new_job['jobReference']['jobId']
         logger.info('Started import job %s:%s', project_id, job_id)
         while True:
-            status = self.client.jobs().get(projectId=project_id, jobId=job_id).execute()
+            status = self.client.jobs().get(projectId=project_id, jobId=job_id).execute(num_retries=10)
             if status['status']['state'] == 'DONE':
                 if status['status'].get('errorResult'):
                     raise Exception('BigQuery job failed: {}'.format(status['status']['errorResult']))

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -328,12 +328,12 @@ class BigQueryClient(object):
         while True:
             status = self.client.jobs().get(projectId=project_id, jobId=job_id).execute()
             if status['status']['state'] == 'DONE':
-                if status['status'].get('errors'):
-                    raise Exception('BigQuery job failed: {}'.format(status['status']['errors']))
+                if status['status'].get('errorResult'):
+                    raise Exception('BigQuery job failed: {}'.format(status['status']['errorResult']))
                 return
 
             logger.info('Waiting for job %s:%s to complete...', project_id, job_id)
-            time.sleep(5.0)
+            time.sleep(5)
 
     def copy(self,
              source_table,


### PR DESCRIPTION
## Description
Add retries when polling for the job status in BigQuery, in case of specific HTTP errors encountered.

## Motivation and Context
As suggested by documentation from Google, in case of `5xx` errors encountered while polling for the job status via `jobs.get()`, it is advised to try to poll again [1].
Without this fix, Luigi might exit with a failing Task even if the underlying loading job to BigQuery is still running.

Additionally, the way the job success is verified is changed to use `status.errorResult` instead of `status.errors` [2].

## Have you tested this? If so, how?
- Tested that these changes cover a success scenario in the exact same way as before.
- Tested that critical failures are handled in the same way as before, but using `errorResult`:
```
  File "/src/luigi/luigi/contrib/bigquery.py", line 332, in run_job
    raise Exception('BigQuery job failed: {}'.format(status['status']['errorResult']))
Exception: BigQuery job failed: {u'reason': u'invalid', u'message': u'The Apache Avro library failed to parse file...
```
- Unfortunately it is hard to reproduce a `5xx` http error to test the retrying mechanism  [3], but I think in the worst case Luigi would just fail instead of retrying thus handling this scenario no worse than before.

---
[1] - https://cloud.google.com/bigquery/troubleshooting-errors#backendError
[2] - https://cloud.google.com/bigquery/loading-data#loading_avro_files
[3] - https://google.github.io/google-api-python-client/docs/epy/googleapiclient.http.HttpRequest-class.html#execute
