### PR TITLE
Allow namespaces to be set to python module

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -19,7 +19,7 @@ Package containing core luigi functionality.
 """
 
 from luigi import task
-from luigi.task import Task, Config, ExternalTask, WrapperTask, namespace
+from luigi.task import Task, Config, ExternalTask, WrapperTask, namespace, auto_namespace
 
 from luigi import target
 from luigi.target import Target
@@ -51,7 +51,7 @@ from .tools import range  # just makes the tool classes available from command l
 
 
 __all__ = [
-    'task', 'Task', 'Config', 'ExternalTask', 'WrapperTask', 'namespace',
+    'task', 'Task', 'Config', 'ExternalTask', 'WrapperTask', 'namespace', 'auto_namespace',
     'target', 'Target', 'LocalTarget', 'rpc', 'RemoteScheduler',
     'RPCError', 'parameter', 'Parameter', 'DateParameter', 'MonthParameter',
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'DateSecondParameter', 'range',

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -57,10 +57,10 @@ def namespace(namespace=None, scope=''):
     It is often desired to call this function with the keyword argument
     ``scope=__name__``.
 
-    The ``scope`` keyword makes so this call is only affective for task classes
-    with a matching [*]_ ``__module__``. The default value for ``scope`` is the
-    empty string, which means all classes. Multiple calls with the same scope
-    simply replace each other.
+    The ``scope`` keyword makes it so that this call is only effective for task
+    classes with a matching [*]_ ``__module__``. The default value for
+    ``scope`` is the empty string, which means all classes. Multiple calls with
+    the same scope simply replace each other.
 
     The namespace of a :py:class:`Task` can also be changed by specifying the property
     ``task_namespace``.
@@ -70,7 +70,7 @@ def namespace(namespace=None, scope=''):
         class Task2(luigi.Task):
             task_namespace = 'namespace2'
 
-    This explicit setting takes priority over whatever is set in
+    This explicit setting takes priority over whatever is set in the
     ``namespace()`` method, and it's also inherited through normal python
     inheritence.
 
@@ -79,7 +79,7 @@ def namespace(namespace=None, scope=''):
     *New since Luigi 2.6.0:* ``scope`` keyword argument.
 
     .. [*] When there are multiple levels of matching module scopes like
-           ``a.b`` vs ``a.b.c``, the more specific one wins.
+           ``a.b`` vs ``a.b.c``, the more specific one (``a.b.c``) wins.
     .. seealso:: The new and better scaling :py:func:`auto_namespace`
     """
     Register._default_namespace_dict[scope] = namespace or ''
@@ -92,12 +92,12 @@ def auto_namespace(scope=''):
     reasons:
 
      * Two tasks with the same name will not have conflicting task families
-     * It's more pythonic, as modules are pythons recommended way to
+     * It's more pythonic, as modules are Python's recommended way to
        do namespacing.
-     * It's traceable, when you see the full name of a task, you can immedietly
+     * It's traceable. When you see the full name of a task, you can immediately
        identify where it is defined.
 
-    We recommend to call this function from your package's outermost
+    We recommend calling this function from your package's outermost
     ``__init__.py`` file. The file contents could look like this:
 
     .. code-block:: python

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -47,27 +47,72 @@ TASK_ID_INCLUDE_PARAMS = 3
 TASK_ID_TRUNCATE_PARAMS = 16
 TASK_ID_TRUNCATE_HASH = 10
 TASK_ID_INVALID_CHAR_REGEX = re.compile(r'[^A-Za-z0-9_]')
+_SAME_AS_PYTHON_MODULE = '_same_as_python_module'
 
 
-def namespace(namespace=None):
+def namespace(namespace=None, scope=''):
     """
     Call to set namespace of tasks declared after the call.
 
-    It is best practice to call this function without arguments at the end of any file it has been
-    used in. That is to ensure that subsequent tasks have the default namespace again.
+    It is often desired to call this function with the keyword argument
+    ``scope=__name__``.
+
+    The ``scope`` keyword makes so this call is only affective for task classes
+    with a matching [*]_ ``__module__``. The default value for ``scope`` is the
+    empty string, which means all classes. Multiple calls with the same scope
+    simply replace each other.
 
     The namespace of a :py:class:`Task` can also be changed by specifying the property
-    ``task_namespace``. This solution has the advantage that the namespace
-    doesn't have to be restored.
+    ``task_namespace``.
 
     .. code-block:: python
 
         class Task2(luigi.Task):
             task_namespace = 'namespace2'
 
+    This explicit setting takes priority over whatever is set in
+    ``namespace()`` method, and it's also inherited through normal python
+    inheritence.
+
     There's no equivalent way to set the ``task_family``.
+
+    *New since Luigi 2.6.0:* ``scope`` keyword argument.
+
+    .. [*] When there are multiple levels of matching module scopes like
+           ``a.b`` vs ``a.b.c``, the more specific one wins.
+    .. seealso:: The new and better scaling :py:func:`auto_namespace`
     """
