### PR TITLE
dataproc: more consistently get authentication arguments

### DIFF
--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -4,19 +4,20 @@ import os
 import time
 import logging
 import luigi
+from luigi.contrib import gcp
 
 logger = logging.getLogger('luigi-interface')
 
 _dataproc_client = None
 
 try:
-    import httplib2
     import oauth2client.client
     from googleapiclient import discovery
     from googleapiclient.errors import HttpError
 
     DEFAULT_CREDENTIALS = oauth2client.client.GoogleCredentials.get_application_default()
-    _dataproc_client = discovery.build('dataproc', 'v1', credentials=DEFAULT_CREDENTIALS, http=httplib2.Http())
+    authenticate_kwargs = gcp.get_authenticate_kwargs(DEFAULT_CREDENTIALS)
+    _dataproc_client = discovery.build('dataproc', 'v1', **authenticate_kwargs)
 except ImportError:
     logger.warning("Loading Dataproc module without the python packages googleapiclient & oauth2client. \
         This will crash at runtime if Dataproc functionality is used.")

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -7,12 +7,11 @@ import unittest
 
 try:
     import oauth2client
-    import httplib2
     from luigi.contrib import dataproc
     from googleapiclient import discovery
 
     default_credentials = oauth2client.client.GoogleCredentials.get_application_default()
-    default_client = discovery.build('dataproc', 'v1', credentials=default_credentials, http=httplib2.Http())
+    default_client = discovery.build('dataproc', 'v1', credentials=default_credentials)
     dataproc.set_dataproc_client(default_client)
 except ImportError:
     raise unittest.SkipTest('Unable to load google cloud dependencies')


### PR DESCRIPTION
Arguments `http` and `credentials` are mutually exclusive as of https://github.com/google/google-api-python-client/pull/319.

This makes the gcloud integration tests pass for me. (They have been disabled on Travis for long because of another reason, still unfixed I guess, https://github.com/spotify/luigi/pull/1931.)
