### PR TITLE
Fix unreachable variable status. Replaced by statuses

### DIFF
--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -94,7 +94,7 @@ def _track_tasks(task_ids):
             break
         time.sleep(POLL_TIME)
         logger.debug('ECS task status for tasks {0}: {1}'.format(
-            ','.join(task_ids), status))
+            ','.join(task_ids), statuses))
 
 
 class ECSTask(luigi.Task):


### PR DESCRIPTION
Original status variable caused a crash by logging a null
variable.

Signed-off-by: Pablo Cholaky <waltercool@slash.cl>
