### PR TITLE
Remember family and status

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -513,7 +513,7 @@
                 </nav>
             </div>
             <div class="main-sidebar">
-                <div class="sidebar">
+                <div class="sidebar" id="familySidebar">
                 </div>
             </div>
 

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -431,6 +431,16 @@ function visualiserApp(luigi) {
             }
             $("#serverSideCheckbox").prop('checked', fragmentQuery.filterOnServer === '1' ? true : false);
             dt.search(fragmentQuery.search__search);
+
+            $('#familySidebar li').removeClass('active');
+            $('#familySidebar li .badge').removeClass('bg-green');
+            if (fragmentQuery.family) {
+                family_item = $('#familySidebar li[data-task="' + fragmentQuery.family + '"]');
+                family_item.addClass('active');
+                family_item.find('.badge').addClass('bg-green');
+                filterByTaskFamily(fragmentQuery.family, dt);
+            }
+
             if (fragmentQuery.order) {
                 dt.order = [fragmentQuery.order.split(',')];
             }
@@ -810,6 +820,8 @@ function visualiserApp(luigi) {
             else {
                 $('#warnings').html(renderWarnings());
             }
+
+            processHashChange();
         });
     }
 
@@ -903,6 +915,13 @@ function visualiserApp(luigi) {
                     delete state.search__search;
                 }
 
+                var family_search = data.columns[1].search.search;
+                if (family_search) {
+                    state.family = family_search.substring(1, family_search.length - 1);
+                } else {
+                    delete state.family;
+                }
+
                 if (data.order && data.order.length) {
                     state.order = '' + data.order[0][0] + ',' + data.order[0][1];
                 }
@@ -926,6 +945,11 @@ function visualiserApp(luigi) {
                     order = [fragmentQuery.order.split(',')];
                 }
 
+                var family_search = {};
+                if (fragmentQuery.family) {
+                    family_search = {'search': '^' + fragmentQuery.family + '$', 'regex': true};
+                }
+
                 // Prepare state for datatable.
                 var o = {
                     order: order,                 // Table rows order.
@@ -934,7 +958,7 @@ function visualiserApp(luigi) {
                     time: new Date().getTime(),   // Current time to help datatable.js to handle asynchronous.
                     columns: [
                         {visible: true, search: {}},
-                        {visible: true, search: {}},  // Name column
+                        {visible: true, search: family_search},  // Name column
                         {visible: true, search: {}},  // Details column
                         {visible: true, search: {}},  // Priority column
                         {visible: true, search: {}},  // Time column
@@ -943,7 +967,9 @@ function visualiserApp(luigi) {
                     // Search input state.
                     search: {
                         caseInsensitive: true,
-                        search: fragmentQuery.search__search}};
+                        search: fragmentQuery.search__search
+                    }
+                };
 
                 return o;
             },
