### PR TITLE
Recursively normalize DictParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -857,11 +857,18 @@ class DictParameter(Parameter):
                 return obj.get_wrapped()
             return json.JSONEncoder.default(self, obj)
 
+    def _normalize_value(self, v):
+        if isinstance(v, Mapping):
+            return self.normalize(v)
+        elif isinstance(v, list):
+            return ListParameter().normalize(v)
+        return v
+
     def normalize(self, value):
         """
         Ensure that dictionary parameter is converted to a _FrozenOrderedDict so it can be hashed.
         """
-        return _FrozenOrderedDict(value)
+        return _FrozenOrderedDict({k: self._normalize_value(v) for k, v in value.items()})
 
     def parse(self, s):
         """

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -782,7 +782,7 @@ class EnumParameter(Parameter):
         return e.name
 
 
-class FrozenOrderedDict(Mapping):
+class _FrozenOrderedDict(Mapping):
     """
     It is an immutable wrapper around ordered dictionaries that implements the complete :py:class:`collections.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability and ordering are desired.
@@ -848,20 +848,20 @@ class DictParameter(Parameter):
     values (like a database connection config).
     """
 
-    class DictParamEncoder(JSONEncoder):
+    class _DictParamEncoder(JSONEncoder):
         """
-        JSON encoder for :py:class:`~DictParameter`, which makes :py:class:`~FrozenOrderedDict` JSON serializable.
+        JSON encoder for :py:class:`~DictParameter`, which makes :py:class:`~_FrozenOrderedDict` JSON serializable.
         """
         def default(self, obj):
-            if isinstance(obj, FrozenOrderedDict):
+            if isinstance(obj, _FrozenOrderedDict):
                 return obj.get_wrapped()
             return json.JSONEncoder.default(self, obj)
 
     def normalize(self, value):
         """
-        Ensure that dictionary parameter is converted to a FrozenOrderedDict so it can be hashed.
+        Ensure that dictionary parameter is converted to a _FrozenOrderedDict so it can be hashed.
         """
-        return FrozenOrderedDict(value)
+        return _FrozenOrderedDict(value)
 
     def parse(self, s):
         """
@@ -874,10 +874,10 @@ class DictParameter(Parameter):
 
         :param s: String to be parse
         """
-        return json.loads(s, object_pairs_hook=FrozenOrderedDict)
+        return json.loads(s, object_pairs_hook=_FrozenOrderedDict)
 
     def serialize(self, x):
-        return json.dumps(x, cls=DictParameter.DictParamEncoder)
+        return json.dumps(x, cls=DictParameter._DictParamEncoder)
 
 
 class ListParameter(Parameter):

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -820,7 +820,7 @@ def _recursively_freeze(value):
     Recursively walks ``Mapping``s and ``list``s and converts them to ``_FrozenOrderedDict`` and ``tuples``, respectively.
     """
     if isinstance(value, Mapping):
-        return _FrozenOrderedDict({k: _recursively_freeze(v) for k, v in value.items()})
+        return _FrozenOrderedDict(((k, _recursively_freeze(v)) for k, v in value.items()))
     elif isinstance(value, list):
         return tuple(_recursively_freeze(v) for v in value)
     return value

--- a/test/dict_parameter_test.py
+++ b/test/dict_parameter_test.py
@@ -58,6 +58,6 @@ class DictParameterTest(unittest.TestCase):
 
     def test_hash_normalize(self):
         self.assertRaises(TypeError, lambda: hash(luigi.DictParameter().parse('{"a": {"b": []}}')))
-        a = luigi.DictParameter().normalize({"a": {"b": []}})
-        b = luigi.DictParameter().normalize({"a": {"b": []}})
+        a = luigi.DictParameter().normalize({"a": [{"b": []}]})
+        b = luigi.DictParameter().normalize({"a": [{"b": []}]})
         self.assertEqual(hash(a), hash(b))

--- a/test/dict_parameter_test.py
+++ b/test/dict_parameter_test.py
@@ -55,3 +55,9 @@ class DictParameterTest(unittest.TestCase):
 
     def test_parse_invalid_input(self):
         self.assertRaises(ValueError, lambda: luigi.DictParameter().parse('{"invalid"}'))
+
+    def test_hash_normalize(self):
+        self.assertRaises(TypeError, lambda: hash(luigi.DictParameter().parse('{"a": {"b": []}}')))
+        a = luigi.DictParameter().normalize({"a": {"b": []}})
+        b = luigi.DictParameter().normalize({"a": {"b": []}})
+        self.assertEqual(hash(a), hash(b))


### PR DESCRIPTION
## Description
This recursively calls normalize on `Mapping`s and `list`s when calling `DictParameter.normalize`.  Also, makes `OrderedFrozenDict` and `DictParameter.DictParamEncoder` private, as requested by @Tarrasch.

## Motivation and Context
Fixes issue #2094.

## Have you tested this? If so, how?
Added a test, but am open to suggestions of better tests.
