### PR TITLE
Hide re-enable and forgive buttons on success

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1196,20 +1196,29 @@ function visualiserApp(luigi) {
         } );
 
         $('#taskTable tbody').on('click', 'td.details-control .forgiveFailures', function (ev) {
-            var tr = $(this).closest('tr');
+            var that = $(this);
+            var tr = that.closest('tr');
             var row = dt.row( tr );
             var data = row.data();
             luigi.forgiveFailures(data.taskId, function(data) {
-                if (ev.altKey){
+                if (ev.altKey) {
                     updateTasks(); // update may not be cheap
+                } else {
+                    that.tooltip('hide');
+                    that.remove();
                 }
             });
         } );
 
-        $('#taskTable tbody').on('click', 'td.details-control .re-enable-button', function () {
+        $('#taskTable tbody').on('click', 'td.details-control .re-enable-button', function (ev) {
             var that = $(this);
-            luigi.reEnable($(this).attr("data-task-id"), function(data) {
-                updateTasks();
+            luigi.reEnable(that.attr("data-task-id"), function(data) {
+                if (ev.altKey) {
+                    updateTasks(); // update may not be cheap
+                } else {
+                    that.tooltip('hide');
+                    that.remove();
+                }
             });
         });
 


### PR DESCRIPTION
## Description
Make re-enable and forgive failure buttons disappear on server response. Also add the ability to hold alt with the re-enable to get an update like with forgive failures. This doesn't check for whether the server was successful in its response.

## Motivation and Context
After fixing a bug or system issue that causes a class of jobs to fail, I'm often left with a lot of disabled jobs that need to be re-enabled. I usually click one button and then try to quickly click as many as I can before the refresh. This process is made much slower and less reliable by all the reloads. Some of my co-workers use the javascript console to ensure they can click every available button in time.

On the other hand, I'm not even sure if I successfully clicked on the forgive failures button when I want to make a job pending again. These buttons have very similar functions but wildly different behavior. In order to make them more consistent and more reasonable, we delete them to indicate receipt of the server response.

## Have you tested this? If so, how?
I tried this out on my production server and it works fine.