### PR TITLE
Add option for tasks to run on main process

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -284,6 +284,10 @@ class Task(object):
         # TODO(erikbern): we should think about a language-agnostic mechanism
         return self.__class__.__module__
 
+    @property
+    def run_on_main_process(self):
+        return False
+
     _visible_in_registry = True  # TODO: Consider using in luigi.util as well
 
     __not_user_specified = '__not_user_specified'

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -911,7 +911,7 @@ class Worker(object):
 
         self._running_tasks[task_id] = task_process
 
-        if task_process.use_multiprocessing:
+        if task_process.use_multiprocessing and not task.run_on_main_process:
             with fork_lock:
                 task_process.start()
         else:


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
When using multiple workers, the main process is used for the scheduler and the tasks run on the rest of the cores. If you're using a function that utilizes multiple cores, running that function not from the main core can cause some issues. So in some cases, you want your workflow to run on multiple cores except from one task that you want to run on the main core. I added an open to add a property to your task "run_on_main_process" which you can set to true (default is false) and using that will force that task to run on the main process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using functions from libraries that use multiple cores (like Scikit-Learn) will have unexpected outcomes when running from a core that's not the main core. Adding that property will solve that issue.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I tried it and it worked. Plus, I only changed 1 line of core code with that so I'm not sure how to add unit tests for it (Would love for some help with that if needed).

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
