### PR TITLE
hivevar option in hive query task

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -286,9 +286,18 @@ class HiveQueryTask(luigi.contrib.hadoop.BaseHadoopJobTask):
         """
         return luigi.configuration.get_config().get('hive', 'hiverc-location', default=None)
 
+    def hivevars(self):
+        """
+        Returns a dict of key=value settings to be passed along
+        to the hive command line via --hivevar.
+        This option can be used as a separated namespace for script local variables.
+        See https://cwiki.apache.org/confluence/display/Hive/LanguageManual+VariableSubstitution
+        """
+        return {}
+
     def hiveconfs(self):
         """
-        Returns an dict of key=value settings to be passed along
+        Returns a dict of key=value settings to be passed along
         to the hive command line via --hiveconf. By default, sets
         mapred.job.name to task_id and if not None, sets:
 
@@ -342,6 +351,25 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                     except FileAlreadyExists:
                         pass
 
+    def get_arglist(self, f_name, job):
+        arglist = load_hive_cmd() + ['-f', f_name]
+        hiverc = job.hiverc()
+        if hiverc:
+            if isinstance(hiverc, str):
+                hiverc = [hiverc]
+            for rcfile in hiverc:
+                arglist += ['-i', rcfile]
+        hiveconfs = job.hiveconfs()
+        if hiveconfs:
+            for k, v in six.iteritems(hiveconfs):
+                arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
+        hivevars = job.hivevars()
+        if hivevars:
+            for k, v in six.iteritems(hivevars):
+                arglist += ['--hivevar', '{0}={1}'.format(k, v)]
+        logger.info(arglist)
+        return arglist
+
     def run_job(self, job, tracking_url_callback=None):
         if tracking_url_callback is not None:
             warnings.warn("tracking_url_callback argument is deprecated, task.set_tracking_url is "
@@ -354,18 +382,7 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
                 query = query.encode('utf8')
             f.write(query)
             f.flush()
-            arglist = load_hive_cmd() + ['-f', f.name]
-            hiverc = job.hiverc()
-            if hiverc:
-                if isinstance(hiverc, str):
-                    hiverc = [hiverc]
-                for rcfile in hiverc:
-                    arglist += ['-i', rcfile]
-            if job.hiveconfs():
-                for k, v in six.iteritems(job.hiveconfs()):
-                    arglist += ['--hiveconf', '{0}={1}'.format(k, v)]
-
-            logger.info(arglist)
+            arglist = self.get_arglist(f.name, job)
             return luigi.contrib.hadoop.run_and_track_hadoop_job(arglist, job.set_tracking_url)
 
 

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 from helpers import unittest
 
+from luigi import six
 import luigi.contrib.hive
 import mock
 from luigi import LocalTarget
@@ -287,12 +288,45 @@ class MyHiveTask(luigi.contrib.hive.HiveQueryTask):
 
 
 class TestHiveTask(unittest.TestCase):
+    task_class = MyHiveTask
 
     @mock.patch('luigi.contrib.hadoop.run_and_track_hadoop_job')
     def test_run(self, run_and_track_hadoop_job):
-        success = luigi.run(['MyHiveTask', '--param', 'foo', '--local-scheduler', '--no-lock'])
+        success = luigi.run([self.task_class.__name__, '--param', 'foo', '--local-scheduler', '--no-lock'])
         self.assertTrue(success)
         self.assertEqual('hive', run_and_track_hadoop_job.call_args[0][0][0])
+
+
+class MyHiveTaskArgs(MyHiveTask):
+
+    def hivevars(self):
+        return {'my_variable1': 'value1', 'my_variable2': 'value2'}
+
+    def hiveconfs(self):
+        return {'hive.additional.conf': 'conf_value'}
+
+
+class TestHiveTaskArgs(TestHiveTask):
+    task_class = MyHiveTaskArgs
+
+    def test_arglist(self):
+        task = self.task_class(param='foo')
+        f_name = 'my_file'
+        runner = luigi.contrib.hive.HiveQueryRunner()
+        arglist = runner.get_arglist(f_name, task)
+
+        f_idx = arglist.index('-f')
+        self.assertEqual(arglist[f_idx + 1], f_name)
+
+        hivevars = ['{}={}'.format(k, v) for k, v in six.iteritems(task.hivevars())]
+        for var in hivevars:
+            idx = arglist.index(var)
+            self.assertEqual(arglist[idx - 1], '--hivevar')
+
+        hiveconfs = ['{}={}'.format(k, v) for k, v in six.iteritems(task.hiveconfs())]
+        for conf in hiveconfs:
+            idx = arglist.index(conf)
+            self.assertEqual(arglist[idx - 1], '--hiveconf')
 
 
 class TestHiveTarget(unittest.TestCase):


### PR DESCRIPTION
## Description
`hivevars` method was added. Dictionary items from `hivevars` are included to argument list as --hivevar options. It is needed for separate variables namespace. 

## Motivation and Context
The hiveconf namespace and --hiveconf should be used to set Hive configuration values.
The hivevar namespace and --hivevar should be used to define user variables.
Setting user variables under the hiveconf namespace probably won't break anything, but isn't recommended.

https://cwiki.apache.org/confluence/display/Hive/LanguageManual+VariableSubstitution

## Have you tested this? If so, how?
I have included unit tests.