### PR TITLE
flake8: Put configuration into standardized place

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,9 +71,16 @@ commands =
   python --version
   nosetests -v --tests=test/visualiser
 
+# Flake8 Configuration, inspired from https://gitlab.com/pycqa/flake8/blob/master/tox.ini
+# By putting it here, local flake8 runs will also pick it up.
+[flake8]
+max-line-length=160
+
 [testenv:flake8]
-deps = flake8>=3.2.0
-commands = flake8 --max-line-length=160 --exclude=doc,luigi/six.py,.tox
+deps =
+  flake8>=3.2.0
+commands =
+  flake8 --exclude=doc,luigi/six.py,.tox
   flake8 --max-line-length=100 --ignore=E265 doc
 
 [testenv:autopep8]


### PR DESCRIPTION
## Description

flake8: Put configuration into standardized place

As I found described here:
http://flake8.pycqa.org/en/latest/user/configuraton.html

## Motivation and Context

My motivation for doing this was that I always get 100 warnings in vim
when I save my file.  As this follows the standardized way, I hope
anything can without effort ripe the benefits.


## Have you tested this? If so, how?

I tested the autolinting functionality I have in vim (syntastic?) as
well as running the -e flake8 using tox.