### PR TITLE
Refactored setup of google api clients

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -24,9 +24,6 @@ from luigi.contrib import gcp
 logger = logging.getLogger('luigi-interface')
 
 try:
-    import httplib2
-    import oauth2client
-
     from googleapiclient import discovery
     from googleapiclient import http
 except ImportError:

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -19,6 +19,7 @@ import collections
 import logging
 import luigi.target
 import time
+from luigi.contrib import gcp
 
 logger = logging.getLogger('luigi-interface')
 
@@ -107,15 +108,12 @@ class BigQueryClient(object):
     """
 
     def __init__(self, oauth_credentials=None, descriptor='', http_=None):
-        http_ = http_ or httplib2.Http()
-
-        if not oauth_credentials:
-            oauth_credentials = oauth2client.client.GoogleCredentials.get_application_default()
+        authenticate_kwargs = gcp.get_authenticate_kwargs(oauth_credentials, http_)
 
         if descriptor:
-            self.client = discovery.build_from_document(descriptor, credentials=oauth_credentials, http=http_)
+            self.client = discovery.build_from_document(descriptor, **authenticate_kwargs)
         else:
-            self.client = discovery.build('bigquery', 'v2', credentials=oauth_credentials, http=http_)
+            self.client = discovery.build('bigquery', 'v2', **authenticate_kwargs)
 
     def dataset_exists(self, dataset):
         """Returns whether the given dataset exists.

--- a/luigi/contrib/gcp.py
+++ b/luigi/contrib/gcp.py
@@ -1,0 +1,46 @@
+"""
+Common code for GCP (google cloud services) integration
+"""
+import logging
+logger = logging.getLogger('luigi-interface')
+
+try:
+    import httplib2
+    import oauth2client
+except ImportError:
+    logger.warning("Loading GCP module without the python packages httplib2, oauth2client. \
+        This *could* crash at runtime if no other credentials are provided.")
+
+
+def get_authenticate_kwargs(oauth_credentials=None, http_=None):
+    """Returns a dictionary with keyword arguments for use with discovery
+
+    Prioritizes oauth_credentials or a http client provided by the user
+    If none provided, falls back to default credentials provided by google's command line
+    utilities. If that also fails, tries using httplib2.Http()
+
+    Used by `gcs.GCSClient` and `bigquery.BigQueryClient` to initiate the API Client
+    """
+    if oauth_credentials:
+        authenticate_kwargs = {
+            "credentials": oauth_credentials
+        }
+    elif http_:
+        authenticate_kwargs = {
+            "http": http_
+        }
+    else:
+        # neither http_ or credentials provided
+        try:
+            # try default credentials
+            oauth_credentials = oauth2client.client.GoogleCredentials.get_application_default()
+            authenticate_kwargs = {
+                "credentials": oauth_credentials
+            }
+        except oauth2client.client.GoogleCredentials.ApplicationDefaultCredentialsError:
+            # try http using httplib2
+            authenticate_kwargs = {
+                "http": httplib2.Http()
+            }
+
+    return authenticate_kwargs

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     from urllib.parse import urlsplit
 
+from luigi.contrib import gcp
 import luigi.target
 from luigi import six
 from luigi.six.moves import xrange
@@ -110,15 +111,12 @@ class GCSClient(luigi.target.FileSystem):
     def __init__(self, oauth_credentials=None, descriptor='', http_=None,
                  chunksize=CHUNKSIZE):
         self.chunksize = chunksize
-        http_ = http_ or httplib2.Http()
-
-        if not oauth_credentials:
-            oauth_credentials = oauth2client.client.GoogleCredentials.get_application_default()
+        authenticate_kwargs = gcp.get_authenticate_kwargs(oauth_credentials, http_)
 
         if descriptor:
-            self.client = discovery.build_from_document(descriptor, credentials=oauth_credentials, http=http_)
+            self.client = discovery.build_from_document(descriptor, **authenticate_kwargs)
         else:
-            self.client = discovery.build('storage', 'v1', credentials=oauth_credentials, http=http_)
+            self.client = discovery.build('storage', 'v1', **authenticate_kwargs)
 
     def _path_to_bucket_and_key(self, path):
         (scheme, netloc, path, _, _) = urlsplit(path)

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -37,7 +37,6 @@ logger = logging.getLogger('luigi-interface')
 
 try:
     import httplib2
-    import oauth2client.client
 
     from googleapiclient import errors
     from googleapiclient import discovery


### PR DESCRIPTION
## Description
* Adds out-of-the-box support for google cli authentication auto-discovery (`get_application_default`)
* Reuses more code between gcs and bigquery implementations

## Motivation and Context
Works with the current version of the cli tools and api client (google-api-python-client==1.6.1), which was previously not working (http and oauth could not both be provided as was the default/required behavior by the previous code).

##Tests 
I ran tasks both for gcs (cloud storage) uploads and big query integration and both work after this patch. I don't see how it would break anything for people who use manual configuration of the authentication process, but it would of course be nice if someone who has a GCS/BigQuery pipeline running tested this out as well :)