### PR TITLE
Fix "Show Upstream Dependencies" in visualiser

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -454,7 +454,7 @@ function visualiserApp(luigi) {
                     });
                 }
                 else {
-                    window.location.href = 'index.html#tab=graph&taskId=' + taskId;
+                    window.location.href = 'index.html#tab=graph&visType=d3&taskId=' + taskId;
                 }
             });
         }

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -413,7 +413,7 @@ function visualiserApp(luigi) {
             if (taskId) {
                 var depGraphCallback = makeGraphCallback(fragmentQuery.visType, taskId, paint);
 
-                if (fragmentQuery.invertDependencies) {
+                if (fragmentQuery.invert) {
                     luigi.getInverseDependencyGraph(taskId, depGraphCallback, !hideDone);
                 } else {
                     luigi.getDependencyGraph(taskId, depGraphCallback, !hideDone);


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Fixes the "Show Upstream Dependencies" checkbox which did not have any effect on the displayed chart.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I tested the UI with my jobs on my local installation.