### PR TITLE
Remove assert that verifies if tables were marked 

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!---
+Currently, there are no strict procedures or guidelines for submitting issues.
+In short, please just use common sense.
+
+Common sense includes this at bare-minimum:
+
+ * search for similar issues posted before creating a new issue.
+ * Use markdown to format all code/logs. Issues which are hard to read
+   when rendered on GitHub might be closed with a friendly reminder of this.
+
+Also, add steps to reproduce the bug, if applicable. Sample code would be nice too :)
+
+For more information on how to submit valuable contributions,
+see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
+-->

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -162,9 +162,6 @@ class PostgresTarget(luigi.Target):
                 (self.update_id, self.table,
                  datetime.datetime.now()))
 
-        # make sure update is properly marked
-        assert self.exists(connection)
-
     def exists(self, connection=None):
         if connection is None:
             connection = self.connect()

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.6.0',
+    version='2.6.0-patched',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
A summary of this would be that having multiple workers and multiple
insert/select on the same table causes a lot of issues. Please refer
yourself to the issue below to have a better idea.

fixes glossier#2