### PR TITLE
tests: Remove `__name__ == '__main__'` guards

### DIFF
--- a/test/contrib/scalding_test.py
+++ b/test/contrib/scalding_test.py
@@ -60,7 +60,3 @@ class ScaldingTest(unittest.TestCase):
         success = luigi.run(['MyScaldingTask', '--scala-source', self.scala_source, '--local-scheduler', '--no-lock'])
         self.assertTrue(success)
         # TODO: check more stuff
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -128,7 +128,3 @@ class CustomizedWorkerTest(unittest.TestCase):
         self.assertFalse(self.worker_scheduler_factory.worker.complete())
         luigi.run(['DummyTask', '--n', '4'], worker_scheduler_factory=self.worker_scheduler_factory)
         self.assertTrue(self.worker_scheduler_factory.worker.complete())
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/factorial_test.py
+++ b/test/factorial_test.py
@@ -48,7 +48,3 @@ class FactorialTest(unittest.TestCase):
     def test_invoke(self):
         luigi.build([Factorial(100)], local_scheduler=True)
         self.assertEqual(Factorial(42).value, 1405006117752879898543142606244511569936384000000000)
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -76,7 +76,3 @@ class FibTest(FibTestBase):
 
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_10'), b'55\n')
         self.assertEqual(MockTarget.fs.get_data('/tmp/fib_100'), b'354224848179261915075\n')
-
-
-if __name__ == '__main__':
-    luigi.run()

--- a/test/instance_test.py
+++ b/test/instance_test.py
@@ -90,7 +90,3 @@ class InstanceTest(unittest.TestCase):
             x = luigi.Parameter()
 
         dummy = DummyTask(x={})  # NOQA
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/subtask_test.py
+++ b/test/subtask_test.py
@@ -56,7 +56,3 @@ class AbstractSubclassTest(unittest.TestCase):
 
     def test_instantiate(self):
         self.assertEqual("bar,hellohello", Implementation(k=2).run())
-
-
-if __name__ == '__main__':
-    luigi.run()


### PR DESCRIPTION
This is exactly like https://github.com/spotify/luigi/pull/1922, only
that I forgot to search for '__main__' with single qoutes. This patch
completes that PR.