### PR TITLE
Convert dates to datetimes for DateHourParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -479,6 +479,12 @@ class _DatetimeParameterBase(Parameter):
             return str(dt)
         return dt.strftime(self.date_format)
 
+    @staticmethod
+    def _convert_to_dt(dt):
+        if not isinstance(dt, datetime.datetime):
+            dt = datetime.datetime.combine(dt, datetime.time.min)
+        return dt
+
     def normalize(self, dt):
         """
         Clamp dt to every Nth :py:attr:`~_DatetimeParameterBase.interval` starting at
@@ -486,6 +492,8 @@ class _DatetimeParameterBase(Parameter):
         """
         if dt is None:
             return None
+
+        dt = self._convert_to_dt(dt)
 
         dt = dt.replace(microsecond=0)  # remove microseconds, to avoid float rounding issues.
         delta = (dt - self.start).total_seconds()

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -70,6 +70,10 @@ class DateHourParameterTest(unittest.TestCase):
         dh = luigi.DateHourParameter().parse('2013-02-01T18')
         self.assertEqual(dh, datetime.datetime(2013, 2, 1, 18, 0, 0))
 
+    def test_date_to_dh(self):
+        date = luigi.DateHourParameter().normalize(datetime.date(2000, 1, 1))
+        self.assertEqual(date, datetime.datetime(2000, 1, 1, 0))
+
     def test_serialize(self):
         dh = luigi.DateHourParameter().serialize(datetime.datetime(2013, 2, 1, 18, 0, 0))
         self.assertEqual(dh, '2013-02-01T18')


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Base class for DateHourParameter throws an error when a date instead of a datetime is passed as an argument.  Code was added to convert dates to datetimes when passed to DateHourParameters in order to alleviate aforementioned issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current Luigi set up I work with utilizes base tasks to avoid repeating code.  Some processes use DateParameters and others use DateHourParameters and errors arise when trying to pass dates to DateHourParameters

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Unit test is included

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
