### PR TITLE
Pass tracking_url to scheduler

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -777,6 +777,7 @@ class Worker(object):
             params=task.to_str_params(),
             family=task.task_family,
             module=task.task_module,
+            tracking_url=getattr(task, 'tracking_url', None),
             batchable=task.batchable,
             retry_policy_dict=_get_retry_policy_dict(task),
         )
@@ -994,6 +995,7 @@ class Worker(object):
                            params=task.to_str_params(),
                            family=task.task_family,
                            module=task.task_module,
+                           tracking_url=getattr(task, 'tracking_url', None),
                            new_deps=new_deps,
                            assistant=self._assistant,
                            retry_policy_dict=_get_retry_policy_dict(task))


### PR DESCRIPTION
## Description
This change allows tracking_url to be passed to scheduler when adding the task.

## Motivation and Context
We have fairly predictable URL for our log viewer. With this change, `tracking_url` can be defined as a `@property` and works as expected.

## Have you tested this? If so, how?
"I ran my jobs with this code and it works for me."
