### PR TITLE
Check whether renames worked in atomic hdfs pipes

### DIFF
--- a/luigi/contrib/hdfs/format.py
+++ b/luigi/contrib/hdfs/format.py
@@ -3,9 +3,14 @@ import logging
 import os
 from luigi.contrib.hdfs.config import load_hadoop_cmd
 from luigi.contrib.hdfs import config as hdfs_config
-from luigi.contrib.hdfs.clients import remove, rename, mkdir
+from luigi.contrib.hdfs.clients import remove, rename, mkdir, listdir
+from luigi.contrib.hdfs.error import HDFSCliError
 
 logger = logging.getLogger('luigi-interface')
+
+
+class HdfsAtomicWriteError(IOError):
+    pass
 
 
 class HdfsReadPipe(luigi.format.InputPipeProcessWrapper):
@@ -42,7 +47,12 @@ class HdfsAtomicWritePipe(luigi.format.OutputPipeProcessWrapper):
 
     def close(self):
         super(HdfsAtomicWritePipe, self).close()
-        rename(self.tmppath, self.path)
+        try:
+            remove(self.path)
+        except HDFSCliError:
+            pass
+        if not all(result['result'] for result in rename(self.tmppath, self.path) or []):
+            raise HdfsAtomicWriteError('Atomic write to {} failed'.format(self.path))
 
 
 class HdfsAtomicWriteDirPipe(luigi.format.OutputPipeProcessWrapper):
@@ -64,7 +74,18 @@ class HdfsAtomicWriteDirPipe(luigi.format.OutputPipeProcessWrapper):
 
     def close(self):
         super(HdfsAtomicWriteDirPipe, self).close()
-        rename(self.tmppath, self.path)
+        try:
+            remove(self.path)
+        except HDFSCliError:
+            pass
+
+        # it's unlikely to fail in this way but better safe than sorry
+        if not all(result['result'] for result in rename(self.tmppath, self.path) or []):
+            raise HdfsAtomicWriteError('Atomic write to {} failed'.format(self.path))
+
+        if os.path.basename(self.tmppath) in map(os.path.basename, listdir(self.path)):
+            remove(self.path)
+            raise HdfsAtomicWriteError('Atomic write to {} failed'.format(self.path))
 
 
 class PlainFormat(luigi.format.Format):


### PR DESCRIPTION
## Description
Using the snakebite client, renaming a file to an existing file fails without raising an exception. Instead, it returns a list of moves and whether each ones succeeded. This means that when using the snakebite client, atomic writes to existing files fail silently versus failing while throwing an error with the hadoopcli client.

There are two ways to fix this. First, we can simply remove the target file if it already exists. Second, we can ensure that we read the snakebite error and throw it if it happens. This PR does both.

For atomic directory writes, this also adds a check for whether the directory was renamed to the target or moved inside an existing target directory.

## Motivation and Context
As described in #2118, I was having an issue where jobs that seemed to be running correctly were not resulting in updated files. This resolves #2118.

## Have you tested this? If so, how?
I added minicluster unit tests. I have also tested the part of this that removes the target if it exists for the non-directory pipe. The demonstration code works as expected with that added. I added the other fixes after coming up with unit tests.