### PR TITLE
Resource url hash

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -412,7 +412,7 @@
                 <h3 class="box-title">{{name}}</h3>
                 {{#num_consumer}}
                 <div class="box-tools pull-right">
-                    <i class="fa fa-navicon" data-toggle="collapse" data-target="#collapse-{{name}}" aria-expanded="false" aria-controls="collapse-{{name}}"></i>
+                    <i class="fa fa-navicon resources-collapse" data-target="#collapse-{{name}}"></i>
                 </div><!-- /.box-tools -->
                 {{/num_consumer}}
             </div><!-- /.box-header -->
@@ -424,7 +424,7 @@
                 </div>
 
                 {{#num_consumer}}
-                <div class="collapse" id="collapse-{{name}}">
+                <div class="collapse resource-box" id="collapse-{{name}}" data-resource="{{name}}">
                     <table class="table table-striped worker-table">
                         <thead>
                             <th>Name</th>

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -438,7 +438,7 @@
                                 <td>{{displayName}}</td>
                                 <td>{{priority}}</td>
                                 <td>{{displayTime}}</td>
-                                <td><a href="#{{taskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a></td>
+                                <td><a href="#tab=graph&taskId={{taskId}}&hideDone=1" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a></td>
                             </tr>
                             {{/tasks}}
                         </tbody>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -391,6 +391,7 @@ function visualiserApp(luigi) {
         if (fragmentQuery.tab == "workers") {
             switchTab("workerList");
         } else if (fragmentQuery.tab == "resources") {
+            expandResources(fragmentQuery.resources);
             switchTab("resourceList");
         } else if (fragmentQuery.tab == "graph") {
             var taskId = fragmentQuery.taskId;
@@ -875,6 +876,25 @@ function visualiserApp(luigi) {
         location.hash = '#' + URI.buildQuery(fragmentQuery);
     }
 
+   function expandedResources() {
+        return $('.resource-box.in').toArray().map(function (val) { return val.dataset.resource; });
+    }
+
+    function expandResources(resources) {        
+        if (resources === undefined) {
+            resources = [];
+        } else {
+            resources = JSON.parse(resources);
+        }
+        $('.resource-box').each(function (i, item) {
+            if (resources.indexOf(item.dataset.resource) === -1) {
+                $(item).collapse('hide');
+            } else {
+                $(item).collapse('show');
+            }
+        });
+    }
+
     $(document).ready(function() {
         loadTemplates();
 
@@ -889,6 +909,24 @@ function visualiserApp(luigi) {
 
         luigi.getResourceList(function(resources) {
             $("#resourceList").append(renderResources(resources));
+            expandResources(URI.parseQuery(location.hash.replace('#', '')).resources);
+            $('.resources-collapse').click(function (e) {
+                e.preventDefault();
+                var collapse_block = $(this.dataset.target);
+                if (collapse_block.hasClass('collapsing')) {
+                    return;
+                }
+                var resource = collapse_block.attr('data-resource');
+                var resourceList = expandedResources();
+                var resourceIdx = resourceList.indexOf(resource);
+                if (resourceIdx === -1) {
+                    resourceList.push(resource);
+                } else {
+                    resourceList.splice(resourceIdx, 1);
+                }
+                changeState('resources', resourceList.length > 0 ? JSON.stringify(resourceList) : null);
+                collapse_block.collapse('toggle');
+            });
         });
 
         dt = $('#taskTable').DataTable({
@@ -1155,6 +1193,7 @@ function visualiserApp(luigi) {
             } else if (tabId == 'workerList') {
                 state.tab = 'workers';
             } else if (tabId == 'resourceList') {
+                state.resources = JSON.stringify(expandedResources());
                 state.tab = 'resources';
             }
 


### PR DESCRIPTION
## Description
Add expanded resources from the resource tab to the URL bar and fix the graph links on the resource page.

## Motivation and Context
Now that we have the luxury of the task list and graph tab states being stored in the URL, I wanted it on every page. I like to refresh the resource page a lot and always need to re-expand the resources I'm interested in. Not anymore! I also updated the graph links in the expanded resource boxes so they actually work again.

## Have you tested this? If so, how?
Ran this locally and in production. I'm willing to add unit tests if possible.