### PR TITLE
emails: Increase logging if email is misconfigured

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -204,8 +204,8 @@ def send_email_smtp(sender, subject, message, recipients, image_png):
         msg_root = generate_email(sender, subject, message, recipients, image_png)
 
         smtp_conn.sendmail(sender, recipients, msg_root.as_string())
-    except socket.error:
-        logger.error("Not able to connect to smtp server")
+    except socket.error as exception:
+        logger.error("Not able to connect to smtp server: %s", exception)
 
 
 def send_email_ses(sender, subject, message, recipients, image_png):


### PR DESCRIPTION
## Have you tested this? If so, how?

Yes. I got more verbose output when testing with `luigi TestNotificationsTask --local-scheduler --email-force-send`

I got something like this:

```
ERROR: Not able to connect to smtp server: timed out
```

Instead of a mere `ERROR: Not able to connect to smtp server`.