### PR TITLE
Fixed a typo in docstring

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -686,7 +686,7 @@ class BigQueryExtractTask(luigi.Task):
     Extracts (unloads) a table from BigQuery to GCS.
 
     This tasks requires the input to be exactly one BigQueryTarget while the
-    output should be one or more GCSTargets from luigi.contrib.gcs depening on
+    output should be one or more GCSTargets from luigi.contrib.gcs depending on
     the use of destinationUris property.
     """
     @property


### PR DESCRIPTION
Fixed a minor typo in docstring of 'BigQueryExtractTask' from "depening" to "depending" in [bigquery.py on line 689](https://github.com/spotify/luigi/blob/4bc00ca8caf5e2598910a2fc6fbbbef82d179b4d/luigi/contrib/bigquery.py#L689)