### PR TITLE
Make luigi.task.externalize return shallow copies 

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -669,15 +669,18 @@ def externalize(taskclass_or_taskobject):
     If you however want a task class to be external from the beginning, you're
     better off inheriting :py:class:`ExternalTask` rather than :py:class:`Task`.
 
-    This function tries to be side-effect free by creating a (shallow) copy of
-    the class or the object passed in and then modify that object. In
-    particular this code shouldn't do anything.
+    This function tries to be side-effect free by creating a copy of the class
+    or the object passed in and then modify that object. In particular this
+    code shouldn't do anything.
 
     .. code-block:: python
 
         externalize(MyTask)  # BAD: This does nothing (as after luigi 2.4.0)
     """
-    copied_value = copy.copy(taskclass_or_taskobject)
+    # Seems like with python < 3.3 copy.copy can't copy classes
+    # and objects with specified metaclass http://bugs.python.org/issue11480
+    compatible_copy = copy.copy if six.PY3 else copy.deepcopy
+    copied_value = compatible_copy(taskclass_or_taskobject)
     if copied_value is taskclass_or_taskobject:
         # Assume it's a class
         clazz = taskclass_or_taskobject

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -31,6 +31,7 @@ import warnings
 import json
 import hashlib
 import re
+import copy
 
 from luigi import six
 
@@ -622,16 +623,6 @@ class MixinNaiveBulkComplete(object):
         return generated_tuples
 
 
-def externalize(task):
-    """
-    Returns an externalized version of the Task.
-
-    See :py:class:`ExternalTask`.
-    """
-    task.run = None
-    return task
-
-
 class ExternalTask(Task):
     """
     Subclass for references to external dependencies.
