### PR TITLE
Adding an optional `name` parameter in Parameter.serialize in order to make warnings more helpful

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -252,9 +252,13 @@ class Parameter(object):
 
         :param x: the value to serialize.
         """
-        if not isinstance(x, six.string_types) and self.__class__ == Parameter:
-            warnings.warn("Parameter {0} is not of type string.".format(str(x)))
         return str(x)
+
+    def _warn_on_wrong_param_type(self, param_name, param_value):
+        if self.__class__ != Parameter:
+            return
+        if not isinstance(param_value, six.string_types):
+            warnings.warn('Parameter "{}" with value "{}" is not of type string.'.format(param_name, param_value))
 
     def normalize(self, x):
         """
@@ -692,8 +696,6 @@ class TimeDeltaParameter(Parameter):
 
         :param x: the value to serialize.
         """
-        if not isinstance(x, datetime.timedelta) and self.__class__ == TimeDeltaParameter:
-            warnings.warn("Parameter {0} is not of type timedelta.".format(str(x)))
         weeks = x.days // 7
         days = x.days % 7
         hours = x.seconds // 3600
@@ -701,6 +703,12 @@ class TimeDeltaParameter(Parameter):
         seconds = (x.seconds % 3600) % 60
         result = "{} w {} d {} h {} m {} s".format(weeks, days, hours, minutes, seconds)
         return result
+
+    def _warn_on_wrong_param_type(self, param_name, param_value):
+        if self.__class__ != TimeDeltaParameter:
+            return
+        if not isinstance(param_value, datetime.timedelta):
+            warnings.warn('Parameter "{}" with value "{}" is not of type timedelta.'.format(param_name, param_value))
 
 
 class TaskParameter(Parameter):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -432,6 +432,7 @@ class Task(object):
         self.param_args = tuple(value for key, value in param_values)
         self.param_kwargs = dict(param_values)
 
+        self._warn_on_wrong_param_types()
         self.task_id = task_id_str(self.get_task_family(), self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
 
@@ -443,6 +444,11 @@ class Task(object):
         Returns ``True`` if the Task is initialized and ``False`` otherwise.
         """
         return hasattr(self, 'task_id')
+
+    def _warn_on_wrong_param_types(self):
+        params = dict(self.get_params())
+        for param_name, param_value in six.iteritems(self.param_kwargs):
+            params[param_name]._warn_on_wrong_param_type(param_name, param_value)
 
     @classmethod
     def from_str_params(cls, params_str):


### PR DESCRIPTION

## Description
I added an optional `name` Parameter in https://github.com/voyages-sncf-technologies/luigi/blob/master/luigi/parameter.py#L247 in order to improve warnings.
I also passed this new parameter in many place where `Parameter.serialize` is invoked (not all, only when possible).
Finally I updated existing tests and added new ones.

## Motivation and Context
When this `name` parameter is passed to `Parameter.serialize`, warnings raised will now include the parameter name, helping to diagnose the issue.
This is especially helpful in https://github.com/spotify/luigi/blob/master/luigi/task.py#L473 this is called to validate `luigi.cfg`.

## Have you tested this? If so, how?
I have included unit tests and I used the patched version in our own luigi pipelines.
