### PR TITLE
Remove length from state when it equals default

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -910,6 +910,8 @@ function visualiserApp(luigi) {
                 if (data.length && data.length !== 10) {
                     // Keep in hash only if length is not default.
                     state.length = data.length;
+                } else {
+                    delete state.length;
                 }
 
                 if (state.filterOnServer) {


### PR DESCRIPTION
## Description
Delete the length from the url hash when it's default.

## Motivation and Context
We previously just didn't set the default value, but this would result in a non-default value being preserved in the hash after you set to the default value.

## Have you tested this? If so, how?
Ran this locally and in production.