### PR TITLE
Fix unicode formatting.

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -335,8 +335,8 @@ class Task(object):
 
     @property
     def pretty_id(self):
-        param_str = ', '.join('{}={}'.format(key, value) for key, value in sorted(self.params.items()))
-        return '{}({})'.format(self.family, param_str)
+        param_str = ', '.join(u'{}={}'.format(key, value) for key, value in sorted(self.params.items()))
+        return u'{}({})'.format(self.family, param_str)
 
 
 class Worker(object):

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -27,6 +27,12 @@ from helpers import with_config
 
 class SchedulerIoTest(unittest.TestCase):
 
+    def test_pretty_id_unicode(self):
+        scheduler = luigi.scheduler.Scheduler()
+        scheduler.add_task(worker='A', task_id='1', params={u'foo': u'\u2192bar'})
+        [task] = list(scheduler._state.get_active_tasks())
+        task.pretty_id
+
     def test_load_old_state(self):
         tasks = {}
         active_workers = {'Worker1': 1e9, 'Worker2': time.time()}


### PR DESCRIPTION
On Python 2.x, `scheduler.Task.pretty_id` methods fails with the following error when a parameter's value contains a unicode code point:

```
Traceback (most recent call last):
  File "/Users/piotr/counsyl/luigi/test/scheduler_test.py", line 34, in test_pretty_id_unicode
    task.pretty_id
  File "/Users/piotr/counsyl/luigi/luigi/scheduler.py", line 338, in pretty_id
    param_str = ', '.join('{}={}'.format(key, value) for key, value in sorted(self.params.items()))
  File "/Users/piotr/counsyl/luigi/luigi/scheduler.py", line 338, in <genexpr>
    param_str = ', '.join('{}={}'.format(key, value) for key, value in sorted(self.params.items()))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2192' in position 0: ordinal not in range(128)
```

## Description
Do not attempt to convert unicode to str, but return unicode object instead.

## Have you tested this? If so, how?
I have included unit tests. I've also ran my jobs with this code and it works for me.