### PR TITLE
Address JS error in visualizer when displaying the dependency graph

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -22,7 +22,7 @@ function visualiserApp(luigi) {
     /*
      * Updates view of the Visualization type.
      */
-    function updateVisType (newVisType) {
+    function updateVisType(newVisType) {
         $('#toggleVisButtons label').removeClass('active');
         $('#toggleVisButtons input[value="' + newVisType + '"]').parent().addClass('active');
     }

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -504,9 +504,6 @@ function visualiserApp(luigi) {
 
         $('input[name=vis-type]').on('change', function () {
             changeState('visType', $(this).val());
-
-            initVisualisation(visType);
-            updateVisType(fragmentQuery.visType);
         });
 
         /*


### PR DESCRIPTION
## Description
In the current version of the visualizer an error raises when switching to the Dependency Graph tab. To reproduce it just load the visualizer page, open a javascript console and go to the Dependency Graph tab.

<img width="1440" alt="screen shot 2017-02-25 at 12 16 08 pm" src="https://cloud.githubusercontent.com/assets/1711369/23331284/1545801a-fb63-11e6-82d4-64d223deccd7.png">

The error is happening because the variable `visType` is not defined. The variable `fragmentQuery.visType` in the function call in the next line is not defined either.

To address the issue I removed the function calls that were raising an error because of undeclared variables. The function calls were anyway not required, because line 506 modifies the state of the address bar. An event listening to changes on the address bar takes care of updating the visualization graph.

## Motivation and Context
I think the error was introduced in [this commit](https://github.com/spotify/luigi/commit/24a896fb22ef1aa027493409d4fbba95a79baac2).

## Have you tested this? If so, how?
I tested the fix locally, now the visualizer does not produce errors in the dependency graph tab and still works normally.
