### PR TITLE
Add worker config check_unfulfilled_deps.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -255,6 +255,14 @@ send-failure-email
   handled by the scheduler.
   Defaults to true.
 
+check_unfulfilled_deps
+  If true, the worker checks for completeness of dependencies before running a
+  task. In case unfulfilled dependencies are detected, an exception is raised
+  and the task will not run. This mechanism is useful to detect situations
+  where tasks do not create their outputs properly, or when targets were
+  removed after the dependency tree was built.
+  Defaults to true.
+
 
 [elasticsearch]
 ---------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -260,7 +260,10 @@ check_unfulfilled_deps
   task. In case unfulfilled dependencies are detected, an exception is raised
   and the task will not run. This mechanism is useful to detect situations
   where tasks do not create their outputs properly, or when targets were
-  removed after the dependency tree was built.
+  removed after the dependency tree was built. It is recommended to disable
+  this feature only when the completeness checks are known to be bottlenecks,
+  e.g. when the ``exists()`` calls of the dependencies' outputs are
+  resource-intensive.
   Defaults to true.
 
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -111,7 +111,7 @@ class TaskProcess(multiprocessing.Process):
     Mainly for convenience since this is run in a separate process. """
 
     def __init__(self, task, worker_id, result_queue, status_reporter,
-                 use_multiprocessing=False, worker_timeout=0):
+                 use_multiprocessing=False, worker_timeout=0, check_unfulfilled_deps=True):
         super(TaskProcess, self).__init__()
         self.task = task
         self.worker_id = worker_id
@@ -121,6 +121,7 @@ class TaskProcess(multiprocessing.Process):
             worker_timeout = task.worker_timeout
         self.timeout_time = time.time() + worker_timeout if worker_timeout else None
         self.use_multiprocessing = use_multiprocessing or self.timeout_time is not None
+        self.check_unfulfilled_deps = check_unfulfilled_deps
 
     def _run_get_new_deps(self):
         self.task.set_tracking_url = self.status_reporter.update_tracking_url
@@ -168,7 +169,7 @@ class TaskProcess(multiprocessing.Process):
             # don't care about unfulfilled dependencies, because we are just
             # checking completeness of self.task so outputs of dependencies are
             # irrelevant.
-            if not _is_external(self.task):
+            if self.check_unfulfilled_deps and not _is_external(self.task):
                 missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]
                 if missing:
                     deps = 'dependency' if len(missing) == 1 else 'dependencies'
@@ -367,6 +368,9 @@ class worker(Config):
     no_install_shutdown_handler = BoolParameter(default=False,
                                                 description='If true, the SIGUSR1 shutdown handler will'
                                                 'NOT be install on the worker')
+    check_unfulfilled_deps(default=True,
+                           description='If true, check for completeness of dependencies before '
+                                       'running a task')
 
 
 class KeepAliveThread(threading.Thread):
@@ -910,7 +914,8 @@ class Worker(object):
         return TaskProcess(
             task, self._id, self._task_result_queue, reporter,
             use_multiprocessing=bool(self.worker_processes > 1),
-            worker_timeout=self._config.timeout
+            worker_timeout=self._config.timeout,
+            check_unfulfilled_deps=self._config.check_unfulfilled_deps
         )
 
     def _purge_children(self):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -915,7 +915,7 @@ class Worker(object):
             task, self._id, self._task_result_queue, reporter,
             use_multiprocessing=bool(self.worker_processes > 1),
             worker_timeout=self._config.timeout,
-            check_unfulfilled_deps=self._config.check_unfulfilled_deps
+            check_unfulfilled_deps=self._config.check_unfulfilled_deps,
         )
 
     def _purge_children(self):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -368,9 +368,9 @@ class worker(Config):
     no_install_shutdown_handler = BoolParameter(default=False,
                                                 description='If true, the SIGUSR1 shutdown handler will'
                                                 'NOT be install on the worker')
-    check_unfulfilled_deps(default=True,
-                           description='If true, check for completeness of dependencies before '
-                                       'running a task')
+    check_unfulfilled_deps = BoolParameter(default=True,
+                                           description='If true, check for completeness of '
+                                           'dependencies before running a task')
 
 
 class KeepAliveThread(threading.Thread):


### PR DESCRIPTION
## Description

When a worker is about to run a task, it checks whether its dependencies are complete. This PR adds a configuration parameter which makes that behavior optional.


## Motivation and Context

In our workflow, we use remote targets that are stored in various locations on the [WLCG](http://wlcg.web.cern.ch/). Some of our tasks have O(1000) dependencies with O(10) output targets each. When running these tasks, the dependency tree is built by checking if the targets exist, which results in network load. But before a worker actually *runs* a task, [it checks its dependencies again](https://github.com/spotify/luigi/blob/master/luigi/worker.py#L167). By skipping this, we could significantly reduce the network load. Therefore, I added a `[worker]` config parameter `check_unfulfilled_deps ` to alter this behavior.
