### PR TITLE
fix contrib.docker_runner exit code check #2355

### DIFF
--- a/luigi/contrib/docker_runner.py
+++ b/luigi/contrib/docker_runner.py
@@ -205,6 +205,10 @@ class DockerTask(luigi.Task):
             self._client.start(container['Id'])
 
             exit_status = self._client.wait(container['Id'])
+            # docker-py>=3.0.0 returns a dict instead of the status code directly
+            if type(exit_status) is dict:
+                exit_status = exit_status['StatusCode']
+
             if exit_status != 0:
                 stdout = False
                 stderr = True


### PR DESCRIPTION
Prior to `3.0.0`, `docker-py` used to return the status code as an `int` - it now returns a `dict` (cf. [2.7.0 `Container.wait` doc](http://docker-py.readthedocs.io/en/2.7.0/containers.html#docker.models.containers.Container.wait) vs [3.0.1 `Container.wait` doc](http://docker-py.readthedocs.io/en/3.0.1/containers.html#docker.models.containers.Container.wait))

The fix is to check if the return type is a dict, to attempt to maintain backward compatibility.