### PR TITLE
Add ExtractTask to luigi.contrib.BigQuery module

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -71,6 +71,22 @@ class FieldDelimiter(object):
     PIPE = "|"
 
 
+class PrintHeader(object):
+    TRUE = True
+    FALSE = False
+
+
+class DestinationFormat(object):
+    AVRO = 'AVRO'
+    CSV = 'CSV'
+    NEWLINE_DELIMITED_JSON = 'NEWLINE_DELIMITED_JSON'
+
+
+class Compression(object):
+    GZIP = 'GZIP'
+    NONE = 'NONE'
+
+
 class Encoding(object):
     """
     [Optional] The character encoding of the data. The supported values are UTF-8 or ISO-8859-1. The default value is UTF-8.
@@ -666,6 +682,91 @@ class ExternalBigQueryTask(MixinBigQueryBulkComplete, luigi.ExternalTask):
     An external task for a BigQuery target.
     """
     pass
+
+
+class BigQueryExtractTask(luigi.Task):
+    """
+    Extracts (unloads) a table from BigQuery to GCS.
+
+    This tasks requires the input to be exactly one BigQueryTarget while the
+    output should be one or more GCSTargets from luigi.contrib.gcs depening on
+    the use of destinationUris property.
+    """
+    @property
+    def destination_uris(self):
+        """
+        The fully-qualified URIs that point to your data in Google Cloud
+        Storage. Each URI can contain one '*' wildcard character and it must
+        come after the 'bucket' name.
+
+        Wildcarded destinationUris in GCSQueryTarget might not be resolved
+        correctly and result in incomplete data. If a GCSQueryTarget is used to
+        pass wildcarded destinationUris be sure to overwrite this property to
+        suppress the warning.
+        """
+        return [x.path for x in luigi.task.flatten(self.output())]
+
+    @property
+    def print_header(self):
+        """Whether to print the header or not."""
+        return PrintHeader.TRUE
+
+    @property
+    def field_delimiter(self):
+        """
+        The separator for fields in a CSV file. The separator can be any
+        ISO-8859-1 single-byte character.
+        """
+        return FieldDelimiter.COMMA
+
+    @property
+    def destination_format(self):
+        """
+        The destination format to use (see :py:class:`DestinationFormat`).
+        """
+        return DestinationFormat.CSV
+
+    @property
+    def compression(self):
+        """Whether to use compression."""
+        return Compression.NONE
+
+    def run(self):
+        input = luigi.task.flatten(self.input())[0]
+        assert (
+            isinstance(input, BigQueryTarget) or
+            (len(input) == 1 and isinstance(input[0], BigQueryTarget))), \
+            'Input must be exactly one BigQueryTarget, not %s' % (input)
+        bq_client = input.client
+
+        destination_uris = self.destination_uris
+        assert all(x.startswith('gs://') for x in destination_uris)
+
+        logger.info('Launching Extract Job')
+        logger.info('Extract source: %s', input)
+        logger.info('Extract destination: %s', destination_uris)
+
+        job = {
+            'configuration': {
+                'extract': {
+                    'sourceTable': {
+                        'projectId': input.table.project_id,
+                        'datasetId': input.table.dataset_id,
+                        'tableId': input.table.table_id
+                    },
+                    'destinationUris': destination_uris,
+                    'printHeader': self.print_header,
+                    'fieldDelimiter': self.field_delimiter,
+                    'destinationFormat': self.destination_format,
+                    'compression': self.compression
+                }
+            }
+        }
+
+        bq_client.run_job(
+            input.table.project_id,
+            job,
+            dataset=input.table.dataset)
 
 
 # the original inconsistently capitalized aliases, for backwards compatibility

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -755,13 +755,17 @@ class BigQueryExtractTask(luigi.Task):
                         'tableId': input.table.table_id
                     },
                     'destinationUris': destination_uris,
-                    'printHeader': self.print_header,
-                    'fieldDelimiter': self.field_delimiter,
                     'destinationFormat': self.destination_format,
                     'compression': self.compression
                 }
             }
         }
+
+        if self.destination_format == 'CSV':
+            # "Only exports to CSV may specify a field delimiter."
+            job['configuration']['extract']['printHeader'] = self.print_header
+            job['configuration']['extract']['fieldDelimiter'] = \
+                self.field_delimiter
 
         bq_client.run_job(
             input.table.project_id,


### PR DESCRIPTION
The extract job is currently not implemented in `contrib.bigquery` module. Scope of this PR is to implement it according to https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs .

## Motivation and Context
Without the extract we can only assemble pipelines **into** BigQuery but not from BQ to elsewhere.

## Description
- Fill job configuration according to https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs for extract jobs.
- Add assertitions for the jobs to be sane.
- Add basic unittest for extracts
- Add Integration test with basic configuration

## Have you tested this? If so, how?
- Added basic unit and integration tests
- A version of this runs in our production environment.

## Questions
Being relatively new to luigi ecosystem I am not 100% certain I correctly followed the luigi *style* everywhere. Happy to receive feedback.
