### PR TITLE
Update resources from the visualiser

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -928,6 +928,13 @@ class Scheduler(object):
             self._resources = {}
         self._resources.update(resources)
 
+    @rpc_method()
+    def update_resource(self, resource, amount):
+        if not isinstance(amount, int) or amount < 0:
+            return False
+        self._resources[resource] = amount
+        return True
+
     def _generate_retry_policy(self, task_retry_policy_dict):
         retry_policy_dict = self._config._get_retry_policy()._asdict()
         retry_policy_dict.update({k: v for k, v in six.iteritems(task_retry_policy_dict) if v is not None})

--- a/luigi/static/visualiser/css/luigi.css
+++ b/luigi/static/visualiser/css/luigi.css
@@ -203,3 +203,7 @@ span.status-icon {
   font-style: italic;
   color: red;
 }
+
+#resourceList i.resources-collapse {
+  padding-left: 10px;
+}

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -197,17 +197,55 @@
         </script>
 
         <script type="text/template" name="resourceTemplate">
+        <div class="modal fade" id="setResourcesModal" tabindex="-1" role="dialog" aria-labelledby="setResourcesLabel">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="setResourcesLabel">Set resources</h4>
+              </div>
+              <div class="modal-body">
+                <form>
+                  <div class="form-group">
+                    <label for="setResourcesInput">New number of resources:</label>
+                    <input type="text" class="form-control" id="setResourcesInput" placeholder="non-negative integer">
+                  </div>
+                </form>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button type="button" id="setResourcesButton" data-dismiss="modal" class="btn btn-primary">Set</button>
+              </div>
+            </div>
+          </div>
+        </div>
         {{#resources}}
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title">{{name}}</h3>
-                {{#num_consumer}}
                 <div class="box-tools pull-right">
+                    <div class="btn-group">
+                      <button type="button" class="btn btn-sm btn-default dropdown-toggle btn-set-resources" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Change resources
+                      </button>
+                      <ul class="dropdown-menu">
+                        <li><a href="#" class="btn-increment-resources" data-resource="{{name}}">
+                          <i class="glyphicon glyphicon-plus"></i> Add 1 resource
+                        </a></li>
+                        <li><a href="#" class="btn-decrement-resources" data-resource="{{name}}">
+                          <i class="glyphicon glyphicon-minus"></i> Remove 1 resource
+                        </a></li>
+                        <li><a href="#" class="btn-set-resources" data-toggle="modal" data-target="#setResourcesModal" data-resource="{{name}}">
+                          <i class="glyphicon glyphicon-pencil"></i> Set resources ...
+                        </a></li>
+                      </ul>
+                    </div>
+                    {{#num_consumer}}
                     <i class="fa fa-navicon resources-collapse" data-target="#collapse-{{name}}"></i>
+                    {{/num_consumer}}
                 </div><!-- /.box-tools -->
-                {{/num_consumer}}
             </div><!-- /.box-header -->
-            <div class="box-body">
+            <div class="box-body" id="{{name}}-resource-box">
                 <div class="progress">
                     <div class="progress-bar progress-bar-{{bar_type}}" style="width: {{percent_used}}%">
                         <b>{{num_used}}/{{num_total}}</b>

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -166,5 +166,12 @@ var LuigiAPI = (function() {
         });
     }
 
+    LuigiAPI.prototype.updateResource = function(resource, n, callback) {
+        var data = {'resource': resource, 'amount': n};
+        jsonRPC(this.urlRoot + "/update_resource", data, function(response) {
+            callback();
+        });
+    }    
+
     return LuigiAPI;
 })();

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -897,6 +897,42 @@ function visualiserApp(luigi) {
         });
     }
 
+    /**
+     * Updates the number of units of a given resource available in the scheduler
+     * @param resource: the name of the resource
+     * @param n: the number of units to set the resource limit to
+     */
+    function updateResourceCount(resource, n) {
+        var progressBar = $('#' + resource + '-resource-box .progress-bar');
+        var used = /(\S+)\//.exec(progressBar.text())[1];
+        nVal = parseInt(n);
+        if (isNaN(nVal) || nVal < 0) {
+            return;
+        }
+        usedVal = parseInt(used);
+        width = Math.floor(100 * usedVal / nVal);
+        if (width < 0) {
+            width = 0;
+        }
+        if (width > 100) {
+            width = 100;
+        }
+        luigi.updateResource(resource, n, function() {
+            progressBar.text(usedVal + '/' + nVal);
+            progressBar.attr('style', 'width: ' + width + '%');
+        });
+    }
+
+    /**
+     * Returns the current units of a resource used
+     * @param resource: the name of the resource
+     */
+    function currentResourceCount(resource) {
+        var progressBar = $('#' + resource + '-resource-box .progress-bar');
+        var count = /\/(\S+)/.exec(progressBar.text())[1];
+        return parseInt(count);
+    }
+
     function changeState(key, value) {
         var fragmentQuery = URI.parseQuery(location.hash.replace('#', ''));
         if (value) {
@@ -1226,6 +1262,43 @@ function visualiserApp(luigi) {
             $event.preventDefault();
         });
 
+        $('#resourceList').on('click', '.btn-increment-resources', function($event) {
+            $event.preventDefault();
+            var resource = $(this).data('resource');
+            var count = currentResourceCount(resource);
+            updateResourceCount(resource, count + 1);
+        });
+
+        $('#resourceList').on('click', '.btn-decrement-resources', function($event) {
+            $event.preventDefault();
+            var resource = $(this).data('resource');
+            var count = currentResourceCount(resource);
+            updateResourceCount(resource, count - 1);
+        });
+
+        $('#resourceList').on('show.bs.modal', '#setResourcesModal', function($event) {
+            $('#setResourcesButton').data('resource', $($event.relatedTarget).data('resource'));
+            var $input = $(this).find('#setResourcesInput').on('keypress', function($event) {
+                if (event.keyCode == 13) {
+                    $('#resourceList').find('#setResourcesButton').trigger('click');
+                }
+                $event.stopPropagation();
+            });
+            setTimeout(function() {
+                $input.focus();
+            }.bind(this), 600);
+        });
+
+        $('#resourceList').on('hidden.bs.modal', '#setResourcesModal', function() {
+            $(this).find('#setResourcesInput').off('keypress').val('');
+        });
+
+        $('#resourceList').on('click', '#setResourcesButton', function($event) {
+            var resource = $(this).data('resource');
+            var n = parseInt($("#setResourcesInput").val());
+            updateResourceCount(resource, n);
+            $event.preventDefault();
+        });
         $('.js-nav-link').click(function(e) {
             // User followed tab from navigation link. Copy state from fields to hash.
             e.preventDefault();


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Update individual resource counts from the visualiser, like we can do with number of workers now.

This works exactly like updating the worker counts in the workers tab, except that the counts are referenced in the progress bar rather than on the button itself. This is because we already have the counts in the progress bar, so adding them to a button would only complicate things.

The only other difference between this and the worker counts is that this allows resources to be set to 0, effectively pausing certain kinds of jobs.

Note that when you update the resource counts using the visualiser, it only affects the currently running scheduler. If you restart the scheduler it will reload the resource counts from the config.

Screenshots:

![image](https://user-images.githubusercontent.com/2091885/26899247-6982cec4-4b83-11e7-8f41-abf462d5732f.png)

![image](https://user-images.githubusercontent.com/2091885/26899267-77a08c76-4b83-11e7-99c7-f06eca43d7d4.png)

![image](https://user-images.githubusercontent.com/2091885/26899291-8674698e-4b83-11e7-94ad-0dd463445d2a.png)

## Motivation and Context
Sometimes you need to quickly tweak a resource in response to your jobs falling behind or your cluster getting overloaded. In order to make such tweaks a little easier, this adds the option to change the limits for all resources stored in the scheduler right in the visualiser.

Use case 1: you notice that your pipeline is backed up and is currently being constrained by the mapreduce resource. You realize that the mapreduce resource was set a little arbitrarily so you want to try raising its maximum count. You can now quickly do this without having to restart the scheduler.

Use case 2: there is a production fire where the redis cluster keeps going down. While debugging, the backend team requests that you stop all redis uploads from the data pipeline. Now you can do that without having to pause the whole pipeline or restart the scheduler.

## Have you tested this? If so, how?
I added a test, verified the js both locally on this branch and in production since last week.
