### PR TITLE
Removed message 'No Instance(s) Available.' in Windows when starting …

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -37,7 +37,7 @@ def getpcmd(pid):
     """
     if os.name == "nt":
         # Use wmic command instead of ps on Windows.
-        cmd = 'wmic path win32_process where ProcessID=%s get Commandline' % (pid, )
+        cmd = 'wmic path win32_process where ProcessID=%s get Commandline 2> nul' % (pid, )
         with os.popen(cmd, 'r') as p:
             lines = [line for line in p.readlines() if line.strip("\r\n ") != ""]
             if lines:

--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import tempfile
 import mock
+import os
 from helpers import unittest
 
 import luigi
@@ -31,11 +32,18 @@ luigi.notifications.DEBUG = True
 class TestCmd(unittest.TestCase):
 
     def test_getpcmd(self):
-        p = subprocess.Popen(["sleep", "1"])
+        if os.name == 'nt':
+            command = ["ping", "1.1.1.1", "-w", "1000"]
+        else:
+            command = ["sleep", "1"]
+
+        external_process = subprocess.Popen(command)
+        result = luigi.lock.getpcmd(external_process.pid)
+
         self.assertTrue(
-            luigi.lock.getpcmd(p.pid) in ["sleep 1", '[sleep]']
+            result.strip() in ["sleep 1", '[sleep]', 'ping 1.1.1.1 -w 1000']
         )
-        p.kill()
+        external_process.kill()
 
 
 class LockTest(unittest.TestCase):

--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -19,7 +19,6 @@ import os
 import subprocess
 import tempfile
 import mock
-import os
 from helpers import unittest
 
 import luigi


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

In Window when starting luigi the message `No Instance(s) Available.` is shown in the terminal. This is due to the fact that command `wmic` throws this error if no process with the given pid is found. We really do not care about this error, so this change redirects the error message to `nul`

The method of redirecting standard error was found here:

https://stackoverflow.com/questions/4507312/how-to-redirect-stderr-to-null-in-cmd-exe

## Motivation and Context
The message was confusing to new users and gave no important information.

See for example here: https://stackoverflow.com/questions/40593709/luigi-no-instances-available

## Have you tested this? If so, how?
Updated the unit tests to work with Windows, and have run my pipeline without problems.


