### PR TITLE
Fix formatting of documentation

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -59,6 +59,7 @@ class S3CopyToTable(rdbms.CopyToTable):
     Usage:
 
     * Subclass and override the required attributes:
+    
       * `host`,
       * `database`,
       * `user`,

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -59,7 +59,7 @@ class S3CopyToTable(rdbms.CopyToTable):
     Usage:
 
     * Subclass and override the required attributes:
-    
+
       * `host`,
       * `database`,
       * `user`,


### PR DESCRIPTION
Because of the missing blank, when generating the documentation the bulleted list is mal formatted.


