### PR TITLE
Add redshift copy support for role-based credential string

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -77,17 +77,31 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         return None
 
-    @abc.abstractproperty
+    @property
     def aws_access_key_id(self):
         """
         Override to return the key id.
         """
         return None
 
-    @abc.abstractproperty
+    @property
     def aws_secret_access_key(self):
         """
         Override to return the secret access key.
+        """
+        return None
+
+    @property
+    def aws_account_id(self):
+        """
+        Override to return the account id.
+        """
+        return None
+
+    @property
+    def aws_arn_role_name(self):
+        """
+        Override to return the arn role name.
         """
         return None
 
@@ -262,22 +276,38 @@ class S3CopyToTable(rdbms.CopyToTable):
     def copy(self, cursor, f):
         """
         Defines copying from s3 into redshift.
+
+        If both key-based and role-based credentials are provided, role-based will be used.
         """
-        # if session token is set, create token string
-        if self.aws_session_token:
-            token = ';token=%s' % self.aws_session_token
-        # otherwise, leave token string empty
+        # format the credentials string dependent upon which type of credentials were provided
+        if self.aws_account_id and self.aws_arn_role_name:
+            cred_str = 'aws_iam_role=arn:aws:iam::{id}:role/{role}'.format(
+                id=self.aws_account_id,
+                role=self.aws_arn_role_name
+            )
+        elif self.aws_access_key_id and self.aws_secret_access_key:
+            cred_str = 'aws_access_key_id={key};aws_secret_key={secret}{opt}'.format(
+                key=self.aws_access_key_id,
+                secret=self.aws_secret_access_key,
+                opt=';token={}'.format(self.aws_session_token) if self.aws_session_token else ''
+            )
         else:
-            token = ''
+            raise NotImplementedError("Missing Credentials. "
+                                      "Override one of the following pairs of auth-args: "
+                                      "'aws_access_key_id' AND 'aws_secret_access_key' OR "
+                                      "'aws_account_id' AND 'aws_arn_role_name'")
 
         logger.info("Inserting file: %s", f)
         cursor.execute("""
-         COPY %s from '%s'
-         CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s%s'
-         %s
-         ;""" % (self.table, f, self.aws_access_key_id,
-                 self.aws_secret_access_key, token,
-                 self.copy_options))
+         COPY {table} from '{source}'
+         CREDENTIALS '{creds}'
+         {options}
+         ;""".format(
+            table=self.table,
+            source=f,
+            creds=cred_str,
+            options=self.copy_options)
+        )
 
     def output(self):
         """

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -53,6 +53,7 @@ class DummyS3CopyToTableBase(luigi.contrib.redshift.S3CopyToTable):
     def s3_load_path(self):
         return 's3://%s/%s' % (BUCKET, KEY)
 
+
 class DummyS3CopyToTableKey(DummyS3CopyToTableBase):
     aws_access_key_id = AWS_ACCESS_KEY
     aws_secret_access_key = AWS_SECRET_KEY


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Redshift copy supports key-based (with optional session token) or role-based credentials. This PR adds support for role-based credentials, making them the default choice if both role- and key-based are provided (since they are more restrictive and thus secure), and refactors implementation of optional session token for the key-based credential string.

## Description
<!--- Describe your changes -->
* Added two new properties `aws_account_id` and `aws_arn_role_name`  
* Changed `aws_access_key_id` and `aws_secret_access_key` from `@abc.abstractproperty` to `@property`
    * Added possible `NotImplementedError` when no pair of credentials are provided to account for the lack of `@abc.abstractproperty` pair of credentials  
* Defaults to role-based creds if both pairs are provided. 
* Added test to ensure that `NotImplementedError` raises if no pair of creds are provided.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Transitioning to the use of role-based cred string for redshift copy. Maintain key-based creds. Refactor key-based session token.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Single unit test for ensuring exception is raised if no pair of creds are provided.

Actual success of use has been verified for the 4 (most likely) cases:
* role-based and key-based are provided (role is used)  
* key-based only  
* role-based only  
* neither (exception is raised)  