### PR TITLE
Preserve graph options when clicking d3 nodes

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -486,7 +486,8 @@ function visualiserApp(luigi) {
                     });
                 }
                 else {
-                    window.location.href = 'index.html#tab=graph&visType=d3&taskId=' + taskId;
+                    fragmentQuery['taskId'] = taskId;
+                    window.location.href = 'index.html#' + URI.buildQuery(fragmentQuery);
                 }
             });
         }


### PR DESCRIPTION
## Description
Just replace the taskId in the current url when clicking a d3 node rather than building a whole new options hash.

## Motivation and Context
When clicking a d3 node, the new url was built up with a static set of options, clearing out things like hide done and invert. This means the graph would flip or gain lots of nodes when you click a link. In order to better preserve the options, we now simply change the taskId rather than building the full link.

## Have you tested this? If so, how?
Ran locally and tried clicking links in a d3 graph to make sure things work as expected.