### PR TITLE
Fix a warning in googleapiclient usage in contrib.gcs

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -245,7 +245,7 @@ class GCSClient(luigi.target.FileSystem):
         resumable = os.path.getsize(filename) > 0
 
         mimetype = mimetype or mimetypes.guess_type(dest_path)[0] or DEFAULT_MIMETYPE
-        media = http.MediaFileUpload(filename, mimetype, chunksize=chunksize, resumable=resumable)
+        media = http.MediaFileUpload(filename, mimetype=mimetype, chunksize=chunksize, resumable=resumable)
 
         self._do_put(media, dest_path)
 


### PR DESCRIPTION
The constructor of `googleapiclient.http.MediaFileUpload` is marked with `@positional(2)`, which means it only accepts 2 positional arguments (`self` and `filename`). This change should get rid of mysterious `__init__() takes at most 2 positional arguments (3 given)` message in the task output.
