### PR TITLE
Fix typo in docstring

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -140,7 +140,7 @@ class BulkCompleteNotImplementedError(NotImplementedError):
 
     pylint thinks anything raising NotImplementedError needs to be implemented
     in any subclass. bulk_complete isn't like that. This tricks pylint into
-    thinking that the default implementation is a valid implementation and no
+    thinking that the default implementation is a valid implementation and not
     an abstract method."""
     pass
 


### PR DESCRIPTION
Typo in `BulkCompleteNotImplementedError`

## Description

I fixed a typo in a docstring of a class.

## Motivation and Context

Fixes readability and grammatical correctness.

## Have you tested this? If so, how?

Docstring change only
