### PR TITLE
Clean up unittest deprecations and warnings

### DIFF
--- a/examples/ssh_remote_execution.py
+++ b/examples/ssh_remote_execution.py
@@ -23,7 +23,7 @@ from luigi import six
 
 import luigi
 from luigi.contrib.ssh import RemoteContext, RemoteTarget
-from luigi.mock import MockFile
+from luigi.mock import MockTarget
 
 SSH_HOST = "some.accessible.host"
 
@@ -58,7 +58,7 @@ class ProcessRemoteData(luigi.Task):
     """
     Create a toplist of users based on how many running processes they have on a remote machine.
 
-    In this example the processed data is stored in a MockFile.
+    In this example the processed data is stored in a MockTarget.
     """
 
     def requires(self):
@@ -96,4 +96,4 @@ class ProcessRemoteData(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`~luigi.target.Target`)
         """
-        return MockFile("output", mirror_on_stderr=True)
+        return MockTarget("output", mirror_on_stderr=True)

--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -83,11 +83,11 @@ modified example would look as shown below:
     from sqlalchemy import String
     import luigi
     from luigi.contrib import sqla
-    from luigi.mock import MockFile
+    from luigi.mock import MockTarget
 
     class BaseTask(luigi.Task):
         def output(self):
-            return MockFile("BaseTask")
+            return MockTarget("BaseTask")
 
         def run(self):
             out = self.output().open("w")

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -26,8 +26,6 @@ import os
 import sys
 from subprocess import Popen, PIPE
 
-from luigi import six
-
 
 def getpcmd(pid):
     """

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -63,7 +63,7 @@ def getpcmd(pid):
         # https://github.com/spotify/luigi/pull/1876
         try:
             with open('/proc/{0}/cmdline'.format(pid), 'r') as fh:
-                return fh.read().replace('\0', ' ').rstrip()
+                return fh.read().replace('\0', ' ').decode('utf8').rstrip()
         except IOError:
             # the system may not allow reading the command line
             # of a process owned by another user

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -26,6 +26,8 @@ import os
 import sys
 from subprocess import Popen, PIPE
 
