### PR TITLE
Move visualiser graph type default to a constant

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -646,7 +646,7 @@
                       <div class="form-group col-md-3">
                         <label>Visualisation Type</label>
                         <div id="toggleVisButtons" class="btn-group" data-toggle="buttons">
-                            <label class="btn btn-default active">
+                            <label class="btn btn-default">
                                 <input type="radio" name="vis-type" value="d3"/> D3
                             </label>
                             <label class="btn btn-default">

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -18,7 +18,7 @@ function visualiserApp(luigi) {
         DISABLED: 'minus-circle',
         UPSTREAM_DISABLED: 'warning'
     };
-    var VISTYPE_DEFAULT = 'd3';
+    var VISTYPE_DEFAULT = 'svg';
 
     /*
      * Updates view of the Visualization type.

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -18,6 +18,7 @@ function visualiserApp(luigi) {
         DISABLED: 'minus-circle',
         UPSTREAM_DISABLED: 'warning'
     };
+    var VISTYPE_DEFAULT = 'd3';
 
     /*
      * Updates view of the Visualization type.
@@ -414,18 +415,14 @@ function visualiserApp(luigi) {
             $('#hideDoneCheckbox').prop('checked', hideDone);
             $("#invertCheckbox").prop('checked', fragmentQuery.invert === '1' ? true : false);
             $("#js-task-id").val(fragmentQuery.taskId);
-            if (fragmentQuery.visType == 'svg') {
-                $("input[name=vis-type][value=svg]").prop('checked', true);
-            } else {
-                // d3 is default visualization.
-                $("input[name=vis-type][value=d3]").prop('checked', true);
-            }
 
             // Empty errors.
             $("#searchError").empty();
             $("#searchError").removeClass();
+
+            var visType = fragmentQuery.visType || VISTYPE_DEFAULT;
             if (taskId) {
-                var depGraphCallback = makeGraphCallback(fragmentQuery.visType, taskId, paint);
+                var depGraphCallback = makeGraphCallback(visType, taskId, paint);
 
                 if (fragmentQuery.invert) {
                     luigi.getInverseDependencyGraph(taskId, depGraphCallback, !hideDone);
@@ -433,8 +430,8 @@ function visualiserApp(luigi) {
                     luigi.getDependencyGraph(taskId, depGraphCallback, !hideDone);
                 }
             }
-            updateVisType(fragmentQuery.visType || 'd3');
-            initVisualisation(fragmentQuery.visType);
+            updateVisType(visType);
+            initVisualisation(visType);
             switchTab("dependencyGraph");
         } else {
             // Tasks tab.


### PR DESCRIPTION
## Description
Refactors the way the visType default is handled so it's controlled by a constant defined at the top of visualiserApp.js

This also cleans up a few places where the default was being set
unnecessarily:
  - don't set it in html since we set it in javascript instantly anyway
  - remove code to set buttons to checked since this has no meaning

## Motivation and Context
In my fork of Luigi, I use svg as the graph type default. This results in annoying merges when javascript related to handling the defaults changes. In order to make different defaults easier to maintain, this uses a constant in visualiserApp.js to determine which graph type is default rather than hard-coding it everywhere the default value is used.

## Have you tested this? If so, how?
I ran it locally with both d3 and svg as defaults and tried loading pages. It seems to work.