### PR TITLE
Fix Python 3 TypeError in contrib.hive.HiveTableTarget.exists()

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -68,7 +68,7 @@ def run_hive(args, check_return_code=True):
     if check_return_code and p.returncode != 0:
         raise HiveCommandError("Hive command: {0} failed with error code: {1}".format(" ".join(cmd), p.returncode),
                                stdout, stderr)
-    return stdout
+    return stdout.decode('utf-8')
 
 
 def run_hive_cmd(hivecmd, check_return_code=True):

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -32,7 +32,7 @@ class HiveTest(unittest.TestCase):
     def mock_hive_cmd(self, args, check_return=True):
         self.last_hive_cmd = args
         self.count += 1
-        return "statement{0}".format(self.count)
+        return six.u("statement{0}".format(self.count))
 
     def setUp(self):
         self.run_hive_cmd_saved = luigi.contrib.hive.run_hive
@@ -262,7 +262,7 @@ class HiveCommandClientTest(unittest.TestCase):
         # I'm testing this again to check the return codes
         # I didn't want to tear up all the existing tests to change how run_hive is mocked
         comm = mock.Mock(name='communicate_mock')
-        comm.return_value = "some return stuff", ""
+        comm.return_value = six.b("some return stuff"), ""
 
         preturn = mock.Mock(name='open_mock')
         preturn.returncode = 0
@@ -275,7 +275,7 @@ class HiveCommandClientTest(unittest.TestCase):
         preturn.returncode = 17
         self.assertRaises(luigi.contrib.hive.HiveCommandError, luigi.contrib.hive.run_hive, ["blah", "blah"])
 
-        comm.return_value = "", "some stderr stuff"
+        comm.return_value = six.b(""), "some stderr stuff"
         returned = luigi.contrib.hive.run_hive(["blah", "blah"], False)
         self.assertEqual("", returned)
 


### PR DESCRIPTION
## Description
Stdout is `bytes` which is fine in Python 2 since the rest of the strings are too, but in Python 3 we need it to be `unicode` so we can do string comparisons. This fixes a long-standing bug, it seems!

## Motivation and Context
See #1012.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.