+from luigi import six
+
 
 def getpcmd(pid):
     """
@@ -62,8 +64,11 @@ def getpcmd(pid):
         # worked. See the pull request at
         # https://github.com/spotify/luigi/pull/1876
         try:
-            with open('/proc/{0}/cmdline'.format(pid), 'rb') as fh:
-                return fh.read().replace('\0', ' ').decode('utf8').rstrip()
+            with open('/proc/{0}/cmdline'.format(pid), 'r') as fh:
+                if six.PY3:
+                    return fh.read().replace('\0', ' ').rstrip()
+                else:
+                    return fh.read().replace('\0', ' ').decode('utf8').rstrip()
         except IOError:
             # the system may not allow reading the command line
             # of a process owned by another user

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -23,6 +23,8 @@ from __future__ import print_function
 
 import hashlib
 import os
+import sys
+from subprocess import Popen, PIPE
 
 from luigi import six
 
@@ -41,6 +43,20 @@ def getpcmd(pid):
             if lines:
                 _, val = lines
                 return val
+    elif sys.platform == "darwin":
+        # Use pgrep instead of /proc on macOS.
+        pidfile = ".%d.pid" % (pid, )
+        with open(pidfile, 'w') as f:
+            f.write(str(pid))
+        try:
+            p = Popen(['pgrep', '-lf', '-F', pidfile], stdout=PIPE)
+            stdout, _ = p.communicate()
+            line = stdout.decode('utf8').strip()
+            if line:
+                _, scmd = line.split(' ', 1)
+                return scmd
+        finally:
+            os.unlink(pidfile)
     else:
         # Use the /proc filesystem
         # At least on android there have been some issues with not all
@@ -65,12 +81,7 @@ def get_info(pid_dir, my_pid=None):
         my_pid = os.getpid()
 
     my_cmd = getpcmd(my_pid)
-
-    if six.PY3:
-        cmd_hash = my_cmd.encode('utf8')
-    else:
-        cmd_hash = my_cmd
-
+    cmd_hash = my_cmd.encode('utf8')
     pid_file = os.path.join(pid_dir, hashlib.md5(cmd_hash).hexdigest()) + '.pid'
 
     return my_pid, my_cmd, pid_file

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -62,7 +62,7 @@ def getpcmd(pid):
         # worked. See the pull request at
         # https://github.com/spotify/luigi/pull/1876
         try:
-            with open('/proc/{0}/cmdline'.format(pid), 'r') as fh:
+            with open('/proc/{0}/cmdline'.format(pid), 'rb') as fh:
                 return fh.read().replace('\0', ' ').decode('utf8').rstrip()
         except IOError:
             # the system may not allow reading the command line

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -122,7 +122,7 @@ class BigQueryTest(unittest.TestCase):
         TestRunQueryTask.client = client
 
         complete = list(TestRunQueryTask.bulk_complete(parameters))
-        self.assertEquals(complete, ['table2'])
+        self.assertEqual(complete, ['table2'])
 
     def test_dataset_doesnt_exist(self):
         client = MagicMock()
@@ -130,7 +130,7 @@ class BigQueryTest(unittest.TestCase):
         TestRunQueryTask.client = client
 
         complete = list(TestRunQueryTask.bulk_complete(['table1']))
-        self.assertEquals(complete, [])
+        self.assertEqual(complete, [])
 
     def test_query_property(self):
         task = TestRunQueryTask(table='table2')

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -75,7 +75,7 @@ class DataprocTaskTest(_DataprocBaseTestCase):
             .list(projectId=PROJECT_ID, region=REGION, clusterName=CLUSTER_NAME).execute()
         lastJob = response['jobs'][0]['sparkJob']
 
-        self.assertEquals(lastJob['mainClass'], "my.MinimalMainClass")
+        self.assertEqual(lastJob['mainClass'], "my.MinimalMainClass")
 
     def test_4_submit_spark_job(self):
         # The job itself will fail because the job files don't exist
@@ -95,9 +95,9 @@ class DataprocTaskTest(_DataprocBaseTestCase):
             .list(projectId=PROJECT_ID, region=REGION, clusterName=CLUSTER_NAME).execute()
         lastJob = response['jobs'][0]['sparkJob']
 
-        self.assertEquals(lastJob['mainClass'], "my.MainClass")
-        self.assertEquals(lastJob['jarFileUris'], ["one.jar", "two.jar"])
-        self.assertEquals(lastJob['args'], ["foo", "bar"])
+        self.assertEqual(lastJob['mainClass'], "my.MainClass")
+        self.assertEqual(lastJob['jarFileUris'], ["one.jar", "two.jar"])
+        self.assertEqual(lastJob['args'], ["foo", "bar"])
 
     def test_5_submit_pyspark_job(self):
         # The job itself will fail because the job files don't exist
@@ -117,9 +117,9 @@ class DataprocTaskTest(_DataprocBaseTestCase):
             .list(projectId=PROJECT_ID, region=REGION, clusterName=CLUSTER_NAME).execute()
         lastJob = response['jobs'][0]['pysparkJob']
 
-        self.assertEquals(lastJob['mainPythonFileUri'], "main_job.py")
-        self.assertEquals(lastJob['pythonFileUris'], ["extra1.py", "extra2.py"])
-        self.assertEquals(lastJob['args'], ["foo", "bar"])
+        self.assertEqual(lastJob['mainPythonFileUri'], "main_job.py")
+        self.assertEqual(lastJob['pythonFileUris'], ["extra1.py", "extra2.py"])
+        self.assertEqual(lastJob['args'], ["foo", "bar"])
 
     def test_6_delete_cluster(self):
         success = luigi.run(['--local-scheduler',

--- a/test/contrib/external_program_test.py
+++ b/test/contrib/external_program_test.py
@@ -197,7 +197,7 @@ class ExternalPythonProgramTaskTest(unittest.TestCase):
         self.assertTrue(proc_env['PATH'].startswith('/path/to/venv/bin'))
         self.assertTrue(proc_env['PATH'].endswith('/base/path'))
         self.assertIn('VIRTUAL_ENV', proc_env)
-        self.assertEquals(proc_env['VIRTUAL_ENV'], '/path/to/venv')
+        self.assertEqual(proc_env['VIRTUAL_ENV'], '/path/to/venv')
 
     @patch.dict('os.environ', {}, clear=True)
     @patch('luigi.contrib.external_program.subprocess.Popen')

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -288,7 +288,7 @@ class TestS3Client(unittest.TestCase):
         tmp_file_path = tmp_file.name
 
         s3_client.get('s3://mybucket/putMe', tmp_file_path)
-        self.assertEquals(tmp_file.read(), self.tempFileContents)
+        self.assertEqual(tmp_file.read(), self.tempFileContents)
 
         tmp_file.close()
 
@@ -300,7 +300,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe')
 
-        self.assertEquals(contents, self.tempFileContents)
+        self.assertEqual(contents, self.tempFileContents)
 
     def test_get_key(self):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -438,7 +438,6 @@ class TestS3Client(unittest.TestCase):
         """
         self._run_copy_test(self.test_put_multipart_empty_file)
 
