### PR TITLE
Added BigQuery chunking logic for huge uploads

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -529,8 +529,6 @@ class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
         output = self.output()
         assert isinstance(output, BigQueryTarget), 'Output must be a BigQueryTarget, not %s' % (output)
 
-        print "Enable chunking :" + str(output.enable_chunking)
-        print "Chunk Size: " + str(output.chunk_size_gb)
         project_id = output.table.project_id
 
         bq_client = output.client
@@ -578,11 +576,9 @@ class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
                 partial_table_ids.append(output.table.project_id + "." + output.table.dataset_id + "." + table_id)
 
         if not output.enable_chunking:
-            print "NO CHUNK"
             # Default to previous behaviour
             submit_load_job(source_uris, output.table.table_id)
         else:
-            print "CHUNK"
             source_counter = 0
             for source_uri in source_uris:
                 if '*' in source_uri:

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -393,6 +393,11 @@ class GCSClient(luigi.target.FileSystem):
 
         return return_fp
 
+    def get_object(self, bucket_name, blob_name):
+        if self._obj_exists(bucket_name, blob_name):
+            return self.client.objects().get(bucket=bucket_name, object=blob_name).execute()
+        else:
+            return None
 
 class _DeleteOnCloseFile(io.FileIO):
     def close(self):

--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -399,6 +399,7 @@ class GCSClient(luigi.target.FileSystem):
         else:
             return None
 
+
 class _DeleteOnCloseFile(io.FileIO):
     def close(self):
         super(_DeleteOnCloseFile, self).close()

--- a/test/contrib/bigquery_gcloud_test.py
+++ b/test/contrib/bigquery_gcloud_test.py
@@ -247,30 +247,6 @@ class BigQueryGcloudTest(unittest.TestCase):
         self.assertTrue(self.bq_client.dataset_exists(self.table))
         self.assertTrue(self.bq_client.table_exists(self.table))
 
-    def test_avg_blob_size(self):
-        uris = [
-            "gs://luigi-travistestenvironment/176348453/contrib.gcs_test.GCSTargetTest.test_writelines",
-            "gs://luigi-travistestenvironment-docker-bq-test/bigquery_test_folder/contrib.bigquery_gcloud_test.BigQueryGcloudTest.test_table_uri"
-        ]
-        avg_blob_size = TestLoadTask.calculate_avg_blob_size(self.gcs_client, uris)
-        self.assertEqual(avg_blob_size, 33)
-
-    def test_chunk_intervals(self):
-        uris = [
-            "gs://luigi-travistestenvironment/176348453/contrib.gcs_test.GCSTargetTest.test_writelines",
-            "gs://luigi-travistestenvironment-docker-bq-test/bigquery_test_folder/contrib.bigquery_gcloud_test.BigQueryGcloudTest.test_table_uri"
-        ]
-        task = TestLoadTask(source=self.gcs_file,
-                            dataset=self.table.dataset.dataset_id,
-                            table=self.table.table_id,
-                            enable_chunking=True,
-                            chunk_size_gb=500)
-        chunk_intervals, uris_per_chunk = task.calculate_chunk_intervals(self.gcs_client, uris, 0.00000003)
-        print chunk_intervals
-        print uris_per_chunk
-        self.assertEqual(chunk_intervals, [0, 1])
-        self.assertEqual(uris_per_chunk, 1)
-
 
 @attr('gcloud')
 class BigQueryLoadAvroTest(unittest.TestCase):

--- a/test/contrib/bigquery_gcloud_test.py
+++ b/test/contrib/bigquery_gcloud_test.py
@@ -271,6 +271,7 @@ class BigQueryGcloudTest(unittest.TestCase):
         self.assertEqual(chunk_intervals, [0, 1])
         self.assertEqual(uris_per_chunk, 1)
 
+
 @attr('gcloud')
 class BigQueryLoadAvroTest(unittest.TestCase):
     def _produce_test_input(self):

--- a/test/contrib/bigquery_gcloud_test.py
+++ b/test/contrib/bigquery_gcloud_test.py
@@ -81,8 +81,7 @@ class TestLoadTask(bigquery.BigQueryLoadTask):
         return [self.source]
 
     def output(self):
-        return bigquery.BigQueryTarget(PROJECT_ID, self.dataset, self.table, location=self.location,
-                                       enable_chunking=self.enable_chunking, chunk_size_gb=self.chunk_size_gb)
+        return bigquery.BigQueryTarget(PROJECT_ID, self.dataset, self.table, location=self.location)
 
 
 @attr('gcloud')


### PR DESCRIPTION
## Motivation and Context
Some people are uploading huge amounts of data (15+ TB) and they are hitting BQ Timeouts. The easiest solution is to chunk data and upload partially.

## Description
We added two new Luigi Parameters:
 - Boolean `chunking-enabled` - when True (default is False) it will chunk your source data and upload synchronously with a default chunk size (1 TB)
- Int `chunk-size-gb` - user can adjust (optionally) chunk size 

If chunking is disabled, then the upload logic is not changed. If chunking is enabled, we will upload chunks to separated temp tables, then we will atomically merge them and store result in one final table. All the temp tables are removed after successful run.

We have a heuristic calculating the size of the input data to be chunked, so chunk size can vary. We are also assuming that files within a a folder to be chunked are of a similar size. So we can handle let's say 22000 files 90MB each or 500 files 17GB each. 

## Have you tested this? If so, how?
We have included unit tests and did some stress and manual tests in house.

We will be cleaning up some unnecessary printouts, we are looking for some architectural and technical feedback.

Thanks!