### PR TITLE
docs: Update link to ConfigParser

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -7,9 +7,9 @@ All configuration can be done by adding configuration files. They are looked for
  * ``luigi.cfg`` (or its legacy name ``client.cfg``) in your current working directory
  * ``LUIGI_CONFIG_PATH`` environment variable
 
-in increasing order of preference. The order only matters in case of key conflicts (see docs for ConfigParser_). These files are meant for both the client and ``luigid``. If you decide to specify your own configuration you should make sure that both the client and ``luigid`` load it properly.
+in increasing order of preference. The order only matters in case of key conflicts (see docs for ConfigParser.read_). These files are meant for both the client and ``luigid``. If you decide to specify your own configuration you should make sure that both the client and ``luigid`` load it properly.
 
-.. _ConfigParser: https://docs.python.org/2/library/configparser.html
+.. _ConfigParser.read: https://docs.python.org/3.6/library/configparser.html#configparser.ConfigParser.read
 
 The config file is broken into sections, each controlling a different part of the config. Example configuration file:
 


### PR DESCRIPTION
So that we link to the section that actually is about reading multiple configuration paths.

## Motivation and Context

Confusion in mailing list about how this machinery works.