### PR TITLE
Deprecate param_args

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -532,7 +532,7 @@ class Task(object):
         return task_str
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.param_args == other.param_args
+        return self.__class__ == other.__class__ and self.param_kwargs == other.param_kwargs
 
     def complete(self):
         """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -428,8 +428,7 @@ class Task(object):
         for key, value in param_values:
             setattr(self, key, value)
 
-        # Register args and kwargs as an attribute on the class. Might be useful
-        self.param_args = tuple(value for key, value in param_values)
+        # Register kwargs as an attribute on the class. Might be useful
         self.param_kwargs = dict(param_values)
 
         self._warn_on_wrong_param_types()
@@ -439,6 +438,11 @@ class Task(object):
         self.set_tracking_url = None
         self.set_status_message = None
         self.set_progress_percentage = None
+
+    @property
+    def param_args(self):
+        warnings.warn("Use of param_args has been deprecated.", DeprecationWarning)
+        return tuple(self.param_kwargs[k] for k, v in self.get_params())
 
     def initialized(self):
         """


### PR DESCRIPTION
## Description
This change deprecates `param_args` on `Task` and changes the equality check to use `param_kwargs` instead. This is the only place that uses the property.

The property itself duplicates the information already available in `param_kwargs` and `get_params()`  and that's one more thing to maintain and possibly go out of sync.

This aims to not change behaviour so tests are left intact.