### PR TITLE
Split up the list of users in two lists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,9 @@ or held presentations about Luigi:
 * `TrustYou <http://www.trustyou.com/>`_ `(presentation, 2015) <https://speakerdeck.com/mfcabrera/pydata-berlin-2015-processing-hotel-reviews-with-python>`_
 * `Groupon <https://www.groupon.com/>`_ / `OrderUp <https://orderup.com>`_ `(alternative implementation) <https://github.com/groupon/luigi-warehouse>`_
 * `Red Hat - Marketing Operations <https://www.redhat.com>`_ `(blog, 2017) <https://github.com/rh-marketingops/rh-mo-scc-luigi>`_
+
+Some more companies are using Luigi but haven't had a chance yet to write about it:
+
 * `Schibsted <http://www.schibsted.com/>`_
 * `enbrite.ly <http://enbrite.ly/>`_
 * `Dow Jones / The Wall Street Journal <http://wsj.com>`_


### PR DESCRIPTION

## Description

Break up the long list of users in two lists, one for blogs/presentation, one without

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

encourage people to add presentations/blogs, but also not lose out on companies that don't

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->



<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
