### PR TITLE
Document that Parameter() now must be a string.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -74,7 +74,7 @@ class DuplicateParameterException(ParameterException):
 
 class Parameter(object):
     """
-    An untyped Parameter
+    Parameter whose value is a ``str``, and a base class for other parameter types.
 
     Parameters are objects set on the Task class level to make it possible to parameterize tasks.
     For instance:
@@ -107,9 +107,6 @@ class Parameter(object):
         * With ``[TASK_NAME]>PARAM_NAME: <serialized value>`` syntax. See :ref:`ParamConfigIngestion`
 
         * Any default value set using the ``default`` flag.
-
-    There are subclasses of ``Parameter`` that define what type the parameter has. This is not
-    enforced within Python, but are used for command line interaction.
 
     Parameter objects may be reused, but you must then set the ``positional=False`` flag.
     """


### PR DESCRIPTION
In #1607 it was decided that Parameter must be serializable and thus can no longer be an untyped object. This pull request changes the documentation to reflect this.