### PR TITLE
Optional parameter

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -36,7 +36,7 @@ from luigi.parameter import (
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BoolParameter,
     TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter,
-    NumericalParameter, ChoiceParameter
+    NumericalParameter, ChoiceParameter, OptionalParameter
 )
 
 from luigi import configuration
@@ -59,5 +59,5 @@ __all__ = [
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
-    'NumericalParameter', 'ChoiceParameter'
+    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter'
 ]

--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -133,8 +133,8 @@ class ECSTask(luigi.Task):
 
     """
 
-    task_def_arn = luigi.Parameter(default=None)
-    task_def = luigi.Parameter(default=None)
+    task_def_arn = luigi.OptionalParameter(default=None)
+    task_def = luigi.OptionalParameter(default=None)
     cluster = luigi.Parameter(default='default')
 
     @property

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -72,10 +72,13 @@ TRACKING_RE = re.compile(r'(tracking url|the url to track the job):\s+(?P<url>.+
 
 
 class hadoop(luigi.task.Config):
-    pool = luigi.Parameter(default=None,
-                           description='Hadoop pool so use for Hadoop tasks. '
-                           'To specify pools per tasks, see '
-                           'BaseHadoopJobTask.pool')
+    pool = luigi.OptionalParameter(
+        default=None,
+        description=(
+            'Hadoop pool so use for Hadoop tasks. To specify pools per tasks, '
+            'see BaseHadoopJobTask.pool'
+        ),
+    )
 
 
 def attach(*packages):
@@ -668,7 +671,7 @@ class LocalJobRunner(JobRunner):
 
 
 class BaseHadoopJobTask(luigi.Task):
-    pool = luigi.Parameter(default=None, significant=False, positional=False)
+    pool = luigi.OptionalParameter(default=None, significant=False, positional=False)
     # This value can be set to change the default batching increment. Default is 1 for backwards compatibility.
     batch_counter_default = 1
 

--- a/luigi/contrib/hdfs/config.py
+++ b/luigi/contrib/hdfs/config.py
@@ -36,18 +36,19 @@ except ImportError:
 
 class hdfs(luigi.Config):
     client_version = luigi.IntParameter(default=None)
-    effective_user = luigi.Parameter(
+    effective_user = luigi.OptionalParameter(
         default=os.getenv('HADOOP_USER_NAME'),
         description="Optionally specifies the effective user for snakebite. "
                     "If not set the environment variable HADOOP_USER_NAME is "
                     "used, else USER")
     snakebite_autoconfig = luigi.BoolParameter(default=False)
-    namenode_host = luigi.Parameter(default=None)
+    namenode_host = luigi.OptionalParameter(default=None)
     namenode_port = luigi.IntParameter(default=None)
     client = luigi.Parameter(default='hadoopcli')
-    tmp_dir = luigi.Parameter(default=None,
-                              config_path=dict(section='core', name='hdfs-tmp-dir'),
-                              )
+    tmp_dir = luigi.OptionalParameter(
+        default=None,
+        config_path=dict(section='core', name='hdfs-tmp-dir'),
+    )
 
 
 class hadoopcli(luigi.Config):

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -47,7 +47,7 @@ from luigi.six.moves import range
 
 from luigi import configuration
 from luigi.format import get_default_format
-from luigi.parameter import Parameter
+from luigi.parameter import OptionalParameter, Parameter
 from luigi.target import FileAlreadyExists, FileSystem, FileSystemException, FileSystemTarget, AtomicLocalFile, MissingParentDirectory
 from luigi.task import ExternalTask
 
@@ -808,7 +808,7 @@ class S3FlagTask(ExternalTask):
     An external task that requires the existence of EMR output in S3.
     """
     path = Parameter()
-    flag = Parameter(default=None)
+    flag = OptionalParameter(default=None)
 
     def output(self):
         return S3FlagTarget(self.path, flag=self.flag)

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -302,6 +302,26 @@ class Parameter(object):
         return "store"
 
 
+class OptionalParameter(Parameter):
+    """ A Parameter that treats empty string as None """
+
+    def serialize(self, x):
+        if x is None:
+            return ''
+        else:
+            return str(x)
+
+    def parse(self, x):
+        return x or None
+
+    def _warn_on_wrong_param_type(self, param_name, param_value):
+        if self.__class__ != OptionalParameter:
+            return
+        if not isinstance(param_value, six.string_types) and param_value is not None:
+            warnings.warn('OptionalParameter "{}" with value "{}" is not of type string or None.'.format(
+                param_name, param_value))
+
+
 _UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
 
 

--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -69,7 +69,7 @@ class upstream(luigi.task.Config):
     '''
     Used to provide the parameter upstream-family
     '''
-    family = parameter.Parameter(default=None)
+    family = parameter.OptionalParameter(default=None)
 
 
 def find_deps(task, upstream_task_family):


### PR DESCRIPTION
## Description
Create an OptionalParameter class that serializes None as the empty string and use this class whenever we have a parameter with default None. Empty string gets parsed to None.

## Motivation and Context
I get a long series of type warnings from default None values in the Luigi codebase whenever I run my pipeline. This gets rid of those, and should be safe as long as no one needs to differentiate between the empty string and None.

## Have you tested this? If so, how?
I added some unit tests for the OptionalParameter class. I haven't tried running a pipeline with it yet, but I will soon.