### PR TITLE
Load os.environ into the config singleton

### DIFF
--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -128,4 +128,4 @@ def get_config():
     """
     Convenience method (for backwards compatibility) for accessing config singleton.
     """
-    return LuigiConfigParser.instance()
+    return LuigiConfigParser.instance(os.environ)


### PR DESCRIPTION

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

`LuigiConfigParser` is a derived class of python's `ConfigParser`. When there is a need to have environment variable interpolation support in the cfg/ini file we can pass `os.environ` to the initializer to make it work. This PR looks for bringing that support to the project.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I think it would be neat if luigi.cfg could interpolate some environment
variables. I think this is the minimum required amount of work to make
this happen but I'm looking for guidance.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I've tested this in the way of overriding `luigi.configuration.get_config`:

```
luigi.configuration.get_config = lambda: luigi.configuration.LuigiConfigParser.instance(os.environ)
```

Example luigi.cfg file:

```
[DatabaseConfiguration]
host=%(DATABASE_HOST)s
database=%(DATABASE_NAME)s
user=%(DATABASE_USER)s
password=%(DATABASE_PASSWORD)s
```
