### PR TITLE
Add 'IF NOT EXISTS' to prevent duplicate table exception

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -219,7 +219,7 @@ class PostgresTarget(luigi.Target):
                       inserted TIMESTAMP);
                   """.format(marker_table=self.marker_table)
 
-        cursor.execute(sql) 
+        cursor.execute(sql)
         connection.close()
 
     def open(self, mode):

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -207,13 +207,13 @@ class PostgresTarget(luigi.Target):
         connection.autocommit = True
         cursor = connection.cursor()
         if self.use_db_timestamps:
-            sql = """ CREATE TABLE {marker_table} (
+            sql = """ CREATE TABLE IF NOT EXISTS {marker_table} (
                       update_id TEXT PRIMARY KEY,
                       target_table TEXT,
                       inserted TIMESTAMP DEFAULT NOW())
-                """.format(marker_table=self.marker_table)
+                  """.format(marker_table=self.marker_table)
         else:
-            sql = """ CREATE TABLE {marker_table} (
+            sql = """ CREATE TABLE IF NOT EXISTS {marker_table} (
                       update_id TEXT PRIMARY KEY,
                       target_table TEXT,
                       inserted TIMESTAMP);
@@ -221,10 +221,7 @@ class PostgresTarget(luigi.Target):
         try:
             cursor.execute(sql)
         except psycopg2.ProgrammingError as e:
-            if e.pgcode == psycopg2.errorcodes.DUPLICATE_TABLE:
-                pass
-            else:
-                raise
+            raise
         connection.close()
 
     def open(self, mode):

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -218,10 +218,8 @@ class PostgresTarget(luigi.Target):
                       target_table TEXT,
                       inserted TIMESTAMP);
                   """.format(marker_table=self.marker_table)
-        try:
-            cursor.execute(sql)
-        except psycopg2.ProgrammingError as e:
-            raise
+
+        cursor.execute(sql) 
         connection.close()
 
     def open(self, mode):


### PR DESCRIPTION
PR for issue #2060: Avoid exception handling for PostgresTarget.create_marker_table() with "CREATE TABLE IF NOT EXISTS"

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
adding Postgresq `IF NOT EXISTS` clause in order to avoid having to rely on a exception handling when the `marker_table` already exists

## Motivation and Context
Fix issue #2060 

## Have you tested this? If so, how?
Not tested directly, but the SQL query is valid for Postgresql since version 9.1