### PR TITLE
introduce rpc-attempt retry count and wait time in configuration

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -159,6 +159,15 @@ rpc-connect-timeout
   Number of seconds to wait before timing out when making an API call.
   Defaults to 10.0
 
+rpc-retry-attempts
+  The maximum number of retries to connect the central scheduler before giving up.
+  Defaults to 3
+
+rpc-retry-wait
+  Number of seconds to wait before the next attempt will be started to
+  connect to the central scheduler between two retry attempts.
+  Defaults to 30
+
 
 .. _worker-config:
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -104,7 +104,7 @@ class RemoteScheduler(object):
             connect_timeout = config.getfloat('core', 'rpc-connect-timeout', 10.0)
         self._connect_timeout = connect_timeout
 
-        self._rpc_retry_attemps = config.getint('core', 'rpc-retry-attempts', 3)
+        self._rpc_retry_attempts = config.getint('core', 'rpc-retry-attempts', 3)
         self._rpc_retry_wait = config.getint('core', 'rpc-retry-wait', 30)
 
         if HAS_REQUESTS:
@@ -120,10 +120,10 @@ class RemoteScheduler(object):
         full_url = _urljoin(self._url, url_suffix)
         last_exception = None
         attempt = 0
-        while attempt < self._rpc_retry_attemps:
+        while attempt < self._rpc_retry_attempts:
             attempt += 1
             if last_exception:
-                logger.info("Retrying %r/%r" %(attempt, self._rpc_retry_attemps))
+                logger.info("Retrying attempt %r of %r (max)" % (attempt, self._rpc_retry_attempts))
                 self._wait()  # wait for a bit and retry
             try:
                 response = self._fetcher.fetch(full_url, body, self._connect_timeout)
@@ -136,7 +136,7 @@ class RemoteScheduler(object):
         else:
             raise RPCError(
                 "Errors (%d attempts) when connecting to remote scheduler %r" %
-                (self._rpc_retry_attemps, self._url),
+                (self._rpc_retry_attempts, self._url),
                 last_exception
             )
         return response

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -104,22 +104,26 @@ class RemoteScheduler(object):
             connect_timeout = config.getfloat('core', 'rpc-connect-timeout', 10.0)
         self._connect_timeout = connect_timeout
 
+        self._rpc_retry_attemps = config.getint('core', 'rpc-retry-attempts', 3)
+        self._rpc_retry_wait = config.getint('core', 'rpc-retry-wait', 30)
+
         if HAS_REQUESTS:
             self._fetcher = RequestsFetcher(requests.Session())
         else:
             self._fetcher = URLLibFetcher()
 
     def _wait(self):
-        time.sleep(30)
+        logger.info("Wait for %d seconds" % self._rpc_retry_wait)
+        time.sleep(self._rpc_retry_wait)
 
-    def _fetch(self, url_suffix, body, log_exceptions=True, attempts=3):
+    def _fetch(self, url_suffix, body, log_exceptions=True):
         full_url = _urljoin(self._url, url_suffix)
         last_exception = None
         attempt = 0
-        while attempt < attempts:
+        while attempt < self._rpc_retry_attemps:
             attempt += 1
             if last_exception:
-                logger.info("Retrying...")
+                logger.info("Retrying %r/%r" %(attempt, self._rpc_retry_attemps))
                 self._wait()  # wait for a bit and retry
             try:
                 response = self._fetcher.fetch(full_url, body, self._connect_timeout)
@@ -132,7 +136,7 @@ class RemoteScheduler(object):
         else:
             raise RPCError(
                 "Errors (%d attempts) when connecting to remote scheduler %r" %
-                (attempts, self._url),
+                (self._rpc_retry_attemps, self._url),
                 last_exception
             )
         return response
@@ -141,7 +145,7 @@ class RemoteScheduler(object):
         body = {'data': json.dumps(data)}
 
         for _ in range(attempts):
-            page = self._fetch(url, body, log_exceptions, attempts)
+            page = self._fetch(url, body, log_exceptions)
             response = json.loads(page)["response"]
             if allow_null or response is not None:
                 return response


### PR DESCRIPTION
## Description
I find the retries in this short time (3x30s=90 seconds) 
nearly useless. So i changed the rpc.py in this way
that i can do handle the retry attempts and the wait
time by configuration.

## Motivation and Context
We got "to often" the 
"RPCError: Errors (3 attempts) when connecting to remote scheduler"

## Tested?
I ran some testjobs with it and it works for me. 