### PR TITLE
Improve retcodes and execution summary for retry success

### DIFF
--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -378,10 +378,14 @@ def _summary_format(set_tasks, worker):
     smiley = ""
     reason = ""
     if set_tasks["failed"]:
-        smiley = ":("
-        reason = "there were failed tasks"
-        if set_tasks["scheduling_error"]:
-            reason += " and tasks whose scheduling failed"
+        if not (set_tasks["failed"] - set_tasks["completed"]):
+            smiley = ":)"
+            reason = "there were failed tasks but suceeded in retry"
+        else:
+            smiley = ":("
+            reason = "there were failed tasks"
+            if set_tasks["scheduling_error"]:
+                reason += " and tasks whose scheduling failed"
     elif set_tasks["scheduling_error"]:
         smiley = ":("
         reason = "there were tasks whose scheduling failed"

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -278,7 +278,6 @@ _PENDING_SUB_STATUSES = set(_ORDERED_STATUSES[_ORDERED_STATUSES.index("still_pen
 _COMMENTS = set((
     ("already_done", 'present dependencies were encountered'),
     ("completed", 'ran successfully'),
-    ("ever_failed", 'ever failed'),
     ("failed", 'failed'),
     ("scheduling_error", 'failed scheduling'),
     ("still_pending", 'were left pending, among these'),
@@ -354,7 +353,7 @@ def _summary_format(set_tasks, worker):
     for status in _ORDERED_STATUSES:
         if status not in comments:
             continue
-        if status == 'ever_failed' and (set_tasks["ever_failed"]==set_tasks["failed"]):
+        if status == 'ever_failed' and (set_tasks["ever_failed"] == set_tasks["failed"]):
             continue
         str_output += '{0}'.format(comments[status])
         if status != 'still_pending':
@@ -385,7 +384,7 @@ def _summary_format(set_tasks, worker):
     if set_tasks["ever_failed"]:
         if not set_tasks["failed"]:
             smiley = ":)"
-            reason = "there were failed tasks but suceeded in retry"
+            reason = "there were failed tasks but they all suceeded in a retry"
         else:
             smiley = ":("
             reason = "there were failed tasks"

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -353,8 +353,6 @@ def _summary_format(set_tasks, worker):
     for status in _ORDERED_STATUSES:
         if status not in comments:
             continue
-        if status == 'ever_failed':
-            continue
         str_output += '{0}'.format(comments[status])
         if status != 'still_pending':
             str_output += '{0}\n'.format(_get_str(group_tasks[status], status in _PENDING_SUB_STATUSES))

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -353,7 +353,7 @@ def _summary_format(set_tasks, worker):
     for status in _ORDERED_STATUSES:
         if status not in comments:
             continue
-        if status == 'ever_failed' and (set_tasks["ever_failed"] == set_tasks["failed"]):
+        if status == 'ever_failed':
             continue
         str_output += '{0}'.format(comments[status])
         if status != 'still_pending':

--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -82,6 +82,11 @@ def run_with_retcodes(argv):
 
     task_sets = luigi.execution_summary._summary_dict(worker)
     root_task = luigi.execution_summary._root_task(worker)
+    if root_task in task_sets['completed']:
+        completed_tasks = task_sets['completed']
+        for key in task_sets.keys():
+            if key != 'completed':
+                task_sets[key] = task_sets[key] - completed_tasks
     non_empty_categories = {k: v for k, v in task_sets.items() if v}.keys()
 
     def has(status):

--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -95,7 +95,7 @@ def run_with_retcodes(argv):
 
     codes_and_conds = (
         (retcodes.missing_data, has('still_pending_ext')),
-        (retcodes.task_failed, has('failed')),
+        (retcodes.task_failed, has('ever_failed')),
         (retcodes.already_running, has('run_by_other_worker')),
         (retcodes.scheduling_error, has('scheduling_error')),
         (retcodes.not_run, has('not_run')),

--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -82,11 +82,6 @@ def run_with_retcodes(argv):
 
     task_sets = luigi.execution_summary._summary_dict(worker)
     root_task = luigi.execution_summary._root_task(worker)
-    if root_task in task_sets['completed']:
-        completed_tasks = task_sets['completed']
-        for key in task_sets.keys():
-            if key != 'completed':
-                task_sets[key] = task_sets[key] - completed_tasks
     non_empty_categories = {k: v for k, v in task_sets.items() if v}.keys()
 
     def has(status):
@@ -95,7 +90,7 @@ def run_with_retcodes(argv):
 
     codes_and_conds = (
         (retcodes.missing_data, has('still_pending_ext')),
-        (retcodes.task_failed, has('ever_failed')),
+        (retcodes.task_failed, has('failed')),
         (retcodes.already_running, has('run_by_other_worker')),
         (retcodes.scheduling_error, has('scheduling_error')),
         (retcodes.not_run, has('not_run')),

--- a/test/execution_summary_test.py
+++ b/test/execution_summary_test.py
@@ -1087,6 +1087,9 @@ class ExecutionSummaryTest(LuigiTestCase):
         self.assertNotIn('00:00:00', s)
         self.assertNotIn('\n\n\n', s)
 
+    """
+    Test that a task once crashing and then succeeding should be counted as no failure.
+    """
     def test_status_with_task_retry(self):
         class Foo(luigi.Task):
             run_count = 0
@@ -1104,6 +1107,7 @@ class ExecutionSummaryTest(LuigiTestCase):
         d = self.summary_dict()
         self.assertEqual({Foo()}, d['completed'])
         self.assertEqual({Foo()}, d['ever_failed'])
+        self.assertFalse(d['failed'])
         self.assertFalse(d['upstream_failure'])
         self.assertFalse(d['upstream_missing_dependency'])
         self.assertFalse(d['run_by_other_worker'])

--- a/test/execution_summary_test.py
+++ b/test/execution_summary_test.py
@@ -1111,4 +1111,5 @@ class ExecutionSummaryTest(LuigiTestCase):
         s = self.summary()
         self.assertIn('Scheduled 1 task', s)
         self.assertIn('Luigi Execution Summary', s)
+        self.assertNotIn('ever failed', s)
         self.assertIn('\n\nThis progress looks :) because there were failed tasks but they all suceeded in a retry', s)

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -176,17 +176,16 @@ class RetcodesTest(LuigiTestCase):
     """
     def test_retry_sucess_task(self):
         class Foo(luigi.Task):
-            num = luigi.IntParameter()
             run_count = 0
 
             def run(self):
                 self.run_count += 1
-                if self.num == 0 and self.run_count == 1:
+                if self.run_count == 1:
                     raise ValueError()
 
             def complete(self):
                 return self.run_count > 0
 
-        self.run_and_expect('Foo --scheduler-retry-delay=0 --num 0', 0)
-        self.run_and_expect('Foo --scheduler-retry-delay=0 --retcode-task-failed 5 --num 0', 0)
-        self.run_with_config(dict(task_failed='3'), 'Foo --num 0', 0)
+        self.run_and_expect('Foo --scheduler-retry-delay=0', 0)
+        self.run_and_expect('Foo --scheduler-retry-delay=0 --retcode-task-failed=5', 0)
+        self.run_with_config(dict(task_failed='3'), 'Foo', 0)

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -190,8 +190,6 @@ class RetcodesTest(LuigiTestCase):
                 self.run_count += 1
                 if self.num == 0 and self.run_count == 1:
                     raise ValueError()
-                else:
-                    pass
 
             def complete(self):
                 return self.has_run

--- a/test/retcodes_test.py
+++ b/test/retcodes_test.py
@@ -171,17 +171,13 @@ class RetcodesTest(LuigiTestCase):
             self.run_and_expect('RequiringTask', 0)
             self.run_and_expect('RequiringTask --retcode-not-run 5', 5)
 
-    @with_config({'worker': {'keep_alive': 'True'}})
+    """
+    Test that a task once crashing and then succeeding should be counted as no failure.
+    """
     def test_retry_sucess_task(self):
         class Foo(luigi.Task):
             num = luigi.IntParameter()
             run_count = 0
-
-            def priority(self):
-                if self.num == 0:
-                    return 100
-                else:
-                    return 0
 
             def run(self):
                 self.run_count += 1


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Let luigi to consider task retry success in return code handling and execution summary.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue #1932 .

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran test in local env.
Som tests(server_test) failed. I could not find why but they seems to be not related.


The current code does not consider the case when a task once
failed but succeeded in retry.