### PR TITLE
 Fix MRO on tasks using util.requires #2054

### DIFF
--- a/luigi/util.py
+++ b/luigi/util.py
@@ -274,8 +274,11 @@ class inherits(object):
         self.task_to_inherit = task_to_inherit
 
     def __call__(self, task_that_inherits):
+        # Get all parameter objects from the underlying task
         for param_name, param_obj in self.task_to_inherit.get_params():
+            # Check if the parameter exists in the inheriting task
             if not hasattr(task_that_inherits, param_name):
+                # If not, add it to the inheriting task
                 setattr(task_that_inherits, param_name, param_obj)
 
         # Modify task_that_inherits by subclassing it and adding methods

--- a/luigi/util.py
+++ b/luigi/util.py
@@ -281,14 +281,12 @@ class inherits(object):
                 # If not, add it to the inheriting task
                 setattr(task_that_inherits, param_name, param_obj)
 
-        # Modify task_that_inherits by subclassing it and adding methods
-        @task._task_wraps(task_that_inherits)
-        class Wrapped(task_that_inherits):
+        # Modify task_that_inherits by adding methods
+        def clone_parent(_self, **args):
+            return _self.clone(cls=self.task_to_inherit, **args)
+        task_that_inherits.clone_parent = clone_parent
 
-            def clone_parent(_self, **args):
-                return _self.clone(cls=self.task_to_inherit, **args)
-
-        return Wrapped
+        return task_that_inherits
 
 
 class requires(object):
@@ -303,14 +301,12 @@ class requires(object):
     def __call__(self, task_that_requires):
         task_that_requires = self.inherit_decorator(task_that_requires)
 
-        # Modify task_that_requres by subclassing it and adding methods
-        @task._task_wraps(task_that_requires)
-        class Wrapped(task_that_requires):
+        # Modify task_that_requres by adding methods
+        def requires(_self):
+            return _self.clone_parent()
+        task_that_requires.requires = requires
 
-            def requires(_self):
-                return _self.clone_parent()
-
-        return Wrapped
+        return task_that_requires
 
 
 class copies(object):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -18,11 +18,89 @@ from helpers import LuigiTestCase, RunOnceTask
 
 import luigi
 import luigi.task
-from luigi.util import requires
+from luigi.util import inherits, requires
 
 
 class BasicsTest(LuigiTestCase):
+    # following tests using inherits decorator
+    def test_task_ids_using_inherits(self):
+        class ParentTask(luigi.Task):
+            my_param = luigi.Parameter()
+        luigi.namespace('blah')
 
+        @inherits(ParentTask)
+        class ChildTask(luigi.Task):
+            def requires(self):
+                return self.clone(ParentTask)
+        luigi.namespace('')
+        child_task = ChildTask(my_param='hello')
+        self.assertEqual(str(child_task), 'blah.ChildTask(my_param=hello)')
+        self.assertIn(ParentTask(my_param='hello'), luigi.task.flatten(child_task.requires()))
+
+    def test_task_ids_using_inherits_2(self):
+        # Here we use this decorator in a unnormal way.
+        # But it should still work.
+        class ParentTask(luigi.Task):
+            my_param = luigi.Parameter()
+        decorator = inherits(ParentTask)
+        luigi.namespace('blah')
+
+        class ChildTask(luigi.Task):
+            def requires(self):
+                return self.clone_parent()
+        luigi.namespace('')
+        ChildTask = decorator(ChildTask)
+        child_task = ChildTask(my_param='hello')
+        self.assertEqual(str(child_task), 'blah.ChildTask(my_param=hello)')
+        self.assertIn(ParentTask(my_param='hello'), luigi.task.flatten(child_task.requires()))
+
+    def _setup_parent_and_child_inherits(self):
+        class ParentTask(luigi.Task):
+            my_parameter = luigi.Parameter()
+            class_variable = 'notset'
+
+            def run(self):
+                self.__class__.class_variable = self.my_parameter
+
+            def complete(self):
+                return self.class_variable == 'actuallyset'
+
+        @inherits(ParentTask)
+        class ChildTask(RunOnceTask):
+            def requires(self):
+                return self.clone_parent()
+
+        return ParentTask
+
+    def test_inherits_has_effect_run_child(self):
+        ParentTask = self._setup_parent_and_child_inherits()
+        self.assertTrue(self.run_locally_split('ChildTask --my-parameter actuallyset'))
+        self.assertEqual(ParentTask.class_variable, 'actuallyset')
+
+    def test_inherits_has_effect_run_parent(self):
+        ParentTask = self._setup_parent_and_child_inherits()
+        self.assertTrue(self.run_locally_split('ParentTask --my-parameter actuallyset'))
+        self.assertEqual(ParentTask.class_variable, 'actuallyset')
+
+    def _setup_inherits_inheritence(self):
+        class InheritedTask(luigi.Task):
+            pass
+
+        class ParentTask(luigi.Task):
+            pass
+
+        @inherits(InheritedTask)
+        class ChildTask(ParentTask):
+            pass
+
+        return ChildTask
+
+    def test_inherits_has_effect_MRO(self):
+        ChildTask = self._setup_inherits_inheritence()
+        self.assertNotEqual(str(ChildTask.__mro__[0]),
+                            str(ChildTask.__mro__[1]))
+
+    # following tests using requires decorator
     def test_task_ids_using_requries(self):
         class ParentTask(luigi.Task):
             my_param = luigi.Parameter()

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -78,3 +78,21 @@ class BasicsTest(LuigiTestCase):
         ParentTask = self._setup_parent_and_child()
         self.assertTrue(self.run_locally_split('ParentTask --my-parameter actuallyset'))
         self.assertEqual(ParentTask.class_variable, 'actuallyset')
+
+    def _setup_requires_inheritence(self):
+        class RequiredTask(luigi.Task):
+            pass
+
+        class ParentTask(luigi.Task):
+            pass
+
+        @requires(RequiredTask)
+        class ChildTask(ParentTask):
+            pass
+
+        return ChildTask
+
+    def test_requires_has_effect_MRO(self):
+        ChildTask = self._setup_requires_inheritence()
+        self.assertNotEqual(str(ChildTask.__mro__[0]),
+                            str(ChildTask.__mro__[1]))


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a test for luigi.util.requires which fails, as the inherits and requires decorators mess with the MRO and a super call results in infinite loops (#2054).
Document a bit of the source code for clarity.
Instead of subclassing in the decorators add the methods clone_parent and requires to the task that inherits by monkey patching them as proposed in #2054.
This is my first contribution to a bigger GitHub project, so please watch out for newbie mistakes :)

## Motivation and Context
This fixes the issue #2054!

## Have you tested this? If so, how?
I added a test specifically looking at the MRO of a requiring task, which fails on the current master and returns ok on my fix. Running all tests using `tox -e py27-nonhdfs` returned the same 30 skips and 3 errors both on the master and my fix (excluding my new test for the master). Those tests have no apparent connection to luigi.util.requires and inherits (see [test-output.txt](https://github.com/spotify/luigi/files/1548207/test-output.txt)).

## Possible issue with this PR
I am not sure what the exact reason was for using a wrapped class to add the methods clone_parent and requires in the first place, at least I could not come up with a scenario, that would require subclassing instead of monkey patching. If there is such a reason/scenario one might want to check if this PR breaks it!

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
