### PR TITLE
ExternalHiveTask use DictParameter

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -451,11 +451,10 @@ class ExternalHiveTask(luigi.ExternalTask):
 
     database = luigi.Parameter(default='default')
     table = luigi.Parameter()
-    # since this is an external task and will never be initialized from the CLI, partition can be any python object, in this case a dictionary
-    partition = luigi.Parameter(default=None, description='Python dictionary specifying the target partition e.g. {"date": "2013-01-25"}')
+    partition = luigi.DictParameter(default={}, description='Python dictionary specifying the target partition e.g. {"date": "2013-01-25"}')
 
     def output(self):
-        if self.partition is not None:
+        if len(self.partition) != 0:
             assert self.partition, "partition required"
             return HivePartitionTarget(table=self.table,
                                        partition=self.partition,


### PR DESCRIPTION
Fix execution_summary error for `ExternalHiveTask`, the error message is fellow:
```
Traceback (most recent call last):
File "run_script.py", line 91, in 
luigi.run()
File "/usr/local/lib/python2.7/site-packages/luigi/interface.py", line 210, in run
return _run(_args, *_kwargs)['success']
File "/usr/local/lib/python2.7/site-packages/luigi/interface.py", line 238, in _run
return _schedule_and_run([cp.get_task_obj()], worker_scheduler_factory)
File "/usr/local/lib/python2.7/site-packages/luigi/interface.py", line 198, in _schedule_and_run
logger.info(execution_summary.summary(worker))
File "/usr/local/lib/python2.7/site-packages/luigi/execution_summary.py", line 384, in summary
return _summary_wrap(_summary_format(_summary_dict(worker), worker))
File "/usr/local/lib/python2.7/site-packages/luigi/execution_summary.py", line 333, in _summary_format
str_output += '{0}\n'.format(_get_str(group_tasks[status], status in _PENDING_SUB_STATUSES))
File "/usr/local/lib/python2.7/site-packages/luigi/execution_summary.py", line 132, in _get_str
params = _get_set_of_params(tasks)
File "/usr/local/lib/python2.7/site-packages/luigi/execution_summary.py", line 173, in _get_set_of_params
params[param] = {getattr(task, param[0]) for task in tasks}
File "/usr/local/lib/python2.7/site-packages/luigi/execution_summary.py", line 173, in 
params[param] = {getattr(task, param[0]) for task in tasks}
TypeError: unhashable type: 'dict'
```

## Description

This error make the `luigi` task return code not zero.

## Have you tested this? If so, how?

I ran my jobs with this code and it works for me.
