### PR TITLE
Update check for table existence to be case insensitive

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -332,11 +332,11 @@ class S3CopyToTable(rdbms.CopyToTable):
         if '.' in self.table:
             query = ("select 1 as table_exists "
                      "from information_schema.tables "
-                     "where table_schema = %s and table_name = %s limit 1")
+                     "where table_schema = lower(%s) and table_name = lower(%s) limit 1")
         else:
             query = ("select 1 as table_exists "
                      "from pg_table_def "
-                     "where tablename = %s limit 1")
+                     "where tablename = lower(%s) limit 1")
         cursor = connection.cursor()
         try:
             cursor.execute(query, tuple(self.table.split('.')))

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -123,7 +123,7 @@ class TestS3CopyToTable(unittest.TestCase):
         # Check the SQL query in `S3CopyToTable.does_table_exist`.
         mock_cursor.execute.assert_called_with("select 1 as table_exists "
                                                "from pg_table_def "
-                                               "where tablename = %s limit 1",
+                                               "where tablename = lower(%s) limit 1",
                                                (task.table,))
 
         return
@@ -188,7 +188,7 @@ class TestS3CopyToTable(unittest.TestCase):
         mock_cursor.execute.assert_any_call(
             "select 1 as table_exists "
             "from pg_table_def "
-            "where tablename = %s limit 1",
+            "where tablename = lower(%s) limit 1",
             (task.table,),
         )
 
@@ -212,8 +212,8 @@ class TestS3CopyToSchemaTable(unittest.TestCase):
         mock_cursor.execute.assert_called_with(
             "select 1 as table_exists "
             "from information_schema.tables "
-            "where table_schema = %s and "
-            "table_name = %s limit 1",
+            "where table_schema = lower(%s) and "
+            "table_name = lower(%s) limit 1",
             tuple(task.table.split('.')),
         )
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Redshift schema/table/column names are case-insensitive. So if you create table `MyTable` in schema `MySchema`, redshift saves those values in `pg_table_def` and `information_schema.tables` in all lowercase. Therefore, the check for table existence in `does_table_exist()` will fail.

This PR just surrounds the table and schema parameters in `lower()`.

From [Redshift documentation](http://docs.aws.amazon.com/redshift/latest/dg/r_names.html):

> ASCII letters in standard and delimited identifiers are case-insensitive and are folded to lower case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Issue #2080 

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Works for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
