### PR TITLE
Set datatable order correctly on hash change

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -461,7 +461,7 @@ function visualiserApp(luigi) {
             }
 
             if (fragmentQuery.order) {
-                dt.order = [fragmentQuery.order.split(',')];
+                dt.order([fragmentQuery.order.split(',')]);
             }
             dt.draw();
             switchTab("taskList");


### PR DESCRIPTION
## Description
Use the datatable order setter to change order in processHashChange rather than overwriting the order function with the intended new order.

## Motivation and Context
In the current visualiser, if you use any of the sorting controls on the datatable and change tabs, you won't be able to change back to task list due to javascript errors. It turns out this happens because we overwrite the datatable's order function in processHashChange with an array. If we instead just use the order function as a setter, everything works as expected.

## Have you tested this? If so, how?
Triggered the bug repeatedly locally and in production with the old code, ran the same steps with the new code and the bug is gone.