### PR TITLE
Make task_id deterministic with DictParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -916,7 +916,7 @@ class DictParameter(Parameter):
         return json.loads(s, object_pairs_hook=_FrozenOrderedDict)
 
     def serialize(self, x):
-        return json.dumps(x, cls=_DictParamEncoder)
+        return json.dumps(x, cls=_DictParamEncoder, sort_keys=True)
 
 
 class ListParameter(Parameter):


### PR DESCRIPTION
## Description
Sort DictParameter keys when serializing,

## Motivation and Context
The DictParameter serialization is not deterministic and so is not the task_id of a task containing a DictParameter. Note that this behaviour might vary among versions of python.

The changes are minimal and should not break anything (not worsening existing behaviour).
  
This PR fixes this issue https://github.com/spotify/luigi/issues/2324

## Have you tested this? If so, how?
Tested with  `luigi==2.7.1` and `Python 3.5.2.` in different processes.
