### PR TITLE
Fix emailing of unexpected error in `Worker._announce_scheduling_failure`.

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -572,9 +572,9 @@ class Worker(object):
                 owners=task._owner_list(),
             )
         except Exception:
-            raise
             formatted_traceback = traceback.format_exc()
             self._email_unexpected_error(task, formatted_traceback)
+            raise
 
     def _email_complete_error(self, task, formatted_traceback):
         self._announce_scheduling_failure(task, formatted_traceback)


### PR DESCRIPTION
## Description
This PR fixes a small issue with error reporting.

## Motivation and Context
The code after ``raise`` is unreachable and ``_email_unexpected_error`` will never be executed in this case. It seems like a typo.

## Have you tested this? If so, how?
This code branch is not tested (as I see in coverage info), so it should not affect any builds. But I can include a test case for this if needed.

Kind Regards