### PR TITLE
accept kwargs for mysql connection

### DIFF
--- a/luigi/contrib/mysqldb.py
+++ b/luigi/contrib/mysqldb.py
@@ -36,7 +36,7 @@ class MySqlTarget(luigi.Target):
 
     marker_table = luigi.configuration.get_config().get('mysql', 'marker-table', 'table_updates')
 
-    def __init__(self, host, database, user, password, table, update_id):
+    def __init__(self, host, database, user, password, table, update_id, **cnx_kwargs):
         """
         Initializes a MySqlTarget instance.
 
@@ -50,6 +50,8 @@ class MySqlTarget(luigi.Target):
         :type password: str
         :param update_id: an identifier for this data set.
         :type update_id: str
+        :param cnx_kwargs: optional params for mysql connector constructor.
+            See https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html.
         """
         if ':' in host:
             self.host, self.port = host.split(':')
@@ -62,6 +64,7 @@ class MySqlTarget(luigi.Target):
         self.password = password
         self.table = table
         self.update_id = update_id
+        self.cnx_kwargs = cnx_kwargs
 
     def touch(self, connection=None):
         """
@@ -113,7 +116,8 @@ class MySqlTarget(luigi.Target):
                                              host=self.host,
                                              port=self.port,
                                              database=self.database,
-                                             autocommit=autocommit)
+                                             autocommit=autocommit,
+                                             **self.cnx_kwargs)
         return connection
 
     def create_marker_table(self):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows you to supply additional connection params to mysql connector.  E.g. if you need to supply an SSL cert.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I observed that it allowed me to connect and use the target.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
