### PR TITLE
Allow 0 time timedeltas, fix serialize to allow passing timedelta par…

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -647,13 +647,14 @@ class TimeDeltaParameter(Parameter):
     def _apply_regex(self, regex, input):
         import re
         re_match = re.match(regex, input)
-        if re_match:
+        if re_match and any(re_match.groups()):
             kwargs = {}
             has_val = False
             for k, v in six.iteritems(re_match.groupdict(default="0")):
                 val = int(v)
-                has_val = has_val or val > -1
-                kwargs[k] = val
+                if val > -1:
+                    has_val = True
+                    kwargs[k] = val
             if has_val:
                 return datetime.timedelta(**kwargs)
 
@@ -683,7 +684,7 @@ class TimeDeltaParameter(Parameter):
         result = self._parseIso8601(input)
         if not result:
             result = self._parseSimple(input)
-        if result:
+        if result is not None:
             return result
         else:
             raise ParameterException("Invalid time delta - could not parse %s" % input)

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -652,7 +652,7 @@ class TimeDeltaParameter(Parameter):
             has_val = False
             for k, v in six.iteritems(re_match.groupdict(default="0")):
                 val = int(v)
-                has_val = has_val or val != 0
+                has_val = has_val or val > -1
                 kwargs[k] = val
             if has_val:
                 return datetime.timedelta(**kwargs)
@@ -687,6 +687,22 @@ class TimeDeltaParameter(Parameter):
             return result
         else:
             raise ParameterException("Invalid time delta - could not parse %s" % input)
+
+    def serialize(self, x):
+        """
+        Converts datetime.timedelta to a string
+
+        :param x: the value to serialize.
+        """
+        if not isinstance(x, datetime.timedelta) and self.__class__ == TimeDeltaParameter:
+            warnings.warn("Parameter {0} is not of type timedelta.".format(str(x)))
+        weeks = x.days // 7
+        days = x.days % 7
+        hours = x.seconds // 3600
+        minutes = (x.seconds % 3600) // 60
+        seconds = (x.seconds % 3600) % 60
+        result = "{} w {} d {} h {} m {} s".format(weeks, days, hours, minutes, seconds)
+        return result
 
 
 class TaskParameter(Parameter):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -906,6 +906,15 @@ class TestSerializeDateParameters(LuigiTestCase):
         self.assertEqual(luigi.DateHourParameter().serialize(dt), '2013-02-03T04')
 
 
+class TestSerializeTimeDeltaParameters(LuigiTestCase):
+
+    def testSerialize(self):
+        tdelta = timedelta(weeks=5, days=4, hours=3, minutes=2, seconds=1)
+        self.assertEqual(luigi.TimeDeltaParameter().serialize(tdelta), '5 w 4 d 3 h 2 m 1 s')
+        tdelta = timedelta(seconds=0)
+        self.assertEqual(luigi.TimeDeltaParameter().serialize(tdelta), '0 w 0 d 0 h 0 m 0 s')
+
+
 class TestTaskParameter(LuigiTestCase):
 
     def testUsage(self):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -629,6 +629,16 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         expected = luigi.date_interval.Custom.parse("2001-02-03-2001-02-28")
         self.assertEqual(expected, _value(p))
 
+    @with_config({"foo": {"bar": "0 seconds"}})
+    def testTimeDeltaNoSeconds(self):
+        p = luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar"))
+        self.assertEqual(timedelta(seconds=0), _value(p))
+
+    @with_config({"foo": {"bar": "0 d"}})
+    def testTimeDeltaNoDays(self):
+        p = luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar"))
+        self.assertEqual(timedelta(days=0), _value(p))
+
     @with_config({"foo": {"bar": "1 day"}})
     def testTimeDelta(self):
         p = luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar"))

--- a/test/task_serialize_test.py
+++ b/test/task_serialize_test.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 import string
 import luigi
 import json
+from datetime import timedelta
 
 import hypothesis as hyp
 from hypothesis.extra.datetime import datetimes as hyp_datetimes
@@ -96,6 +97,10 @@ def _task_from_dict(task_cls, param_dict):
     return task_cls(**task_params)
 
 
+class TimeDeltaTask(luigi.Task):
+    time = luigi.TimeDeltaParameter()
+
+
 @hyp.given(tasks_with_defaults)
 def test_serializable(task_cls):
     task = task_cls()
@@ -125,5 +130,23 @@ def test_task_id_alphanumeric(task_cls):
     valid = string.ascii_letters + string.digits + '_'
 
     assert [x for x in task_id if x not in valid] == []
+
+
+def test_timedelta_params():
+    task = TimeDeltaTask(timedelta(weeks=5, days=4, hours=3, minutes=2, seconds=1))
+
+    param_dict = _task_to_dict(task)
+    task2 = _task_from_dict(TimeDeltaTask, param_dict)
+
+    assert task.time == task2.time
+
+
+def test_no_time_timedelta_params():
+    task = TimeDeltaTask(timedelta(seconds=0))
+
+    param_dict = _task_to_dict(task)
+    task2 = _task_from_dict(TimeDeltaTask, param_dict)
+
+    assert task.time == task2.time
 
 # TODO : significant an non-significant parameters

--- a/test/task_serialize_test.py
+++ b/test/task_serialize_test.py
@@ -30,7 +30,6 @@ from __future__ import print_function
 import string
 import luigi
 import json
-from datetime import timedelta
 
 import hypothesis as hyp
 from hypothesis.extra.datetime import datetimes as hyp_datetimes
@@ -97,10 +96,6 @@ def _task_from_dict(task_cls, param_dict):
     return task_cls(**task_params)
 
 
-class TimeDeltaTask(luigi.Task):
-    time = luigi.TimeDeltaParameter()
-
-
 @hyp.given(tasks_with_defaults)
 def test_serializable(task_cls):
     task = task_cls()
@@ -130,23 +125,5 @@ def test_task_id_alphanumeric(task_cls):
     valid = string.ascii_letters + string.digits + '_'
 
     assert [x for x in task_id if x not in valid] == []
-
-
-def test_timedelta_params():
-    task = TimeDeltaTask(timedelta(weeks=5, days=4, hours=3, minutes=2, seconds=1))
-
-    param_dict = _task_to_dict(task)
-    task2 = _task_from_dict(TimeDeltaTask, param_dict)
-
-    assert task.time == task2.time
-
-
-def test_no_time_timedelta_params():
-    task = TimeDeltaTask(timedelta(seconds=0))
-
-    param_dict = _task_to_dict(task)
-    task2 = _task_from_dict(TimeDeltaTask, param_dict)
-
-    assert task.time == task2.time
 
 # TODO : significant an non-significant parameters


### PR DESCRIPTION
…ams to subtasks

This PR primarily fixes the serialize function for TimeDeltaParameters to allow passing the parameter to a subtask that is required or yielded in the run function. It also allows creating a parameter with 0 time, which helps with setting defaults.

## Description
This is to address problems raised in issue #1966 

## Motivation and Context
This is to address problems raised in issue #1966

## Have you tested this? If so, how?
I have included unit tests and tested it working on another project
