### PR TITLE
Adding autocommit property for Redshift queries for Vacuums, etc.

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -348,7 +348,8 @@ class PostgresQuery(rdbms.Query):
     Template task for querying a Postgres compatible database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. Optionally one can override the `autocommit` attribute to put the connection for the query in autocommit mode.
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. 
+    Optionally one can override the `autocommit` attribute to put the connection for the query in autocommit mode.
 
     Override the `run` method if your use case requires some action with the query result.
 

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -360,8 +360,7 @@ class PostgresQuery(rdbms.Query):
 
     def run(self):
         connection = self.output().connect()
-        if self.autocommit:
-            connection.autocommit=self.autocommit
+        connection.autocommit=self.autocommit
         cursor = connection.cursor()
         sql = self.query
 

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -348,7 +348,7 @@ class PostgresQuery(rdbms.Query):
     Template task for querying a Postgres compatible database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes.
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. Optionally one can override the `autocommit` attribute to put the connection for the query in autocommit mode.
 
     Override the `run` method if your use case requires some action with the query result.
 
@@ -359,6 +359,8 @@ class PostgresQuery(rdbms.Query):
 
     def run(self):
         connection = self.output().connect()
+        if self.autocommit:
+            connection.autocommit=self.autocommit
         cursor = connection.cursor()
         sql = self.query
 

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -348,7 +348,7 @@ class PostgresQuery(rdbms.Query):
     Template task for querying a Postgres compatible database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. 
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes.
     Optionally one can override the `autocommit` attribute to put the connection for the query in autocommit mode.
 
     Override the `run` method if your use case requires some action with the query result.
@@ -360,7 +360,7 @@ class PostgresQuery(rdbms.Query):
 
     def run(self):
         connection = self.output().connect()
-        connection.autocommit=self.autocommit
+        connection.autocommit = self.autocommit
         cursor = connection.cursor()
         sql = self.query
 

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -149,6 +149,10 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
         * `table`,
         * `query`
 
+        Optionally override:
+
+        * `autocommit`
+
         Subclass and override the following methods:
 
         * `output`
@@ -177,6 +181,10 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
     @abc.abstractproperty
     def query(self):
         return None
+
+    @abc.abstractproperty
+    def autocommit(self):
+        return False
 
     @abc.abstractmethod
     def run(self):

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -182,7 +182,7 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
     def query(self):
         return None
 
-    @abc.abstractproperty
+    @property
     def autocommit(self):
         return False
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -639,7 +639,8 @@ class RedshiftUnloadTask(postgres.PostgresQuery, _CredentialsMixin):
     Template task for running UNLOAD on an Amazon Redshift database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. Optionally, override the `autocommit` atribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. 
+    Optionally, override the `autocommit` atribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
     Override the `run` method if your use case requires some action with the query result.
     Task instances require a dynamic `update_id`, e.g. via parameter(s), otherwise the query will only execute once
     To customize the query signature as recorded in the database marker table, override the `update_id` property.

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -639,7 +639,7 @@ class RedshiftUnloadTask(postgres.PostgresQuery, _CredentialsMixin):
     Template task for running UNLOAD on an Amazon Redshift database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. 
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes.
     Optionally, override the `autocommit` atribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
     Override the `run` method if your use case requires some action with the query result.
     Task instances require a dynamic `update_id`, e.g. via parameter(s), otherwise the query will only execute once

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -639,7 +639,7 @@ class RedshiftUnloadTask(postgres.PostgresQuery, _CredentialsMixin):
     Template task for running UNLOAD on an Amazon Redshift database
 
     Usage:
-    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes.
+    Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes. Optionally, override the `autocommit` atribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
     Override the `run` method if your use case requires some action with the query result.
     Task instances require a dynamic `update_id`, e.g. via parameter(s), otherwise the query will only execute once
     To customize the query signature as recorded in the database marker table, override the `update_id` property.

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -284,3 +284,34 @@ class TestRedshiftUnloadTask(unittest.TestCase):
             "credentials 'aws_access_key_id=AWS_ACCESS_KEY;aws_secret_access_key=AWS_SECRET_KEY' "
             "DELIMITER ',' ADDQUOTES GZIP ALLOWOVERWRITE PARALLEL OFF;"
         )
+
+
+class DummyRedshiftAutocommitQuery(luigi.contrib.redshift.RedshiftQuery):
+    # Class attributes taken from `DummyPostgresImporter` in
+    # `../postgres_test.py`.
+    host = 'dummy_host'
+    database = 'dummy_database'
+    user = 'dummy_user'
+    password = 'dummy_password'
+    table = luigi.Parameter(default='dummy_table')
+    autocommit = True
+
+    def query(self):
+        return "SELECT 'a' as col_a, current_date as col_b"
+
+
+class TestRedshiftAutocommitQuery(unittest.TestCase):
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_redshift_autocommit_query(self, mock_redshift_target):
+
+        task = DummyRedshiftAutocommitQuery()
+        task.run()
+
+        # The mocked connection cursor passed to
+        # RedshiftUnloadTask.
+        mock_connect = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value)
+
+        # Check the Unload query.
+        self.assertTrue(mock_connect.autocommit)

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -310,8 +310,8 @@ class TestRedshiftAutocommitQuery(unittest.TestCase):
         # The mocked connection cursor passed to
         # RedshiftUnloadTask.
         mock_connect = (mock_redshift_target.return_value
-                                           .connect
-                                           .return_value)
+                                            .connect
+                                            .return_value)
 
         # Check the Unload query.
         self.assertTrue(mock_connect.autocommit)


### PR DESCRIPTION
This solves  #2047 

I've added the ability to override the autocommit property in Postgres Queries (used by Redshift Queries) - this will allow the user to make queries in autocommit mode as some operations require this.

The user only needs to set:
`autocommit = True `
in their RedshiftQuery subclass to make use of it.

Specifically this was done so that we could run VACUUMs in Redshift from Luigi.

I've tested it locally against our database, but I couldn't get the tox tests to run on my machine.

(Sorry for the 2 separate commits, it seems my attempt at squashing them failed)