### PR TITLE
Fix task_namespace inheritance.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -125,7 +125,7 @@ class Task(object):
 
     ``Task.task_namespace``
       optional string which is prepended to the task name for the sake of
-      scheduling. If it isn't overridden in a Task, whatever was last declared
+      scheduling. If it isn't overridden in or inherited by a Task, whatever was last declared
       using `luigi.namespace` will be used.
     """
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -52,9 +52,9 @@ def namespace(namespace=None):
     Call to set namespace of tasks declared after the call.
 
     If called without arguments or with ``None`` as the namespace, the namespace
-    is reset, which is recommended to do at the end of any file where the
-    namespace is set to avoid unintentionally setting namespace on tasks outside
-    of the scope of the current file.
+    is reset to :py:attr:`Register._UNSET_NAMESPACE`., which is recommended to do
+    at the end of any file where the namespace is set to avoid unintentionally
+    setting namespace on tasks outside of the scope of the current file.
 
     The namespace of a Task can also be changed by specifying the property
     ``task_namespace``. This solution has the advantage that the namespace
@@ -65,6 +65,9 @@ def namespace(namespace=None):
         class Task2(luigi.Task):
             task_namespace = 'namespace2'
     """
+    if namespace is None:
+        namespace = Register._UNSET_NAMESPACE
+
     Register._default_namespace = namespace
 
 
@@ -149,6 +152,9 @@ class Task(object):
 
     #: Maximum number of tasks to run together as a batch. Infinite by default
     max_batch_size = float('inf')
+
+    #: Default namespace of the task.
+    task_namespace = Register._default_namespace
 
     @property
     def batchable(self):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -51,12 +51,10 @@ def namespace(namespace=None):
     """
     Call to set namespace of tasks declared after the call.
 
-    If called without arguments or with ``None`` as the namespace, the namespace
-    is reset to :py:attr:`Register._UNSET_NAMESPACE`., which is recommended to do
-    at the end of any file where the namespace is set to avoid unintentionally
-    setting namespace on tasks outside of the scope of the current file.
+    It is best practice to call this function without arguments at the end of any file it has been
+    used in. That is to ensure that subsequent tasks have the default namespace again.
 
-    The namespace of a Task can also be changed by specifying the property
+    The namespace of a :py:class:`Task` can also be changed by specifying the property
     ``task_namespace``. This solution has the advantage that the namespace
     doesn't have to be restored.
 

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -67,7 +67,7 @@ class Register(abc.ABCMeta):
         """
         cls = super(Register, metacls).__new__(metacls, classname, bases, classdict)
 
-        if getattr(cls, "task_namespace", None) is None:
+        if cls.task_namespace is None:
             cls.task_namespace = metacls._default_namespace
 
         metacls._reg.append(cls)

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -62,12 +62,14 @@ class Register(abc.ABCMeta):
 
         Also register all subclasses.
 
-        Set the task namespace to whatever the currently declared namespace is.
+        When the set or inherited namespace evaluates to ``None``, set the task namespace to
+        whatever the currently declared namespace is.
         """
-        if "task_namespace" not in classdict:
-            classdict["task_namespace"] = metacls._default_namespace
-
         cls = super(Register, metacls).__new__(metacls, classname, bases, classdict)
+
+        if getattr(cls, "task_namespace", None) is None:
+            cls.task_namespace = metacls._default_namespace
+
         metacls._reg.append(cls)
 
         return cls

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -49,7 +49,8 @@ class Register(abc.ABCMeta):
     2. Keep track of all subclasses of :py:class:`Task` and expose them.
     """
     __instance_cache = {}
-    _default_namespace = None
+    _UNSET_NAMESPACE = object()
+    _default_namespace = _UNSET_NAMESPACE
     _reg = []
     AMBIGUOUS_CLASS = object()  # Placeholder denoting an error
     """If this value is returned by :py:meth:`_get_reg` then there is an
@@ -67,7 +68,9 @@ class Register(abc.ABCMeta):
         """
         cls = super(Register, metacls).__new__(metacls, classname, bases, classdict)
 
