### PR TITLE
Fix os.makedirs issue in multithreading (#2039)

### DIFF
--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -71,12 +71,17 @@ class LocalFileSystem(FileSystem):
                 return
 
         if parents:
-            error_to_catch = getattr(__builtins__, 'FileExistsError', OSError)
+            # for Python 2 compatibility
+            try:
+                FileNotExistsError
+            except NameError:
+                FileNotExistsError = OSError
+
             try:
                 os.makedirs(path)
-            except error_to_catch as err:
+            except FileNotExistsError as err:
                 # somebody already created the path
-                if getattr(err, 'errno', 0) != errno.EEXIST:
+                if err.errno != errno.EEXIST:
                     raise
         else:
             if not os.path.exists(os.path.dirname(path)):

--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -71,7 +71,13 @@ class LocalFileSystem(FileSystem):
                 return
 
         if parents:
-            os.makedirs(path)
+            error_to_catch = getattr(__builtins__, 'FileExistsError', OSError)
+            try:
+                os.makedirs(path)
+            except error_to_catch as err:
+                # somebody already created the path
+                if getattr(err, 'errno', 0) != errno.EEXIST:
+                    raise
         else:
             if not os.path.exists(os.path.dirname(path)):
                 raise MissingParentDirectory()

--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -71,15 +71,9 @@ class LocalFileSystem(FileSystem):
                 return
 
         if parents:
-            # for Python 2 compatibility
-            try:
-                FileNotExistsError
-            except NameError:
-                FileNotExistsError = OSError
-
             try:
                 os.makedirs(path)
-            except FileNotExistsError as err:
+            except OSError as err:
                 # somebody already created the path
                 if err.errno != errno.EEXIST:
                     raise


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes -->
There is a problem that os.makedirs is not atomic in multithreading.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This problem is reported in issue #2039.

Since exist_ok was added in Python 3.2 or later, it cannot be used in Python 2.7, so we need to check OSError.errno that we caught.
But in Python 3.x, os.makedirs raise FileExistsError instead of OSError.
FileExistsError is a subclass of OSError but does not have errno attribute.



## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
In my environment, it seems to work well.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
