### PR TITLE
Allow a dictionary to be passed that contains the logging configuration.

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -56,6 +56,8 @@ def setup_interface_logging(conf_file=''):
         stream_handler.setFormatter(formatter)
 
         logger.addHandler(stream_handler)
+    elif isinstance(conf_file, dict):
+        logging.config.dictConfig(conf_file)
     else:
         logging.config.fileConfig(conf_file, disable_existing_loggers=False)
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow a predefined/preconfigured logging dictionary to be processed by luigi.

## Motivation and Context
I setup my logging via a YAML based configuration file and it was more convenient to be able to pass the dictionary to luigi rather than maintain an external .ini based logging config.

## Have you tested this? If so, how?
I have been running this in my production code. (Using Python 2.7.x)
