### PR TITLE
added generated data files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,14 +15,16 @@ pig_property_file
 
 packages.tar
 
+# Ignore the data files
+data
 test/data
+examples/data
 
 Vagrantfile
 
 *.pickle
 *.rej
 *.orig
-
 
 # Created by https://www.gitignore.io
 


### PR DESCRIPTION
## Description
When running the examples, there are files which are generated.  Just to be clean, I've added them to the .gitignore file.  Pretty minor stuff.

## Have you tested this? If so, how?
I've run `git status` and verified that files stored in the `data` directory are no longer considered when they change.