### PR TITLE
Add slack notifications module

### DIFF
--- a/luigi/contrib/slack_notifications.py
+++ b/luigi/contrib/slack_notifications.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+''' Supports sending slack notifications for different task events.
+
+Usage:
+
+Create an incomming webhook on slack: https://api.slack.com/incoming-webhooks
+
+Setup the slack integration with the following code.
+This can be done in the same module where the luigi tasks are defined.
+
+.. code-block:: python
+
+    from luigi.contrib.slack_notifications import configure_slack
+    configure_slack()
+
+Use a configuration like the following on luigi.cfg
+
+.. code-block:: ini
+
+    [slack]
+    webhook = https://hooks.slack.com/services/something
+    events = ["START", "SUCCESS", "FAILURE"]
+    template = Luigi task {task_id} event {event}: {args} {kwargs}
+
+
+Alternatives:
+
+Another plugin with similar purpouse is luigi-slack (https://github.com/bonzanini/luigi-slack). The major differences between this and luigi-slack is that:
+
+- Inspired by email notifications (notifications.py): simple configuration though luigi.cfg (no need for python configuration)
+- Minimal changes to python code (only call configure_slack()), no need create a new wrapper around luigi.run.
+- This only depends on requests module (does not depend on slackclient).
+- Work both for python 2 and 3
+- Configurable template, per event, that can expose specific task properties
+
+'''
+
+
+import logging
+import luigi
+import json
+
+logger = logging.getLogger(__name__)
+
+try:
+    import requests
+except ImportError:
+    logger.warning("Module %s requires the python package 'requests'." % __name__)
+
+
+class slack(luigi.Config):
+    webhook = luigi.parameter.Parameter(
+        default='',
+        description='Webhook URL to send the notifications')
+    channel = luigi.parameter.Parameter(
+        default='',
+        description='Channel to send slack notifications to')
+    username = luigi.parameter.Parameter(
+        default='',
+        description='Slack username originating the message')
+    icon_emoji = luigi.parameter.Parameter(
+        default='',
+        description='Slack bot icon emoji')
+    events = luigi.parameter.ListParameter(
+        default=['START', 'FAILURE', 'SUCCESS'],
+        description='List of events to be handled as slack notifications')
+    template = luigi.parameter.Parameter(
+        default='Luigi task {task_id} event {event}: {args} {kwargs}',
+        description='Template message for event handling slack notifications')
+    event_templates = luigi.parameter.DictParameter(
+        default={},
+        description='Custom template message per event')
+
+
+class SafeGetAttr(object):
+    """
+    Wraps an object returning a default_value for undefined attributes
+    """
+    def __init__(self, obj, default_value=None):
+        self._obj = obj
+        self._default_value = default_value
+
+    def __getattr__(self, attr):
+        return getattr(getattr(self, '_obj'), attr, getattr(self, '_default_value'))
+
+
+class SlackNotifyHandling():
+    slack_hook_url = None
+
+    def __init__(self, slack_config):
+        self.slack_hook_url = slack_config.webhook
+        self.channel = slack_config.channel
+        self.events = slack_config.events
+        self.template = slack_config.template
+        self.username = slack_config.username
+        self.icon_emoji = slack_config.icon_emoji
+        self.event_templates = slack_config.event_templates
+
+    @property
+    def is_configured(self):
+        """
+        Check if the slack web hook is configured so that slack messages can be sent
+        """
+        return bool(self.slack_hook_url)
+
+    def _make_data(self, text):
+        data = dict(text=text)
+        if self.channel:
+            data['channel'] = self.channel
+        if self.username:
+            data['username'] = self.username
+        if self.icon_emoji:
+            data['icon_emoji'] = self.icon_emoji
+        return json.dumps(data)
+
+    def send_slack_message(self, text):
+        """
+        Send a string as a slack message
+        """
+        r = requests.post(self.slack_hook_url, data=self._make_data(text))
+        if not r.status_code == 200:
+            logger.error('Could not notify slack, got error: %s ' % r.text)
+            return False
+        return True
+
+    def _handler_for_template(self, template, event):
+        def handle(task, *args, **kwargs):
+            msg = template.format(
+                event=event,
+                args=args,
+                kwargs=kwargs,
+                task_id=task.task_id,
+                task=SafeGetAttr(task, '')
+            )
+            self.send_slack_message(msg)
+        return handle
+
+    _is_set_handlers = False
+
+    def set_handlers(self):
+        """
+        Configure all luigi.task.event_handler if slack notifications ar e configured
+        To avoid setting up event handler multiple times, this only runs once
+        """
+        if not self.is_configured or self.__class__._is_set_handlers:
+            return
+        logger.info('Configuring slack notifications event handling...')
+        event_aliases = {
+            'START': luigi.Event.START,
+            'SUCCESS': luigi.Event.SUCCESS,
+            'FAILURE': luigi.Event.FAILURE
+        }
+        for event in self.events:
+            luigi_event = event_aliases.get(event, event)
+            template = self.event_templates.get(event, self.template)
+            luigi.Task.event_handler(luigi_event)(self._handler_for_template(template, event))
+        self.__class__._is_set_handlers = True
+
+
+def configure_slack():
+    """
+    Setup task event handlers to send slack notifications
+    """
+    SlackNotifyHandling(slack()).set_handlers()

