### PR TITLE
Fix history display

### DIFF
--- a/luigi/templates/header.html
+++ b/luigi/templates/header.html
@@ -1,4 +1,0 @@
-<!doctype html>
-<title>Luigi Task History</title>
-<link href="/static/visualiser/lib/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
-<script src="/static/visualiser/lib/bootstrap3/js/bootstrap.min.js"></script>

--- a/luigi/templates/layout.html
+++ b/luigi/templates/layout.html
@@ -82,10 +82,10 @@
       .lead { margin-top: -17px; margin-bottom: 13px; }
 
     </style>
-    <link href="{{ static_url("visualiser/lib/bootstrap/css/bootstrap.css") }}" rel="stylesheet">
+    <link href="{{ static_url("visualiser/lib/bootstrap3/css/bootstrap.min.css") }}" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.7.0/nv.d3.min.css" rel="stylesheet">
-	<script type="text/javascript" src="http://code.jquery.com/jquery.min.js"></script>
-    <script src="{{ static_url("visualiser/lib/bootstrap/js/bootstrap.js") }}"></script>
+    <script src="{{ static_url("visualiser/lib/jquery-1.10.0.min.js") }}"></script>
+    <script src="{{ static_url("visualiser/lib/bootstrap3/js/bootstrap.min.js") }}"></script>
   </head>
   <body>
 

--- a/luigi/templates/recent.html
+++ b/luigi/templates/recent.html
@@ -1,4 +1,5 @@
-{% include "header.html" %}
+{% extends "layout.html" %}
+{% block content %}
 <h2>Luigi Task History</h2>
 <table class="table table-striped table-bordered">
   <thead>
@@ -24,3 +25,4 @@
     {% end %}
   </tbody>
 </table>
+{% end %}

--- a/luigi/templates/show.html
+++ b/luigi/templates/show.html
@@ -1,4 +1,5 @@
-{% include "header.html" %}
+{% extends "layout.html" %}
+{% block content %}
 <div class="row">
   <div class="span6">
     <h3>Info</h3>
@@ -59,3 +60,4 @@
 
   </tbody>
 </table>
+{% end %}


### PR DESCRIPTION
Some of the JS/CSS imports in the history page are broken. This leads to a couple of wrong-displayed elements (see screenshots).

Moreover I think they should be integrated in the visualizer (as a new tab?). In that way the history feature would be more visible and possibly lead to a more extended use. Probably this is not the proper place to discuss this last point but I don't know where can be discussed otherwise, sorry about that.

## Description
I fixed the paths on the imports and now bootstrap and jQuery are imported properly. Moreover I used the default layout more extensively and removed a, now, unused file. The use of the layout page is important since it creates a container div in which the other elements are placed.

## Motivation and Context
Currently there are some issues on how the history pages are displayed.`localhost:8082/tasklist`:

<img width="217" alt="screen shot 2017-03-12 at 3 58 03 pm" src="https://cloud.githubusercontent.com/assets/1711369/23835115/d736b28e-0761-11e7-9421-9a593b04b8dd.png">

And `localhost:8082/history/by_id/1` (note that a part of the text is even outside of the screen!):

<img width="1440" alt="screen shot 2017-03-12 at 4 32 49 pm" src="https://cloud.githubusercontent.com/assets/1711369/23835118/deb321dc-0761-11e7-8553-60f99e49023b.png">

After the changes:

<img width="1153" alt="screen shot 2017-03-12 at 3 58 39 pm" src="https://cloud.githubusercontent.com/assets/1711369/23835132/22b51552-0762-11e7-9735-29bd13700dca.png">

<img width="1440" alt="screen shot 2017-03-12 at 4 34 59 pm" src="https://cloud.githubusercontent.com/assets/1711369/23835139/48105cbc-0762-11e7-989d-d9fc9809946c.png">


## Have you tested this? If so, how?
I ran the central scheduler like so:

    luigid --pidfile pidfile --logdir log/ --state-path state/state

I ran one of the example tasks:

    luigi --module examples.foo examples.Foo --workers 2

This is how my `luigi.cfg` looks like:

    [scheduler]
    record_task_history = True
    state-path = /Users/name/develop/luigi/luigi-state.pkl

    [task_history]
    db_connection = sqlite:////Users/name/develop/luigi/luigi-task-hist.db

After accessing localhost:8082/history the pages are displayed properly.