### PR TITLE
Initial pass at metrics collection for Central Scheduler

### DIFF
--- a/luigi/contrib/prometheus.py
+++ b/luigi/contrib/prometheus.py
@@ -1,0 +1,30 @@
+import logging
+
+from luigi.metrics import MetricsCollector
+
+from prometheus_client import Counter, Gauge
+from prometheus_client.exposition import generate_latest as generate_latest_metrics
+
+
+PROMETHEUS_CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
+'''Content type of the latest text format'''
+
+class PrometheusMetricsCollector(MetricsCollector):
+
+    def __init__(self, *args, **kwargs):
+        super(PrometheusMetricsCollector, self).__init__(*args, **kwargs)
+
+        self.task_counter = Counter('luigi_task_count', 'Number of luigi tasks', ['status', 'task_family'])
+        self.worker_counter = Counter('luigi_worker_count', 'Number of luigi Workers', ['status', 'host', 'username'])
+
+    def handle_task_status_change(self, task, status):
+        self._increment_task_counter(status.lower(), task.family)
+
+    def handle_worker_status_change(self, worker, status):
+        self._increment_worker_counter(status.lower(), worker.info.get('host', None), worker.info.get('username', None))
+
+    def _increment_task_counter(self, status, task_family):
+        self.task_counter.labels(status=status, task_family=task_family).inc()
+
+    def _increment_worker_counter(self, status, host, username):
+        self.worker_counter.labels(status=status, host=host, username=username).inc()

--- a/luigi/metrics.py
+++ b/luigi/metrics.py
@@ -1,0 +1,14 @@
+
+
+class MetricsCollector(object):
+    """
+    Dummy MetricsCollecter base class that can be replace by tool specific implementation
+    """
+    def __init__(self, scheduler):
+        self._scheduler = scheduler
+
+    def handle_task_status_change(self, task, status):
+        pass
+
+    def handle_worker_status_change(self, worker, status):
+        pass

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -789,6 +789,9 @@ class Worker(object):
         self._worker_info.append(('first_task', self._first_task))
         self._scheduler.add_worker(self._id, self._worker_info)
 
+    def _remove_worker(self):
+        self._scheduler.remove_worker(self._id)
+
     def _log_remote_tasks(self, get_work_response):
         logger.debug("Done")
         logger.debug("There are no more tasks to run at this time")
@@ -1088,6 +1091,8 @@ class Worker(object):
         while len(self._running_tasks):
             logger.debug('Shut down Worker, %d more tasks to go', len(self._running_tasks))
             self._handle_next_task()
+
+        self._remove_worker()
 
         return self.run_succeeded
 


### PR DESCRIPTION
## Description
This is an initial pass at adding metric collection functionality to the Central Scheduler, and is still a work in progress. I'm looking for feedback on the general approach.

Summary of changes:

- Dummy `MetricsCollector` class (luigi/metrics.py) with no-op methods, but can be subclassed for a specific metric collection tool.
- `PrometheusMetricsCollector` class (luigi/contrib/prometheus.py) that subclasses the above, as an example implementation.
- New `scheduler` config option/parameter to select the metric collection tool.
- changes to `SimpleTaskState` to identify and trigger metric updates.
- Added `Scheduler.remove_worker` rpc_method to related `Worker._remove_worker` method to allow workers to tell the scheduler when they are finishing and disconnecting. This allows us to distinguish between deliberate disconnects and worker failures.


## Motivation and Context
This is an attempt to provide functionality desired in [issue 2306](https://github.com/spotify/luigi/issues/2036)

## Have you tested this? If so, how?
Does not yet include any tests.
I have run it against some very simple pipelines and it seems to do as expected.
