### PR TITLE
 FileSystemExternalProgramTask, redirects stdout from externalProgram…

### DIFF
--- a/test/contrib/external_program_test.py
+++ b/test/contrib/external_program_test.py
@@ -22,7 +22,7 @@ from helpers import unittest
 import luigi
 import luigi.contrib.hdfs
 from luigi import six
-from luigi.contrib.external_program import ExternalProgramTask, ExternalPythonProgramTask
+from luigi.contrib.external_program import ExternalProgramTask, ExternalPythonProgramTask,FileSystemOutputExternalProgramTask
 from luigi.contrib.external_program import ExternalProgramRunError
 from mock import patch, call
 
@@ -223,3 +223,31 @@ class ExternalPythonProgramTaskTest(unittest.TestCase):
         self.assertIn('PYTHONPATH', proc_env)
         self.assertTrue(proc_env['PYTHONPATH'].startswith('/extra/pythonpath'))
         self.assertTrue(proc_env['PYTHONPATH'].endswith('/base/pythonpath'))
+
+
+class FileSystemOutputExternalProgramTaskTest(unittest.TestCase):
+
+    class SimpleOutputTask(FileSystemOutputExternalProgramTask):
+
+        def program_args(self):
+            return ["echo", "sample text"]
+
+        def output(self):
+            return luigi.LocalTarget('output')
+
+    def test_get_output(self):
+
+        job = self.SimpleOutputTask()
+        job.run()
+
+        self.assertTrue(job.output().exists())
+
+    def test_match_output(self):
+
+        job = self.SimpleOutputTask()
+        job.run()
+
+        with job.output().open('r') as target_file:
+            task_output = target_file.read()
+            self.assertEquals(task_output.strip('\n'),"sample text")
+


### PR DESCRIPTION
…Task to task Target

This PR adds a new type of ExternalProgramTask which redirects output of the task the task target. This allows , for example, to run shell commands and use the output in the workflow. 

<!--- Describe your changes -->
Simply modified ExternalProgramTask which creates a tmp file to capture stdout. Instead, we open the task target and use that fd to capture the ExternalProgram output. 

## Motivation and Context
This allows better integration of external shell commands into Luigi, by directly capturing its output. In particular I was using some s3 CLI commands which produced a custom output. By putting all those commands into an .sh file and capturing its output I was able to easy integrate those scripts instead of rewriting them using boto bindings.

## Have you tested this? If so, how?
I've included some basic tests and I'am currently using the modifications.
