### PR TITLE
Fix indention issue in deps_tree

### DIFF
--- a/luigi/tools/deps_tree.py
+++ b/luigi/tools/deps_tree.py
@@ -8,19 +8,19 @@ Use this to visualize the execution plan in the terminal.
 
     $ luigi-deps-tree --module foo_complex examples.Foo
     ...
-    └─--[Foo-{} (PENDING)]
-       |--[Bar-{'num': '0'} (PENDING)]
-       |  |--[Bar-{'num': '4'} (PENDING)]
-       |  └─--[Bar-{'num': '5'} (PENDING)]
-       |--[Bar-{'num': '1'} (PENDING)]
-       └─--[Bar-{'num': '2'} (PENDING)]
-          └─--[Bar-{'num': '6'} (PENDING)]
-             |--[Bar-{'num': '7'} (PENDING)]
-             |  |--[Bar-{'num': '9'} (PENDING)]
-             |  └─--[Bar-{'num': '10'} (PENDING)]
-             |     └─--[Bar-{'num': '11'} (PENDING)]
-             └─--[Bar-{'num': '8'} (PENDING)]
-                └─--[Bar-{'num': '12'} (PENDING)]
+    └── [Foo-{} (PENDING)]
+        ├── [Bar-{'num': '0'} (PENDING)]
+        │    ├── [Bar-{'num': '4'} (PENDING)]
+        │    └── [Bar-{'num': '5'} (PENDING)]
+        ├── [Bar-{'num': '1'} (PENDING)]
+        └── [Bar-{'num': '2'} (PENDING)]
+            └── [Bar-{'num': '6'} (PENDING)]
+                ├── [Bar-{'num': '7'} (PENDING)]
+                │   ├── [Bar-{'num': '9'} (PENDING)]
+                │   └── [Bar-{'num': '10'} (PENDING)]
+                │       └── [Bar-{'num': '11'} (PENDING)]
+                └── [Bar-{'num': '8'} (PENDING)]
+                    └── [Bar-{'num': '12'} (PENDING)]
 """
 
 from luigi.task import flatten
@@ -30,19 +30,19 @@ import warnings
 
 
 class bcolors:
-    '''
+    """
     colored output for task status
-    '''
+    """
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
     ENDC = '\033[0m'
 
 
 def print_tree(task, indent='', last=True):
-    '''
+    """
     Return a string representation of the tasks, their statuses/parameters in a dependency tree format
-    '''
-    # dont bother printing out warnings about tasks with no output
+    """
+    # don't bother printing out warnings about tasks with no output
     with warnings.catch_warnings():
         warnings.filterwarnings(action='ignore', message='Task .* without outputs has no custom complete\(\) method')
         is_task_complete = task.complete()
@@ -50,12 +50,12 @@ def print_tree(task, indent='', last=True):
     name = task.__class__.__name__
     params = task.to_str_params(only_significant=True)
     result = '\n' + indent
-    if(last):
-        result += '└─--'
-        indent += '   '
+    if last:
+        result += '└── '
+        indent += '    '
     else:
-        result += '|--'
-        indent += '|  '
+        result += '├── '
+        indent += '│   '
     result += '[{0}-{1} ({2})]'.format(name, params, is_complete)
     children = flatten(task.requires())
     for index, child in enumerate(children):


### PR DESCRIPTION
## Description
The last node at each level in the tree representation was indented more than the previous sibling nodes.  I fixed this by changing the level indentation strings to different characters and ensured that all nodes at the same level lined up.

## Motivation and Context
In using this tool I mistakenly thought the last task was a child of the previous task when in fact it was a sibling.  This visual cue led me to find this small issue.

## Have you tested this? If so, how?
I tested the change against the complex example task 'examples.Foo' in the examples.foo_complex module.