### PR TITLE
add Weebly to list of Luigi users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Squarespace <https://www.squarespace.com/>`_
 * `OAO <https://adops.com/>`_
 * `Grovo <https://grovo.com/>`_
+* `Weebly <https://www.weebly.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Addition to documentation

## Motivation and Context
This solves the issue that Weebly is a cool company but people don't know they use Luigi.

## Have you tested this? If so, how?
I clicked 'Preview' and it looked fine.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