@@ -1122,6 +1148,13 @@ function visualiserApp(luigi) {
 
                 if ($('#serverSideCheckbox').is(':checked')) {
                     state.filterOnServer = '1';
+                }
+
+                var family = $('#familySidebar li.active').attr('data-task')
+                if (family) {
+                    state.family = family;
+                } else {
+                    delete state.family;
                 }
 
                 if (search) {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -122,7 +122,20 @@ function visualiserApp(luigi) {
     /**
      * Filter table by all activated info boxes.
      */
-    function filterByCategory(dt) {
+    function filterByCategory(dt, activeBoxes) {
+        if (activeBoxes === undefined) {
+            activeBoxes = getActiveBoxes();
+        }
+        currentFilter.taskCategory = activeBoxes;
+        dt.column(0).search(categoryQuery(activeBoxes), regex=true).draw();
+    }
+
+    function categoryQuery(activeBoxes) {
+        // Searched content will be <icon> <category>.
+        return '\\b(' + activeBoxes.join('|') + ')\\b';
+    }
+
+    function getActiveBoxes() {
         var infoBoxes = $('.info-box');
 
         var activeBoxes = [];
@@ -131,10 +144,7 @@ function visualiserApp(luigi) {
                 activeBoxes.push(infoBoxes[i].dataset.category);
             }
         });
-        // Searched content will be <icon> <category>.
-        var pattern = '\\b(' + activeBoxes.join('|') + ')\\b';
-        currentFilter.taskCategory = activeBoxes;
-        dt.column(0).search(pattern, regex=true).draw();
+        return activeBoxes;
     }
 
     function filterByTaskFamily(taskFamily, dt) {
@@ -147,12 +157,12 @@ function visualiserApp(luigi) {
         }
     }
 
-    function toggleInfoBox(infoBox) {
+    function toggleInfoBox(infoBox, activate) {
         var infoBoxColor = infoBox.dataset.color;
         var infoBoxIcon = $(infoBox).find('.info-box-icon');
         var colorClass = 'bg-' + infoBoxColor;
 
-        if ((infoBox.dataset.on === undefined) || (infoBox.dataset.on === 'no')) {
+        if ((infoBox.dataset.on === undefined) || (infoBox.dataset.on === 'no') || activate) {
             infoBox.dataset.on = 'yes';
             infoBoxIcon.removeClass(colorClass);
             $(infoBox).addClass(colorClass);
@@ -439,6 +449,14 @@ function visualiserApp(luigi) {
                 family_item.addClass('active');
                 family_item.find('.badge').addClass('bg-green');
                 filterByTaskFamily(fragmentQuery.family, dt);
+            }
+
+            if (fragmentQuery.statuses) {
+                var statuses = JSON.parse(fragmentQuery.statuses);
+                $.each(statuses, function (status) {
+                    toggleInfoBox($('#' + statuses[status] + '_info')[0], true);
+                });
+                filterByCategory(dt, statuses);
             }
 
             if (fragmentQuery.order) {
@@ -922,6 +940,12 @@ function visualiserApp(luigi) {
                     delete state.family;
                 }
 
+                if (currentFilter.taskCategory.length > 0) {
+                    state.statuses = JSON.stringify(currentFilter.taskCategory);
+                } else {
+                    delete state.statuses;
+                }
+
                 if (data.order && data.order.length) {
                     state.order = '' + data.order[0][0] + ',' + data.order[0][1];
                 }
@@ -950,6 +974,13 @@ function visualiserApp(luigi) {
                     family_search = {'search': '^' + fragmentQuery.family + '$', 'regex': true};
                 }
 
+                var status_search = {};
+                if (fragmentQuery.statuses) {
+                    var statuses = JSON.parse(fragmentQuery.statuses);
+                    currentFilter.taskCategory = statuses;
+                    status_search = {'search': categoryQuery(statuses), 'regex': true};
+                }
+
                 // Prepare state for datatable.
                 var o = {
                     order: order,                 // Table rows order.
@@ -957,7 +988,7 @@ function visualiserApp(luigi) {
                     start: 0,                     // Pagination initial page.
                     time: new Date().getTime(),   // Current time to help datatable.js to handle asynchronous.
                     columns: [
-                        {visible: true, search: {}},
+                        {visible: true, search: status_search},
                         {visible: true, search: family_search},  // Name column
                         {visible: true, search: {}},  // Details column
                         {visible: true, search: {}},  // Priority column
@@ -1155,6 +1186,12 @@ function visualiserApp(luigi) {
                     state.family = family;
                 } else {
                     delete state.family;
+                }
+
+                if (currentFilter.taskCategory.length > 0) {
+                    state.statuses = currentFilter.taskCategory;
+                } else {
+                    delete state.statuses;
                 }
 
                 if (search) {


### PR DESCRIPTION
## Description
Remember status and task family selectors from the tasks page in the visualiser in the url hash.

## Motivation and Context
Now that the search query is stored, it would be nicer if the rest of the filters could be sent in links and survive refreshes too.

## Have you tested this? If so, how?
It's working for me in production right now. Tested on chrome and firefox. I'm not 100% sure about this code but I tried my best to find any corner cases where it might break.