### PR TITLE
Preserve filter on server on reload

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1182,6 +1182,7 @@ function visualiserApp(luigi) {
             }
         });
 
+        processHashChange();
         updateTasks();
         bindListEvents();
 


### PR DESCRIPTION
## Description
Run processHashChange before updateTasks on page load so the server-side filtering box gets properly checked.

## Motivation and Context
processHashChange only gets called after updateTasks, so filter on the checkbox only gets checked after we make the server request without filtering. This results in a checked box but no server-side filtering.

## Have you tested this? If so, how?
Ran the server locally with a small max_shown tasks and tried refreshing with a server-side filter. Without this change, no tasks are shown after the refresh. With this change, the filtered tasks are shown.