### PR TITLE
Remove the long-deprecated BooleanParameter

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -34,7 +34,7 @@ from luigi.parameter import (
     Parameter,
     DateParameter, MonthParameter, YearParameter, DateHourParameter, DateMinuteParameter, DateSecondParameter,
     DateIntervalParameter, TimeDeltaParameter,
-    IntParameter, FloatParameter, BooleanParameter, BoolParameter,
+    IntParameter, FloatParameter, BoolParameter,
     TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter,
     NumericalParameter, ChoiceParameter
 )
@@ -56,7 +56,7 @@ __all__ = [
     'RPCError', 'parameter', 'Parameter', 'DateParameter', 'MonthParameter',
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'DateSecondParameter', 'range',
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
-    'FloatParameter', 'BooleanParameter', 'BoolParameter', 'TaskParameter',
+    'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
     'NumericalParameter', 'ChoiceParameter'

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -604,20 +604,6 @@ class BoolParameter(Parameter):
         return 'store_true'
 
 
-class BooleanParameter(BoolParameter):
-    """
-    DEPRECATED. Use :py:class:`~BoolParameter`
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            'BooleanParameter is deprecated, use BoolParameter instead',
-            DeprecationWarning,
-            stacklevel=2
-        )
-        super(BooleanParameter, self).__init__(*args, **kwargs)
-
-
 class DateIntervalParameter(Parameter):
     """
     A Parameter whose value is a :py:class:`~luigi.date_interval.DateInterval`.

--- a/test/import_test.py
+++ b/test/import_test.py
@@ -64,6 +64,6 @@ class ImportTest(unittest.TestCase):
             luigi.MonthParameter, luigi.YearParameter,
             luigi.DateIntervalParameter, luigi.TimeDeltaParameter,
             luigi.IntParameter, luigi.FloatParameter,
-            luigi.BooleanParameter, luigi.BoolParameter,
+            luigi.BoolParameter,
         ]
         self.assertGreater(len(expected), 0)

--- a/test/task_serialize_test.py
+++ b/test/task_serialize_test.py
@@ -63,7 +63,7 @@ parameters_def = _mk_param_strategy(luigi.Parameter, text, True)
 int_parameters_def = _mk_param_strategy(luigi.IntParameter, hyp.strategies.integers(), True)
 float_parameters_def = _mk_param_strategy(luigi.FloatParameter,
                                           hyp.strategies.floats(min_value=-1e100, max_value=+1e100), True)
-bool_parameters_def = _mk_param_strategy(luigi.BooleanParameter, hyp.strategies.booleans(), True)
+bool_parameters_def = _mk_param_strategy(luigi.BoolParameter, hyp.strategies.booleans(), True)
 date_parameters_def = _mk_param_strategy(luigi.DateParameter, hyp_datetimes(min_year=1900, timezones=[]), True)
 
 any_default_parameters = hyp.strategies.one_of(


### PR DESCRIPTION
## Description

That parameter has been deprecated since way over one year. I believe also before 2.0.

The correct  parameter to use is `BoolParameter`.