### PR TITLE
Introduced process_requires

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -575,6 +575,18 @@ class Task(object):
         """
         return []  # default impl
 
+    def process_requires(self, requires):
+        """
+        Override in "template" tasks which themselves are supposed to be
+        subclassed and thus have their requires() overridden (name preserved to
+        provide consistent end-user experience), yet need to introduce
+        custom behaviour into dependencies.
+
+        This defers from _requires in that this will not directly call task.requires
+        and this is being used by dependencies yielded by run
+        """
+        return requires
+
     def requires(self):
         """
         The Tasks that this Task depends on.
@@ -627,7 +639,7 @@ class Task(object):
         Returns the flattened list of requires.
         """
         # used by scheduler
-        return flatten(self._requires())
+        return flatten(self.process_requires(self._requires()))
 
     def run(self):
         """

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -147,7 +147,7 @@ class TaskProcess(multiprocessing.Process):
             except StopIteration:
                 return None
 
-            new_req = flatten(requires)
+            new_req = flatten(self.task.process_requires(requires))
             if all(t.complete() for t in new_req):
                 next_send = getpaths(requires)
             else:


### PR DESCRIPTION
## Description
Adds a `process_requires` method to `Task` class. Similar to `_requires` and `process_resources`, this allows a Template task to inspect and modify dependencies before passing them to Luigi worker.

This is different from `_requires` or `deps` in that this works with dynamic dependencies yielded from `run` as well.

## Motivation and Context
We have a template task that needed to pass some parameters along the dependency tree. This change could be used to obviate the need for using `clone` in every Task:
```
def process_requires(self, requires):
    for req in luigi.task.flatten(requires):
        req.job_id = self.job_id
    return requires
```

## Have you tested this? If so, how?
"We ran our jobs with this code and it works for us."
I could use some help in adding unit tests!