--- a/test/contrib/slack_notifications_test.py
+++ b/test/contrib/slack_notifications_test.py
@@ -1,0 +1,175 @@
+
+
+from helpers import (unittest, with_config)
+import mock
+import json
+import luigi
+from luigi.contrib.slack_notifications import SlackNotifyHandling, slack, configure_slack
+
+
+def mocked_requests(ret_code=200):
+
+    class MockResponse:
+        def __init__(self, body, status_code):
+            self.body = body
+            self.status_code = status_code
+
+        @property
+        def text(self):
+            return self.body
+
+        def raise_for_status(self):
+            return None
+
+    def mocked(*args, **kwargs):
+        return MockResponse('', ret_code)
+
+    return mocked
+
+
+def mocked_event_handler(*args, **kwargs):
+    def setup_handler(callback):
+        return callback
+
+    return setup_handler
+
+
+class TestSlackTask(luigi.Task):
+
+    @property
+    def custom_property(self):
+        return 'custom-value'
+
+
+DEMO_WEBHOOK = 'http://some-webhook/'
+BASIC_CONFIG = {'slack': {'webhook': DEMO_WEBHOOK}}
+
+
+class SlackNotificationsTestCase(unittest.TestCase):
+
+    @with_config({'slack': {}})
+    def test_not_configured(self):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.assertFalse(self.slack_notify.is_configured)
+
+    @with_config(BASIC_CONFIG)
+    def test_is_configured(self):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.assertTrue(self.slack_notify.is_configured)
+
+    @mock.patch('requests.post', side_effect=mocked_requests(200))
+    @with_config(BASIC_CONFIG)
+    def test_send_slack_message(self, mock_post):
+        self.slack_notify = SlackNotifyHandling(slack())
+        ret = self.slack_notify.send_slack_message('some-message')
+        mock_post.assert_called_once_with('http://some-webhook/', data='{"text": "some-message"}')
+        self.assertTrue(ret)
+
+    @mock.patch('requests.post', side_effect=mocked_requests(400))
+    @with_config(BASIC_CONFIG)
+    def test_failed_send_slack_message(self, mock_post):
+        self.slack_notify = SlackNotifyHandling(slack())
+        ret = self.slack_notify.send_slack_message('some-message')
+        mock_post.assert_called_once_with('http://some-webhook/', data='{"text": "some-message"}')
+        self.assertFalse(ret)
+
+    @mock.patch('requests.post', side_effect=mocked_requests())
+    @with_config({'slack': {
+        'webhook': DEMO_WEBHOOK,
+        'channel': '#some-channel',
+        'icon_emoji': ':some-icon-emoji:',
+        'username': 'someusername'}})
+    def test_send_configured_slack_message(self, mock_post):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.slack_notify.send_slack_message('some-message')
+        mock_post.assert_called_once_with(DEMO_WEBHOOK, data=mock.ANY)
+        args, kwargs = mock_post.call_args
+        self.assertEquals(json.loads(kwargs['data']), {
+            "icon_emoji": ":some-icon-emoji:",
+            "text": "some-message",
+            "channel": "#some-channel",
+            "username": "someusername"})
+
+
+class SlackNotificationsSetupEventHandlerTestCase(unittest.TestCase):
+
+    def tearDown(self):
+        SlackNotifyHandling._is_set_handlers = False
+
+    @with_config(BASIC_CONFIG)
+    @mock.patch('luigi.Task.event_handler', side_effect=mocked_event_handler)
+    def test_set_default_handlers(self, mock_event_handler):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.slack_notify.set_handlers()
+        calls = [mock.call(luigi.Event.START),
+                 mock.call(luigi.Event.SUCCESS),
+                 mock.call(luigi.Event.FAILURE)]
+        mock_event_handler.assert_has_calls(calls, any_order=True)
+
+    @with_config(BASIC_CONFIG)
+    @mock.patch('luigi.Task.event_handler', side_effect=mocked_event_handler)
+    def test_set_handlers_only_once(self, mock_event_handler):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.slack_notify.set_handlers()
+        mock_event_handler.reset_mock()
+        self.slack_notify.set_handlers()
+        self.assertFalse(mock_event_handler.called)
+
+    @with_config({'slack': {'webhook': DEMO_WEBHOOK, 'events': '["START", "custom.event"]'}})
+    @mock.patch('luigi.Task.event_handler', side_effect=mocked_event_handler)
+    def test_custom_handlers(self, mock_event_handler):
+        self.slack_notify = SlackNotifyHandling(slack())
+        self.slack_notify.set_handlers()
+        calls = [mock.call(luigi.Event.START),
+                 mock.call('custom.event')]
+        mock_event_handler.assert_has_calls(calls, any_order=True)
+
+    @with_config(BASIC_CONFIG)
+    @mock.patch('luigi.Task.event_handler', side_effect=mocked_event_handler)
+    def test_configure_handlers_slack(self, mock_event_handler):
+        configure_slack()
+        calls = [mock.call(luigi.Event.START),
+                 mock.call(luigi.Event.SUCCESS),
+                 mock.call(luigi.Event.FAILURE)]
+        mock_event_handler.assert_has_calls(calls, any_order=True)
+
+
+class SlackNotificationsTriggerEventTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.demo_task = TestSlackTask()
+
+    def tearDown(self):
+        SlackNotifyHandling._is_set_handlers = False
+        luigi.Task._event_callbacks = {}
+
+    @with_config(BASIC_CONFIG)
+    def test_send_message_on_trigger_start(self):
+        self.slack_notify = SlackNotifyHandling(slack())
+        mocked = self.slack_notify.send_slack_message = mock.Mock()
+        self.slack_notify.set_handlers()
+        self.demo_task.trigger_event(luigi.Event.START, self.demo_task)
+        mocked.assert_called_once_with('Luigi task TestSlackTask__99914b932b event START: () {}')
+
+    @with_config({'slack': {
+        'webhook': DEMO_WEBHOOK,
+        'template': 'Custom template {task_id} event {event} - {task.custom_property}'}})
+    def test_send_message_with_custom_template(self):
+        self.slack_notify = SlackNotifyHandling(slack())
+        mocked = self.slack_notify.send_slack_message = mock.Mock()
+        self.slack_notify.set_handlers()
+        self.demo_task.trigger_event(luigi.Event.SUCCESS, self.demo_task)
+        mocked.assert_called_once_with('Custom template TestSlackTask__99914b932b event SUCCESS - custom-value')
+
+    @with_config({'slack': {
+        'webhook': DEMO_WEBHOOK,
+        'event_templates': '{"START": "custom template for start {task_id}"}'}})
+    def test_send_message_with_custom_event_template(self):
+        self.slack_notify = SlackNotifyHandling(slack())
+        mocked = self.slack_notify.send_slack_message = mock.Mock()
+        self.slack_notify.set_handlers()
+        self.demo_task.trigger_event(luigi.Event.START, self.demo_task)
+        self.demo_task.trigger_event(luigi.Event.SUCCESS, self.demo_task)
+        calls = [mock.call('custom template for start TestSlackTask__99914b932b'),
+                 mock.call('Luigi task TestSlackTask__99914b932b event SUCCESS: () {}')]
+        mocked.assert_has_calls(calls)


### PR DESCRIPTION
## Description

This module configures and listen for task event handlers to send slack
notifications. The configuration is done through `luigi.cfg` file.

## Motivation and Context

The goal is to have slack notifications on luigi event transitions: on START, SUCCESS and FAILURE. Using this module and a slack channel for the notifications is very easy to get status and some basic info of the luigi tasks.

It also support some basic configuration and templating. In this way the user can send some task `@property` or attribute in the slack message.

I am using in production in some of the pipelines here in Spotify. The reason for this PR is that this is a generic feature that any other team could benefit from.

## Have you tested this? If so, how?

- Unit tests covering all the code are included
- Running in production for over a month
