### PR TITLE
Add section to the patterns doc about avoiding simultaneous updates to single file

### DIFF
--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -206,9 +206,13 @@ available while others are running.
 Avoiding concurrent writes to a single file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are updating a single file from several tasks, you may need to ensure that
-no two tasks try to do so simultaneously.  By turning 'resources' into a Python
-property, it can return a value dependent on the task parameters or other dynamic attributes:
+Updating a single file from several tasks is almost always a bad idea, and you 
+need to be very confident that no other good solution exists before doing this.
+If, however, you have no other option, then you will probably at least need to ensure that
+no two tasks try to write to the file _simultaneously_.  
+
+By turning 'resources' into a Python property, it can return a value dependent on 
+the task parameters or other dynamic attributes:
 
 .. code-block:: python
 

--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -203,6 +203,25 @@ batch_running. Using a unique resource will prevent multiple tasks from
 writing to the same location at the same time if a new one becomes
 available while others are running.
 
+Avoiding concurrent writes to a single file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are updating a single file from several tasks, you may need to ensure that
+no two tasks try to do so simultaneously.  By turning 'resources' into a Python
+property, it can return a value dependent on the task parameters or other dynamic attributes:
+
+.. code-block:: python
+
+    class A(luigi.Task):
+        ...
+
+        @property
+        def resources(self):
+            return { self.important_file_name: 1 }
+
+Since, by default, resources have a usage limit of 1, no two instances of Task A 
+will now run if they have the same `important_file_name` property.
+
 Monitoring task pipelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Description

Adds a section to the 'Luigi patterns' documentation about how to avoid multiple workers trying to write to a single destination simultaneously.

## Motivation and Context

I had created tasks and targets that would create new tables in an existing HDF5 file.  The problem was that if two simultaneous processes tried to write to the same file, it would be corrupted.  But I couldn't find examples of how to avoid this, except by using workers=1.

Finally, I came across daveFNbuck's example on making 'resources' dynamic, at the end of #1362, which was a perfect and neat solution to my file problem, and thought something along those lines deserved a place in the documentation: it would have saved me many, many hours...

## Have you tested this? If so, how?

Have built with the tox -e docs and the output looks good.
