### PR TITLE
PySparkTask fix for bytes / str type error and import error

### DIFF
--- a/luigi/contrib/pyspark_runner.py
+++ b/luigi/contrib/pyspark_runner.py
@@ -34,11 +34,15 @@ except ImportError:
     import pickle
 import logging
 import sys
+import os
 
 
 class PySparkRunner(object):
 
     def __init__(self, job, *args):
+        # Append job directory to PYTHON_PATH to enable dynamic import
+        # of the module in which the class resides on unpickling
+        sys.path.append(os.path.dirname(job))
         with open(job, "rb") as fd:
             self.job = pickle.load(fd)
         self.args = args

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -289,7 +289,7 @@ class PySparkTask(SparkSubmitTask):
             if self.__module__ == '__main__':
                 d = pickle.dumps(self)
                 module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-                d = d.replace(b'(c__main__', "(c" + module_name)
+                d = d.replace(b'c__main__', b'c' + module_name.encode('ascii'))
                 fd.write(d)
             else:
                 pickle.dump(self, fd)

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -22,6 +22,7 @@ import tempfile
 import shutil
 import importlib
 import tarfile
+import inspect
 try:
     import cPickle as pickle
 except ImportError:
@@ -278,6 +279,9 @@ class PySparkTask(SparkSubmitTask):
         self.run_path = tempfile.mkdtemp(prefix=self.name)
         self.run_pickle = os.path.join(self.run_path, '.'.join([self.name.replace(' ', '_'), 'pickle']))
         with open(self.run_pickle, 'wb') as fd:
+            # Copy module file to run path.
+            module_path = os.path.abspath(inspect.getfile(self.__class__))
+            shutil.copy(module_path, os.path.join(self.run_path, '.'))
             self._dump(fd)
         try:
             super(PySparkTask, self).run()

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -225,7 +225,7 @@ class PySparkTaskTest(unittest.TestCase):
             run_path = os.path.dirname(task.app_command()[1])
             self.assertTrue(os.path.exists(os.path.join(run_path, os.path.basename(__file__))))
             # Check that the python path contains the run_path
-            #self.assertTrue(run_path in sys.path)
+            self.assertTrue(run_path in sys.path)
             # Check if find_class finds the class for the correct module name.
             with open(task.app_command()[1], 'rb') as fp:
                 self.assertTrue(pickle.Unpickler(fp).find_class('spark_test', 'TestPySparkTask'))

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -17,6 +17,8 @@
 
 import unittest
 import os
+import sys
+import pickle
 import luigi
 import luigi.contrib.hdfs
 from luigi import six
@@ -219,6 +221,14 @@ class PySparkTaskTest(unittest.TestCase):
             PySparkRunner(*task.app_command()[1:]).run()
             # Check py-package exists
             self.assertTrue(os.path.exists(sc.addPyFile.call_args[0][0]))
+            # Check that main module containing the task exists.
+            run_path = os.path.dirname(task.app_command()[1])
+            self.assertTrue(os.path.exists(os.path.join(run_path, os.path.basename(__file__))))
+            # Check that the python path contains the run_path
+            #self.assertTrue(run_path in sys.path)
+            # Check if find_class finds the class for the correct module name.
+            with open(task.app_command()[1], 'rb') as fp:
+                self.assertTrue(pickle.Unpickler(fp).find_class('spark_test', 'TestPySparkTask'))
 
         with patch.object(SparkSubmitTask, 'run', mock_spark_submit):
             job = TestPySparkTask()


### PR DESCRIPTION
## Description
With master, the following exception occurs when e.g. executing the "pyspark_wc.py" example: 

```
ERROR: [pid 18936] Worker Worker(salt=451680745, workers=1, host=..., username=..., pid=18936) failed    InlinePySparkWordCount()
Traceback (most recent call last):
  File ".../luigi/worker.py", line 191, in run
    new_deps = self._run_get_new_deps()
  File ".../luigi/worker.py", line 129, in _run_get_new_deps
    task_gen = self.task.run()
  File ".../luigi/contrib/spark.py", line 281, in run
    self._dump(fd)
  File ".../luigi/contrib/spark.py", line 292, in _dump
    d = d.replace(b'(c__main__', "(c" + module_name)
TypeError: can't concat bytes to str
```

## Motivation and Context
Resolves the issue with python 3.6 and python 2.7

## Have you tested this? If so, how?
This stage can now be successful executed given the pyspark_wc.py file is put in the PYTHON_PATH (see #1576)

Resolves #1988 
