### PR TITLE
Remove assert that verifies if tables were marked for PSQL integrations

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -162,9 +162,6 @@ class PostgresTarget(luigi.Target):
                 (self.update_id, self.table,
                  datetime.datetime.now()))
 
-        # make sure update is properly marked
-        assert self.exists(connection)
-
     def exists(self, connection=None):
         if connection is None:
             connection = self.connect()


### PR DESCRIPTION
In summary, having multiple workers and multiple insert/select on the same table was causing issues where PSQL was throwing an error due to the table being locked. An example of this error would be: `DETAIL:  Serializable isolation violation on table - 202909, transactions forming the cycle are: 877989, 877991 (pid:3940)`

To have a better understanding on the problem that this assert was causing, please refer yourself to this issue https://github.com/glossier/luigi/issues/2. It provides an in-depth explanation of reasoning behind the removal of that line of code.

We've been running on this code for many months and everything is fine an dandy

Fixes https://github.com/spotify/luigi/issues/1905