### PR TITLE
REDSHIFT: standardize credential usage

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -21,11 +21,6 @@ import logging
 import time
 import os
 
-try:
-    from ConfigParser import NoSectionError
-except:
-    from configparser import NoSectionError
-
 import luigi
 from luigi import postgres
 from luigi.contrib import rdbms
@@ -95,10 +90,7 @@ class _CredentialsMixin():
     def _get_configuration_attribute(self, attribute):
         config = luigi.configuration.get_config()
 
-        try:
-            value = config.get(self.configuration_section, attribute)
-        except NoSectionError:
-            value = None
+        value = config.get(self.configuration_section, attribute, default=None)
 
         if not value:
             value = os.environ.get(attribute.upper(), None)
@@ -124,7 +116,9 @@ class _CredentialsMixin():
             )
         else:
             raise NotImplementedError("Missing Credentials. "
-                                      "Override one of the following pairs of auth-args: "
+                                      "Ensure one of the pairs of auth args below are set "
+                                      "in a configuration file, environment variables or by "
+                                      "being overridden in the task: "
                                       "'aws_access_key_id' AND 'aws_secret_access_key' OR "
                                       "'aws_account_id' AND 'aws_arn_role_name'")
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -50,45 +50,53 @@ class _CredentialsMixin():
     """
 
     @property
+    def configuration_section(self):
+      """
+      Override to change the configuration section used
+      to obtain default credentials.
+      """
+      return 'redshift'
+
+    @property
     def aws_access_key_id(self):
         """
         Override to return the key id.
         """
-        return self._get_s3_configuration_attribute('aws_access_key_id')
+        return self._get_configuration_attribute('aws_access_key_id')
 
     @property
     def aws_secret_access_key(self):
         """
         Override to return the secret access key.
         """
-        return self._get_s3_configuration_attribute('aws_secret_access_key')
+        return self._get_configuration_attribute('aws_secret_access_key')
 
     @property
     def aws_account_id(self):
         """
         Override to return the account id.
         """
-        return None
+        return self._get_configuration_attribute('aws_account_id')
 
     @property
     def aws_arn_role_name(self):
         """
         Override to return the arn role name.
         """
-        return None
+        return self._get_configuration_attribute('aws_arn_role_name')
 
     @property
     def aws_session_token(self):
         """
         Override to return the session token.
         """
-        return None
+        return self._get_configuration_attribute('aws_session_token')
 
-    def _get_s3_configuration_attribute(self, attribute):
+    def _get_configuration_attribute(self, attribute):
         config = luigi.configuration.get_config()
 
         try:
-            value = config.get('s3', attribute)
+            value = config.get(self.configuration_section, attribute)
         except NoSectionError:
             value = None
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -92,14 +92,14 @@ class _CredentialsMixin():
         except NoSectionError:
             value = None
 
-        if value is None or value == '':
+        if not value:
             value = os.environ.get(attribute.upper(), None)
 
         return value
 
     def _credentials(self):
         """
-        Return a credentials string for the provided task. If no valid
+        Return a credential string for the provided task. If no valid
         credentials are set, raise a NotImplementedError.
         """
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -51,11 +51,11 @@ class _CredentialsMixin():
 
     @property
     def configuration_section(self):
-      """
-      Override to change the configuration section used
-      to obtain default credentials.
-      """
-      return 'redshift'
+        """
+        Override to change the configuration section used
+        to obtain default credentials.
+        """
+        return 'redshift'
 
     @property
     def aws_access_key_id(self):

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -154,8 +154,9 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
       * `columns`,
       * `s3_load_path`.
 
-    * You must also override the attributes provided by the
-      CredentialsMixin.
+    * You can also override the attributes provided by the
+      CredentialsMixin if they are not supplied by your
+      configuration or environment variables.
     """
 
     @abc.abstractmethod
@@ -423,8 +424,9 @@ class S3CopyJSONToTable(S3CopyToTable, _CredentialsMixin):
             * `jsonpath`,
             * `copy_json_options`.
 
-    * You must also override the attributes provided by the
-      CredentialsMixin.
+    * You can also override the attributes provided by the
+      CredentialsMixin if they are not supplied by your
+      configuration or environment variables.
     """
 
     @abc.abstractproperty
@@ -641,7 +643,7 @@ class RedshiftUnloadTask(postgres.PostgresQuery, _CredentialsMixin):
     Override the `run` method if your use case requires some action with the query result.
     Task instances require a dynamic `update_id`, e.g. via parameter(s), otherwise the query will only execute once
     To customize the query signature as recorded in the database marker table, override the `update_id` property.
-    You must also override the attributes provided by the CredentialsMixin.
+    You can also override the attributes provided by the CredentialsMixin if they are not supplied by your configuration or environment variables.
     """
 
     @property

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -15,7 +15,9 @@
 import luigi
 import luigi.contrib.redshift
 import mock
+from helpers import with_config
 
+import os
 import unittest
 
 
@@ -73,6 +75,26 @@ class DummyS3CopyToTempTable(DummyS3CopyToTableKey):
     prune_table = 'stage_dummy_table'
 
     queries = ["insert into dummy_table select * from stage_dummy_table;"]
+
+
+class TestInternalCredentials(unittest.TestCase, DummyS3CopyToTableKey):
+    def test_from_property(self):
+        self.assertEqual(self.aws_access_key_id, AWS_ACCESS_KEY)
+        self.assertEqual(self.aws_secret_access_key, AWS_SECRET_KEY)
+
+
+class TestExternalCredentials(unittest.TestCase, DummyS3CopyToTableBase):
+    @mock.patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "env_key",
+                                  "AWS_SECRET_ACCESS_KEY": "env_secret"})
+    def test_from_env(self):
+        self.assertEqual(self.aws_access_key_id, "env_key")
+        self.assertEqual(self.aws_secret_access_key, "env_secret")
+
+    @with_config({"redshift": {"aws_access_key_id": "config_key",
+                               "aws_secret_access_key": "config_secret"}})
+    def test_from_config(self):
+        self.assertEqual(self.aws_access_key_id, "config_key")
+        self.assertEqual(self.aws_secret_access_key, "config_secret")
 
 
 class TestS3CopyToTable(unittest.TestCase):


### PR DESCRIPTION
## Description
Obtaining the credentials for a redshift connection is now uniform
accross all of the redshift tasks. This has the added benefit of
allowing role-based credentials in all of the tasks as well.

## Motivation and Context
I need to use role-based credentials for all of my redshift tasks, not just some of them.

## Have you tested this? If so, how?
I ran this against the current unit tests for the redshift files and everything passed. If anything else is needed, please let me know.