### PR TITLE
#2174

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -971,10 +971,18 @@ class Worker(object):
                     self.add(t)
                 new_deps = [t.task_id for t in new_req]
 
+            try:
+                expl_json = json.dumps(expl)
+            except UnicodeDecodeError:
+                logger.info('Unicode decode error occur during %s task metadata serialisation, '
+                            'falling back to latin1 encoding.', task_id)
+
+                expl_json = json.dumps(expl, encoding='latin1')
+
             self._add_task(worker=self._id,
                            task_id=task_id,
                            status=status,
-                           expl=json.dumps(expl),
+                           expl=expl_json,
                            resources=task.process_resources(),
                            runnable=None,
                            params=task.to_str_params(),


### PR DESCRIPTION
Task metadata json serialisation failure due invalid unicode symbols is fixed.

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
