### PR TITLE
Silence Parameter type warning in WebHdfsClient

### DIFF
--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -41,7 +41,7 @@ logger = logging.getLogger('luigi-interface')
 class webhdfs(luigi.Config):
     port = luigi.IntParameter(default=50070,
                               description='Port for webhdfs')
-    user = luigi.Parameter(default=None, description='Defaults to $USER envvar',
+    user = luigi.Parameter(default='', description='Defaults to $USER envvar',
                            config_path=dict(section='hdfs', name='user'))
 
 


### PR DESCRIPTION
## Motivation and Description
In the webhdfs configuration, the parameter `user` has the default value None, which triggers the annoying warning `parameter.py:259: UserWarning: Parameter None is not of type string.` every time a WebHdfsClient is created. This commit prevents this by setting the default value to `''`.

## Have you tested this? If so, how?
Manual testing that the warning is gone. 