### PR TITLE
AWS_SESSION_Token read from ENV

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -106,7 +106,7 @@ class S3Client(FileSystem):
         role_arn = options.get('aws_role_arn')
         role_session_name = options.get('aws_role_session_name')
 
-        aws_session_token = None
+        aws_session_token = os.environ.get('AWS_SESSION_TOKEN')
 
         if role_arn and role_session_name:
             from boto import sts


### PR DESCRIPTION
Currently, Luigi offers the option to start the process of role assumption if `aws_role_arn` and `aws_role_session_name` are provided in the config. In production, sometimes the `sts:assumeRole` is given to the ec2/ecs resources and the access key, secret and session token are available as an env variables, instead of config.

The current setup forces the session token to be `None` which doesn't allow for this scenario:
- assume-role has been called from outside luigi and the temporary auth keys and session token are available as env variables.

