### PR TITLE
Fix CDH3 mkdir implementation

### DIFF
--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -229,7 +229,7 @@ class HdfsClientCdh3(HdfsClient):
         try:
             self.call_check(load_hadoop_cmd() + ['fs', '-mkdir', path])
         except hdfs_error.HDFSCliError as ex:
-            if "File exists" in ex.stderr:
+            if raise_if_exists and "File exists" in ex.stderr:
                 raise FileAlreadyExists(ex.stderr)
             else:
                 raise

--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -229,8 +229,9 @@ class HdfsClientCdh3(HdfsClient):
         try:
             self.call_check(load_hadoop_cmd() + ['fs', '-mkdir', path])
         except hdfs_error.HDFSCliError as ex:
-            if raise_if_exists and "File exists" in ex.stderr:
-                raise FileAlreadyExists(ex.stderr)
+            if "File exists" in ex.stderr:
+                if raise_if_exists:
+                    raise FileAlreadyExists(ex.stderr)
             else:
                 raise
 


### PR DESCRIPTION
## Description
Complete the implementation of work started under #2184.

## Motivation and Context
After updating the method signature in #2184, while running in production it became obvious I'd neglected to implement the `raise_if_exists` option. Running `mkdir` on an existing directory was always failing, even when `raise_if_exists=False`.

## Have you tested this? If so, how?
Yes, this version has been run on our production system.
