### PR TITLE
Updated Kubernetes task to recieve KubeConfig object

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -68,7 +68,9 @@ class KubernetesJobTask(luigi.Task):
     def _init_kubernetes(self):
         self.__logger = logger
         self.__logger.debug("Kubernetes auth method: " + self.auth_method)
-        if(self.auth_method == "kubeconfig"):
+        if(self.kube_config.__class__ == KubeConfig):
+            self.__kube_api = HTTPClient(self.kube_config)
+        elif(self.auth_method == "kubeconfig"):
             self.__kube_api = HTTPClient(KubeConfig.from_file(self.kubeconfig_path))
         elif(self.auth_method == "service-account"):
             self.__kube_api = HTTPClient(KubeConfig.from_service_account())


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
I have updated the `KubernetesJobTask` in `luigi.contrib.kubernetes` to receive a pykube KubeConfig object to instantiate the task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, there the only two options to configure a kubernetes task is by using a config file or using service accounts. 

The `KubernetesJobTask` is a wrapper around the pykube library. Within this library, `KubeConfig` objects are used to configure the client in a number of different ways. By allowing the `KubernetesJobTask` to receive `KubeConfig` objects for initialisation, we can expand the number of use cases dramatically.

<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
In my current use case, I want to configure Kubernetes using environment variables rather than a file. Using this patch I am able to instantiate a `KubeConfig` object using envirnoment variables then pass it to the KubernetesTask.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
