### PR TITLE
WIP: Restore gcloud tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
       # minicluster (cdh) tests disabled as lack of love, #2140.
       # Sometimes it runs too slow for Travis. And sometimes it crashes on downloading cdh
     - TOXENV=pypy-scheduler
-    # - TOXENV=py27-gcloud # At least broken as of  https://github.com/spotify/luigi/pull/1917
+    - TOXENV=py27-gcloud
+    - TOXENV=py34-gcloud
     - TOXENV=py27-postgres
       # - TOXENV=visualiser
       # Disabling this test because of intermittent failures :-/


### PR DESCRIPTION
Restore the gcloud tests that were disabled in https://github.com/spotify/luigi/pull/1917.

During local execution, `py27-gcloud` succeeds, while `py34-gcloud` currently fails, which I will address in the next commits.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As a follow up to #2130, I noticed Google Cloud tests were disabled. Since the 2.7 version seems to run okay locally, this PR is an attempt to get them to run in Travis again.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Tested locally with `tox -e py34-gcloud` and `tox -e py27-gcloud`.

    $ export GCS_TEST_PROJECT_ID=macro-mile-158613 \
      GCS_TEST_BUCKET=macro-mile-158613 \
      DATAPROC_TEST_PROJECT_ID=macro-mile-158613
    $ tox -e py27-gcloud
    $ tox -e py34-gcloud