### PR TITLE
Preserve options in svg graph links

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -33,7 +33,7 @@ Graph = (function() {
             name: task.name,
             taskId: task.taskId,
             status: task.status,
-            trackingUrl: "#tab=graph&taskId=" + task.taskId,
+            trackingUrl: this.hashBase + task.taskId,
             deps: deps,
             params: task.params,
             priority: task.priority,
@@ -125,9 +125,10 @@ Graph = (function() {
     }
 
     /* Parses a list of tasks to a graph format */
-    function createGraph(tasks) {
+    function createGraph(tasks, hashBase) {
         if (tasks.length === 0) return {nodes: [], links: []};
 
+        this.hashBase = hashBase;
         var nodes = $.map(tasks, nodeFromTask);
         var nodeIndex = uniqueIndexByProperty(nodes, "taskId");
 
@@ -259,9 +260,9 @@ Graph = (function() {
         });
     };
 
-    DependencyGraph.prototype.updateData = function(taskList) {
+    DependencyGraph.prototype.updateData = function(taskList, hashBase) {
         $('.popover').popover('destroy');
-        this.graph = createGraph(taskList);
+        this.graph = createGraph(taskList, hashBase);
         bounds = findBounds(this.graph.nodes);
         this.renderGraph();
         this.svg.attr("height", bounds.y+10);

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -359,7 +359,10 @@ function visualiserApp(luigi) {
             $("#searchError").removeClass();
             if(dependencyGraph.length > 0) {
                 $("#dependencyTitle").text(dependencyGraph[0].display_name);
-                $("#graphPlaceholder").get(0).graph.updateData(dependencyGraph);
+                var hashBaseObj = URI.parseQuery(location.hash.replace('#', ''));
+                delete hashBaseObj.taskId;
+                var hashBase = '#' + URI.buildQuery(hashBaseObj) + '&taskId=';
+                $("#graphPlaceholder").get(0).graph.updateData(dependencyGraph, hashBase);
                 $("#graphContainer").show();
                 bindGraphEvents();
             } else {


### PR DESCRIPTION
## Description
Include options from url hash in svg graph node links.

## Motivation and Context
When clicking on the nodes in an svg graph, a graph will load with that node as the root but with hide done and show upstream dependencies unset. This can be very annoying when you suddenly have to load a much larger graph or your graph flips orientation.

In order to preserve these and any future options, we pass the hash with taskId stripped out of it into the dependency graph so it can use that as a basis for the node links. This preserves the options present when the graph was created, which should match the current options on the
page.

D3 graphs also suffer from the same bug, but they are not addressed by this change.

## Have you tested this? If so, how?
Ran locally and in production. Willing to write tests once I learn how.