### PR TITLE
Bubble up exit codes from run_with_retcodes instead of exiting directly

### DIFF
--- a/luigi/cmdline.py
+++ b/luigi/cmdline.py
@@ -8,7 +8,7 @@ from luigi.retcodes import run_with_retcodes
 
 
 def luigi_run(argv=sys.argv[1:]):
-    run_with_retcodes(argv)
+    return run_with_retcodes(argv)
 
 
 def luigid(argv=sys.argv[1:]):

--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -21,7 +21,6 @@ given task, and if not why.
 """
 
 import luigi
-import sys
 import logging
 from luigi import IntParameter
 
@@ -73,12 +72,12 @@ def run_with_retcodes(argv):
     try:
         worker = luigi.interface._run(argv)['worker']
     except luigi.interface.PidLockAlreadyTakenExit:
-        sys.exit(retcodes.already_running)
+        return retcodes.already_running
     except Exception:
         # Some errors occur before logging is set up, we set it up now
         luigi.interface.setup_interface_logging()
         logger.exception("Uncaught exception in luigi")
-        sys.exit(retcodes.unhandled_exception)
+        return retcodes.unhandled_exception
 
     task_sets = luigi.execution_summary._summary_dict(worker)
     root_task = luigi.execution_summary._root_task(worker)
@@ -100,6 +99,6 @@ def run_with_retcodes(argv):
     if expected_ret_code == 0 and \
        root_task not in task_sets["completed"] and \
        root_task not in task_sets["already_done"]:
-        sys.exit(retcodes.not_run)
+        return retcodes.not_run
     else:
-        sys.exit(expected_ret_code)
+        return expected_ret_code


### PR DESCRIPTION
…d of calling sys.exit inside run_with_retcodes

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
See here for background https://groups.google.com/d/msg/luigi-user/Q2VxlBEFt2o/122V3R1lAQAJ

Changes retcodes.run_with_retcodes() and cmdline.luigi_run() such that the exit code determined in run_with_retcodes() is returned to luigi_run(), and then returned by luigi_run() to its caller (typically the "luigi" script file). As a result, the "luigi" script should return the same values it does today, but that value is now recoverable from luigi_run() if a user has written their own invocation wrapper rather than use the provided "luigi" script.

The net result for luigi programs that are invoked with the "luigi" script should be no change, the same codes will be returned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm currently working on several large (thousands of tasks) luigi-based workflows which need to perform setup (teardown) steps before (after) luigi runs their tasks. The need for setup code means I can't make use of the "luigi" script, and because the current implementation of run_with_retcodes calls sys.exit() directly, running teardown code is difficult, and mapping luigi's return codes to a set of return codes that work for me and my calling environment is very-difficult-bordering-on-impossible.

Also, calling sys.exit() from multiple locations deep in the call stack is, I believe, not generally regarded as a good practice.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I've been running one large job with this change applied to luigi 2.7.1 and haven't had any issues.

The flake8 and py27-nonhdfs tox suites fail, but they also fail on master, so I don't know what to make of that. I ran test/cmdline_test.py by itself and it runs the same (18 failed, 15 passed) as before my change, but it's worth noting that while several tests in that file check for a return code of 0, none check for return codes other than 0.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
