### PR TITLE
Make getpaths type-aware, add getpaths test.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -817,18 +817,18 @@ def getpaths(struct):
     if isinstance(struct, Task):
         return struct.output()
     elif isinstance(struct, dict):
-        r = {}
+        r = struct.__class__()
         for k, v in six.iteritems(struct):
             r[k] = getpaths(v)
         return r
+    elif isinstance(struct, (list, tuple)):
+        return struct.__class__(getpaths(r) for r in struct)
     else:
-        # Remaining case: assume r is iterable...
+        # Remaining case: assume struct is iterable...
         try:
-            s = list(struct)
+            return [getpaths(r) for r in struct]
         except TypeError:
             raise Exception('Cannot map %s to Task/dict/list' % str(struct))
-
-        return [getpaths(r) for r in s]
 
 
 def flatten(struct):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -817,10 +817,7 @@ def getpaths(struct):
     if isinstance(struct, Task):
         return struct.output()
     elif isinstance(struct, dict):
-        r = struct.__class__()
-        for k, v in six.iteritems(struct):
-            r[k] = getpaths(v)
-        return r
+        return struct.__class__((k, getpaths(v)) for k, v in six.iteritems(struct))
     elif isinstance(struct, (list, tuple)):
         return struct.__class__(getpaths(r) for r in struct)
     else:

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -82,6 +82,29 @@ class TaskTest(unittest.TestCase):
         task = load_task("luigi", "ExternalTask", {})
         assert(isinstance(task, luigi.ExternalTask))
 
+    def test_getpaths(self):
+        class RequiredTask(luigi.Task):
+            def output(self):
+                return luigi.LocalTarget("/path/to/target/file")
+
+        t = RequiredTask()
+        reqs = {}
+        reqs["bare"] = t
+        reqs["dict"] = {"key": t}
+        reqs["OrderedDict"] = collections.OrderedDict([("key", t)])
+        reqs["list"] = [t]
+        reqs["tuple"] = (t,)
+        reqs["generator"] = (t for _ in range(10))
+
+        struct = luigi.task.getpaths(reqs)
+        self.assertIsInstance(struct, dict)
+        self.assertIsInstance(struct["bare"], luigi.Target)
+        self.assertIsInstance(struct["dict"], dict)
+        self.assertIsInstance(struct["OrderedDict"], collections.OrderedDict)
+        self.assertIsInstance(struct["list"], list)
+        self.assertIsInstance(struct["tuple"], tuple)
+        self.assertIsInstance(struct["generator"], list)
+
     def test_flatten(self):
         flatten = luigi.task.flatten
         self.assertEqual(sorted(flatten({'a': 'foo', 'b': 'bar'})), ['bar', 'foo'])

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -103,7 +103,7 @@ class TaskTest(unittest.TestCase):
         self.assertIsInstance(struct["OrderedDict"], collections.OrderedDict)
         self.assertIsInstance(struct["list"], list)
         self.assertIsInstance(struct["tuple"], tuple)
-        self.assertIsInstance(struct["generator"], list)
+        self.assertTrue(hasattr(struct["generator"], "__iter__"))
 
     def test_flatten(self):
         flatten = luigi.task.flatten


### PR DESCRIPTION
## Description

This PR slightly updates `luigi.task.getpaths` which is used to replace tasks in the structured object returned by `Task.requires` with their respective outputs. The change makes that procedure type-aware, so e.g. when the struct's class is a subclass of dict, the returned struct has the same class.


## Motivation and Context

We often rely on the order in which we define our task requirements, e.g. via an `OrderedDict`. However, when looping over `self.input()`, that order might not be preserved at the moment, because the returned object type is a plain `dict`.


## Tests

I added `task_test.TaskTest.test_getpaths` and checked for several types.
