### PR TITLE
#2279 Add Python 3.6 to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@
 .. image:: https://img.shields.io/pypi/l/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 
-Luigi is a Python (2.7, 3.3, 3.4, 3.5) package that helps you build complex pipelines of batch
-jobs. It handles dependency resolution, workflow management, visualization,
-handling failures, command line integration, and much more.
+Luigi is a Python (2.7, 3.3, 3.4, 3.5, 3.6) package that helps you build complex
+pipelines of batch jobs. It handles dependency resolution, workflow management,
+visualization, handling failures, command line integration, and much more.
 
 Getting Started
 ---------------


### PR DESCRIPTION
## Description
Adds Python 3.6 to the list of supported versions in `README.rst`.

## Motivation and Context
Closes #2279.

## Have you tested this? If so, how?
I successfully built the documentation locally using the [Writing documentation](https://github.com/mattayes/luigi/blob/2.7.1/CONTRIBUTING.rst#writing-documentation) docs.