### PR TITLE
Fix worker tool box in visualizer

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -322,7 +322,7 @@
                 </div>
               </div>
             </div>
-            {{#workers}}
+            {{#workerList}}
             {{#is_disabled}}
             <div class="box box-solid box-default">
             {{/is_disabled}}
@@ -336,6 +336,7 @@
                       <span class="label-unread-worker-messages">{{num_unread_rpc_messages}} unread message(s)</span>
                       {{/num_unread_rpc_messages}}
                       {{^is_disabled}}
+                      {{#workers}}
                       <div class="btn-group">
                         <button type="button" class="btn btn-sm btn-default dropdown-toggle btn-set-workers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Workers: <span id="label-n-workers" data-worker="{{name}}">{{workers}}</span> <span class="caret"></span>
@@ -352,6 +353,7 @@
                           </a></li>
                         </ul>
                       </div>
+                      {{/workers}}
                       <div class="button-tooltip" data-toggle="tooltip" title="Disable Worker">
                         <button type="button" class="btn btn-sm btn-danger btn-disable-worker" data-toggle="modal" data-target="#disableWorkerModal" data-worker="{{name}}">
                           <i class="fa fa-fire-extinguisher"></i>
@@ -399,7 +401,7 @@
                     </table>
                 </div>
             </div>
-            {{/workers}}
+            {{/workerList}}
         </script>
 
         <script type="text/template" name="resourceTemplate">

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1038,8 +1038,10 @@ function visualiserApp(luigi) {
             luigi.disableWorker(worker);
 
             // show the worker as disabled in the visualiser
-            triggerButton.parents('.box').addClass('box-solid box-default');
-            triggerButton.remove();
+            var box = triggerButton.parents('.box').addClass('box-solid box-default');
+
+            // remove the worker tools
+            box.find('.box-tools').remove();
         });
 
         $('#workerList').on('click', '#btn-increment-workers', function($event) {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -229,7 +229,7 @@ function visualiserApp(luigi) {
     }
 
     function renderWorkers(workers) {
-        return renderTemplate("workerTemplate", {"workers": workers.map(processWorker)});
+        return renderTemplate("workerTemplate", {"workerList": workers.map(processWorker)});
     }
 
     function processResource(resource) {


### PR DESCRIPTION
## Description

The worker toolbox in the visualizer shows some buggy information in the phase between adding a worker to the scheduler and actual task processing (so while the dependency tree is built). This looks like:

![bug](https://dl.dropboxusercontent.com/u/1021570/wtb.png)

The reason is that `workers` is both used for the list of worker objects in the visualizer for rendering and the number of worker processes of a worker. See [here](https://github.com/spotify/luigi/blob/00d637f553f814b75dec717a77d7b26ced90b7e1/luigi/static/visualiser/index.html#L325-L341) (first and last line in the marked area). Initially, there's no 'worker' field in the worker object so Mustache falls back to the list of workers which renders to the example above.


## Motivation and Context

A simple renaming of the variable that holds the list of worker objects for rendering fixes the bug (2nd commit). In addition, the worker toolbox is removed now entirely when a worker is disabled (1st commit). Previously, the "disable" button was removed while the "add workers" menu was still visible.

