### PR TITLE
Update scheduler.py ISSUE #1948

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -135,7 +135,7 @@ class scheduler(Config):
     disable_window = parameter.IntParameter(default=3600,
                                             config_path=dict(section='scheduler', name='disable-window-seconds'))
     retry_count = parameter.IntParameter(default=999999999,
-                                         config_path=dict(section='scheduler', name='disable_failures'))
+                                         config_path=dict(section='scheduler', name='retry_count'))
     disable_hard_timeout = parameter.IntParameter(default=999999999,
                                                   config_path=dict(section='scheduler', name='disable-hard-timeout'))
     disable_persist = parameter.IntParameter(default=86400,


### PR DESCRIPTION
## Description
Renaming disable_failures to retry_count in configuration file to be consistent with the documentation.

## Motivation and Context
Currently if a job fails it will continue to run because the retry_count configuration is being referenced improperly.

## Have you tested this? If so, how?
I was running luigi with 2 workers having 1 job run properly and 1 job fail every minute. When I use retry_count=2, the job will continue to fail. However, when i use disable_failures, the job will stop and disable the job. I have come to the assumption that the code is wrong in scheduler.py because it is looking for disable_failures. It would be easier to change here than to redo the documentation.

The configuration for retry_count has an incorrect variable name of disable_failures. This should be retry_count.