### PR TITLE
Make temporary_path work with paths not containing a directory

### DIFF
--- a/luigi/target.py
+++ b/luigi/target.py
@@ -287,7 +287,8 @@ class FileSystemTarget(Target):
                     self.target._trailing_slash())
                 # TODO: os.path doesn't make sense here as it's os-dependent
                 tmp_dir = os.path.dirname(slashless_path)
-                self.target.fs.mkdir(tmp_dir, parents=True, raise_if_exists=False)
+                if tmp_dir:
+                    self.target.fs.mkdir(tmp_dir, parents=True, raise_if_exists=False)
 
             def __enter__(self):
                 return self._temp_path

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -347,3 +347,10 @@ class TemporaryPathTest(unittest.TestCase):
 
         with target.temporary_path():
             self.fs.mkdir.assert_called_once_with('/my/dir/is', parents=True, raise_if_exists=False)
+
+    def test_file_in_current_dir(self):
+        target = self.target_cls('foo.txt')
+
+        with target.temporary_path() as tmp_path:
+            self.fs.mkdir.assert_not_called()  # there is no dir to create
+        self.fs.rename_dont_move.assert_called_once_with(tmp_path, target.path)


### PR DESCRIPTION
## Motivation and Context
The context manager returned by FileSystemTarget.temporary_path creates
the parent directory of the target path. However this fails when the
path does not contain a directory and an exception is raised. To be able
to use paths without a directory (e.g. "foobar.txt"), the creation of
the parent directoy is skipped in this case.

## Have you tested this? If so, how?
Verified that no exception is raises when the target path does not contain a directory.


