### PR TITLE
Set authors to "The Luigi Authors"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: luigi
 Section: libs
 Priority: extra
-Maintainer: Elias Freider <freider@spotify.com>
+Maintainer: The Luigi Authors <luigi-user@googlegroups.com>
 Build-Depends:	debhelper (>= 7),
 		python-all (>= 2.7),
 		python-psycopg2,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Luigi'
-copyright = u"2011-{}, Erik Bernhardsson and Elias Freider".format(datetime.datetime.now().year)
+authors = u"The Luigi Authors"
+copyright = u"2011-{}, {}".format(datetime.datetime.now().year, authors)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -277,7 +278,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     ('index', 'Luigi.tex', u'Luigi Documentation',
-     u'Erik Bernhardsson and Elias Freider', 'manual'),
+     authors, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -307,7 +308,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'luigi', u'Luigi Documentation',
-     [u'Erik Bernhardsson and Elias Freider'], 1)
+     [authors], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -321,7 +322,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'Luigi', u'Luigi Documentation',
-     u'Erik Bernhardsson and Elias Freider', 'Luigi', 'One line description of project.',
+     authors, 'Luigi', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     version='2.5.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
-    author='Erik Bernhardsson',
+    author='The Luigi Authors',
     url='https://github.com/spotify/luigi',
     license='Apache License 2.0',
     packages=[


### PR DESCRIPTION
As of there being close to 300 commiters to luigi, and today's main
contributors to the code base are not the two original founders anymore
(which is a good sign of success :)). It makes more sense to mention
a generic term as the authors of the software.

I took the name from the Tornado docs (obviously replacing "Tornado"
with "Luigi"). The original authors are still mentioned in the bottom of
the README.md.