### PR TITLE
Add method rename_dont_move to LocalFileSystem

### DIFF
--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -99,7 +99,7 @@ class LocalFileSystem(FileSystem):
         but cannot be guaranteed.
         """
         if raise_if_exists and os.path.exists(new_path):
-            raise RuntimeError('Destination exists: %s' % new_path)
+            raise FileAlreadyExists('Destination exists: %s' % new_path)
         d = os.path.dirname(new_path)
         if d and not os.path.exists(d):
             self.mkdir(d)
@@ -113,6 +113,14 @@ class LocalFileSystem(FileSystem):
                 os.remove(old_path)
             else:
                 raise err
+
+    def rename_dont_move(self, path, dest):
+        """
+        Rename ``path`` to ``dest``, but don't move it into the ``dest``
+        folder (if it is a folder). This method is just a wrapper around the
+        ``move`` method of LocalTarget.
+        """
+        self.move(path, dest, raise_if_exists=True)
 
 
 class LocalTarget(FileSystemTarget):


### PR DESCRIPTION
## Description
See issue #2050

## Motivation and Context
When the method `temporary_path` is called on LocalTarget, a warning is
given because the default implementation of the method `rename_dont_move`
is used. However LocalFileSystem has already a more sophisticated
implementation of the desired functionality in the `move` method. Here
`rename_dont_move` is implemented by means of this `move` method.

Additionally the exception raised by `move` is changed from RuntimeError
to FileAlreadyExists, as the latter is expected by the test of
`rename_dont_move`.


## Have you tested this? If so, how?
Run the tests in test/local_target_test.py

