### PR TITLE
Adds Task.on_external_failure method to provide custom error messages for failed External Tasks

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -562,6 +562,19 @@ class Task(object):
         Default behavior is to send an None value"""
         pass
 
+    def on_external_failure(self):
+        """
+        Override for custom error handling for failed external tasks.
+
+        This method gets called if a task is an :py:class:`luigi.task.ExternalTask`, or if a
+        :py:class:`luigi.task.Task`'s :py:meth:`run` method is not implemented.
+
+        The returned value is json encoded and sent to the scheduler as the `expl` argument.
+
+        Default behavior is to send a None value
+        """
+        pass
+
     @contextmanager
     def no_unpicklable_properties(self):
         """

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -186,8 +186,10 @@ class TaskProcess(multiprocessing.Process):
                     status = DONE
                 else:
                     status = FAILED
-                    expl = 'Task is an external data dependency ' \
-                        'and data does not exist (yet?).'
+                    expl = self.task.on_external_failure()
+                    if not expl:
+                        expl = 'Task is an external data dependency ' \
+                            'and data does not exist (yet?).'
             else:
                 new_deps = self._run_get_new_deps()
                 status = DONE if not new_deps else PENDING


### PR DESCRIPTION
## Description
This PR adds an `on_external_failure` method to the `Task` class.  This method is called in the `TaskProcess.run` method when an external task fails, and enables the user to provide a custom failure message for external tasks.  I also add 2 relevant tests to cover the additional codepaths.

## Motivation and Context
My pipeline consists of a fair amount of external tasks, many of which have overridden `Task.complete` methods.  One thing that I'd like to be able to do is provide a more informative explanation for why an external task failed in the luigi dashboard.   Currently, there is no way to do this, and I can't repurpose the existing `on_failure` method because no Exception was raised.

I added the method directly to the `Task` class in case users use the `externalize` method instead of inheriting from the `ExternalTask` class.

## Have you tested this? If so, how?
Included 2 additional unit tests that pass.