### PR TITLE
Update outdated mainClass to mainJarFileUri

### DIFF
--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -62,12 +62,12 @@ class DataprocBaseTask(_DataprocBaseTask):
             },
             "sparkJob": {
                 "args": job_args,
-                "mainClass": main_class,
+                "mainJarFileUri": main_class,
                 "jarFileUris": jars
             }
         }}
         self.submit_job(job_config)
-        self._job_name = os.path.basename(self._job['sparkJob']['mainClass'])
+        self._job_name = os.path.basename(self._job['sparkJob']['mainJarFileUri'])
         logger.info("Submitted new dataproc job:{} id:{}".format(self._job_name, self._job_id))
         return self._job
 


### PR DESCRIPTION
The current dataproc API does not accept mainClass as a parameter, the correct parameter name is now mainJarFileUri.

## Description
Changed outdated REST API parameter in the method submit_spark_job from mainClass to mainJarFileUri

## Motivation and Context
The current code is broken and dataproc can not find the .jar-files specified in mainClass.

## Have you tested this? If so, how?
Yes, the Spark jobs now run as they should.