### PR TITLE
Handle multiprocessing with request sessions

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -81,6 +81,7 @@ class RequestsFetcher(object):
         from requests import exceptions as requests_exceptions
         self.raises = requests_exceptions.RequestException
         self.session = session
+        self.process_id = os.getpid()
 
     def fetch(self, full_url, body, timeout):
         # if the process id change changed from when the session was created

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -83,13 +83,15 @@ class RequestsFetcher(object):
         self.session = session
         self.process_id = os.getpid()
 
-    def fetch(self, full_url, body, timeout):
+    def check_pid(self):
         # if the process id change changed from when the session was created
         # a new session needs to be setup since requests isn't multiprocessing safe.
         if os.getpid() != self.process_id:
             self.session = requests.Session()
             self.process_id = os.getpid()
 
+    def fetch(self, full_url, body, timeout):
+        self.check_pid()
         resp = self.session.get(full_url, data=body, timeout=timeout)
         resp.raise_for_status()
         return resp.text

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from multiprocessing import Process, Queue
-
-import requests
-
 from helpers import unittest
 try:
     from unittest import mock
@@ -31,6 +27,9 @@ import luigi.server
 from server_test import ServerTestBase
 import time
 import socket
+from multiprocessing import Process, Queue
+import requests
+
 
 
 class RemoteSchedulerTest(unittest.TestCase):
@@ -139,4 +138,4 @@ class RequestsFetcherTest(ServerTestBase):
         p.start()
         p.join()
 
-        self.assertTrue(q.get())
+        self.assertTrue(q.get(), 'the requests.Session should have changed in the new process')

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -31,7 +31,6 @@ from multiprocessing import Process, Queue
 import requests
 
 
-
 class RemoteSchedulerTest(unittest.TestCase):
     def testUrlArgumentVariations(self):
         for url in ['http://zorg.com', 'http://zorg.com/']:


### PR DESCRIPTION
When luigi forks with `--workers` it uses the same requests `Session` object leading to bugs.

## Description

`Session` is not multiproc safe. It uses http keep alives, and re-using the session across procs can lead to weird multiplexing. This was the cause of my RPCErrors, from what I can tell. 

```
RPCError: Received null response from remote scheduler
```

## Motivation and Context

Relates to #2209

## Have you tested this? If so, how?

I ran under load, 50 workers with and without the fix. With the fix I no longer get the `RPCErrors`