### PR TITLE
Fix ListParameter Hashability

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -923,7 +923,7 @@ class ListParameter(Parameter):
     """
     def normalize(self, x):
         """
-        Ensure that list parameter is converted to a tuple so it can be hashed.
+        Ensure that struct is recursively converted to a tuple so it can be hashed.
 
         :param str x: the value to parse.
         :return: the normalized (hashable/immutable) value.
@@ -950,7 +950,7 @@ class ListParameter(Parameter):
         return json.dumps(x, cls=_DictParamEncoder)
 
 
-class TupleParameter(Parameter):
+class TupleParameter(ListParameter):
     """
     Parameter whose value is a ``tuple`` or ``tuple`` of tuples.
 
@@ -978,15 +978,6 @@ class TupleParameter(Parameter):
 
         $ luigi --module my_tasks MyTask --book_locations '((12,3),(4,15),(52,1))'
     """
-    def normalize(self, x):
-        """
-        Ensure that tuple parameter is recursively converted to a tuples so it can be hashed.
-
-        :param str x: the value to parse.
-        :return: the normalized (hashable/immutable) value.
-        """
-        return _recursively_freeze(x)
-
     def parse(self, x):
         """
         Parse an individual value from the input.
@@ -1011,16 +1002,6 @@ class TupleParameter(Parameter):
             return tuple(tuple(x) for x in json.loads(x, object_pairs_hook=_FrozenOrderedDict))
         except ValueError:
             return literal_eval(x)  # if this causes an error, let that error be raised.
-
-    def serialize(self, x):
-        """
-        Opposite of :py:meth:`parse`.
-
-        Converts the value ``x`` to a string.
-
-        :param x: the value to serialize.
-        """
-        return json.dumps(x, cls=_DictParamEncoder)
 
 
 class NumericalParameter(Parameter):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -392,6 +392,14 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.TupleParameter()
         self.assertEqual(hash(Foo(args=(1, "hello")).args), hash(p.parse('(1,"hello")')))
 
+    def test_tuple_dict(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.TupleParameter()
+
+        p = luigi.parameter.TupleParameter()
+        self.assertEqual(hash(Foo(args=({'foo': 'bar'}, {'doge': 'wow'})).args),
+                         hash(p.normalize(p.parse('({"foo": "bar"}, {"doge": "wow"})'))))
+
     def test_task(self):
         class Bar(luigi.Task):
             pass

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -377,6 +377,14 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.ListParameter()
         self.assertEqual(hash(Foo(args=[1, "hello"]).args), hash(p.normalize(p.parse('[1,"hello"]'))))
 
+    def test_list_dict(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.ListParameter()
+
+        p = luigi.parameter.ListParameter()
+        self.assertEqual(hash(Foo(args=[{'foo': 'bar'}, {'doge': 'wow'}]).args),
+                         hash(p.normalize(p.parse('[{"foo": "bar"}, {"doge": "wow"}]'))))
+
     def test_tuple(self):
         class Foo(luigi.Task):
             args = luigi.parameter.TupleParameter()

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -385,6 +385,14 @@ class TestParametersHashability(LuigiTestCase):
         self.assertEqual(hash(Foo(args=[{'foo': 'bar'}, {'doge': 'wow'}]).args),
                          hash(p.normalize(p.parse('[{"foo": "bar"}, {"doge": "wow"}]'))))
 
+    def test_list_nested(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.ListParameter()
+
+        p = luigi.parameter.ListParameter()
+        self.assertEqual(hash(Foo(args=[['foo', 'bar'], ['doge', 'wow']]).args),
+                         hash(p.normalize(p.parse('[["foo", "bar"], ["doge", "wow"]]'))))
+
     def test_tuple(self):
         class Foo(luigi.Task):
             args = luigi.parameter.TupleParameter()
@@ -399,6 +407,14 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.TupleParameter()
         self.assertEqual(hash(Foo(args=({'foo': 'bar'}, {'doge': 'wow'})).args),
                          hash(p.normalize(p.parse('({"foo": "bar"}, {"doge": "wow"})'))))
+
+    def test_tuple_nested(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.TupleParameter()
+
+        p = luigi.parameter.TupleParameter()
+        self.assertEqual(hash(Foo(args=(('foo', 'bar'), ('doge', 'wow'))).args),
+                         hash(p.normalize(p.parse('(("foo", "bar"), ("doge", "wow"))'))))
 
     def test_task(self):
         class Bar(luigi.Task):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
With the merge of #2115, `ListParameter` normalization uses the `_recursively_freeze()` method to transform lists of dictionaries into tuples of `_FrozenOrderedDict`. However, `ListParameter`'s `parse()` and `serialize()` methods were not updated to utilize the `_DictParamEncoder`, allowing JSON serialization.

This PR resolves the serialization of lists of dictionaries provided to `ListParameter`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes unhashability of `ListParameter` when provided a list of dictionaries caused by #2115.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Added hashability test for list of dictionaries.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
