### PR TITLE
Rework the logic and the tests of the graph visualization type checkboxes.

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -25,7 +25,9 @@ function visualiserApp(luigi) {
      */
     function updateVisType(newVisType) {
         $('#toggleVisButtons label').removeClass('active');
-        $('#toggleVisButtons input[value="' + newVisType + '"]').parent().addClass('active');
+        var visTypeInput = $('#toggleVisButtons input[value="' + newVisType + '"]');
+        visTypeInput.parent().addClass('active');
+        visTypeInput.prop('checked', true);
     }
 
     function loadTemplates() {

--- a/test/visualiser/visualiser_test.py
+++ b/test/visualiser/visualiser_test.py
@@ -89,7 +89,6 @@ class TestVisualiser(ServerTestBase):
 
     # tasks tab tests.
     def test_keeps_entries_after_page_refresh(self):
-
         port = self.get_http_port()
         driver = webdriver.PhantomJS()
 
@@ -121,7 +120,6 @@ class TestVisualiser(ServerTestBase):
         assert len(driver.find_elements_by_css_selector('#taskTable tbody tr')) == 50
 
     def test_keeps_table_filter_after_page_refresh(self):
-
         port = self.get_http_port()
         driver = webdriver.PhantomJS()
 
@@ -147,7 +145,6 @@ class TestVisualiser(ServerTestBase):
         assert len(driver.find_elements_by_css_selector('#taskTable tbody tr')) == 1
 
     def test_keeps_order_after_page_refresh(self):
-
         port = self.get_http_port()
         driver = webdriver.PhantomJS()
 
@@ -235,7 +232,6 @@ class TestVisualiser(ServerTestBase):
         assert invert_checkbox.is_selected()
 
     def test_keeps_task_id_after_page_refresh(self):
-
         port = self.get_http_port()
         driver = webdriver.PhantomJS()
 
@@ -276,7 +272,7 @@ class TestVisualiser(ServerTestBase):
         hide_done_checkbox = driver.find_element_by_css_selector('#hideDoneCheckbox')
         assert hide_done_checkbox.is_selected()
 
-    def test_keeps_svg_visualisation_after_page_refresh(self):
+    def test_keeps_visualisation_type_after_page_refresh(self):
         port = self.get_http_port()
         driver = webdriver.PhantomJS()
 
@@ -284,17 +280,18 @@ class TestVisualiser(ServerTestBase):
 
         # Check initial state.
         svg_radio = driver.find_element_by_css_selector('input[value=svg]')
-        assert svg_radio.is_selected() is False
+        assert svg_radio.is_selected()
 
-        # Change invert checkbox by clicking on label.
-        svg_radio.find_element_by_xpath('..').click()
+        # Change vistype to d3 by clicking on its label.
+        d3_radio = driver.find_element_by_css_selector('input[value=d3]')
+        d3_radio.find_element_by_xpath('..').click()
 
-        # Now refresh page and check. Invert checkbox shoud be checked.
+        # Now refresh page and check. D3 checkbox shoud be checked.
         driver.refresh()
 
         # Once page refreshed we have to find all selectors again.
-        svg_radio = driver.find_element_by_css_selector('input[value=svg]')
-        assert svg_radio.is_selected()
+        d3_radio = driver.find_element_by_css_selector('input[value=d3]')
+        assert d3_radio.is_selected()
 
     def test_synchronizes_fields_on_graph_tab(self):
         # Check fields population if tasks tab was opened by direct link.
@@ -353,7 +350,7 @@ class UberTask(luigi.Task):
     """
     _done = False
 
-    base_task = luigi.Parameter()
+    base_task = luigi.TaskParameter()
     x = luigi.Parameter()
     copies = luigi.IntParameter()
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
* In addition to the `active` class on the visualization type checkboxes. I have added the `checked` state of the input. (Also, this modification fix the selenium test `test_synchronizes_fields_on_graph_tab`.)
* Transform the failing selenium test `test_keeps_svg_visualisation_after_page_refresh` into a `test_keeps_visualisation_type_after_page_refresh` in order to make it more useful (in my opinion).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before beginning the rework / recode of the visualizer (#2172). It it was important to fix all the tests of the current one.
Before this PR, [it was not the case](https://github.com/spotify/luigi/issues/2172#issuecomment-317725386).

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs and the unit tests with this code and it works for me.

```
test (visualiser.visualiser_test.TestVisualiser) ... Loaded http://localhost:64400, status: success
[ OK ]  failed_info_test
[ OK ]  done_info_test
[ OK ]  upstream_failure_info_test
[ OK ]  result_count_test
[ OK ]  filtered_result_count_test1
[ OK ]  filtered_result_count_test2
[ OK ]  filtered_result_count_test3
[ OK ]  filtered_result_count_test4
[ OK ]  filtered_result_count_test5
[ OK ]  filtered_result_count_test5
[ OK ]  filtered_result_count_test5
[ OK ]  filtered_result_count_test5
[ OK ]  searched_result_count_test1
[ OK ]  searched_result_count_test1
RESULT: true
ok
test_keeps_entries_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_filter_on_server_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_hide_done_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_invert_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_order_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_table_filter_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_task_id_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_keeps_visualisation_type_after_page_refresh (visualiser.visualiser_test.TestVisualiser) ... ok
test_synchronizes_fields_on_graph_tab (visualiser.visualiser_test.TestVisualiser) ... ok
test_synchronizes_fields_on_tasks_tab (visualiser.visualiser_test.TestVisualiser) ... ok

----------------------------------------------------------------------
Ran 11 tests in 58.570s

OK
__________________________ summary __________________________
  visualiser: commands succeeded
  congratulations :)
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
