### PR TITLE
Set utf-8 encoding in the MIMEText constructor

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -141,8 +141,7 @@ def generate_email(sender, subject, message, recipients, image_png):
 
     msg_root = MIMEMultipart('related')
 
-    msg_text = MIMEText(message, email().format)
-    msg_text.set_charset('utf-8')
+    msg_text = MIMEText(message, email().format, 'utf-8')
     msg_root.attach(msg_text)
 
     if image_png:

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -22,6 +22,7 @@ import socket
 
 from helpers import with_config
 from luigi import notifications
+from luigi.notifications import generate_email
 from luigi.scheduler import Scheduler
 from luigi.worker import Worker
 from luigi import six
@@ -146,6 +147,15 @@ class ExceptionFormatTest(unittest.TestCase):
         six.assertCountEqual(self, notifications._email_recipients("a@a.a"), ["a@a.a"])
         six.assertCountEqual(self, notifications._email_recipients(["a@a.a", "b@b.b"]),
                              ["a@a.a", "b@b.b"])
+
+    def test_generate_unicode_email(self):
+        generate_email(
+            sender='test@example.com',
+            subject=six.u('sübjéct'),
+            message=six.u("你好"),
+            recipients=['receiver@example.com'],
+            image_png=None,
+        )
 
 
 class NotificationFixture(object):


### PR DESCRIPTION
## Description
Pass the e-mail encoding into the MIMEText constructor rather than 

## Motivation and Context
If this is not set during the constructor, an exception is thrown in Python 2 when the e-mail body contains unicode.

## Have you tested this? If so, how?
Added a unit test, deployed to production but it'll take a while before I see any unicode e-mails.