### PR TITLE
Serialize statuses array for URL hash

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1254,7 +1254,7 @@ function visualiserApp(luigi) {
                 }
 
                 if (currentFilter.taskCategory.length > 0) {
-                    state.statuses = currentFilter.taskCategory;
+                    state.statuses = JSON.stringify(currentFilter.taskCategory);
                 } else {
                     delete state.statuses;
                 }


### PR DESCRIPTION
## Description
When updating the status hash during tab switching, use JSON to stringify the status array so it works properly.

## Motivation and Context
When switching tabs away from Task List and back with statuses selected, the url hash ends up with something like `statuses=FAILED` rather than `statuses=%5B%22FAILED%22%5D`, which is the json-serialized array. This causes a json parsing error when trying to deserialize the expected json.

## Have you tested this? If so, how?
Switched back and forth between tabs with statuses selected. Before the change, this would always break the visualiser. After the change, it works as expected.