### PR TITLE
Handle e-mail failures in batch notifier

### DIFF
--- a/luigi/batch_notifier.py
+++ b/luigi/batch_notifier.py
@@ -187,19 +187,21 @@ class BatchNotifier(object):
             send_email(subject, email_body, email().sender, (owner,))
 
     def send_email(self):
-        for owner, failures in six.iteritems(self._fail_counts):
-            self._send_email(
-                fail_counts=failures,
-                disable_counts=self._disabled_counts[owner],
-                scheduling_counts=self._scheduling_fail_counts[owner],
-                fail_expls=self._fail_expls[owner],
-                owner=owner,
-            )
-        self._update_next_send()
-        self._fail_counts.clear()
-        self._disabled_counts.clear()
-        self._scheduling_fail_counts.clear()
-        self._fail_expls.clear()
+        try:
+            for owner, failures in six.iteritems(self._fail_counts):
+                self._send_email(
+                    fail_counts=failures,
+                    disable_counts=self._disabled_counts[owner],
+                    scheduling_counts=self._scheduling_fail_counts[owner],
+                    fail_expls=self._fail_expls[owner],
+                    owner=owner,
+                )
+        finally:
+            self._update_next_send()
+            self._fail_counts.clear()
+            self._disabled_counts.clear()
+            self._scheduling_fail_counts.clear()
+            self._fail_expls.clear()
 
     def update(self):
         if time.time() >= self._next_send:


### PR DESCRIPTION
## Description
Ignore e-mail send failures, and ensure we still clean up as if the e-mails were send.

## Motivation and Context
#1957, failed e-mail sends can stall the scheduler. As there's not much we can do about not sending e-mails, we just ignore the error. In order to prevent constant e-mail processing, we also clear all the e-mails from the queue and reset the time period for the next send.

## Have you tested this? If so, how?
Unit tests, plus I've been using this in production for about 6 months.