### PR TITLE
Add possibility to specify Redshift column compression.

### DIFF
--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -299,6 +299,24 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
                 table_attributes=self.table_attributes)
 
             connection.cursor().execute(query)
+        elif len(self.columns[0]) == 3:
+            # if columns is specified as (name, type, encoding) tuples
+            # possible column encodings: https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html
+            coldefs = ','.join(
+                '{name} {type} ENCODE {encoding}'.format(
+                    name=name,
+                    type=type,
+                    encoding=encoding) for name, type, encoding in self.columns
+            )
+            query = ("CREATE {type} TABLE "
+                     "{table} ({coldefs}) "
+                     "{table_attributes}").format(
+                type=self.table_type,
+                table=self.table,
+                coldefs=coldefs,
+                table_attributes=self.table_attributes)
+
+            connection.cursor().execute(query)
         else:
             raise ValueError("create_table() found no columns for %r"
                              % self.table)

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -58,6 +58,7 @@ class DummyS3CopyToTableKey(DummyS3CopyToTableBase):
     aws_access_key_id = AWS_ACCESS_KEY
     aws_secret_access_key = AWS_SECRET_KEY
 
+
 class DummyS3CopyToTableWithCompressionEncodings(DummyS3CopyToTableKey):
     columns = (
         ('some_text', 'varchar(255)', 'LZO'),
@@ -185,8 +186,8 @@ class TestS3CopyToTable(unittest.TestCase):
                 return_value=False)
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_s3_copy_to_missing_table_with_compression_encodings(self,
-                                      mock_redshift_target,
-                                      mock_does_exist):
+                                                                 mock_redshift_target,
+                                                                 mock_does_exist):
         """
         Test missing table creation with compression encodings
         """

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -58,6 +58,12 @@ class DummyS3CopyToTableKey(DummyS3CopyToTableBase):
     aws_access_key_id = AWS_ACCESS_KEY
     aws_secret_access_key = AWS_SECRET_KEY
 
+class DummyS3CopyToTableWithCompressionEncodings(DummyS3CopyToTableKey):
+    columns = (
+        ('some_text', 'varchar(255)', 'LZO'),
+        ('some_int', 'int', 'DELTA'),
+    )
+
 
 class DummyS3CopyToTableRole(DummyS3CopyToTableBase):
     aws_account_id = AWS_ACCESS_KEY
@@ -172,6 +178,38 @@ class TestS3CopyToTable(unittest.TestCase):
                                            .return_value)
         assert mock_cursor.execute.call_args_list[0][0][0].startswith(
             "CREATE  TABLE %s" % task.table)
+
+        return
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_table_exist",
+                return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_to_missing_table_with_compression_encodings(self,
+                                      mock_redshift_target,
+                                      mock_does_exist):
+        """
+        Test missing table creation with compression encodings
+        """
+        # Ensure `S3CopyToTable.create_table` does not throw an error.
+        task = DummyS3CopyToTableWithCompressionEncodings()
+        task.run()
+
+        # Make sure the cursor was successfully used to create the table in
+        # `create_table` as expected.
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+        encode_string = ','.join(
+                '{name} {type} ENCODE {encoding}'.format(
+                    name=name,
+                    type=type,
+                    encoding=encoding) for name, type, encoding in task.columns
+            )
+
+        assert mock_cursor.execute.call_args_list[0][0][0].startswith(
+            "CREATE  TABLE %s (%s)" % (task.table, encode_string))
 
         return
 


### PR DESCRIPTION


## Description

I have added the possibility to specify Redshift column compression encodings in the coldefs tuple. At the moment we never specify them so if the table is created via Luigi, Redshift will estimate the best compression given the data imported in _only_ that first COPY. 


## Motivation and Context


Sometimes we know a priori what compression we want to use, and so this allows us to specify it in the coldefs directly with an additional element in the tuple.

Redshift Compression Encodings: https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html


We might also consider adding similar default value support in the future (i.e. to set some columns to have a default of 0 rather than NULL) - but in this case we would likely need to change the current tuple structure we use.

## Have you tested this? If so, how?

I have tested it on our development cluster and checked that the tables are created with the corresponding compression encodings.
