### PR TITLE
Do not raise HDFSCliError inside snakebite client.

### DIFF
--- a/luigi/contrib/hdfs/snakebite_client.py
+++ b/luigi/contrib/hdfs/snakebite_client.py
@@ -23,7 +23,6 @@ Originally written by Alan Brenner <alan@magnetic.com> github.com/alanbbr
 
 
 from luigi.contrib.hdfs import config as hdfs_config
-from luigi.contrib.hdfs import error as hdfs_error
 from luigi.contrib.hdfs import abstract_client as hdfs_abstract_client
 from luigi import six
 import luigi.contrib.target
@@ -89,10 +88,7 @@ class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         :type path: string
         :return: boolean, True if path exists in HDFS
         """
-        try:
-            return self.get_bite().test(path, exists=True)
-        except Exception as err:    # IGNORE:broad-except
-            raise hdfs_error.HDFSCliError("snakebite.test", -1, str(err), repr(err))
+        return self.get_bite().test(path, exists=True)
 
     def move(self, path, dest):
         """

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -377,9 +377,7 @@ class HiveTableTarget(luigi.Target):
     def __init__(self, table, database='default', client=None):
         self.database = database
         self.table = table
-        if client is None:
-            client = get_default_client()
-        self.client = client
+        self.client = client or get_default_client()
 
     def exists(self):
         logger.debug("Checking if Hive table '%s.%s' exists", self.database, self.table)
@@ -408,9 +406,7 @@ class HivePartitionTarget(luigi.Target):
         self.database = database
         self.table = table
         self.partition = partition
-        if client is None:
-            client = get_default_client()
-        self.client = client
+        self.client = client or get_default_client()
 
         self.fail_missing_table = fail_missing_table
 

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -377,7 +377,6 @@ class HiveTableTarget(luigi.Target):
     def __init__(self, table, database='default', client=None):
         self.database = database
         self.table = table
-        self.hive_cmd = load_hive_cmd()
         if client is None:
             client = get_default_client()
         self.client = client


### PR DESCRIPTION
Re 94e1b9f - In one of snakebite client's methods, `HDFSCliError` is re-raised. I don't think there's any reason for this - it simply has been there ever since snakebite client was "extracted" out of the command line client. When the `HDFSCliError` is re-raised the actual snakebite stacktrace is swallowed and makes debugging more difficult.

+ Two tiny code improvements in `contrib/hive` (ef6440a, 54764bb).