### PR TITLE
update contrib.salesforce to use 'wb' when opening output file

### DIFF
--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -213,7 +213,7 @@ class QuerySalesforce(Task):
         """
         Merges the resulting files of a multi-result batch bulk query.
         """
-        outfile = open(self.output().path, 'wb')
+        outfile = open(self.output().path, 'w')
 
         if self.content_type.lower() == 'csv':
             for i, result_id in enumerate(result_ids):

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -183,14 +183,16 @@ class QuerySalesforce(Task):
                 # If there's only one result, just download it, otherwise we need to merge the resulting downloads
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
-                    with open(self.output().path, format=self.output().format) as outfile:
+                    with open(self.output().path,
+                              format=luigi.format.get_default_format()) as outfile:
                         outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
                     # Preferring to do it this way so as to minimize memory consumption.
                     for i, result_id in enumerate(result_ids):
                         logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
-                        with open("%s.%d" % (self.output().path, i), format=self.output().format) as outfile:
+                        with open("%s.%d" % (self.output().path, i),
+                                  format=luigi.format.get_default_format()) as outfile:
                             outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
 
                     logger.info("Merging results of batch %s" % batch_id)
@@ -204,7 +206,8 @@ class QuerySalesforce(Task):
             data_file = sf.query_all(self.soql)
 
             reader = csv.reader(data_file)
-            with open(self.output().path, format=self.output().format) as outfile:
+            with open(self.output().path,
+                      format=luigi.format.get_default_format()) as outfile:
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
@@ -213,7 +216,8 @@ class QuerySalesforce(Task):
         """
         Merges the resulting files of a multi-result batch bulk query.
         """
-        outfile = open(self.output().path, format=self.output().format)
+        outfile = open(self.output().path,
+                  format=luigi.format.get_default_format())
 
         if self.content_type.lower() == 'csv':
             for i, result_id in enumerate(result_ids):

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -183,16 +183,14 @@ class QuerySalesforce(Task):
                 # If there's only one result, just download it, otherwise we need to merge the resulting downloads
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
-                    with open(self.output().path,
-                              luigi.format.get_default_format()) as outfile:
+                    with open(self.output().path, 'wb') as outfile:
                         outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
                     # Preferring to do it this way so as to minimize memory consumption.
                     for i, result_id in enumerate(result_ids):
                         logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
-                        with open("%s.%d" % (self.output().path, i),
-                                  luigi.format.get_default_format()) as outfile:
+                        with open("%s.%d" % (self.output().path, i), 'wb') as outfile:
                             outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
 
                     logger.info("Merging results of batch %s" % batch_id)
@@ -206,8 +204,7 @@ class QuerySalesforce(Task):
             data_file = sf.query_all(self.soql)
 
             reader = csv.reader(data_file)
-            with open(self.output().path,
-                      luigi.format.get_default_format()) as outfile:
+            with open(self.output().path, 'wb') as outfile:
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
@@ -216,8 +213,7 @@ class QuerySalesforce(Task):
         """
         Merges the resulting files of a multi-result batch bulk query.
         """
-        outfile = open(self.output().path,
-                       luigi.format.get_default_format())
+        outfile = open(self.output().path, 'wb')
 
         if self.content_type.lower() == 'csv':
             for i, result_id in enumerate(result_ids):

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -184,7 +184,7 @@ class QuerySalesforce(Task):
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
                     with open(self.output().path,
-                              format=luigi.format.get_default_format()) as outfile:
+                              luigi.format.get_default_format()) as outfile:
                         outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
@@ -192,7 +192,7 @@ class QuerySalesforce(Task):
                     for i, result_id in enumerate(result_ids):
                         logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
                         with open("%s.%d" % (self.output().path, i),
-                                  format=luigi.format.get_default_format()) as outfile:
+                                  luigi.format.get_default_format()) as outfile:
                             outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
 
                     logger.info("Merging results of batch %s" % batch_id)
@@ -207,7 +207,7 @@ class QuerySalesforce(Task):
 
             reader = csv.reader(data_file)
             with open(self.output().path,
-                      format=luigi.format.get_default_format()) as outfile:
+                      luigi.format.get_default_format()) as outfile:
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
@@ -217,7 +217,7 @@ class QuerySalesforce(Task):
         Merges the resulting files of a multi-result batch bulk query.
         """
         outfile = open(self.output().path,
-                  format=luigi.format.get_default_format())
+                       luigi.format.get_default_format())
 
         if self.content_type.lower() == 'csv':
             for i, result_id in enumerate(result_ids):

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -183,14 +183,14 @@ class QuerySalesforce(Task):
                 # If there's only one result, just download it, otherwise we need to merge the resulting downloads
                 if len(result_ids) == 1:
                     data = sf.get_batch_result(job_id, batch_id, result_ids[0])
-                    with open(self.output().path, 'w') as outfile:
+                    with open(self.output().path, format=self.output().format) as outfile:
                         outfile.write(data)
                 else:
                     # Download each file to disk, and then merge into one.
                     # Preferring to do it this way so as to minimize memory consumption.
                     for i, result_id in enumerate(result_ids):
                         logger.info("Downloading batch result %s for batch: %s and job: %s" % (result_id, batch_id, job_id))
-                        with open("%s.%d" % (self.output().path, i), 'w') as outfile:
+                        with open("%s.%d" % (self.output().path, i), format=self.output().format) as outfile:
                             outfile.write(sf.get_batch_result(job_id, batch_id, result_id))
 
                     logger.info("Merging results of batch %s" % batch_id)
@@ -204,7 +204,7 @@ class QuerySalesforce(Task):
             data_file = sf.query_all(self.soql)
 
             reader = csv.reader(data_file)
-            with open(self.output().path, 'w') as outfile:
+            with open(self.output().path, format=self.output().format) as outfile:
                 writer = csv.writer(outfile, dialect='excel')
                 for row in reader:
                     writer.writerow(row)
@@ -213,7 +213,7 @@ class QuerySalesforce(Task):
         """
         Merges the resulting files of a multi-result batch bulk query.
         """
-        outfile = open(self.output().path, 'w')
+        outfile = open(self.output().path, format=self.output().format)
 
         if self.content_type.lower() == 'csv':
             for i, result_id in enumerate(result_ids):

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -55,7 +55,7 @@ old__open = open
 
 
 def mocked_open(*args, **kwargs):
-    if re.match("job_data", args[0]):
+    if re.match("job_data", str(args[0])):
         return MockTarget(args[0]).open(args[1])
     else:
         return old__open(*args)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
In `open()` calls, changed option `'w'` to `'wb'` for forward-compatibility with Python3.x

## Motivation and Context
I am attempting to run a QuerySalesforce export task on Python3.5 and am running into an error described in #1647. I tried the provided solution, `format=luigi.format.Nop`, but it does not help because `'w'` appears to be hard-coded into this package.

## Have you tested this? If so, how?
I successfully ran a QuerySalesforce task in both Python2.7 and Python3.5. 