-    @unittest.skip("bug in moto 0.4.21 causing failure: https://github.com/spulec/moto/issues/526")
     def test_copy_multipart_multiple_parts_non_exact_fit(self):
         """
         Test a multipart copy with two parts, where the parts are not exactly the split size.
@@ -446,7 +445,6 @@ class TestS3Client(unittest.TestCase):
         # First, put a file into S3
         self._run_multipart_copy_test(self.test_put_multipart_multiple_parts_non_exact_fit)
 
-    @unittest.skip("bug in moto 0.4.21 causing failure: https://github.com/spulec/moto/issues/526")
     def test_copy_multipart_multiple_parts_exact_fit(self):
         """
         Test a multipart copy with multiple parts, where the parts are exactly the split size.

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -64,9 +64,13 @@ def mocked_open(*args, **kwargs):
 class TestSalesforceAPI(unittest.TestCase):
     # We patch 'requests.get' with our own method. The mock object is passed in to our test case method.
     @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_deprecated_results(self, mock_get):
+    def test_deprecated_results_warning(self, mock_get):
         sf = SalesforceAPI('xx', 'xx', 'xx')
-        result_id = sf.get_batch_results('job_id', 'batch_id')
+        if PY3:
+            with self.assertWarnsRegex(UserWarning, r'get_batch_results is deprecated'):
+                result_id = sf.get_batch_results('job_id', 'batch_id')
+        else:
+            result_id = sf.get_batch_results('job_id', 'batch_id')
         self.assertEqual('1234', result_id)
 
     @mock.patch('requests.get', side_effect=mocked_requests_get)

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -29,7 +29,7 @@ from luigi import six
 import luigi
 import sqlalchemy
 from luigi.contrib import sqla
-from luigi.mock import MockFile
+from luigi.mock import MockTarget
 from nose.plugins.attrib import attr
 from helpers import skipOnTravis
 
@@ -42,7 +42,7 @@ class BaseTask(luigi.Task):
     TASK_LIST = ["item%d\tproperty%d\n" % (i, i) for i in range(10)]
 
     def output(self):
-        return MockFile("BaseTask", mirror_on_stderr=True)
+        return MockTarget("BaseTask", mirror_on_stderr=True)
 
     def run(self):
         out = self.output().open("w")
@@ -268,7 +268,7 @@ class TestSQLA(unittest.TestCase):
         class ModBaseTask(luigi.Task):
 
             def output(self):
-                return MockFile("ModBaseTask", mirror_on_stderr=True)
+                return MockTarget("ModBaseTask", mirror_on_stderr=True)
 
             def run(self):
                 out = self.output().open("w")
@@ -302,7 +302,7 @@ class TestSQLA(unittest.TestCase):
         class ModBaseTask(luigi.Task):
 
             def output(self):
-                return MockFile("BaseTask", mirror_on_stderr=True)
+                return MockTarget("BaseTask", mirror_on_stderr=True)
 
             def run(self):
                 out = self.output().open("w")

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -20,6 +20,7 @@ from helpers import unittest, in_parse
 
 import luigi
 import luigi.interface
+from luigi import six
 
 
 class DateTask(luigi.Task):
@@ -92,7 +93,11 @@ class DateMinuteParameterTest(unittest.TestCase):
         self.assertEqual(dm, datetime.datetime(2013, 2, 1, 18, 7, 0))
 
     def test_parse_deprecated(self):
