### PR TITLE
Issue template: Mention it isn't for questions

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
 <!---
+We use GitHub issues mainly for tracking bugs and feature requests.
+Questions for how to use luigi can be sent to the mailing list.
+
 Currently, there are no strict procedures or guidelines for submitting issues.
 In short, please just use common sense.
 
@@ -7,6 +10,7 @@ Common sense includes this at bare-minimum:
  * search for similar issues posted before creating a new issue.
  * Use markdown to format all code/logs. Issues which are hard to read
    when rendered on GitHub might be closed with a friendly reminder of this.
+ * If applicable, reading relevant parts of the documentation.
 
 Also, add steps to reproduce the bug, if applicable. Sample code would be nice too :)
 


### PR DESCRIPTION
Recently there have been many issues opened with user questions. And they sometimes can add to the maintainer burden.

------

Here are two issues I had in mind when proposing this change:

 * https://github.com/spotify/luigi/issues/2142
 * https://github.com/spotify/luigi/issues/2137

Hopefully with this patch we can save everyone's time.