### PR TITLE
Prevent unlimited resource usage

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1069,7 +1069,7 @@ class Scheduler(object):
             if (best_task and batched_params and task.family == best_task.family and
                     len(batched_tasks) < max_batch_size and task.is_batchable() and all(
                     task.params.get(name) == value for name, value in unbatched_params.items()) and
-                    self._schedulable(task)):
+                    task.resources == best_task.resources and self._schedulable(task)):
                 for name, params in batched_params.items():
                     params.append(task.params.get(name))
                 batched_tasks.append(task)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -515,6 +515,7 @@ class SimpleTaskState(object):
         self.set_status(task, BATCH_RUNNING)
         task.batch_id = batch_id
         task.worker_running = worker_id
+        task.resources_running = task.resources
         task.time_running = time.time()
 
     def set_status(self, task, new_status, config=None):
@@ -799,6 +800,9 @@ class Scheduler(object):
             task.batch_id = batch_id
         if status == RUNNING and not task.worker_running:
             task.worker_running = worker_id
+            if batch_id:
+                task.resources_running = self._state.get_batch_running_tasks(batch_id)[0].resources_running
+            task.time_running = time.time()
 
         if tracking_url is not None or task.status != RUNNING:
             task.tracking_url = tracking_url
@@ -930,8 +934,8 @@ class Scheduler(object):
         used_resources = collections.defaultdict(int)
         if self._resources is not None:
             for task in self._state.get_active_tasks_by_status(RUNNING):
-                if task.resources:
-                    for resource, amount in six.iteritems(task.resources):
+                if getattr(task, 'resources_running', task.resources):
+                    for resource, amount in six.iteritems(getattr(task, 'resources_running', task.resources)):
                         used_resources[resource] += amount
         return used_resources
 
@@ -1078,7 +1082,7 @@ class Scheduler(object):
 
             if task.status == RUNNING and (task.worker_running in greedy_workers):
                 greedy_workers[task.worker_running] -= 1
-                for resource, amount in six.iteritems((task.resources or {})):
+                for resource, amount in six.iteritems((getattr(task, 'resources_running', task.resources) or {})):
                     greedy_resources[resource] += amount
 
             if self._schedulable(task) and self._has_resources(task.resources, greedy_resources):
@@ -1133,6 +1137,7 @@ class Scheduler(object):
         elif best_task:
             self._state.set_status(best_task, RUNNING, self._config)
             best_task.worker_running = worker_id
+            best_task.resources_running = best_task.resources
             best_task.time_running = time.time()
             self._update_task_history(best_task, RUNNING, host=host)
 


### PR DESCRIPTION
## Description
- ensure that all tasks returned as part of a batch run have the same resources
- preserve resources of tasks at time of get_work to prevent changes from avoiding constraints

## Motivation and Context
After changing the resources for one of my jobs and rescheduling it, I saw dozens of copies of the task running at once when the resource constraint should have limited it to one copy only. After digging into the issue, I discovered that one worker would call get_work, obtain a task that uses resource_1, then another worker would call add_task and change the resource for that task to resource_2. By repeating this, we never have a task using resource_1 when we call get_work, so we can always grab another task. However, we have dozens of tasks using resource_2, well beyond its constraint.

In order to fix this, we simply store what the resources were when we applied the limit. So if we scheduled a task because it used resource_1, we remember that and consider it to be using resource_1 until it's done running. Now we won't be able to get another task that uses this resource. While we're scheduling, we will eventually pick up a task that uses resource_2, but we'll still only get one of those. So instead of running every task all at once in this scenario, we only end up with 2 tasks running.

While figuring out how this would work with batch tasks, I also decided we need to enforce a limitation that all tasks in a batch group have the same resources so we can apply that to the runner. Otherwise, it's unclear which resource the task that runs batch jobs should use.

## Have you tested this? If so, how?
I added unit tests and have been using this in production since October.