-        dm = luigi.DateMinuteParameter().parse('2013-02-01T18H42')
+        if six.PY3:
+            with self.assertWarnsRegex(DeprecationWarning, 'Using "H" between hours and minutes is deprecated, omit it instead.'):
+                dm = luigi.DateMinuteParameter().parse('2013-02-01T18H42')
+        else:
+            dm = luigi.DateMinuteParameter().parse('2013-02-01T18H42')
         self.assertEqual(dm, datetime.datetime(2013, 2, 1, 18, 42, 0))
 
     def test_serialize(self):

--- a/test/execution_summary_test.py
+++ b/test/execution_summary_test.py
@@ -286,7 +286,7 @@ class ExecutionSummaryTest(LuigiTestCase):
         for i, line in enumerate(result):
             self.assertEqual(line, expected[i])
 
-    @with_config({'execution_summary': {'summary-length': '1'}})
+    @with_config({'execution_summary': {'summary_length': '1'}})
     def test_config_summary_limit(self):
         class Bar(luigi.Task):
             num = luigi.IntParameter()

--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -50,10 +50,12 @@ class LockTest(unittest.TestCase):
         os.rmdir(self.pid_dir)
 
     def test_get_info(self):
-        p = subprocess.Popen(["yes", "à我ф"], stdout=subprocess.PIPE)
-        pid, cmd, pid_file = luigi.lock.get_info(self.pid_dir, p.pid)
-        p.kill()
-        self.assertEqual(cmd, 'yes à我ф')
+        try:
+            p = subprocess.Popen(["yes", u"à我ф"], stdout=subprocess.PIPE)
+            pid, cmd, pid_file = luigi.lock.get_info(self.pid_dir, p.pid)
+        finally:
+            p.kill()
+        self.assertEqual(cmd, u'yes à我ф')
 
     def test_acquiring_free_lock(self):
         acquired = luigi.lock.acquire_for(self.pid_dir)

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from helpers import unittest
 
 from luigi.mock import MockTarget, MockFileSystem
+from luigi import six
 
 
 class MockFileTest(unittest.TestCase):
@@ -98,4 +99,8 @@ class TestImportMockFile(unittest.TestCase):
 
     def test_mockfile(self):
         from luigi.mock import MockFile
-        self.assertTrue(isinstance(MockFile('foo'), MockTarget))
+        if six.PY3:
+            with self.assertWarnsRegex(DeprecationWarning, r'MockFile has been renamed MockTarget'):
+                self.assertTrue(isinstance(MockFile('foo'), MockTarget))
+        else:
+            self.assertTrue(isinstance(MockFile('foo'), MockTarget))

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -33,7 +33,7 @@ class TestEmail(unittest.TestCase):
     def testEmailNoPrefix(self):
         self.assertEqual("subject", notifications._prefix('subject'))
 
-    @with_config({"core": {"email-prefix": "[prefix]"}})
+    @with_config({"email": {"prefix": "[prefix]"}})
     def testEmailPrefix(self):
         self.assertEqual("[prefix] subject", notifications._prefix('subject'))
 
@@ -87,8 +87,8 @@ class ExceptionFormatTest(unittest.TestCase):
         task = FailSchedulingTask(foo='foo', bar='bar')
         self._run_task_html(task)
 
-    @with_config({'core': {'error-email': 'nowhere@example.com',
-                           'email-prefix': '[TEST] '}})
+    @with_config({'email': {'receiver': 'nowhere@example.com',
+                            'prefix': '[TEST] '}})
     @mock.patch('luigi.notifications.send_error_email')
     def _run_task(self, task, mock_send):
         with Worker(scheduler=self.sch) as w:
@@ -100,9 +100,9 @@ class ExceptionFormatTest(unittest.TestCase):
         self._check_subject(args[0], task)
         self._check_body(args[1], task, html=False)
 
-    @with_config({'core': {'error-email': 'nowhere@axample.com',
-                           'email-prefix': '[TEST] ',
-                           'email-type': 'html'}})
+    @with_config({'email': {'receiver': 'nowhere@axample.com',
+                            'prefix': '[TEST] ',
+                            'format': 'html'}})
     @mock.patch('luigi.notifications.send_error_email')
     def _run_task_html(self, task, mock_send):
         with Worker(scheduler=self.sch) as w:
@@ -133,14 +133,14 @@ class ExceptionFormatTest(unittest.TestCase):
             for param, value in task.param_kwargs.items():
                 self.assertIn('{}: {}\n'.format(param, value), body)
 
