### PR TITLE
(SF) Ensure bulk api output is in requested order

### DIFF
--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 import re
 import csv
 import tempfile
-from StringIO import StringIO
+from luigi.six.moves import StringIO
 
 import luigi
 from luigi import Task

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -184,13 +184,17 @@ class QuerySalesforce(Task):
                 # If there's only one result, just download it, otherwise we need to merge the resulting downloads
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
-                    # ensure that bulk api response is written in order expected
-                    fields = get_soql_fields(self.soql)
-                    with open(self.output().path, 'w') as outfile:
-                        writer = csv.DictWriter(outfile, fieldnames=fields)
-                        writer.writeheader()
-                        for row in csv.DictReader(StringIO(data)):
-                            writer.writerow(row)
+                    if self.content_type == 'CSV':
+                        # ensure that bulk api response is written in order expected
+                        fields = get_soql_fields(self.soql)
+                        with open(self.output().path, 'w') as outfile:
+                            writer = csv.DictWriter(outfile, fieldnames=fields)
+                            writer.writeheader()
+                            for row in csv.DictReader(StringIO(data)):
+                                writer.writerow(row)
+                    else:
+                        with open(self.output().path, 'w') as outfile:
+                            outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
                     # Preferring to do it this way so as to minimize memory consumption.


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
After [4 years of request](https://success.salesforce.com/ideaView?id=08730000000h6C2AAI), Salesforce now allows Foreign Key Relationships within their Bulk API. However, the csv response provided does not always return in the same order as requested. This PR ensures that the output csv is written in the same order as it was requested.

## Description
<!--- Describe your changes -->
For CSV content type, output is written in the same order as the fields of the input SOQL query.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Of my 8 daily Salesforce SOQL Queries, 4 of them do not return with the same column order as was requested in the SOQL. This PR ensures that.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I have run this with my tasks and it works for me. I have specified this check only for CSV content type as it is the only one I use and cannot speak to the validity of return types for other approved SF content types.
