### PR TITLE
use task's last updated time for scheduler rank

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -982,7 +982,7 @@ class Scheduler(object):
         :return:
         """
 
-        return task.priority, -task.time
+        return task.priority, -task.updated
 
     def _schedulable(self, task):
         if task.status != PENDING:


### PR DESCRIPTION
## Description

In very large task graphs with task retry enabled (awaiting updates), the tasks which are scheduled first may never execute because by the time the newer tasks inserted into the graphs expire their re-attempt timeouts, the scheduler will decide to run them again. This results in the earlier scheduled tasks not executing until the later scheduled tasks have completed.

## Motivation and Context
It makes running very large task graphs with task reattempts enabled work as expected. It doesn't seem to affect scheduling otherwise (in a task graph without re-attempts, the tasks which are updated won't be considered in the first place)

See #2259

## Have you tested this? If so, how?
We have been running with this change in production for six months and it has been working as expected. If this breaks or otherwise justifies a test, I haven't tested it though.