@@ -641,6 +632,70 @@ class ExternalTask(Task):
     Luigi.
     """
     run = None
+
+
+def externalize(taskclass_or_taskobject):
+    """
+    Returns an externalized version of a Task. You may both pass an
+    instantiated task object or a task class. Some examples:
+
+    .. code-block:: python
+
+        class RequiringTask(luigi.Task):
+            def requires(self):
+                task_object = self.clone(MyTask)
+                return externalize(task_object)
+
+            ...
+
+    Here's mostly equivalent code, but ``externalize`` is applied to a task
+    class instead.
+
+    .. code-block:: python
+
+        @luigi.util.requires(externalize(MyTask))
+        class RequiringTask(luigi.Task):
+            pass
+            ...
+
+    Of course, it may also be used directly on classes and objects (for example
+    for reexporting or other usage).
+
+    .. code-block:: python
+
+        MyTask = externalize(MyTask)
+        my_task_2 = externalize(MyTask2(param='foo'))
+
+    If you however want a task class to be external from the beginning, you're
+    better off inheriting :py:class:`ExternalTask` rather than :py:class:`Task`.
+
+    This function tries to be side-effect free by creating a (shallow) copy of
+    the class or the object passed in and then modify that object. In
+    particular this code shouldn't do anything.
+
+    .. code-block:: python
+
+        externalize(MyTask)  # BAD: This does nothing (as after luigi 2.4.0)
+    """
+    copied_value = copy.copy(taskclass_or_taskobject)
+    if copied_value is taskclass_or_taskobject:
+        # Assume it's a class
+        clazz = taskclass_or_taskobject
+        new_name = clazz.__name__
+
+        class _CopyOfClass(clazz):
+            # How to copy a class: http://stackoverflow.com/a/9541120/621449
+            pass
+        # I was tempted to use functools.update_wrapper to not manually copy
+        # over the __name__ and not miss any important attributes. But it seems
+        # it's only only for functions, not classes
+        _CopyOfClass.__name__ = new_name
+        _CopyOfClass.run = None
+        return _CopyOfClass
+    else:
+        # We assume it's an object
+        copied_value.run = None
+        return copied_value
 
 
 class WrapperTask(Task):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -146,3 +146,28 @@ class ExternalizeTaskTest(LuigiTestCase):
         self.assertIsNot(task_class, MyTask)
         self.assertIs(MyTask(), MyTask())  # Assert it have enabled the instance caching
         self.assertIsNot(task_class(), MyTask())  # Now, they should not be the same of course
+
+    def test_externalize_same_id(self):
+        class MyTask(luigi.Task):
+            def run(self):
+                pass
+
+        task_normal = MyTask()
+        task_ext_1 = luigi.task.externalize(MyTask)()
+        task_ext_2 = luigi.task.externalize(MyTask())
+        self.assertEqual(task_normal.task_id, task_ext_1.task_id)
+        self.assertEqual(task_normal.task_id, task_ext_2.task_id)
+
+    def test_externalize_same_id_with_task_namespace(self):
+        # Dependent on the new behavior from spotify/luigi#1953
+        class MyTask(luigi.Task):
+            task_namespace = "something.domething"
+
+            def run(self):
+                pass
+
+        task_normal = MyTask()
+        task_ext_1 = luigi.task.externalize(MyTask())
+        task_ext_2 = luigi.task.externalize(MyTask)()
+        self.assertEqual(task_normal.task_id, task_ext_1.task_id)
+        self.assertEqual(task_normal.task_id, task_ext_2.task_id)

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -18,7 +18,7 @@
 import doctest
 import pickle
 
-from helpers import unittest
+from helpers import unittest, LuigiTestCase
 from datetime import datetime, timedelta
 
 import luigi
@@ -103,3 +103,36 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(tracking_url, 'http://test.luigi.com/')
         message = task.set_status_message('message')
         self.assertEqual(message, 'message')
+
+
+class ExternalizeTaskTest(LuigiTestCase):
+
+    def test_externalize_taskclass(self):
+        class MyTask(luigi.Task):
+            def run(self):
+                pass
+
+        self.assertIsNotNone(MyTask.run)  # Assert what we believe
+        task_object = luigi.task.externalize(MyTask)()
+        self.assertIsNone(task_object.run)
+        self.assertIsNotNone(MyTask.run)  # Check immutability
+        self.assertIsNotNone(MyTask().run)  # Check immutability
+
+    def test_externalize_taskobject(self):
+        class MyTask(luigi.Task):
+            def run(self):
+                pass
+
+        task_object = luigi.task.externalize(MyTask())
+        self.assertIsNone(task_object.run)
+        self.assertIsNotNone(MyTask.run)  # Check immutability
+        self.assertIsNotNone(MyTask().run)  # Check immutability
+
+    def test_externalize_taskclass_readable_name(self):
+        class MyTask(luigi.Task):
+            def run(self):
+                pass
+
+        task_class = luigi.task.externalize(MyTask)
+        self.assertIsNot(task_class, MyTask)
+        self.assertIn("MyTask", task_class.__name__)

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -136,3 +136,13 @@ class ExternalizeTaskTest(LuigiTestCase):
         task_class = luigi.task.externalize(MyTask)
         self.assertIsNot(task_class, MyTask)
         self.assertIn("MyTask", task_class.__name__)
+
+    def test_externalize_taskclass_instance_cache(self):
+        class MyTask(luigi.Task):
+            def run(self):
+                pass
+
+        task_class = luigi.task.externalize(MyTask)
+        self.assertIsNot(task_class, MyTask)
+        self.assertIs(MyTask(), MyTask())  # Assert it have enabled the instance caching
+        self.assertIsNot(task_class(), MyTask())  # Now, they should not be the same of course


### PR DESCRIPTION
## Description

Currently, running externalize on an existing class or object will have
serious side effects. Like subsequently created objects from the
original passed in class will also be externalized. This patch changes
the behavior to return a changed copy and not having as much side-effects.

Secondly, this patch officially declares this function to work on both
classes and objects.
I see two reasons we should allow for this (possibly) overly dynamic
behavior in both accepting classes and objects. First, novice users
don't pay attention to the difference, second, it still possible and it
will *seem* to work to pass in the class instead of the object. I was at
least tempted to without being sure if it was "correct". Instead let's
try to be soft on the users for this case.

## Have you tested this? If so, how?

I added many test cases and I've tested this in a little bit of production code.