### PR TITLE
Allow callable default parameter values

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -117,8 +117,8 @@ class Parameter(object):
         """
         :param default: the default value for this parameter. This should match the type of the
                         Parameter, i.e. ``datetime.date`` for ``DateParameter`` or ``int`` for
-                        ``IntParameter``. By default, no default is stored and
-                        the value must be specified at runtime.
+                        ``IntParameter``, or be a callable that returns the appropriate type. By
+                        default, no default is stored and the value must be specified at runtime.
         :param bool significant: specify ``False`` if the parameter should not be treated as part of
                                  the unique identifier for a Task. An insignificant Parameter might
                                  also be used to specify a password or other sensitive information
@@ -200,7 +200,7 @@ class Parameter(object):
             yield (self._get_value_from_config(self._config_path['section'], self._config_path['name']),
                    'The use of the configuration [{}] {} is deprecated. Please use [{}] {}'.format(
                    self._config_path['section'], self._config_path['name'], task_name, param_name))
-        yield (self._default, None)
+        yield (self._default() if six.callable(self._default) else self._default, None)
 
     def has_task_value(self, task_name, param_name):
         return self._get_value(task_name, param_name) != _no_value

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -321,9 +321,8 @@ class ParameterTest(LuigiTestCase):
         self.assertEqual(CallableDefaultParameterTask().x, 'abc')
 
     def test_both_default_and_default_callable_param(self):
-        self.assertRaises(
-            ParameterException,
-            lambda: luigi.parameter.Parameter(default='abc', default_callable=lambda: 'xyz'))
+        with self.assertRaises(ParameterException):
+            luigi.parameter.Parameter(default='abc', default_callable=lambda: 'xyz')
 
 
 class TestParametersHashability(LuigiTestCase):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -158,6 +158,19 @@ class ParameterTest(LuigiTestCase):
     def test_default_param(self):
         self.assertEqual(WithDefault().x, 'xyz')
 
+    def test_default_callable_param(self):
+        default_value = 'xyz'
+
+        class CallableDefaultParameterTask(luigi.Task):
+            x = luigi.Parameter(default=lambda: default_value)
+
+        task = CallableDefaultParameterTask()
+        self.assertEqual(task.x, 'xyz')
+
+        default_value = 'abc'
+        self.assertEqual(task.x, 'xyz')
+        self.assertEqual(CallableDefaultParameterTask().x, 'abc')
+
     def test_missing_param(self):
         def create_a():
             return A()

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -158,19 +158,6 @@ class ParameterTest(LuigiTestCase):
     def test_default_param(self):
         self.assertEqual(WithDefault().x, 'xyz')
 
-    def test_default_callable_param(self):
-        default_value = 'xyz'
-
-        class CallableDefaultParameterTask(luigi.Task):
-            x = luigi.Parameter(default=lambda: default_value)
-
-        task = CallableDefaultParameterTask()
-        self.assertEqual(task.x, 'xyz')
-
-        default_value = 'abc'
-        self.assertEqual(task.x, 'xyz')
-        self.assertEqual(CallableDefaultParameterTask().x, 'abc')
-
     def test_missing_param(self):
         def create_a():
             return A()
@@ -319,6 +306,24 @@ class ParameterTest(LuigiTestCase):
     def test_parse_list_as_tuple(self):
         param = luigi.IntParameter(batch_method=tuple)
         self.assertEqual((7, 17, 5), param._parse_list(['7', '17', '5']))
+
+    def test_default_callable_param(self):
+        default_value = 'xyz'
+
+        class CallableDefaultParameterTask(luigi.Task):
+            x = luigi.Parameter(default_callable=lambda: default_value)
+
+        task = CallableDefaultParameterTask()
+        self.assertEqual(task.x, 'xyz')
+
+        default_value = 'abc'
+        self.assertEqual(task.x, 'xyz')
+        self.assertEqual(CallableDefaultParameterTask().x, 'abc')
+
+    def test_both_default_and_default_callable_param(self):
+        self.assertRaises(
+            ParameterException,
+            lambda: luigi.parameter.Parameter(default='abc', default_callable=lambda: 'xyz'))
 
 
 class TestParametersHashability(LuigiTestCase):


### PR DESCRIPTION
## Description
Allow a the default to be specified for a `Parameter` as a `default_callable`. The callable will be executed and the value locked in when a task is initialized, but initializing another task could yield a different value.

## Motivation and Context
Prior to this change, default parameter values are only evaluated when a task class is initially loaded. For defaults such as `datetime.datetime.utcnow()`, this might not always provide the desired flexibility, since running the task again would result in the same datetime value.

In our case, this is a problem because we trigger tasks in a loop with `luigi.build()`, but often find ourselves duplicating parameter `default` definitions in our executor script so we can recalculate it every time and match the behavior of running on the command line. It would be nice to avoid the duplication.

I imagine there may also be cases where a long running worker wouldn't want to be stuck with the same default value.

## Have you tested this? If so, how?
I have included unit tests.
I ran my jobs with this code and it works for me.