### PR TITLE
Add support for luigi email attachments

### DIFF
--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -170,8 +170,9 @@ class NotificationFixture(object):
                  message."""
     recipients = ['noone@nowhere.no', 'phantom@opera.fr']
     image_png = None
+    attachments = None
 
-    notification_args = [sender, subject, message, recipients, image_png]
+    notification_args = [sender, subject, message, recipients, image_png, attachments]
     mocked_email_msg = '''Content-Type: multipart/related; boundary="===============0998157881=="
 MIME-Version: 1.0
 Subject: Oops!


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adds support for 0 or more attachments per email notification.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Given Luigi already has notification code for emails, particularly SMTP, the addition of attachment support would reduce extraneous code for Luigi users who utilize email for report dispersal via Luigi.

Goal is to not affect current usage, but to add to a feature to Luigi notification support.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Not yet. Tests will be forthcoming.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