-        if cls.task_namespace is None:
+        # check if the namespace is not set, and if so, set it to the current default,
+        # which might not be the _UNSET_NAMESPACE
+        if cls.task_namespace == metacls._UNSET_NAMESPACE:
             cls.task_namespace = metacls._default_namespace
 
         metacls._reg.append(cls)
@@ -124,10 +127,10 @@ class Register(abc.ABCMeta):
         """
         The task family for the given class.
 
-        If ``cls.task_namespace is None`` then it's the name of the class.
+        If ``cls.task_namespace`` is not set, then it's the name of the class.
         Otherwise, ``<task_namespace>.`` is prefixed to the class name.
         """
-        if cls.task_namespace is None:
+        if cls.task_namespace == cls._UNSET_NAMESPACE:
             return cls.__name__
         else:
             return "%s.%s" % (cls.task_namespace, cls.__name__)

--- a/test/namespace_test.py
+++ b/test/namespace_test.py
@@ -34,7 +34,6 @@ class FooSubclass(Foo):
 class TestNamespacing(unittest.TestCase):
 
     def test_vanilla(self):
-        print(Foo.task_namespace)
         self.assertEqual(Foo.task_namespace, Register._UNSET_NAMESPACE)
         self.assertEqual(Foo.task_family, "Foo")
         self.assertEqual(str(Foo()), "Foo()")

--- a/test/namespace_test.py
+++ b/test/namespace_test.py
@@ -18,6 +18,8 @@
 from helpers import unittest
 
 import luigi
+from luigi.task_register import Register
+
 import namespace_test_helper  # declares another Foo in namespace mynamespace
 
 
@@ -32,11 +34,12 @@ class FooSubclass(Foo):
 class TestNamespacing(unittest.TestCase):
 
     def test_vanilla(self):
-        self.assertEqual(Foo.task_namespace, None)
+        print(Foo.task_namespace)
+        self.assertEqual(Foo.task_namespace, Register._UNSET_NAMESPACE)
         self.assertEqual(Foo.task_family, "Foo")
         self.assertEqual(str(Foo()), "Foo()")
 
-        self.assertEqual(FooSubclass.task_namespace, None)
+        self.assertEqual(FooSubclass.task_namespace, Register._UNSET_NAMESPACE)
         self.assertEqual(FooSubclass.task_family, "FooSubclass")
         self.assertEqual(str(FooSubclass()), "FooSubclass()")
 
@@ -48,3 +51,7 @@ class TestNamespacing(unittest.TestCase):
         self.assertEqual(namespace_test_helper.Bar.task_namespace, "othernamespace")
         self.assertEqual(namespace_test_helper.Bar.task_family, "othernamespace.Bar")
         self.assertEqual(str(namespace_test_helper.Bar(1)), "othernamespace.Bar(p=1)")
+
+        self.assertEqual(namespace_test_helper.Baz.task_namespace, "othernamespace")
+        self.assertEqual(namespace_test_helper.Baz.task_family, "othernamespace.Baz")
+        self.assertEqual(str(namespace_test_helper.Baz(1)), "othernamespace.Baz(p=1)")

--- a/test/namespace_test_helper.py
+++ b/test/namespace_test_helper.py
@@ -21,11 +21,15 @@ luigi.namespace("mynamespace")
 
 
 class Foo(luigi.Task):
-    p = luigi.Parameter()
+    p = luigi.IntParameter()
 
 
 class Bar(Foo):
     task_namespace = "othernamespace"  # namespace override
+
+
+class Baz(Bar):  # inherits namespace for Bar
+    pass
 
 
 luigi.namespace()


### PR DESCRIPTION
This PR adresses #1950 and fixes the inheritance of `task_namespace`'s.

### Description

This is just a simple change that implements exactly what is proposed in #1950.

Tested with `nosetests test/namespace_test.py`.