### PR TITLE
Speed up task_list when beyond limit

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -743,7 +743,7 @@ function visualiserApp(luigi) {
         var taskCount;
         /* Check for integers in tasks.  This indicates max-shown-tasks was exceeded */
         if (tasks.length === 1 && typeof(tasks[0]) === 'number') {
-            taskCount = tasks[0];
+            taskCount = tasks[0] === -1 ? 'unknown' : tasks[0];
             missingCategories[category] = {name: category, count: taskCount};
         }
         else {

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1767,6 +1767,21 @@ class SchedulerApiTest(unittest.TestCase):
 
         self.search_pending('ClassA 2016-02-01 num', {expected})
 
+    def test_upstream_beyond_limit(self):
+        sch = Scheduler(max_shown_tasks=3)
+        for i in range(4):
+            sch.add_task(worker=WORKER, family='Test', params={'p': str(i)}, task_id='Test_%i' % i)
+        self.assertEqual({'num_tasks': -1}, sch.task_list('PENDING', 'FAILED'))
+        self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', ''))
+
+    def test_do_not_prune_on_beyond_limit_check(self):
+        sch = Scheduler(max_shown_tasks=3)
+        sch.prune = mock.Mock()
+        for i in range(4):
+            sch.add_task(worker=WORKER, family='Test', params={'p': str(i)}, task_id='Test_%i' % i)
+        self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', ''))
+        sch.prune.assert_not_called()
+
     def test_search_results_beyond_limit(self):
         sch = Scheduler(max_shown_tasks=3)
         for i in range(4):


### PR DESCRIPTION
## Description
In task_list, just return the count for the status when that count is over the max_shown_tasks limit without iterating to check upstream status. This means we can't show counts for upstream statuses, so those are replaced with "unknown" in the visualizer when this happens.

## Motivation and Context
When the number of tasks get into the millions, even refreshing the visualizer can take a minute or more, causing havoc in the pipeline. Since all we really want in these situations is the counts, we can skip the more expensive bits of computation and just return the sizes. This prevents doing upstream checks, but saves a lot of time.

We may want to institute a higher threshold so we can get upstream numbers if you're only a little above the limit for returning all tasks.

## Have you tested this? If so, how?
Added unit tests, have been running this for about a day and it works at scale to reduce visualizer refreshes from minutes to seconds.