-    @with_config({"core": {"error-email": "a@a.a"}})
+    @with_config({"email": {"receiver": "a@a.a"}})
     def testEmailRecipients(self):
         six.assertCountEqual(self, notifications._email_recipients(), ["a@a.a"])
         six.assertCountEqual(self, notifications._email_recipients("b@b.b"), ["a@a.a", "b@b.b"])
         six.assertCountEqual(self, notifications._email_recipients(["b@b.b", "c@c.c"]),
                              ["a@a.a", "b@b.b", "c@c.c"])
 
-    @with_config({"core": {}}, replace_sections=True)
+    @with_config({"email": {}}, replace_sections=True)
     def testEmailRecipientsNoConfig(self):
         six.assertCountEqual(self, notifications._email_recipients(), [])
         six.assertCountEqual(self, notifications._email_recipients("a@a.a"), ["a@a.a"])
@@ -190,17 +190,17 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
     def tearDown(self):
         del sys.modules['smtplib']
 
-    @with_config({"core": {"smtp_ssl": "False",
-                           "smtp_host": "my.smtp.local",
-                           "smtp_port": "999",
-                           "smtp_local_hostname": "ptms",
-                           "smtp_timeout": "1200",
-                           "smtp_login": "Robin",
-                           "smtp_password": "dooH",
-                           "smtp_without_tls": "False"}})
+    @with_config({"smtp": {"ssl": "False",
+                           "host": "my.smtp.local",
+                           "port": "999",
+                           "local_hostname": "ptms",
+                           "timeout": "1200",
+                           "username": "Robin",
+                           "password": "dooH",
+                           "no_tls": "False"}})
     def test_sends_smtp_email(self):
         """
-        Call notificaions.send_email_smtp with fixture parameters with smtp_without_tls  set to False
+        Call notifications.send_email_smtp with fixture parameters with smtp_without_tls  set to False
         and check that sendmail is properly called.
         """
 
@@ -223,17 +223,17 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
                     .assert_called_once_with(self.sender, self.recipients,
                                              self.mocked_email_msg)
 
-    @with_config({"core": {"smtp_ssl": "False",
-                           "smtp_host": "my.smtp.local",
-                           "smtp_port": "999",
-                           "smtp_local_hostname": "ptms",
-                           "smtp_timeout": "1200",
-                           "smtp_login": "Robin",
-                           "smtp_password": "dooH",
-                           "smtp_without_tls": "True"}})
+    @with_config({"smtp": {"ssl": "False",
+                           "host": "my.smtp.local",
+                           "port": "999",
+                           "local_hostname": "ptms",
+                           "timeout": "1200",
+                           "username": "Robin",
+                           "password": "dooH",
+                           "no_tls": "True"}})
     def test_sends_smtp_email_without_tls(self):
         """
-        Call notificaions.send_email_smtp with fixture parameters with smtp_without_tls  set to True
+        Call notifications.send_email_smtp with fixture parameters with no_tls  set to True
         and check that sendmail is properly called without also calling
         starttls.
         """
@@ -256,17 +256,17 @@ class TestSMTPEmail(unittest.TestCase, NotificationFixture):
                     .assert_called_once_with(self.sender, self.recipients,
                                              self.mocked_email_msg)
 
