### PR TITLE
use compress_response by default

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -193,6 +193,7 @@ class RootPathHandler(BaseTaskHistoryHandler):
 def app(scheduler):
     settings = {"static_path": os.path.join(os.path.dirname(__file__), "static"),
                 "unescape": tornado.escape.xhtml_unescape,
+                "compress_response": True,
                 }
     handlers = [
         (r'/api/(.*)', RPCHandler, {"scheduler": scheduler}),


### PR DESCRIPTION
## Description
Tornado.web.Application has the ability to compress responses if clients add Accept-Encoding in their requests

## Motivation and Context
Setting compress_response allows to cut down network traffic particularly when asking for dep_graph on (very) complex workflows. 
I got JSON responses as big as 19MB on huge workflows composed by a relative small number of Task Families, cut down to 200KB.

## Have you tested this? If so, how?
I changed my site-package's luigi version on my preproduction systems, ran my job successfully, then manually changed the code here. 
I don't know how to trigger the travis tests from the github web interface, sorry.
