### PR TITLE
Allow NoneType columns in Redshift COPY job

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -335,7 +335,7 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         """
         logger.info("Inserting file: %s", f)
         colnames = ''
-        if len(self.columns) > 0:
+        if self.columns and len(self.columns) > 0:
             colnames = ",".join([x[0] for x in self.columns])
             colnames = '({})'.format(colnames)
 

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -40,9 +40,11 @@ class DummyS3CopyToTableBase(luigi.contrib.redshift.S3CopyToTable):
     user = 'dummy_user'
     password = 'dummy_password'
     table = luigi.Parameter(default='dummy_table')
-    columns = (
-        ('some_text', 'varchar(255)'),
-        ('some_int', 'int'),
+    columns = luigi.TupleParameter(
+        default=(
+            ('some_text', 'varchar(255)'),
+            ('some_int', 'int'),
+        )
     )
 
     copy_options = ''
@@ -212,6 +214,123 @@ class TestS3CopyToTable(unittest.TestCase):
             "from pg_table_def "
             "where tablename = lower(%s) limit 1",
             (task.table,),
+        )
+
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_with_valid_columns(self, mock_redshift_target):
+        task = DummyS3CopyToTableKey(columns=(
+            ('some_text', 'varchar(255)'),
+            ('some_int', 'int'),
+        ))
+        task.run()
+
+        # The mocked connection cursor passed to
+        # S3CopyToTable.copy(self, cursor, f).
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        # `mock_redshift_target` is the mocked `RedshiftTarget` object
+        # returned by S3CopyToTable.output(self).
+        mock_redshift_target.assert_called_once_with(
+            database=task.database,
+            host=task.host,
+            update_id=task.task_id,
+            user=task.user,
+            table=task.table,
+            password=task.password,
+        )
+
+        # To get the proper intendation in the multiline `COPY` statement the
+        # SQL string was copied from redshift.py.
+        mock_cursor.execute.assert_called_with("""
+         COPY {table} {colnames} from '{source}'
+         CREDENTIALS '{creds}'
+         {options}
+         ;""".format(
+            table='dummy_table',
+            colnames='(some_text,some_int)',
+            source='s3://bucket/key',
+            creds='aws_access_key_id=key;aws_secret_access_key=secret',
+            options='')
+        )
+
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_with_default_columns(self, mock_redshift_target):
+        task = DummyS3CopyToTableKey(columns=[])
+        task.run()
+
+        # The mocked connection cursor passed to
+        # S3CopyToTable.copy(self, cursor, f).
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        # `mock_redshift_target` is the mocked `RedshiftTarget` object
+        # returned by S3CopyToTable.output(self).
+        mock_redshift_target.assert_called_once_with(
+            database=task.database,
+            host=task.host,
+            update_id=task.task_id,
+            user=task.user,
+            table=task.table,
+            password=task.password,
+        )
+
+        # To get the proper intendation in the multiline `COPY` statement the
+        # SQL string was copied from redshift.py.
+        mock_cursor.execute.assert_called_with("""
+         COPY {table} {colnames} from '{source}'
+         CREDENTIALS '{creds}'
+         {options}
+         ;""".format(
+            table='dummy_table',
+            colnames='',
+            source='s3://bucket/key',
+            creds='aws_access_key_id=key;aws_secret_access_key=secret',
+            options='')
+        )
+
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_with_nonetype_columns(self, mock_redshift_target):
+        task = DummyS3CopyToTableKey(columns=None)
+        task.run()
+
+        # The mocked connection cursor passed to
+        # S3CopyToTable.copy(self, cursor, f).
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        # `mock_redshift_target` is the mocked `RedshiftTarget` object
+        # returned by S3CopyToTable.output(self).
+        mock_redshift_target.assert_called_once_with(
+            database=task.database,
+            host=task.host,
+            update_id=task.task_id,
+            user=task.user,
+            table=task.table,
+            password=task.password,
+        )
+
+        # To get the proper intendation in the multiline `COPY` statement the
+        # SQL string was copied from redshift.py.
+        mock_cursor.execute.assert_called_with("""
+         COPY {table} {colnames} from '{source}'
+         CREDENTIALS '{creds}'
+         {options}
+         ;""".format(
+            table='dummy_table',
+            colnames='',
+            source='s3://bucket/key',
+            creds='aws_access_key_id=key;aws_secret_access_key=secret',
+            options='')
         )
 
 

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -218,10 +218,7 @@ class TestS3CopyToTable(unittest.TestCase):
 
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_s3_copy_with_valid_columns(self, mock_redshift_target):
-        task = DummyS3CopyToTableKey(columns=(
-            ('some_text', 'varchar(255)'),
-            ('some_int', 'int'),
-        ))
+        task = DummyS3CopyToTableKey()
         task.run()
 
         # The mocked connection cursor passed to


### PR DESCRIPTION
## Description
Preceding booleanness check lowers requirements for the columns attribute and ensures backward-compatibility.

## Motivation and Context
It fixes issue #2298.
