### PR TITLE
Fix minor spelling mistakes in log and doc strings

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -726,7 +726,7 @@ class Worker(object):
                 runnable = self._config.retry_external_tasks
                 task.trigger_event(Event.DEPENDENCY_MISSING, task)
                 logger.warning('Data for %s does not exist (yet?). The task is an '
-                               'external data depedency, so it can not be run from'
+                               'external data dependency, so it cannot be run from'
                                ' this luigi process.', task)
 
             else:

--- a/test/helpers_test.py
+++ b/test/helpers_test.py
@@ -42,8 +42,8 @@ class RunOnceTaskTest(LuigiTestCase):
         """
         Verify that RunOnceTask works as expected.
 
-        This task will fail if it was a normal ``luigi.Task``, because
-        RequiringTask wouldn't run becaue missing depedency at runtime.
+        This task will fail if it is a normal ``luigi.Task``, because
+        RequiringTask will not run (missing dependency at runtime).
         """
         class MyTask(RunOnceTask):
             pass


### PR DESCRIPTION
Fixes a typo I noticed in the log messages: `depedency` instead of `dependency`.