### PR TITLE
Update the docstring of S3FlagTarget

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -750,8 +750,8 @@ class S3FlagTarget(S3Target):
 
         :param path: the directory where the files are stored.
         :type path: str
-        :param format: see the luigi.format module for options
-        :type format: luigi.format.[Text|UTF8|Nop]
+        :param format: see the luigi.format module for options 
+        :type format: luigi.format.[Text|UTF8|Nop] 
         :param client:
         :type client:
         :param flag:

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -751,7 +751,7 @@ class S3FlagTarget(S3Target):
         :param path: the directory where the files are stored.
         :type path: str
         :param format: see the luigi.format module for options
-        :type luigi.format.<Text|UTF8|Nop>
+        :type luigi.format.[Text|UTF8|Nop]
         :param client:
         :type client:
         :param flag:

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -751,7 +751,7 @@ class S3FlagTarget(S3Target):
         :param path: the directory where the files are stored.
         :type path: str
         :param format: see the luigi.format module for options
-        :type luigi.format.[Text|UTF8|Nop]
+        :type format: luigi.format.[Text|UTF8|Nop]
         :param client:
         :type client:
         :param flag:

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -750,8 +750,8 @@ class S3FlagTarget(S3Target):
 
         :param path: the directory where the files are stored.
         :type path: str
-        :param format: see the luigi.format module for options 
-        :type format: luigi.format.[Text|UTF8|Nop] 
+        :param format: see the luigi.format module for options
+        :type format: luigi.format.[Text|UTF8|Nop]
         :param client:
         :type client:
         :param flag:

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -750,6 +750,8 @@ class S3FlagTarget(S3Target):
 
         :param path: the directory where the files are stored.
         :type path: str
+        :param format: see the luigi.format module for options
+        :type luigi.format.<Text|UTF8|Nop>
         :param client:
         :type client:
         :param flag:


### PR DESCRIPTION
I was confused myself about what the format flag was and it was conspicuously missing from the docstring

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
