### PR TITLE
Set hideDone in worker root task links

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -366,7 +366,7 @@
                 <div class="box-body">
                     Started: {{start_time}}<br>
                     Last Checkin: {{active}}<br>
-                    Root Task: <a href="#tab=graph&taskId={{{encoded_first_task}}}">{{first_task_display_name}}</a><br>
+                    Root Task: <a href="#tab=graph&taskId={{{encoded_first_task}}}&hideDone=1">{{first_task_display_name}}</a><br>
                     Running: {{num_running}}<br>
                     Pending: {{num_pending}}<br>
                     Unique Pending: {{num_uniques}}<br>


### PR DESCRIPTION
## Description
Root tasks have the largest possible graphs, so it's especially important to ensure that we minimize these by default.

## Motivation and Context
Same as #2125, I just missed the links in the worker tab last time.

## Have you tested this? If so, how?
I tried this in my production instance.