### PR TITLE
Don’t use cached autoconfig client in config tests

### DIFF
--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -19,6 +19,7 @@ import functools
 import re
 from helpers import unittest
 import random
+import threading
 import pickle
 
 import helpers
@@ -27,6 +28,9 @@ import mock
 import luigi.format
 from luigi.contrib import hdfs
 from luigi import six
+from luigi.contrib.hdfs import SnakebiteHdfsClient
+from luigi.contrib.hdfs.hadoopcli_clients import HdfsClient
+from luigi.contrib.target import CascadingClient
 from minicluster import MiniClusterTestCase
 from nose.plugins.attrib import attr
 import luigi.contrib.hdfs.clients
@@ -75,17 +79,20 @@ class ConfigurationTest(MiniClusterTestCase):
 
     @helpers.with_config({"hdfs": {"client": "hadoopcli"}})
     def test_hadoopcli(self):
-        client = hdfs.get_autoconfig_client()
+        client = hdfs.get_autoconfig_client(threading.local())
+        self.assertTrue(isinstance(client, HdfsClient))
         self.tezt_rename_dont_move(client)
 
     @helpers.with_config({"hdfs": {"client": "snakebite"}})
     def test_snakebite(self):
-        client = hdfs.get_autoconfig_client()
+        client = hdfs.get_autoconfig_client(threading.local())
+        self.assertTrue(isinstance(client, SnakebiteHdfsClient))
         self.tezt_rename_dont_move(client)
 
     @helpers.with_config({"hdfs": {"client": "snakebite_with_hadoopcli_fallback"}})
     def test_snakebite_with_hadoopcli_fallback(self):
-        client = hdfs.get_autoconfig_client()
+        client = hdfs.get_autoconfig_client(threading.local())
+        self.assertTrue(isinstance(client, CascadingClient))
         self.tezt_rename_dont_move(client)
 
 

--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -83,12 +83,14 @@ class ConfigurationTest(MiniClusterTestCase):
         self.assertTrue(isinstance(client, HdfsClient))
         self.tezt_rename_dont_move(client)
 
+    @unittest.skipIf(six.PY3, "snakebite doesn't work on Python 3 yet.")
     @helpers.with_config({"hdfs": {"client": "snakebite"}})
     def test_snakebite(self):
         client = hdfs.get_autoconfig_client(threading.local())
         self.assertTrue(isinstance(client, SnakebiteHdfsClient))
         self.tezt_rename_dont_move(client)
 
+    @unittest.skipIf(six.PY3, "snakebite doesn't work on Python 3 yet.")
     @helpers.with_config({"hdfs": {"client": "snakebite_with_hadoopcli_fallback"}})
     def test_snakebite_with_hadoopcli_fallback(self):
         client = hdfs.get_autoconfig_client(threading.local())


### PR DESCRIPTION
## Description
In hdfs_test.ConfigurationTest, calls to hdfs.get_autoconfig_client return the version cached in the call to setUp. Because this is called before the config is set by the helpers.with_config decorator, this means that the tests aren’t actually testing different configurations.

Luckily, get_autoconfig_client takes an optional argument to specify its cache. When passing a fresh cache, these will actually test what they’re supposed to. This PR passes a fresh cache to get_autoconfig_client in each test.

## Motivation and Context
While working on #2119 I tried copying code from the config tests to get a snakebite client and found that I was still getting the same responses as expected from a hadoop cli client. This is just applying my solution to that problem from #2119 to the config tests so they'll do what they're supposed to.

## Have you tested this? If so, how?
I ran the unit tests with the `isinstance` check added but not the fix and the two that didn't use hadopcli failed. With the fix, they all succeed.