### PR TITLE
Clear tasks on disabled workers

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -643,7 +643,9 @@ class SimpleTaskState(object):
     def disable_workers(self, worker_ids):
         self._remove_workers_from_tasks(worker_ids, remove_stakeholders=False)
         for worker_id in worker_ids:
-            self.get_worker(worker_id).disabled = True
+            worker = self.get_worker(worker_id)
+            worker.disabled = True
+            worker.tasks.clear()
 
 
 class Scheduler(object):

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -906,6 +906,13 @@ class SchedulerApiTest(unittest.TestCase):
         }
         self.assertEqual(expected, self.sch.count_pending(WORKER))
 
+    def test_count_pending_on_disabled_worker(self):
+        self.sch.add_task(worker=WORKER, task_id='A')
+        self.sch.add_task(worker='other', task_id='B')  # needed to trigger right get_tasks code path
+        self.assertEqual(1, self.sch.count_pending(WORKER)['n_pending_tasks'])
+        self.sch.disable_worker(WORKER)
+        self.assertEqual(0, self.sch.count_pending(WORKER)['n_pending_tasks'])
+
     def test_count_pending_do_not_count_upstream_disabled(self):
         self.sch.add_task(worker=WORKER, task_id='A', status=PENDING)
         self.sch.add_task(worker=WORKER, task_id='B', status=DISABLED)


### PR DESCRIPTION
## Description
Clear worker task lists on disable to ensure a consistent internal state.

## Motivation and Context
One of the uncaught exceptions I was seeing in my scheduler recently was caused by an exception trying to peek at the worker list of a task with empty worker list during count_pending. I solved this in my fork by ignoring the exception, but I think I've now found the real cause.

After a worker is marked disabled, it will call get_work or count_pending one last time before stopping. This call can fail on count_pending when it has a unique task, as that task will now have no
workers but we try to look up the workers from each task.

## Have you tested this? If so, how?
Included unit tests, but I haven't tested this particular fix in production. Should we catch the exception too to be safe?