### PR TITLE
MongoDB target items count

### DIFF
--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -161,3 +161,30 @@ class MongoRangeTarget(MongoTarget):
         )
 
         return set(self._document_ids) - set([doc['_id'] for doc in cursor])
+
+
+class MongoCountTarget(MongoTarget):
+
+    """ Target for a level 0 field in a range of documents """
+
+    def __init__(self, mongo_client, index, collection, target_count):
+        """
+        :param target_count: Value of the desired item count in the target
+        :type field: int
+        """
+        super(MongoCountTarget, self).__init__(mongo_client, index, collection)
+
+        self._target_count = target_count
+
+    def exists(self):
+        """
+        Test if the target has been run
+        Target is considered run if the number of items in the target matches value of self._target_count
+        """
+        return self.read() == self._target_count
+
+    def read(self):
+        """
+        Returns the count number of the target
+        """
+        return self.get_collection().count()

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -186,5 +186,7 @@ class MongoCountTarget(MongoTarget):
     def read(self):
         """
         Returns the count number of the target
+        Using the aggregate method to avoid inaccurate count if using a sharded cluster
+        https://docs.mongodb.com/manual/reference/method/db.collection.count/#behavior
         """
-        return self.get_collection().find().count()
+        return self.get_collection().aggregate([{'$group': {'_id': None, 'count': {'$sum': 1}}}])

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -187,4 +187,4 @@ class MongoCountTarget(MongoTarget):
         """
         Returns the count number of the target
         """
-        return self.get_collection().count()
+        return self.get_collection().find().count()

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -165,7 +165,7 @@ class MongoRangeTarget(MongoTarget):
 
 class MongoCountTarget(MongoTarget):
 
-    """ Target for a level 0 field in a range of documents """
+    """ Target for documents count """
 
     def __init__(self, mongo_client, index, collection, target_count):
         """


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added item count to the MongoDB target using aggregate method.
https://docs.mongodb.com/manual/reference/method/db.collection.count/#behavior

## Motivation and Context
I had a use case where I store data from a CSV file in a mongodb collection for later use. 
The CSV as a very specific number of lines and I don't need to redo the pre-processing each time I re-run the pipeline.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->