### PR TITLE
Introduce Python3 compatibility in example

### DIFF
--- a/examples/foo_complex.py
+++ b/examples/foo_complex.py
@@ -23,6 +23,7 @@ You can run this example like this:
             $ luigi --module examples.foo_complex examples.Foo --workers 2 --local-scheduler
 
 """
+from __future__ import division
 import time
 import random
 
@@ -41,7 +42,7 @@ class Foo(luigi.Task):
 
     def requires(self):
         global current_nodes
-        for i in range(30 / max_depth):
+        for i in range(30 // max_depth):
             current_nodes += 1
             yield Bar(i)
 
@@ -60,7 +61,7 @@ class Bar(luigi.Task):
 
         if max_total_nodes > current_nodes:
             valor = int(random.uniform(1, 30))
-            for i in range(valor / max_depth):
+            for i in range(valor // max_depth):
                 current_nodes += 1
                 yield Bar(current_nodes)
 

--- a/examples/foo_complex.py
+++ b/examples/foo_complex.py
@@ -67,10 +67,10 @@ class Bar(luigi.Task):
 
     def output(self):
         """
-       Returns the target output for this task.
+        Returns the target output for this task.
 
-       :return: the target output for this task.
-       :rtype: object (:py:class:`~luigi.target.Target`)
-       """
+        :return: the target output for this task.
+        :rtype: object (:py:class:`~luigi.target.Target`)
+        """
         time.sleep(1)
         return luigi.LocalTarget('/tmp/bar/%d' % self.num)


### PR DESCRIPTION
The example in `examples/foo_complex.py` does not work in Python3 due to the division operator.

## Description
I fixed the error by importing the division operator from `__future__` and using the integer division operator (`//`).

## Motivation and Context
When running the example using Python3 I was getting the following error:

      File "/Users/amarco/Desktop/luigi/examples/foo_complex.py", line 64, in requires
        for i in range(valor / max_depth):
    TypeError: 'float' object cannot be interpreted as an integer

## Have you tested this? If so, how?
I ran the example task and it completed successfully:

    ===== Luigi Execution Summary =====
    Scheduled 51 tasks of which:
    * 51 ran successfully:
        - 50 examples.Bar(num=0,1,10,11,12,13,14,15,16,17,18,...)
        - 1 examples.Foo()

    This progress looks :) because there were no failed tasks or missing external dependencies
    ===== Luigi Execution Summary =====