### PR TITLE
Replace `set` calls with literals

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -424,7 +424,7 @@ class MixinBigQueryBulkComplete(object):
         tasks_with_params = [(cls(p), p) for p in parameter_tuples]
 
         # Grab the set of BigQuery datasets we are interested in
-        datasets = set([t.output().table.dataset for t, p in tasks_with_params])
+        datasets = {t.output().table.dataset for t, p in tasks_with_params}
         logger.info('Checking datasets %s for available tables', datasets)
 
         # Query the available tables for all datasets

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -166,7 +166,7 @@ class MongoRangeTarget(MongoTarget):
             {'_id': True}
         )
 
-        return set(self._document_ids) - set([doc['_id'] for doc in cursor])
+        return set(self._document_ids) - {doc['_id'] for doc in cursor}
 
 
 class MongoCollectionTarget(MongoTarget):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -275,7 +275,7 @@ _ORDERED_STATUSES = (
     "not_run",
 )
 _PENDING_SUB_STATUSES = set(_ORDERED_STATUSES[_ORDERED_STATUSES.index("still_pending_ext"):])
-_COMMENTS = set((
+_COMMENTS = {
     ("already_done", 'present dependencies were encountered'),
     ("completed", 'ran successfully'),
     ("failed", 'failed'),
@@ -288,7 +288,7 @@ _COMMENTS = set((
     ("upstream_run_by_other_worker", 'had dependencies that were being run by other worker'),
     ("upstream_scheduling_error", 'had dependencies whose scheduling failed'),
     ("not_run", 'was not granted run permission by the scheduler'),
-))
+}
 
 
 def _get_run_by_other_worker(worker):

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -713,7 +713,7 @@ class Scheduler(object):
         self._state.inactivate_workers(remove_workers)
 
     def _prune_tasks(self):
-        assistant_ids = set(w.id for w in self._state.get_assistants())
+        assistant_ids = {w.id for w in self._state.get_assistants()}
         remove_tasks = []
 
         for task in self._state.get_active_tasks():

--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -79,7 +79,7 @@ def find_deps(task, upstream_task_family):
 
     Returns all deps on all paths between task and upstream
     '''
-    return set([t for t in dfs_paths(task, upstream_task_family)])
+    return {t for t in dfs_paths(task, upstream_task_family)}
 
 
 def find_deps_cli():

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -514,7 +514,7 @@ def _constrain_glob(glob, paths, limit=5):
             return list(current.keys())
         char_sets = {}
         for g, p in six.iteritems(current):
-            char_sets[g] = sorted(set(path[pos] for path in p))
+            char_sets[g] = sorted({path[pos] for path in p})
         if sum(len(s) for s in char_sets.values()) > limit:
             return [g.replace('[0-9]', digit_set_wildcard(char_sets[g]), 1) for g in current]
         for g, s in six.iteritems(char_sets):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -656,7 +656,7 @@ class Worker(object):
         # we track queue size ourselves because len(queue) won't work for multiprocessing
         queue_size = 1
         try:
-            seen = set([task.task_id])
+            seen = {task.task_id}
             while queue_size:
                 current = queue.get()
                 queue_size -= 1

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -140,7 +140,7 @@ class TestSQLA(unittest.TestCase):
         with engine.begin() as conn:
             meta = sqlalchemy.MetaData()
             meta.reflect(bind=engine)
-            self.assertEqual(set([u'table_updates', u'item_property']), set(meta.tables.keys()))
+            self.assertEqual({'table_updates', 'item_property'}, set(meta.tables.keys()))
             table = meta.tables[self.SQLATask.table]
             s = sqlalchemy.select([sqlalchemy.func.count(table.c.item)])
             result = conn.execute(s).fetchone()

--- a/test/date_interval_test.py
+++ b/test/date_interval_test.py
@@ -81,7 +81,7 @@ class DateIntervalTest(LuigiTestCase):
         d = DI().parse('2012')
         self.assertTrue(d == c)
         self.assertEqual(d, min(c, b))
-        self.assertEqual(3, len(set([a, b, c, d])))
+        self.assertEqual(3, len({a, b, c, d}))
 
     def test_comparison_different_types(self):
         x = DI().parse('2012')

--- a/test/event_callbacks_test.py
+++ b/test/event_callbacks_test.py
@@ -241,7 +241,7 @@ class TestDependencyEvents(unittest.TestCase):
         for param in range(1, 3):
             D(param).produce_output()
         self._run_test(A(), {
-            'event.core.dependency.discovered': set([
+            'event.core.dependency.discovered': {
                 (A(param=1).task_id, B(param=1).task_id),
                 (A(param=1).task_id, B(param=2).task_id),
                 (B(param=1).task_id, C(param=1).task_id),
@@ -250,14 +250,14 @@ class TestDependencyEvents(unittest.TestCase):
                 (C(param=1).task_id, D(param=2).task_id),
                 (C(param=2).task_id, D(param=2).task_id),
                 (C(param=2).task_id, D(param=3).task_id),
-            ]),
-            'event.core.dependency.missing': set([
+            },
+            'event.core.dependency.missing': {
                 (D(param=3).task_id,),
-            ]),
-            'event.core.dependency.present': set([
+            },
+            'event.core.dependency.present': {
                 (D(param=1).task_id,),
                 (D(param=2).task_id,),
-            ]),
+            },
         })
         self.assertFalse(A().output().exists())
 
@@ -265,7 +265,7 @@ class TestDependencyEvents(unittest.TestCase):
         for param in range(1, 4):
             D(param).produce_output()
         self._run_test(A(), {
-            'event.core.dependency.discovered': set([
+            'event.core.dependency.discovered': {
                 (A(param=1).task_id, B(param=1).task_id),
                 (A(param=1).task_id, B(param=2).task_id),
                 (B(param=1).task_id, C(param=1).task_id),
@@ -274,12 +274,12 @@ class TestDependencyEvents(unittest.TestCase):
                 (C(param=1).task_id, D(param=2).task_id),
                 (C(param=2).task_id, D(param=2).task_id),
                 (C(param=2).task_id, D(param=3).task_id),
-            ]),
-            'event.core.dependency.present': set([
+            },
+            'event.core.dependency.present': {
                 (D(param=1).task_id,),
                 (D(param=2).task_id,),
                 (D(param=3).task_id,),
-            ]),
+            },
         })
         self.assertEqual(eval_contents(A().output()),
                          [A(param=1).task_id,

--- a/test/local_target_test.py
+++ b/test/local_target_test.py
@@ -204,9 +204,9 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
             bt=['', 'b', 't'],
             plus=['', '+']):
         p = itertools.product(rwax, plus, bt)
-        return set([''.join(c) for c in list(
+        return {''.join(c) for c in list(
             itertools.chain.from_iterable(
-                [itertools.permutations(m) for m in p]))])
+                [itertools.permutations(m) for m in p]))}
 
     def valid_io_modes(self, *a, **kw):
         modes = set()

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -863,7 +863,7 @@ class SchedulerApiTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id='E', status=DISABLED)
 
         # scheduler prunes the worker disabled task
-        self.assertEqual(set(['D', 'E']), set(self.sch.task_list(DISABLED, '')))
+        self.assertEqual({'D', 'E'}, set(self.sch.task_list(DISABLED, '')))
         self._test_prune_done_tasks([])
 
     def test_keep_failed_tasks_for_assistant(self):

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -40,8 +40,7 @@ class SchedulerIoTest(unittest.TestCase):
                 state_path=fn.name)
             state.load()
 
-            self.assertEqual(set(state.get_worker_ids()),
-                             set(['Worker1', 'Worker2']))
+            self.assertEqual(set(state.get_worker_ids()), {'Worker1', 'Worker2'})
 
     def test_load_broken_state(self):
         with tempfile.NamedTemporaryFile(delete=True) as fn:

--- a/test/task_bulk_complete_test.py
+++ b/test/task_bulk_complete_test.py
@@ -41,9 +41,7 @@ class MixinNaiveBulkCompleteTest(unittest.TestCase):
     """
     def test_single_arg_list(self):
         single_arg_list = ["A", "B", "x"]
-        expected_single_arg_list = set(
-            [p for p in single_arg_list if p in COMPLETE_TASKS]
-        )
+        expected_single_arg_list = {p for p in single_arg_list if p in COMPLETE_TASKS}
         self.assertEqual(
             expected_single_arg_list,
             set(MockTask.bulk_complete(single_arg_list))
@@ -51,9 +49,7 @@ class MixinNaiveBulkCompleteTest(unittest.TestCase):
 
     def test_multiple_arg_tuple(self):
         multiple_arg_tuple = (("A", "1"), ("B", "2"), ("X", "3"), ("C", "2"))
-        expected_multiple_arg_tuple = set(
-            [p for p in multiple_arg_tuple if p[0] in COMPLETE_TASKS]
-        )
+        expected_multiple_arg_tuple = {p for p in multiple_arg_tuple if p[0] in COMPLETE_TASKS}
         self.assertEqual(
             expected_multiple_arg_tuple,
             set(MockTask.bulk_complete(multiple_arg_tuple))


### PR DESCRIPTION
## Description
This PR changes `set` function calls with literals.

## Motivation and Context
Literals are a bit cleaner and faster. Since Python 2.6 is not supported it is safe to replace function calls with literals.