### PR TITLE
Add HA functionality to WebHdfsClient

### DIFF
--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -52,6 +52,7 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
     The library is using `this api
     <https://hdfscli.readthedocs.io/en/latest/api.html>`__.
     """
+
     def __init__(self, host=None, port=None, user=None):
         self.host = host or hdfs_config.hdfs().namenode_host
         self.port = port or webhdfs().port
@@ -59,7 +60,11 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
 
     @property
     def url(self):
-        return 'http://' + self.host + ':' + str(self.port)
+        # the hdfs package allows it to specify multiple namenodes by passing a string containing
+        # multiple namenodes separated by ';'
+        hosts = self.host.split(";")
+        urls = ['http://' + host + ':' + str(self.port) for host in hosts]
+        return ";".join(urls)
 
     @property
     def client(self):


### PR DESCRIPTION
## Motivation and Description

HDFS supports High Availability (HA) through the use of multiple namenodes. This is currently not supported by WebHdfsClient as it allows to specify only one namenode. Since version 2.1.0, the hdfs package allows to specify multiple namenodes, by passing an url containing multiple namenodes separated by ';'. This functionality is forwarded through to WebHdfsClient in this commit.

## Have you tested this? If so, how?

I tested the HA functionality manually on a cluster with two namenodes. I did not add unit tests, as for this one would need to extend WebHdfsMiniCluster to support multiple namenodes, which is non-trivial and probably overkill.