### PR TITLE
Defer S3 Client instantiation until needed

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -124,6 +124,15 @@ class S3Client(FileSystem):
                                                    **options)
         return self._s3
 
+    @s3.setter
+    def s3(self, value):
+        self._s3 = value
+
+    @s3.deleter
+    def s3(self):
+        if hasattr(self, '_s3'):
+            del self._s3
+
     def exists(self, path):
         """
         Does provided path exist on S3?

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -73,6 +73,8 @@ class S3Client(FileSystem):
     boto-powered S3 client.
     """
 
+    _s3 = None
+
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  **kwargs):
         from boto.s3.key import Key
@@ -94,7 +96,7 @@ class S3Client(FileSystem):
 
         options = dict(self._options)
 
-        if getattr(self, '_s3', None):
+        if self._s3:
             return self._s3
 
         aws_access_key_id = options.get('aws_access_key_id')
@@ -127,11 +129,6 @@ class S3Client(FileSystem):
     @s3.setter
     def s3(self, value):
         self._s3 = value
-
-    @s3.deleter
-    def s3(self):
-        if hasattr(self, '_s3'):
-            del self._s3
 
     def exists(self, path):
         """

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -75,13 +75,31 @@ class S3Client(FileSystem):
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  **kwargs):
+        from boto.s3.key import Key
+        options = self._get_s3_config()
+        options.update(kwargs)
+        if aws_access_key_id:
+            options['aws_access_key_id'] = aws_access_key_id
+        if aws_secret_access_key:
+            options['aws_secret_access_key'] = aws_secret_access_key
+
+        self.Key = Key
+        self._options = options
+
+    @property
+    def s3(self):
         # only import boto when needed to allow top-lvl s3 module import
         import boto
         import boto.s3.connection
-        from boto.s3.key import Key
 
-        options = self._get_s3_config()
-        options.update(kwargs)
+        options = dict(self._options)
+
+        if getattr(self, '_s3', None):
+            return self._s3
+
+        aws_access_key_id = options.get('aws_access_key_id')
+        aws_secret_access_key = options.get('aws_secret_access_key')
+
         # Removing key args would break backwards compability
         role_arn = options.get('aws_role_arn')
         role_session_name = options.get('aws_role_session_name')
@@ -97,22 +115,14 @@ class S3Client(FileSystem):
             aws_access_key_id = assumed_role.credentials.access_key
             aws_session_token = assumed_role.credentials.session_token
 
-        else:
-            if not aws_access_key_id:
-                aws_access_key_id = options.get('aws_access_key_id')
-
-            if not aws_secret_access_key:
-                aws_secret_access_key = options.get('aws_secret_access_key')
-
         for key in ['aws_access_key_id', 'aws_secret_access_key', 'aws_role_session_name', 'aws_role_arn']:
             if key in options:
                 options.pop(key)
-
-        self.s3 = boto.s3.connection.S3Connection(aws_access_key_id,
-                                                  aws_secret_access_key,
-                                                  security_token=aws_session_token,
-                                                  **options)
-        self.Key = Key
+        self._s3 = boto.s3.connection.S3Connection(aws_access_key_id,
+                                                   aws_secret_access_key,
+                                                   security_token=aws_session_token,
+                                                   **options)
+        return self._s3
 
     def exists(self, path):
         """


### PR DESCRIPTION
## Description
Delays instantiation of the S3Client until we need to contact S3, speeding the `output()` method and allowing nested task graphs to use fewer connections.  Fixes #2048.

## Motivation and Context
Previously the S3 Client was instantiated in the `__init__` method of
S3Target, which meant that if you wanted to traverse a large task
graph using `output()`, quickly creating and throwing away targets, you'd end up
incurring a lot of wasted connections and slowness.

Now we create the client only when we want to make a remote request.

This does not change any of the semantics of how the target is
instantiated (still can override `s3` property and the `Key` property),
except that making an STS connection is also deferred until the moment
it's actually used.

## Have you tested this? If so, how?
I tested this with our workflows (which use Openstack Swift as an S3Target) and they continued to work.  I also assume unit tests cover this code as well. (had some issues running the test suite locally).  I also checked that connections were not being generated solely from instantiating S3Targets.