### PR TITLE
Set default log level via config

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -114,6 +114,12 @@ history-filename
   configuration where no history is stored in the output directory by
   Hadoop.
 
+log_level
+  The default log level to use when no logging_conf_file is set. Must be
+  a valid name of a `Python log level
+  <https://docs.python.org/2/library/logging.html#logging-levels>`_.
+  Default is ``DEBUG``.
+
 logging_conf_file
   Location of the logging configuration file.
 

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -46,11 +46,15 @@ def setup_interface_logging(conf_file=''):
         return
 
     if conf_file == '':
+        # no log config given, setup default logging
+        level_name = os.environ.get('LUIGI_DEFAULT_LOG_LEVEL', "DEBUG")
+        level = getattr(logging, level_name, logging.DEBUG)
+
         logger = logging.getLogger('luigi-interface')
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(level)
 
         stream_handler = logging.StreamHandler()
-        stream_handler.setLevel(logging.DEBUG)
+        stream_handler.setLevel(level)
 
         formatter = logging.Formatter('%(levelname)s: %(message)s')
         stream_handler.setFormatter(formatter)

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -134,8 +134,9 @@ class CmdlineTest(unittest.TestCase):
     def test_cmdline_logger(self, setup_mock, warn):
         with mock.patch("luigi.interface.core") as env_params:
             env_params.return_value.logging_conf_file = ''
+            env_params.return_value.log_level = 'DEBUG'
             luigi.run(['SomeTask', '--n', '7', '--local-scheduler', '--no-lock'])
-            self.assertEqual([mock.call('')], setup_mock.call_args_list)
+            self.assertEqual([mock.call('', 'DEBUG')], setup_mock.call_args_list)
 
         with mock.patch("luigi.configuration.get_config") as getconf:
             getconf.return_value.get.side_effect = ConfigParser.NoOptionError(section='foo', option='bar')


### PR DESCRIPTION
## Description

This PR allows for the configuration of the default log level, which is [`DEBUG` by default](https://github.com/spotify/luigi/blob/b92e09b6564e22351a3984dc3a3b9a7823614a6c/luigi/interface.py#L50).


## Motivation and Context

It might be a first world problem, but sometimes it would be nice to control the default log level without the need to create (and deploy) a logging config file, but rather by a simple environment variable. The value of this variable must match the name of a [python logging level](https://docs.python.org/2/library/logging.html#logging-levels). Usage example:

```shell
LUIGI_DEFAULT_LOG_LEVEL=INFO luigi --module my_module MyTask --x 123
```

An other option would be to add `default_log_level` to the core config and to prefer the environment variable if set (at least that's what most libs do).


## Tests

Too trivial to test :P 


## Docs

I couldn't find a place in the docs for this feature, but I sure can add a sentence or two to a section of your choice.