### PR TITLE
Use columns defined for COPY to Redshift so we never rely on order

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -334,7 +334,7 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         If both key-based and role-based credentials are provided, role-based will be used.
         """
         logger.info("Inserting file: %s", f)
-        if len(self.columns)>0:
+        if len(self.columns) > 0:
             colnames = ",".join([x[0] for x in self.columns])
             cursor.execute("""
              COPY {table} ({colnames}) from '{source}'

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -334,30 +334,22 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         If both key-based and role-based credentials are provided, role-based will be used.
         """
         logger.info("Inserting file: %s", f)
+        colnames = ''
         if len(self.columns) > 0:
             colnames = ",".join([x[0] for x in self.columns])
-            cursor.execute("""
-             COPY {table} ({colnames}) from '{source}'
-             CREDENTIALS '{creds}'
-             {options}
-             ;""".format(
-                table=self.table,
-                source=f,
-                creds=self._credentials(),
-                options=self.copy_options,
-                colnames=colnames)
-            )
-        else:
-            cursor.execute("""
-             COPY {table} from '{source}'
-             CREDENTIALS '{creds}'
-             {options}
-             ;""".format(
-                table=self.table,
-                source=f,
-                creds=self._credentials(),
-                options=self.copy_options)
-            )
+            colnames = '({})'.format(colnames)
+
+        cursor.execute("""
+         COPY {table} {colnames} from '{source}'
+         CREDENTIALS '{creds}'
+         {options}
+         ;""".format(
+            table=self.table,
+            colnames=colnames,
+            source=f,
+            creds=self._credentials(),
+            options=self.copy_options)
+        )
 
     def output(self):
         """

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -334,16 +334,30 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         If both key-based and role-based credentials are provided, role-based will be used.
         """
         logger.info("Inserting file: %s", f)
-        cursor.execute("""
-         COPY {table} from '{source}'
-         CREDENTIALS '{creds}'
-         {options}
-         ;""".format(
-            table=self.table,
-            source=f,
-            creds=self._credentials(),
-            options=self.copy_options)
-        )
+        if len(self.columns)>0:
+            colnames = ",".join([x[0] for x in self.columns])
+            cursor.execute("""
+             COPY {table} ({colnames}) from '{source}'
+             CREDENTIALS '{creds}'
+             {options}
+             ;""".format(
+                table=self.table,
+                source=f,
+                creds=self._credentials(),
+                options=self.copy_options,
+                colnames=colnames)
+            )
+        else:
+            cursor.execute("""
+             COPY {table} from '{source}'
+             CREDENTIALS '{creds}'
+             {options}
+             ;""".format(
+                table=self.table,
+                source=f,
+                creds=self._credentials(),
+                options=self.copy_options)
+            )
 
     def output(self):
         """


### PR DESCRIPTION
## Description

See issue #2244 

## Motivation and Context
Right now COPYs to Redshift are dependent upon the column ordering which can break imports.

## Have you tested this? If so, how?
I've tested it locally with our columns defined.