### PR TITLE
Specify default port to comply with change in init for psycopg 2.7

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -110,7 +110,7 @@ class PostgresTarget(luigi.Target):
     use_db_timestamps = True
 
     def __init__(
-        self, host, database, user, password, table, update_id, port=None
+        self, host, database, user, password, table, update_id, port=5432
     ):
         """
         Args:


### PR DESCRIPTION
## Description
Updated psycopg to 2.7 and encountered a fault in the init for postgres.py. Previously, we could define parameters for db connection to postgres with no separate port defined and no port in the host name. If that it attempted in 2.7, it attempts to create a connection with port=None.

Changing the default init value of port from None to int:5432 allows for postgres.py to continue to work with 2.7 as before.

## Have you tested this? If so, how?
I ran my jobs with this code and it worked as before the 2.7 update.
