### PR TITLE
luigi.worker.Worker(retry_external_tasks=True) has no effect

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -723,7 +723,7 @@ class Worker(object):
             elif _is_external(task):
                 deps = None
                 status = PENDING
-                runnable = worker().retry_external_tasks
+                runnable = self._config.retry_external_tasks
                 task.trigger_event(Event.DEPENDENCY_MISSING, task)
                 logger.warning('Data for %s does not exist (yet?). The task is an '
                                'external data depedency, so it can not be run from'


### PR DESCRIPTION
## Description
Use the retry_external_tasks parameter local to the worker instead of the global settings.

## Motivation and Context
The change is required when starting a worker from Python. It is not needed when starting a worker using the luigi binary.

## Have you tested this? If so, how?
I have included unit tests. The test don't run to completion without the change to the code.
