### PR TITLE
Add missing commas to the contrib.sla module code examples.

### DIFF
--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -40,7 +40,7 @@ below:
         table = "item_property"  # name of the table to store data
 
         def rows(self):
-            for row in [("item1" "property1"), ("item2", "property2")]:
+            for row in [("item1", "property1"), ("item2", "property2")]:
                 yield row
 
     if __name__ == '__main__':
@@ -66,7 +66,7 @@ can be set as True. Here is a modified version of the above example:
         table = "item_property"  # name of the table to store data
 
         def rows(self):
-            for row in [("item1" "property1"), ("item2", "property2")]:
+            for row in [("item1", "property1"), ("item2", "property2")]:
                 yield row
 
     if __name__ == '__main__':


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Code examples in the luigi.contrib.sqla module were misleading with the missing commas in tuples.

## Motivation and Context
This code example is copied and pasted in other resources than the Luigi documentation (e.g., http://www.tuicool.com/articles/bumiYr). The motivation here is a better documentation. 

## Have you tested this? If so, how?
I built the documentation with `tox -e docs` and confirmed the changes.
