### PR TITLE
[bug-fix] scheduler won't override running status incorrectly

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -823,8 +823,8 @@ class Scheduler(object):
                 for batch_task in self._state.get_batch_running_tasks(task.batch_id):
                     batch_task.expl = expl
 
-        if not (task.status in (RUNNING, BATCH_RUNNING) and status == PENDING) or new_deps:
-            # don't allow re-scheduling of task while it is running, it must either fail or succeed first
+        if not (task.status in (RUNNING, BATCH_RUNNING) and (status not in (DONE, FAILED, RUNNING) or task.worker_running != worker_id)) or new_deps:
+            # don't allow re-scheduling of task while it is running, it must either fail or succeed on the worker actually running it
             if status == PENDING or status != task.status:
                 # Update the DB only if there was a acctual change, to prevent noise.
                 # We also check for status == PENDING b/c that's the default value

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -102,6 +102,14 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(self.sch.get_work(worker='Y')['task_id'], 'C')
         self.assertEqual(self.sch.get_work(worker='X')['task_id'], 'B')
 
+    def test_status_wont_override(self):
+        # Worker X is running A
+        # Worker Y wants to override the status to UNKNOWN (e.g. complete is throwing an exception)
+        self.sch.add_task(worker='X', task_id='A')
+        self.assertEqual(self.sch.get_work(worker='X')['task_id'], 'A')
+        self.sch.add_task(worker='Y', task_id='A', status=UNKNOWN)
+        self.assertEqual({'A'}, set(self.sch.task_list(RUNNING, '').keys()))
+
     def test_retry(self):
         # Try to build A but fails, will retry after 100s
         self.setTime(0)


### PR DESCRIPTION
## Description
The scheduler can currently override the RUNNING status of a task with something incorrect coming from a different worker other than the one currently running the task.

## Motivation and Context
The issue has been discussed in the mailing list here: https://groups.google.com/forum/#!searchin/luigi-user/stefano|sort:relevance/luigi-user/WCiQfNEfWY4/5zGdX5X6BgAJ

## Have you tested this? If so, how?
It passes tests. We are about to push this into our production env as well.