-    Register._default_namespace = namespace or ''
+    Register._default_namespace_dict[scope] = namespace or ''
+
+
+def auto_namespace(scope=''):
+    """
+    Same as :py:func:`namespace`, but instead of a constant namespace, it will
+    be set to the ``__module__`` of the task class. This is desirable for these
+    reasons:
+
+     * Two tasks with the same name will not have conflicting task families
+     * It's more pythonic, as modules are pythons recommended way to
+       do namespacing.
+     * It's traceable, when you see the full name of a task, you can immedietly
+       identify where it is defined.
+
+    We recommend to call this function from your package's outermost
+    ``__init__.py`` file. The file contents could look like this:
+
+    .. code-block:: python
+
+        import luigi
+
+        luigi.auto_namespace(scope=__name__)
+
+    To reset an ``auto_namespace()`` call, you can use
+    ``namespace(scope='my_scope'``).  But this will not be
+    needed (and is also discouraged) if you use the ``scope`` kwarg.
+
+    *New since Luigi 2.6.0.*
+    """
+    namespace(namespace=_SAME_AS_PYTHON_MODULE, scope=scope)
 
 
 def task_id_str(task_family, params):
@@ -243,6 +288,10 @@ class Task(object):
 
     __not_user_specified = '__not_user_specified'
 
+    # This is here just to help pylint, the Register metaclass will always set
+    # this value anyway.
+    _namespace_at_class_time = None
+
     task_namespace = __not_user_specified
     """
     This value can be overriden to set the namespace that will be used.
@@ -263,6 +312,8 @@ class Task(object):
         """
         if cls.task_namespace != cls.__not_user_specified:
             return cls.task_namespace
+        elif cls._namespace_at_class_time == _SAME_AS_PYTHON_MODULE:
+            return cls.__module__
         return cls._namespace_at_class_time
 
     @property

--- a/test/auto_namespace_test/__init__.py
+++ b/test/auto_namespace_test/__init__.py
@@ -1,0 +1,3 @@
+import luigi
+
+luigi.auto_namespace(scope=__name__)

--- a/test/auto_namespace_test/my_namespace_test.py
+++ b/test/auto_namespace_test/my_namespace_test.py
@@ -1,0 +1,10 @@
+import luigi
+from helpers import LuigiTestCase
+
+
+class MyNamespaceTest(LuigiTestCase):
+    def test_auto_namespace_scope(self):
+        class MyTask(luigi.Task):
+            pass
+        self.assertTrue(self.run_locally(['auto_namespace_test.my_namespace_test.MyTask']))
+        self.assertEqual(MyTask.get_task_namespace(), 'auto_namespace_test.my_namespace_test')

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -285,3 +285,64 @@ class TaskNamespaceTest(LuigiTestCase):
         child_task = _ChildTask()
         self.assertEqual(child_task.task_family, 'b._ChildTask')
         self.assertEqual(str(child_task), 'b._ChildTask()')
+
+    def test_with_scope(self):
+        luigi.namespace('wohoo', scope='task_test')
+        luigi.namespace('bleh', scope='')
+
+        class MyTask(luigi.Task):
+            pass
+        luigi.namespace(scope='task_test')
+        luigi.namespace(scope='')
+        self.assertEqual(MyTask.get_task_namespace(), 'wohoo')
+
+    def test_with_scope_not_matching(self):
+        luigi.namespace('wohoo', scope='incorrect_namespace')
+        luigi.namespace('bleh', scope='')
+
+        class MyTask(luigi.Task):
+            pass
+        luigi.namespace(scope='incorrect_namespace')
+        luigi.namespace(scope='')
+        self.assertEqual(MyTask.get_task_namespace(), 'bleh')
+
+
+class AutoNamespaceTest(LuigiTestCase):
+    this_module = 'task_test'
+
+    def test_auto_namespace_global(self):
+        luigi.auto_namespace()
+
+        class MyTask(luigi.Task):
+            pass
+
+        luigi.namespace()
+        self.assertEqual(MyTask.get_task_namespace(), self.this_module)
+
+    def test_auto_namespace_scope(self):
+        luigi.auto_namespace(scope='task_test')
+        luigi.namespace('bleh', scope='')
+
+        class MyTask(luigi.Task):
+            pass
+        luigi.namespace(scope='task_test')
+        luigi.namespace(scope='')
+        self.assertEqual(MyTask.get_task_namespace(), self.this_module)
+
+    def test_auto_namespace_not_matching(self):
+        luigi.auto_namespace(scope='incorrect_namespace')
+        luigi.namespace('bleh', scope='')
+
+        class MyTask(luigi.Task):
+            pass
+        luigi.namespace(scope='incorrect_namespace')
+        luigi.namespace(scope='')
+        self.assertEqual(MyTask.get_task_namespace(), 'bleh')
+
+    def test_auto_namespace_not_matching_2(self):
+        luigi.auto_namespace(scope='incorrect_namespace')
+
+        class MyTask(luigi.Task):
+            pass
+        luigi.namespace(scope='incorrect_namespace')
+        self.assertEqual(MyTask.get_task_namespace(), '')


### PR DESCRIPTION
This have been a problem I've thought about for years. And also
consciously gradually refactored the code base in previous patches
towards making this relatively short path.

Coming up with the final syntax and implementation also took me a while.
Initially I imagined there would be a [config] parameter one could set,
or specify by command line. But it turned out to be quite troublesome:

 * It's not clear how much it should affect. Should it also affect the
   things luigi exports?
 * It's hard to transition into it. Imagining a company with independent
   teams, the `auto_namespace` function can be applied package by
   package, luigi-version by luigi-version to whoever chooses to apply
   this new convention.

This solution came out to be pretty clean, and with readable tests and
detailed and a bit opinionated documentation.

## Have you tested this? If so, how?

I'm going for a week-long no computer vacation soon. After that I'll try running this in production.