### PR TITLE
Fixed link to HDFS API docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ in Hadoop, as well as
 `Hive <https://luigi.readthedocs.io/en/latest/api/luigi.contrib.hive.html>`__,
 and `Pig <https://luigi.readthedocs.io/en/latest/api/luigi.contrib.pig.html>`__,
 jobs. It also comes with
-`file system abstractions for HDFS <https://luigi.readthedocs.io/en/latest/api/luigi.hdfs.html>`_,
+`file system abstractions for HDFS <https://luigi.readthedocs.io/en/latest/api/luigi.contrib.hdfs.html>`_,
 and local files that ensures all file system operations are atomic. This
 is important because it means your data pipeline will not crash in a
 state containing partial data.


### PR DESCRIPTION
Minor fix to the URL of the link to the HDFS documentation in the README.

I'm not familiar with the history of the API, but it seems that the hdfs module is currently located in contrib.
