### PR TITLE
Test against Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,12 @@ matrix:
       env: TOXENV=py35-unixsocket
     - python: 3.5
       env: TOXENV=py35-cdh
+    - python: 3.6
+      env: TOXENV=py36-nonhdfs
+    - python: 3.6
+      env: TOXENV=py36-unixsocket
+    - python: 3.6
+      env: TOXENV=py36-cdh
 
 sudo: false
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, visualiser, pypy-scheduler, docs, flake8
+envlist = py{27,33,34,35,36}-{cdh,hdp,nonhdfs,gcloud,postgres,unixsocket}, visualiser, pypy-scheduler, docs, flake8
 skipsdist = True
 
 [testenv]
@@ -21,7 +21,7 @@ deps=
   postgres: psycopg2<3.0
   gcloud: google-api-python-client>=1.4.0,<2.0
   py27-gcloud: avro
-  py33-gcloud,py34-gcloud,py35-gcloud: avro-python3
+  py33-gcloud,py34-gcloud,py35-gcloud,py36-gcloud: avro-python3
   gcloud: oauth2client<4.0.0
   coverage>=4.1,<4.2
   codecov>=1.4.0


### PR DESCRIPTION

## Description
Add Python 3.6 to build matrix in .travis.yml.

## Motivation and Context
I want to run Luigi on Python 3.6. I have limited insight to `tox`, so I've made a basic attempt, but it might fail.

## Have you tested this? If so, how?
Hoping travis will test this. 

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