-    @with_config({"core": {"smtp_ssl": "False",
-                           "smtp_host": "my.smtp.local",
-                           "smtp_port": "999",
-                           "smtp_local_hostname": "ptms",
-                           "smtp_timeout": "1200",
-                           "smtp_login": "Robin",
-                           "smtp_password": "dooH",
-                           "smtp_without_tls": "True"}})
+    @with_config({"smtp": {"ssl": "False",
+                           "host": "my.smtp.local",
+                           "port": "999",
+                           "local_hostname": "ptms",
+                           "timeout": "1200",
+                           "username": "Robin",
+                           "password": "dooH",
+                           "no_tls": "True"}})
     def test_sends_smtp_email_exceptions(self):
         """
-        Call notificaions.send_email_smtp when it cannot connect to smtp server (socket.error)
+        Call notifications.send_email_smtp when it cannot connect to smtp server (socket.error)
         starttls.
         """
         smtp_kws = {"host": "my.smtp.local",
@@ -302,11 +302,11 @@ class TestSendgridEmail(unittest.TestCase, NotificationFixture):
     def tearDown(self):
         del sys.modules['sendgrid']
 
-    @with_config({"email": {"SENDGRID_USERNAME": "Nikola",
-                            "SENDGRID_PASSWORD": "jahuS"}})
+    @with_config({"sendgrid": {"username": "Nikola",
+                               "password": "jahuS"}})
     def test_sends_sendgrid_email(self):
         """
-        Call notificaions.send_email_sendgrid with fixture parameters
+        Call notifications.send_email_sendgrid with fixture parameters
         and check that SendGridClient is properly called.
         """
 
@@ -332,7 +332,7 @@ class TestSESEmail(unittest.TestCase, NotificationFixture):
     @with_config({})
     def test_sends_ses_email(self):
         """
-        Call notificaions.send_email_ses with fixture parameters
+        Call notifications.send_email_ses with fixture parameters
         and check that boto is properly called.
         """
 
@@ -365,7 +365,7 @@ class TestSNSNotification(unittest.TestCase, NotificationFixture):
     @with_config({})
     def test_sends_sns_email(self):
         """
-        Call notificaions.send_email_sns with fixture parameters
+        Call notifications.send_email_sns with fixture parameters
         and check that boto3 is properly called.
         """
 
@@ -380,7 +380,7 @@ class TestSNSNotification(unittest.TestCase, NotificationFixture):
     @with_config({})
     def test_sns_subject_is_shortened(self):
         """
-        Call notificaions.send_email_sns with too long Subject (more than 100 chars)
+        Call notifications.send_email_sns with too long Subject (more than 100 chars)
         and check that it is cut to lenght of 100 chars.
         """
 
@@ -421,22 +421,22 @@ class TestNotificationDispatcher(unittest.TestCase, NotificationFixture):
 
             self.assertEqual(tuple(expected_args), call_args)
 
-    @with_config({'email': {'force-send': 'True',
-                            'type': 'smtp'}})
+    @with_config({'email': {'force_send': 'True',
+                            'method': 'smtp'}})
     def test_smtp(self):
         return self.check_dispatcher('send_email_smtp')
 
-    @with_config({'email': {'force-send': 'True',
-                            'type': 'ses'}})
+    @with_config({'email': {'force_send': 'True',
+                            'method': 'ses'}})
     def test_ses(self):
         return self.check_dispatcher('send_email_ses')
 
-    @with_config({'email': {'force-send': 'True',
-                            'type': 'sendgrid'}})
+    @with_config({'email': {'force_send': 'True',
+                            'method': 'sendgrid'}})
     def test_sendgrid(self):
         return self.check_dispatcher('send_email_sendgrid')
 
-    @with_config({'email': {'force-send': 'True',
-                            'type': 'sns'}})
+    @with_config({'email': {'force_send': 'True',
+                            'method': 'sns'}})
     def test_sns(self):
         return self.check_dispatcher('send_email_sns')

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -26,6 +26,7 @@ import luigi.interface
 import luigi.notifications
 from luigi.mock import MockTarget
 from luigi.parameter import ParameterException
+from luigi import six
 from worker_test import email_patch
 
 luigi.notifications.DEBUG = True
@@ -504,23 +505,26 @@ class TestRemoveGlobalParameters(LuigiTestCase):
             self.assertEqual(Dogs().n_dogs, 654)
             self.assertEqual(CatsWithoutSection().n_cats, 321)
 
-    def test_global_significant_param(self):
-        """ We don't want any kind of global param to be positional """
-        class MyTask(luigi.Task):
-            # This could typically be called "--test-dry-run"
-            x_g1 = luigi.Parameter(default='y', is_global=True, significant=True)
+    if six.PY3:
+        def test_global_significant_param_warning(self):
+            """ We don't want any kind of global param to be positional """
+            with self.assertWarnsRegex(DeprecationWarning, 'is_global support is removed. Assuming positional=False'):
+                class MyTask(luigi.Task):
+                    # This could typically be called "--test-dry-run"
+                    x_g1 = luigi.Parameter(default='y', is_global=True, significant=True)
 
-        self.assertRaises(luigi.parameter.UnknownParameterException,
-                          lambda: MyTask('arg'))
+            self.assertRaises(luigi.parameter.UnknownParameterException,
+                            lambda: MyTask('arg'))
 
-    def test_global_insignificant_param(self):
-        """ We don't want any kind of global param to be positional """
-        class MyTask(luigi.Task):
-            # This could typically be "--yarn-pool=development"
-            x_g2 = luigi.Parameter(default='y', is_global=True, significant=False)
+        def test_global_insignificant_param_warning(self):
+            """ We don't want any kind of global param to be positional """
+            with self.assertWarnsRegex(DeprecationWarning, 'is_global support is removed. Assuming positional=False'):
+                class MyTask(luigi.Task):
+                    # This could typically be "--yarn-pool=development"
+                    x_g2 = luigi.Parameter(default='y', is_global=True, significant=False)
 
-        self.assertRaises(luigi.parameter.UnknownParameterException,
-                          lambda: MyTask('arg'))
+            self.assertRaises(luigi.parameter.UnknownParameterException,
+                            lambda: MyTask('arg'))
 
 
 class TestParamWithDefaultFromConfig(LuigiTestCase):
@@ -563,7 +567,11 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
     @with_config({"foo": {"bar": "2001-02-03T04H30"}})
     def testDateMinuteDeprecated(self):
         p = luigi.DateMinuteParameter(config_path=dict(section="foo", name="bar"))
-        self.assertEqual(datetime.datetime(2001, 2, 3, 4, 30, 0), _value(p))
+        if six.PY3:
+            with self.assertWarnsRegex(DeprecationWarning, 'Using "H" between hours and minutes is deprecated, omit it instead.'):
+                self.assertEqual(datetime.datetime(2001, 2, 3, 4, 30, 0), _value(p))
+        else:
+            self.assertEqual(datetime.datetime(2001, 2, 3, 4, 30, 0), _value(p))
 
     @with_config({"foo": {"bar": "2001-02-03T040506"}})
     def testDateSecond(self):
@@ -881,12 +889,20 @@ class OverrideEnvStuff(LuigiTestCase):
 
     @with_config({"core": {"default-scheduler-port": '6543'}})
     def testOverrideSchedulerPort(self):
-        env_params = luigi.interface.core()
+        if six.PY3:
+            with self.assertWarnsRegex(DeprecationWarning, r'default-scheduler-port is deprecated'):
+                env_params = luigi.interface.core()
+        else:
+            env_params = luigi.interface.core()
         self.assertEqual(env_params.scheduler_port, 6543)
 
     @with_config({"core": {"scheduler-port": '6544'}})
     def testOverrideSchedulerPort2(self):
-        env_params = luigi.interface.core()
+        if six.PY3:
+            with self.assertWarnsRegex(DeprecationWarning, r'scheduler_port \(with dashes\) should be avoided'):
+                env_params = luigi.interface.core()
+        else:
+            env_params = luigi.interface.core()
         self.assertEqual(env_params.scheduler_port, 6544)
 
     @with_config({"core": {"scheduler_port": '6545'}})

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -514,7 +514,7 @@ class TestRemoveGlobalParameters(LuigiTestCase):
                     x_g1 = luigi.Parameter(default='y', is_global=True, significant=True)
 
             self.assertRaises(luigi.parameter.UnknownParameterException,
-                            lambda: MyTask('arg'))
+                              lambda: MyTask('arg'))
 
         def test_global_insignificant_param_warning(self):
             """ We don't want any kind of global param to be positional """
