### PR TITLE
Url fixes

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -899,6 +899,8 @@ function visualiserApp(luigi) {
 
                 if (data.search.search) {
                     state.search__search = data.search.search;
+                } else {
+                    delete state.search__search;
                 }
 
                 if (data.order && data.order.length) {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -478,6 +478,7 @@ function visualiserApp(luigi) {
         $('#serverSideCheckbox').click(function(e) {
             e.preventDefault();
             changeState('filterOnServer', this.checked ? '1' : null);
+            updateTasks();
         });
 
         $("#invertCheckbox").click(function(e) {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -413,7 +413,7 @@ function visualiserApp(luigi) {
             if (taskId) {
                 var depGraphCallback = makeGraphCallback(fragmentQuery.visType, taskId, paint);
 
-                if (fragmentQuery.invertDependencies) {
+                if (fragmentQuery.invert) {
                     luigi.getInverseDependencyGraph(taskId, depGraphCallback, !hideDone);
                 } else {
                     luigi.getDependencyGraph(taskId, depGraphCallback, !hideDone);


### PR DESCRIPTION
## Description
Fix a few bugs with how state is stored in the URL:
- Check the correct value for inverting the graph so the graph will actually invert when the box is checked
- Update tasks when the server side checkbox is clicked instead of just updating the URL so it works without having to refresh
- Remove the search query from the url when it's deleted so it matches the current state

## Motivation and Context
I just merged the trunk into my branch and noticed these tiny bugs all related to the same updates.

## Have you tested this? If so, how?
Ran locally and in production, these bugs are gone now.