### PR TITLE
Fix key-based credentials for redshift copy

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -287,7 +287,7 @@ class S3CopyToTable(rdbms.CopyToTable):
                 role=self.aws_arn_role_name
             )
         elif self.aws_access_key_id and self.aws_secret_access_key:
-            cred_str = 'aws_access_key_id={key};aws_secret_key={secret}{opt}'.format(
+            cred_str = 'aws_access_key_id={key};aws_secret_access_key={secret}{opt}'.format(
                 key=self.aws_access_key_id,
                 secret=self.aws_secret_access_key,
                 opt=';token={}'.format(self.aws_session_token) if self.aws_session_token else ''


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Fixes breaking changes to key-based credentials from PR #1962 

## Description
<!--- Describe your changes -->
Mistakenly merged PR using word `aws_secret_key` rather than `aws_secret_access_key`. Caused Redshift `InternalError` when using key-based credentials during Redshift copy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes breaking PR

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Ran fine for me this morning.