@@ -524,7 +524,7 @@ class TestRemoveGlobalParameters(LuigiTestCase):
                     x_g2 = luigi.Parameter(default='y', is_global=True, significant=False)
 
             self.assertRaises(luigi.parameter.UnknownParameterException,
-                            lambda: MyTask('arg'))
+                              lambda: MyTask('arg'))
 
 
 class TestParamWithDefaultFromConfig(LuigiTestCase):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -200,7 +200,7 @@ class ParameterTest(LuigiTestCase):
         self.assertTrue(WithDefaultTrue().x)
 
     def test_bool_coerce(self):
-        self.assertEquals(True, WithDefaultTrue(x='yes').x)
+        self.assertEqual(True, WithDefaultTrue(x='yes').x)
 
     def test_bool_no_coerce_none(self):
         self.assertIsNone(WithDefaultTrue(x=None).x)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -54,7 +54,7 @@ class SchedulerIoTest(unittest.TestCase):
 
             self.assertEqual(list(state.get_worker_ids()), [])
 
-    @with_config({'scheduler': {'retry_count': '44', 'worker-disconnect-delay': '55'}})
+    @with_config({'scheduler': {'retry_count': '44', 'worker_disconnect_delay': '55'}})
     def test_scheduler_with_config(self):
         scheduler = luigi.scheduler.Scheduler()
         self.assertEqual(44, scheduler._config.retry_count)

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -109,7 +109,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
 
     def _assert_complete(self, tasks):
         for t in tasks:
