### PR TITLE
Only run ecs_test.py if nose attribute awsecs is set

### DIFF
--- a/test/contrib/ecs_test.py
+++ b/test/contrib/ecs_test.py
@@ -33,6 +33,8 @@ Written and maintained by Jake Feala (@jfeala) for Outlier Bio (@outlierbio)
 
 import unittest
 
+from nose.plugins.attrib import attr
+
 import luigi
 from luigi.contrib.ecs import ECSTask, _get_task_statuses
 
@@ -73,6 +75,7 @@ class ECSTaskOverrideCommand(ECSTaskNoOutput):
         return [{'name': 'hello-world', 'command': ['/bin/sleep', '10']}]
 
 
+@attr('awsecs')
 class TestECSTask(unittest.TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, visualiser, pypy-scheduler, docs, flake8
+envlist = py{27,33,34,35}-{awsecs,cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, visualiser, pypy-scheduler, docs, flake8
 skipsdist = True
 
 [testenv]
@@ -34,6 +34,7 @@ passenv =
   USER JAVA_HOME POSTGRES_USER DATAPROC_TEST_PROJECT_ID GCS_TEST_PROJECT_ID GCS_TEST_BUCKET GOOGLE_APPLICATION_CREDENTIALS TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT CI
 setenv =
   LC_ALL = en_US.utf-8
+  awsecs: NOSE_ATTR=awsecs
   cdh: HADOOP_DISTRO=cdh
   cdh: HADOOP_HOME={toxinidir}/.tox/hadoop-cdh
   hdp: HADOOP_DISTRO=hdp
@@ -42,7 +43,7 @@ setenv =
   scheduler: NOSE_ATTR=scheduler
   cdh,hdp: NOSE_ATTR=minicluster
   gcloud: NOSE_ATTR=gcloud
-  nonhdfs: NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket
+  nonhdfs: NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket and not awsecs
   unixsocket: NOSE_ATTR=unixsocket
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
   COVERAGE_PROCESS_START={toxinidir}/.coveragerc
@@ -66,7 +67,7 @@ deps =
 passenv = {[testenv]passenv}
 setenv =
   LC_ALL = en_US.utf-8
-  NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket
+  NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket and not awsecs
   LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
   TEST_VISUALISER=1
 commands =


### PR DESCRIPTION
## Motivation and Context

The `test/contrib/ecs_test.py` requires AWS credentials and an AWS account
with a running ECS cluster to execute properly. Previously, it's been
prevented from running by being skipped unless `boto3` has been manually
installed in the test environment.

This was triggered by #1980, which adds `boto3` as a dependency in test.

## Description

To be able to include `boto3` in the default test environment, and still
prevent `ecs_test.py` from running e.g. in CI, this change sets an `awsecs`
[nose attribute][1] on the test, so it will only execute e.g. if
`NOSE_ATTR=awsecs` is in the shell environment, or if tox is invoked
with the `-awsecs` tox-environment:

    tox -e py27-awsecs

Specifically, it should not be executed by the Travis CI engine (even if
`boto3` is installed).

[1]: https://nose.readthedocs.io/en/latest/plugins/attrib.html

## Have you tested this? If so, how?

It has been tested locally using tox.
