### PR TITLE
TaskStatusReporter: update_status -> update_status_message

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -125,7 +125,7 @@ class TaskProcess(multiprocessing.Process):
 
     def _run_get_new_deps(self):
         self.task.set_tracking_url = self.status_reporter.update_tracking_url
-        self.task.set_status_message = self.status_reporter.update_status
+        self.task.set_status_message = self.status_reporter.update_status_message
         self.task.set_progress_percentage = self.status_reporter.update_progress_percentage
 
         task_gen = self.task.run()
@@ -268,7 +268,7 @@ class TaskStatusReporter(object):
             tracking_url=tracking_url
         )
 
-    def update_status(self, message):
+    def update_status_message(self, message):
         self._scheduler.set_task_status_message(self._task_id, message)
 
     def update_progress_percentage(self, percentage):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Just function renaming to make it clear

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The goal of this change is to make it more clear what this function do. 
Before it, when i tried to customise TaskProcess to allow Task set it's status freely from within run, i saw, that function name `update_status` was already defined =)

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
Yes, i've ran some dummy tasks with set_status_message logic and it ran successfully 