### PR TITLE
Adding voyages-sncf.com as a company using luigi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,7 @@ or held presentations about Luigi:
 * `Groupon <https://www.groupon.com/>`_ / `OrderUp <https://orderup.com>`_ `(alternative implementation) <https://github.com/groupon/luigi-warehouse>`__
 * `Red Hat - Marketing Operations <https://www.redhat.com>`_ `(blog, 2017) <https://github.com/rh-marketingops/rh-mo-scc-luigi>`__
 * `GetNinjas <https://www.getninjas.com.br/>`_ `(blog, 2017) <https://labs.getninjas.com.br/using-luigi-to-create-and-monitor-pipelines-of-batch-jobs-eb8b3cd2a574>`__
+* `voyages-sncf.com <https://www.voyages-sncf.com/>`_ `(presentation, 2017) <https://github.com/voyages-sncf-technologies/meetup-afpy-nantes-luigi>`__
 
 Some more companies are using Luigi but haven't had a chance yet to write about it:
 


### PR DESCRIPTION
We presented our use of luigi at voyages-sncf.com last Tuesday at a meetup of the French Python society:
http://nantes.afpy.org