### PR TITLE
externalize: Dont register the copied tasks

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -239,6 +239,8 @@ class Task(object):
         # TODO(erikbern): we should think about a language-agnostic mechanism
         return self.__class__.__module__
 
+    _visible_in_registry = True  # TODO: Consider using in luigi.util as well
+
     __not_user_specified = '__not_user_specified'
 
     task_namespace = __not_user_specified
@@ -724,7 +726,7 @@ def externalize(taskclass_or_taskobject):
         @_task_wraps(clazz)
         class _CopyOfClass(clazz):
             # How to copy a class: http://stackoverflow.com/a/9541120/621449
-            pass
+            _visible_in_registry = False
         _CopyOfClass.run = None
         return _CopyOfClass
     else:

--- a/test/task_register_test.py
+++ b/test/task_register_test.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 VNG Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from helpers import LuigiTestCase
+
+import luigi
+from luigi.task_register import (Register,
+                                 TaskClassNotFoundException,
+                                 TaskClassAmbigiousException,
+                                 )
+
+
+class TaskRegisterTest(LuigiTestCase):
+
+    def test_externalize_taskclass(self):
+        with self.assertRaises(TaskClassNotFoundException):
+            Register.get_task_cls('scooby.Doo')
+
+        class Task1(luigi.Task):
+            @classmethod
+            def get_task_family(cls):
+                return "scooby.Doo"
+
+        self.assertEqual(Task1, Register.get_task_cls('scooby.Doo'))
+
+        class Task2(luigi.Task):
+            @classmethod
+            def get_task_family(cls):
+                return "scooby.Doo"
+
+        with self.assertRaises(TaskClassAmbigiousException):
+            Register.get_task_cls('scooby.Doo')
+
+        class Task3(luigi.Task):
+            @classmethod
+            def get_task_family(cls):
+                return "scooby.Doo"
+
+        # There previously was a rare bug where the third installed class could
+        # "undo" class ambiguity.
+        with self.assertRaises(TaskClassAmbigiousException):
+            Register.get_task_cls('scooby.Doo')

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -206,6 +206,26 @@ class ExternalizeTaskTest(LuigiTestCase):
         self.assertIsNotNone(MyTask.run)  # Check immutability
         self.assertIsNotNone(MyTask().run)  # Check immutability
 
+    def test_externalize_doesnt_affect_the_registry(self):
+        class MyTask(luigi.Task):
+            pass
+        reg_orig = luigi.task_register.Register._get_reg()
+        luigi.task.externalize(MyTask)
+        reg_afterwards = luigi.task_register.Register._get_reg()
+        self.assertEqual(reg_orig, reg_afterwards)
+
+    def test_can_uniquely_command_line_parse(self):
+        class MyTask(luigi.Task):
+            pass
+        # This first check is just an assumption rather than assertion
+        self.assertTrue(self.run_locally(['MyTask']))
+        luigi.task.externalize(MyTask)
+        # Now we check we don't encounter "ambiguous task" issues
+        self.assertTrue(self.run_locally(['MyTask']))
+        # We do this once again, is there previously was a bug like this.
+        luigi.task.externalize(MyTask)
+        self.assertTrue(self.run_locally(['MyTask']))
+
 
 class TaskNamespaceTest(LuigiTestCase):
 


### PR DESCRIPTION
This fixes an implementation detail, so that luigi.task.externalize
actually does what it says it does in the documentation.  Hence I
hope pretty uncontroversial. This makes it so that calling externalize
don't register a new task. A pretty serious bug.

Now, there's still a caveat, as we're mostly hiding that we do side
affects, if anyone would actually inherit from what is returned by
externalize.  That subtask wouldn't be registered either.

## Have you tested this? If so, how?

This code is quite easy to get wrong somewhere. Luckily luigi is
decently tested. To make me even more confident I also added a couple of
tests. Including two tests that didn't pass before.

Further. I will try this in production too. Ensuring everything is actually working this time. :)