### PR TITLE
Update mkdir method signature for CDH3 client.

### DIFF
--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -222,9 +222,9 @@ class HdfsClientCdh3(HdfsClient):
     This client uses CDH3 syntax for file system commands.
     """
 
-    def mkdir(self, path):
+    def mkdir(self, path, parents=True, raise_if_exists=False):
         """
-        No -p switch, so this will fail creating ancestors.
+        No explicit -p switch, this version of Hadoop always creates parent directories.
         """
         try:
             self.call_check(load_hadoop_cmd() + ['fs', '-mkdir', path])


### PR DESCRIPTION
## Description
As of 2.6.2 `mkdir` fails when running on CDH3 and using the `hadoopcli` client.

## Motivation and Context
We're currently running Luigi on CDH3 and just hit this very old issue: #520 

## Have you tested this? If so, how?
Yes, this change has been patched in locally and our tasks now run as expected.
