### PR TITLE
README: avoid _here_ links; ack readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,12 @@ Getting Started
 ---------------
 
 Run ``pip install luigi`` to install the latest stable version from `PyPI
-<https://pypi.python.org/pypi/luigi>`_. Documentation for the latest release is
-hosted `here <https://luigi.readthedocs.io/en/stable/>`__.
+<https://pypi.python.org/pypi/luigi>`_. `Documentation for the latest release
+<https://luigi.readthedocs.io/en/stable/>`__ is hosted on readthedocs.
 
 For the bleeding edge code, ``pip install
-git+https://github.com/spotify/luigi.git``. Bleeding edge documentation can be
-found `here <https://luigi.readthedocs.io/en/latest/>`__.
+git+https://github.com/spotify/luigi.git``. `Bleeding edge documentation
+<https://luigi.readthedocs.io/en/latest/>`__ is also available.
 
 Background
 ----------


### PR DESCRIPTION
## Motivation and Context

> Screen reader users often navigate from link to link, skipping the text in between
>
> Implication 1: Links should make sense out of context. Phrases such as "click here," "more," "click for details," and so on are ambiguous when read out of context. -- http://webaim.org/techniques/hypertext/

https://www.w3.org/TR/WCAG10-HTML-TECHS/#link-text

## Have you tested this? If so, how?

I expect tweaking README text has no testing impact.
