### PR TITLE
Exclude insignificant parameters of tasks in error email

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -426,7 +426,7 @@ def format_task_error(headline, task, command, formatted_exception=None):
         {traceback}
         ''')
 
-        str_params = task.to_str_params()
+        str_params = task.to_str_params(only_significant=True)
         max_width = max([0] + [len(x) for x in str_params.keys()])
         params = '\n'.join('  {:{width}}: {}'.format(*items, width=max_width) for items in str_params.items())
         body = msg_template.format(headline=headline, name=task.task_family, params=params,


### PR DESCRIPTION
## Description
1 line change to exclude insignificant parameters from error emails.

## Motivation and Context
Some Luigi tasks have password as parameters, I would have 
password = luigi.Parameter(significant=False) but the notifications module is emailing out insignificant params.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.