### PR TITLE
Set hideDone on in graph links

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -239,7 +239,7 @@
 
         <script type="text/template" name="actionsTemplate">
             <div class="span2">
-                <a href="#tab=graph&taskId={{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip"><i class="fa fa-sitemap"></i></a>
+                <a href="#tab=graph&taskId={{encodedTaskId}}&hideDone=1" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip"><i class="fa fa-sitemap"></i></a>
                 {{#error}}<button class="btn btn-danger btn-xs showError" title="Show error" data-toggle="tooltip"><i class="fa fa-bug"></i></button>{{/error}}
                 {{#error}}<button class="btn btn-warning btn-xs forgiveFailures" title="Forgive failures" data-toggle="tooltip"><i class="fa fa-ambulance"></i></button>{{/error}}
                 {{#re_enable}}<a class="btn btn-warning btn-xs re-enable-button" title="Re-enable" data-toggle="tooltip" data-task-id="{{taskId}}">Re-enable</a>{{/re_enable}}


### PR DESCRIPTION
# Description
We used to have hideDone set by default, as this default can prevent large graphs from freezing the visualiser. This went away when we moved to storing the checkbox state in the URL bar, but we have an easy fix by adding it to the link.

## Motivation and Context
I tend to have large graphs where most items are done, so this feature is the difference between a near-immediate response and a delay of tens of seconds or minutes. We used to have this feature, it seems to have been an accidental removal.

## Have you tested this? If so, how?
I used this locally and in production and it works.