-            self.assert_(t.complete())
+            self.assertTrue(t.complete())
 
     def _build(self, tasks):
         with luigi.worker.Worker(scheduler=self.scheduler, worker_processes=1) as w:
@@ -135,7 +135,7 @@ class SchedulerVisualisationTest(unittest.TestCase):
         remote = self._remote()
         graph = remote.graph()
         self.assertEqual(len(graph), 2)
-        self.assert_(DummyTask(task_id=1).task_id in graph)
+        self.assertTrue(DummyTask(task_id=1).task_id in graph)
         d1 = graph[DummyTask(task_id=1).task_id]
         self.assertEqual(d1[u'status'], u'DONE')
         self.assertEqual(d1[u'deps'], [])

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1616,7 +1616,7 @@ class TaskLimitTest(unittest.TestCase):
     def tearDown(self):
         MockFileSystem().remove('')
 
-    @with_config({'core': {'worker_task_limit': '6'}})
+    @with_config({'worker': {'task_limit': '6'}})
     def test_task_limit_exceeded(self):
         w = Worker()
         t = ForkBombTask(3, 2)
@@ -1627,7 +1627,7 @@ class TaskLimitTest(unittest.TestCase):
         self.assertEqual(3, sum(t.complete() for t in leaf_tasks),
                          "should have gracefully completed as much as possible even though the single last leaf didn't get scheduled")
 
-    @with_config({'core': {'worker_task_limit': '7'}})
+    @with_config({'worker': {'task_limit': '7'}})
     def test_task_limit_not_exceeded(self):
         w = Worker()
         t = ForkBombTask(3, 2)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1069,7 +1069,7 @@ class WorkerPingThreadTests(unittest.TestCase):
 
 
 def email_patch(test_func, email_config=None):
-    EMAIL_CONFIG = {"core": {"error-email": "not-a-real-email-address-for-test-only"}, "email": {"force-send": "true"}}
+    EMAIL_CONFIG = {"email": {"receiver": "not-a-real-email-address-for-test-only", "force_send": "true"}}
     if email_config is not None:
         EMAIL_CONFIG.update(email_config)
     emails = []
@@ -1369,7 +1369,7 @@ class WorkerEmailTest(LuigiTestCase):
         self.assertEqual(emails, [])
         self.assertTrue(a.complete())
 
-    @custom_email_patch({"core": {"error-email": "not-a-real-email-address-for-test-only", 'email-type': 'none'}})
+    @custom_email_patch({"email": {"receiver": "not-a-real-email-address-for-test-only", 'format': 'none'}})
     def test_disable_emails(self, emails):
         class A(luigi.Task):
 
@@ -1616,7 +1616,7 @@ class TaskLimitTest(unittest.TestCase):
     def tearDown(self):
         MockFileSystem().remove('')
 
-    @with_config({'core': {'worker-task-limit': '6'}})
+    @with_config({'core': {'worker_task_limit': '6'}})
     def test_task_limit_exceeded(self):
         w = Worker()
         t = ForkBombTask(3, 2)
@@ -1627,7 +1627,7 @@ class TaskLimitTest(unittest.TestCase):
         self.assertEqual(3, sum(t.complete() for t in leaf_tasks),
                          "should have gracefully completed as much as possible even though the single last leaf didn't get scheduled")
 
-    @with_config({'core': {'worker-task-limit': '7'}})
+    @with_config({'core': {'worker_task_limit': '7'}})
     def test_task_limit_not_exceeded(self):
         w = Worker()
         t = ForkBombTask(3, 2)


### PR DESCRIPTION
This PR cleans up a number of warnings and notices in the tests. Detailed descriptions are in the commit messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed to get aquatinted with the test infrastructure. Aside from that, general maintenance and keeping things neat.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Tested locally with `tox -e py36-nonhdfs` and `tox -e py27-nonhdfs`.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
