### PR TITLE
WIP: Add support for running MRJob jobs as luigi Tasks (rebase)

### DIFF
--- a/luigi/contrib/dataproc.py
+++ b/luigi/contrib/dataproc.py
@@ -15,9 +15,14 @@ try:
     from googleapiclient import discovery
     from googleapiclient.errors import HttpError
 
-    DEFAULT_CREDENTIALS, _ = google.auth.default()
-    authenticate_kwargs = gcp.get_authenticate_kwargs(DEFAULT_CREDENTIALS)
-    _dataproc_client = discovery.build('dataproc', 'v1', cache_discovery=False, **authenticate_kwargs)
+    try:
+        DEFAULT_CREDENTIALS, _ = google.auth.default()
+        authenticate_kwargs = gcp.get_authenticate_kwargs(DEFAULT_CREDENTIALS)
+        _dataproc_client = discovery.build('dataproc', 'v1', cache_discovery=False, **authenticate_kwargs)
+    except google.auth.exceptions.DefaultCredentialsError as err:
+        logger.warning("Error loading default application credentials."
+                       " This will crash at runtime if Dataproc functionality is used. " +
+                       str(err))
 except ImportError:
     logger.warning("Loading Dataproc module without the python packages googleapiclient & google-auth. \
         This will crash at runtime if Dataproc functionality is used.")

--- a/luigi/contrib/mrjob.py
+++ b/luigi/contrib/mrjob.py
@@ -1,0 +1,330 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2010 bit.ly, 2016 enreach.me
+#
+# Original author Daniel Frank, modified into luigi.contrib by Jyry Suvilehto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" MRJob wrapper for Luigi
+
+This package provides a convenient Luigi wrapper for using `MRJob
+<http://packages.python.org/mrjob/>`_ steps in workflows. See `here
+<https://pythonhosted.org/mrjob/guides/runners.html#running-your-job-programmatically>`_
+for the feature used to implement this functionality.
+
+The wrapper doesn't attempt to be complete or to hide any complexity. The user
+is expected to know their way around MRJob and to configure it separately.
+
+.. code-block:: python
+
+    import luigi
+    from luigi.contrib.mrjob import MRJobTask
+    import mrjob
+
+    class ExternalInputTask(luigi.ExternalTask):
+        def output(self):
+            return luigi.LocalTarget(os.path.join(self.destination, "input"))]
+
+
+
+    class MRJobWordCountTask(MRJobTask):
+        destination = luigi.Parameter()
+
+        job_cls = mrjob.examples.mr_word_freq_count.MRWordFreqCount
+
+        def mrjob_opts(self):
+            return {
+                '-r', 'inline'
+                }
+
+        def requires(self):
+            return ExternalInputTask()
+
+        def output(self):
+            return luigi.LocalTarget(
+                                    os.path.join(self.destination, "output"),
+                                    format=luigi.format.Nop
+                                    )
+
+"""
+
+import abc
+from itertools import chain
+import os
+import sys
+
+import luigi
+from luigi import Task
+from luigi.hdfs import HdfsTarget
+from luigi.s3 import S3Target
+
+
+import logging
+
+logger = logging.getLogger('luigi-mrjob')
+
+
+def _to_opts(flag, value):
+    """ parse a key-value pair to an option or options that can be in the
+        command line to mrjob
+    """
+    if isinstance(value, bool):
+        return [flag] if value else []
+    elif isinstance(value, dict):
+        # this is intended to be used for jobconf option
+        # probably needs to be upgraded to handle other jobconf-like dicts
+        return list(chain(*[(flag, '%s=%s' % (k, v)) for k, v in value.items()]))
+    else:
+        assert isinstance(value, str)
+        return [flag, value]
+
+
+def _get_mrjob_friendly_path(target):
+    """ Ensure target has the s3:// or hdfs:// required by MRJob.
+        May be unnecessary as at least S3Target also requires the
+        path to be a parseable url.
+
+    """
+    path = target.path
+    remote = False
+    if isinstance(target, HdfsTarget) and not path.startswith('hdfs://'):
+        path = 'hdfs://' + path
+    if isinstance(target, S3Target) and not path.startswith('s3://'):
+        path = 's3://' + path
+    if path.startswith('s3://') or path.startswith('hdfs://'):
+        remote = True
+    return path, remote
+
+
+class MRJobTask(Task):
+    ''' Class that runs a MRJob from a Luigi workflow.
+    '''
+    __metaclass__ = abc.ABCMeta
+
+    @property
+    def job_cls(self):
+        '''
+        Override this to return the right mrjob class (not instance)
+        '''
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def requires(self):
+        """ The that can be shimmied to  supported are as follows:
+
+            - one input, will be passed as the command line input
+            - a list of inputs, all passed as command line paths
+            - a dict that contains input under key "input". others are passed
+              as command line parameters. e.g.
+              {"input": ExternalTask(...),
+              "--custom-extra-file": ExternalTask(..)}
+
+            These will be parsed into command line input directives for MRJob.
+            The last one is intended so that it is possible for jobs to depend
+            on files that won't be passed as regular input, e.g. lookup
+            databases, pickled classifier objects or similar that will be
+            distributed to each mapper node separately using MRJob's included
+            batteries.
+
+            Note that most MRJob runners don't really handle moving things to
+            and fro between filesystems. EMR and Hadoop runners can move input
+            data from local file system to S3 or HDFS respectively.
+            Fortunately there's this tool called :py:mod:`luigi` that can
+            help you transfer data from one place to another.
+            """
+        pass
+
+    @abc.abstractmethod
+    def output(self):
+        """ Output formats supported by MRJob:
+            - directory in local filesystem
+            - directory in HDFS
+            - directory in S3
+
+            Custom implemented output formats:
+
+            - `a single file` in local filesystem (this is a custom feature)
+
+        The last one is implemented using
+        `mrjob.Runner.MRJobRunner.stream_output()`. Because said method
+        returns bytes and not strings and luigi expects strings it is best to
+        just pass format.Nop as the format in this case.
+
+        *Note:* on HDFS or S3 if the last step of the workflow fails after
+        producing output then the target directory will have been created.
+        MRJob is quite adamant about not proceeding if the directory exists
+        already. Manual intervention is then required to delete the partial
+        output. Improvements that handle this in a smart way especially on
+        S3 are welcome.
+        """
+        pass
+
+    def mrjob_opts(self):
+        """ Override this to pass command line options. You probably want to
+        pass a config file ( or make one available at the standard locations
+        MRJob reads ) and the runner type.
+        """
+        return {}
+
+    def handle_counters(self, counters):
+        """ Override this if you want to do something with the counters
+        returned by `mrjob.runner.MRJobRunner.counters()`.
+        """
+        return
+
+    def __init__(self, *args, **kwargs):
+        super(MRJobTask, self).__init__(*args, **kwargs)
+        self.opts = self.make_mrjob_opts(*args, **kwargs)
+
+    def _hack_std_stream_buffers(self):
+        """ MRJob is very insistent about fiddling around with standard
+        streams which breaks if there are stringios as input and output as
+        there are in integration tests.
+        """
+        logger.debug("type of sys.stdin is %s" % type(sys.stdin))
+        if sys.version_info < (3, 0):
+            logger.debug("on python 2, not attempting hack")
+        else:
+            logger.debug("on python 3, attempting hack")
+            # the real sys.stdin and sys.stdout have these on py3
+            # but the wrappers created by testing lib don't
+            if not hasattr(sys.stdin, "buffer"):
+                sys.stdin.buffer = None
+            if not hasattr(sys.stdout, "buffer"):
+                sys.stdout.buffer = None
+            if not hasattr(sys.stderr, "buffer"):
+                sys.stderr.buffer = None
+
+    def run(self):
+        self._hack_std_stream_buffers()
+        job = self.job_cls(args=self.opts)
+        with job.make_runner() as jobrunner:
+            jobrunner.run()
+            # if user wanted output in a local file
+            if self.output_is_local_file:
+                with self.output().open('w') as output:
+                    output.writelines(jobrunner.stream_output())
+            self.handle_counters(jobrunner.counters())
+
+    def make_mrjob_opts(self, *args, **kwargs):
+        """ Makes a list of command line parameters to pass to the MRJob class
+        when instantiating. It makes sense to extend this behaviour e.g. if
+        you have some dynamic inputs that need to be passed as command line parameters.
+        """
+        base_opts = self.mrjob_opts()
+        base_opts.update((k, v) for k, v in kwargs.items() if k.startswith('-'))
+        opts_list = list(chain(*[_to_opts(k, v) for k, v in base_opts.items()]))
+        # now add special params: input and ouput
+        # yikes, existence of path field not really enforced
+        input_ = self.input()
+        file_options = []
+        if isinstance(input_, dict):
+            file_opts = input_
+            input_ = input_['input']
+            del file_opts['input']
+            for option, values in file_opts.items():
+                for value in values:
+                    file_options.append(option)
+                    file_options.append(_get_mrjob_friendly_path(value)[0])
+        if not isinstance(input_, list):
+            input_ = [input_]
+        input_files = [
+                        _get_mrjob_friendly_path(in_)[0] for in_ in
+                        input_
+                       ]
+        output_dir, output_remote = _get_mrjob_friendly_path(self.output())
+
+        assert input_files and output_dir, \
+            'Must define output and dependencies or direct input'
+        # if it looks like output should go to a directory, add --no-output
+        # to avoid unnecessary streaming of potentially ginormous output
+        if (not output_remote and os.path.dirname(output_dir)+os.sep == output_dir)\
+                or output_remote:
+            self.output_is_local_file = False
+            opts_list += ['--no-output']
+            return opts_list + file_options + input_files + ['-o', output_dir]
+        elif not output_remote:
+            # if user wants the output to be a local file, enable streaming of output
+            # so we can write the file in runner
+            self.output_is_local_file = True
+            return opts_list + file_options + input_files
+
+
+class LocalMRJobTarget(luigi.file.LocalTarget):
+    """ The local analogue of :py:class:`~luigi.s3.S3FlagTarget` in case you want to
+    run or test jobs locally. Unlike Hadoop, MRJob local runners don't create
+    a _SUCCESS file but they do copy the files to their target more or less
+    atomically so the presence of any file in the target should indicate that
+    a job has been completed.
+
+
+    The copy from a tempdir happens once all steps are completed, as
+    atomically as moving several files in the local filesystem can take place.
+    LocalMRJobTarget assumes that if one file in the directory exists, the job
+    is complete.
+    """
+
+    def __init__(self, path, format=None, flag="_SUCCESS"):
+        self.path = path
+        if path[-1] != os.sep:
+            raise ValueError("LocalMRJobTarget requires the path to be to a"
+                             "directory.  It must end with a slash ( / ).")
+        if format is None:
+            format = luigi.format.get_default_format()
+        super(LocalMRJobTarget, self).__init__(path=path, format=format,
+                                               is_tmp=False)
+
+    def exists(self):
+        """ We take the presence of any file in the target dir to mean that
+        the step has been concluded.
+        """
+        generator = self.fs.listdir(self.path)
+        try:
+            next(generator)
+            return True
+        except StopIteration:
+            return False
+
+    def open(self, mode="r"):
+        if mode == "w":
+            raise ValueError(("Writing to a directory with no filename is"
+                              " not currently supported! (Feel free to add an"
+                              " implementation though)"))
+        elif mode != "r":
+            raise ValueError("Unsupported mode open '%s'" % mode)
+        else:
+            files = self.fs.listdir(self.path)
+            command = ["cat"]
+            command.extend([f for f in files])
+            file_reader = luigi.format.InputPipeProcessWrapper(command)
+            if self.format:
+                return self.format.pipe_reader(file_reader)
+            else:
+                return file_reader
+
+
+class LocalMRJobTask(luigi.task.ExternalTask):
+    """
+    An external task that requires a Hadoop-like flag directory (sans flag)
+    exists in the local filesystem.
+
+    Good for testing workflows. You should be able to replace this with an
+    S3FlagTask when running production flows in EMR. Keep in mind that
+    S3FlagTarget doesn't appear to support open() like LocalMRJobTarget does,
+    though.
+    """
+    path = luigi.Parameter()
+
+    def output(self):
+        return LocalMRJobTarget(self.path)

--- a/luigi/contrib/mrjob.py
+++ b/luigi/contrib/mrjob.py
@@ -66,7 +66,7 @@ import sys
 
 import luigi
 from luigi import Task
-from luigi.hdfs import HdfsTarget
+from luigi.contrib.hdfs import HdfsTarget
 from luigi.s3 import S3Target
 
 

--- a/luigi/contrib/mrjob.py
+++ b/luigi/contrib/mrjob.py
@@ -261,7 +261,7 @@ class MRJobTask(Task):
             return opts_list + file_options + input_files
 
 
-class LocalMRJobTarget(luigi.file.LocalTarget):
+class LocalMRJobTarget(luigi.local_target.LocalTarget):
     """ The local analogue of :py:class:`~luigi.s3.S3FlagTarget` in case you want to
     run or test jobs locally. Unlike Hadoop, MRJob local runners don't create
     a _SUCCESS file but they do copy the files to their target more or less

--- a/luigi/contrib/mrjob.py
+++ b/luigi/contrib/mrjob.py
@@ -67,7 +67,7 @@ import sys
 import luigi
 from luigi import Task
 from luigi.contrib.hdfs import HdfsTarget
-from luigi.s3 import S3Target
+from luigi.contrib.s3 import S3Target
 
 
 import logging

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -10,9 +10,12 @@ try:
     from luigi.contrib import dataproc
     from googleapiclient import discovery
 
-    default_credentials, _ = google.auth.default()
-    default_client = discovery.build('dataproc', 'v1', cache_discovery=False, credentials=default_credentials)
-    dataproc.set_dataproc_client(default_client)
+    try:
+        default_credentials, _ = google.auth.default()
+        default_client = discovery.build('dataproc', 'v1', cache_discovery=False, credentials=default_credentials)
+        dataproc.set_dataproc_client(default_client)
+    except google.auth.exceptions.DefaultCredentialsError:
+        raise unittest.SkipTest('No default credentials to run dataproc tests')
 except ImportError:
     raise unittest.SkipTest('Unable to load google cloud dependencies')
 

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -41,7 +41,11 @@ PROJECT_ID = os.environ.get('GCS_TEST_PROJECT_ID', 'your_project_id_here')
 BUCKET_NAME = os.environ.get('GCS_TEST_BUCKET', 'your_test_bucket_here')
 TEST_FOLDER = os.environ.get('TRAVIS_BUILD_ID', 'gcs_test_folder')
 
-CREDENTIALS, _ = google.auth.default()
+try:
+    CREDENTIALS, _ = google.auth.default()
+except google.auth.DefaultCredentialsError:
+    raise unittest.SkipTest('No default credentials to run GCS tests')
+
 ATTEMPTED_BUCKET_CREATE = False
 
 

--- a/test/contrib/mrjob_test.py
+++ b/test/contrib/mrjob_test.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Enreach Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import print_function
+import luigi
+from luigi.contrib import mrjob as luigi_mrjob
+
+from .mrjob_test_job import MRFreqWithCounters
+import os
+import random
+import shutil
+import tempfile
+import unittest
+import json
+import re
+
+
+WORD_RE = re.compile(r"[\w']+")
+
+
+class ExternalInputTask(luigi.ExternalTask):
+    destination = luigi.Parameter()
+
+    def output(self):
+        return [luigi.LocalTarget(os.path.join(self.destination, "input"))]
+
+
+class CustomFileParameterTask(luigi.ExternalTask):
+    destination = luigi.Parameter()
+
+    def output(self):
+        return [luigi.LocalTarget(os.path.join(self.destination,
+                "extra_input_lookup"))]
+
+
+class MRJobWordCountTask(luigi_mrjob.MRJobTask):
+    destination = luigi.Parameter()
+    job_cls = MRFreqWithCounters
+
+    def mrjob_opts(self):
+        return {}
+
+    def requires(self):
+        return ExternalInputTask(self.destination)
+
+    def output(self):
+        return luigi.LocalTarget(os.path.join(self.destination, "output"),
+                                 format=luigi.format.Nop)
+
+
+class MrJobWordCountTaskWithInputDict(MRJobWordCountTask):
+    def requires(self):
+        return {"input":
+                ExternalInputTask(self.destination)}
+
+
+class MrJobWordCountTaskWithInputDictAndParameter(MRJobWordCountTask):
+    def requires(self):
+        return {"input":
+                ExternalInputTask(self.destination),
+                "--lookup-file": CustomFileParameterTask(self.destination)}
+
+
+class MrJobWordCountWithCounters(MRJobWordCountTask):
+    def handle_counters(self, counters):
+        with open(os.path.join(self.destination, "counters"), "w") as file_:
+            file_.write(json.dumps(counters))
+
+
+class MrJobWordCountWithCustomParameter(MRJobWordCountTask):
+    def mrjob_opts(self):
+        """ Pass a custom option. Option parsing is much more difficult to
+        break than the local runner test that also uses this feature.
+        """
+        return {
+                "--invert-words": True
+               }
+
+
+class MrJobWordCountLocalRunner(MRJobWordCountTask):
+    def mrjob_opts(self):
+        """ The other tests are run against the inline runner for simplicity
+        and speed. The local runner is run in a subprocess and is a much
+        better tool for testing that environment setup steps etc. actually
+        work as intended.
+        """
+        return {
+                "-r": "local"
+               }
+
+
+class MrJobWordCountOutputToDir(MRJobWordCountTask):
+    def output(self):
+        return luigi_mrjob.LocalMRJobTarget(os.path.join(self.destination, "output/"))
+
+
+class MRJobIntegrationTest(unittest.TestCase):
+    """ Test against a real MRJob class with real input data dir etc.
+        Run locally, so not in HDFS (could be tested separately) or EMR
+        (not so simple to automate test against a paid resource).
+    """
+
+    N_WORDS = {
+                "luigi": random.randint(1, 20),
+                "waluigi": random.randint(1, 20),
+                "daisy": random.randint(1, 20)
+              }
+
+    def setUp(self):
+        self.mrjob_tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(self.mrjob_tmpdir, "input"), "w") as file_:
+            for key, val in self.N_WORDS.items():
+                file_.write(" ".join([key]*val) + " ")
+                print("wrote %s %d" % (key, val))
+        with open(os.path.join(self.mrjob_tmpdir, "extra_input_lookup"), "w") as file_:
+            lookup = {}
+            for key, val in self.N_WORDS.items():
+                lookup[key] = key.replace("i", "1")
+            json.dump(lookup, file_)
+
+    def tearDown(self):
+        shutil.rmtree(self.mrjob_tmpdir)
+
+    def test_integration_mrjob(self):
+        """ most basic test with no frills
+        """
+        self._run_task("MRJobWordCountTask")
+
+    def test_dict_inputs_mrjob(self):
+        """ test passing a dict as inputs and only usin "input"
+
+        ToDo: pass another file and assert it is not touched if it's not under
+        "input"
+        """
+        self._run_task("MrJobWordCountTaskWithInputDict")
+
+    def test_local_runner_mrjob(self):
+        """ Test using --runner local
+        """
+        self._run_task("MrJobWordCountLocalRunner")
+
+    def test_word_counter_mrjob(self):
+        self._run_task("MrJobWordCountWithCounters")
+        with open(os.path.join(self.mrjob_tmpdir, "counters"), "r") as file_:
+            counters = json.loads(file_.readline())
+            assert counters[0]["test_counters"]["words_seen_total"] == \
+                sum(self.N_WORDS.values())
+
+    def test_custom_command_line_param_mrjob(self):
+        """ Test command line parameters
+        """
+        self._run_task("MrJobWordCountWithCustomParameter",
+                       processor=lambda x: x[::-1])
+
+    def test_custom_file_parameter(self):
+        """ Test requirements that are custom file parameters
+        """
+        self._run_task("MrJobWordCountTaskWithInputDictAndParameter",
+                       processor=lambda x: x.replace("1", "i"))
+
+    def test_output_dir_mrjob(self):
+        """ Test outputting to a local dir and reading output from (probably)
+        multiple files.
+        """
+        success = luigi.run([
+                            "MrJobWordCountOutputToDir",
+                            '--destination',
+                            self.mrjob_tmpdir,
+                            '--local-scheduler',
+                            '--no-lock'
+                            ])
+        self.assertTrue(success)
+        task = luigi_mrjob.LocalMRJobTask(path=os.path.join(
+                                            self.mrjob_tmpdir,
+                                            "output" + os.sep))
+
+        output = task.output()
+        assert output.exists()
+        for line in output.open("r"):
+            key, val = self.read_default_output_format(line)
+            print("read %s %d" % (key, val))
+            assert self.N_WORDS[key] == val
+
+    def _run_task(self, taskname, processor=lambda x: x):
+        success = luigi.run([
+                            taskname,
+                            '--destination',
+                            self.mrjob_tmpdir,
+                            '--local-scheduler',
+                            '--no-lock'
+                            ])
+        self.assertTrue(success)
+        with open(os.path.join(self.mrjob_tmpdir, "output")) as file_:
+            for line in file_:
+                key, val = self.read_default_output_format(line)
+                print("read %s %d" % (key, val))
+                key = processor(key)
+                assert self.N_WORDS[key] == val
+
+    def read_default_output_format(self, line):
+        parts = line.split("\t")
+        return json.loads(parts[0]), json.loads(parts[1])
+
+    # ToDo: test with Mock as job_cls
+    # ToDo: smoketest the rather cryptic functions that create the args list
+    # and ensure presence of s3 and hdfs in url

--- a/test/contrib/mrjob_test_job.py
+++ b/test/contrib/mrjob_test_job.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 Enreach Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+A really simple MRJob job that can be used in testing.
+
+The if __name__ == "__main__" is really important for MRJob automation so this
+was separated into it's own file. It could probably be merged into the test
+file but that would introduce some difficult to understand magic into why the
+local runner test works.
+
+"""
+
+import mrjob.examples.mr_word_freq_count
+import json
+
+
+class MRFreqWithCounters(mrjob.examples.mr_word_freq_count.MRWordFreqCount):
+    def reducer(self, word, counts):
+        sum_ = sum(counts)
+        # increment a counter so we can test counter parsing functionality
+        self.increment_counter("test_counters", "words_seen_total", sum_)
+        if self.options.invert_words:
+            yield word[::-1], sum_
+        elif self.options.lookup_file:
+            with open(self.options.lookup_file, "r") as instr:
+                lookup = json.load(instr)
+                yield lookup[word], sum_
+        else:
+            yield word, sum_
+
+    def configure_options(self):
+        super(MRFreqWithCounters, self).configure_options()
+        self.add_passthrough_option("--invert-words", action="store_true",
+                                    dest="invert_words", default=False)
+        self.add_file_option('--lookup-file', dest="lookup_file")
+
+
+if __name__ == "__main__":
+    MRFreqWithCounters.run()

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps=
   coverage>=4.1,<4.2
   codecov>=1.4.0
   requests<3.0
+  mrjob>=0.5.2
   unixsocket: requests-unixsocket<1.0
   pygments
   hypothesis[datetime]


### PR DESCRIPTION
This is a rebase of @Jyrsa's PR #1731, which never got merged. The only changes were to accommodate the move from oauth2 to the `google.auth` package. I did not re-write any git commit metadata (eg, change titles).

I tried running `tox` to test, but it looks like there are a whole bunch of test environment needs, so i'm submitting a PR early to have this run on travis.

# Original PR Description

I added a luigi.contrib.mrjob package to support running MRJob steps (particularly on EMR) as part of Luigi workflows.

It's based on waluigi by @danielhfrank with a couple of bells and whistles added that I thought would make sense when testing workflows with small loads on local machines so that moving to EMR or Hadoop would be as effortless as possible.

### Description

A class MRJobTask that parses it's input into the correct format for a MRJob JobRunner and initializes and runs the runner. Support for adding configuration parameters to the MRJob, either everything or an external config file.

The user is assumed to have some previous experience with MRJob.

Also a class LocalMRJobTarget for testing workflows using LocalRunner on local machine and a LocalMRJobTask to boot that I believe follows the naming convention.

### Motivation and Context

I liked the idea of luigi and wanted to use it an envisioned automated data pathway that consisted of both local and EMR steps.

Also,
#294

### Have you tested this? If so, how?

I have included tests that are more integration than unit tests for the basic functionality.

I'll admit that there are a few cryptic functions that could use more testing.

### Notes

I'm not sure about the copyright notices. I put in my company's name as I did this on their time (and got permission to publish). If you want to change that to Spotify like everywhere else let me know.

Also this is my first meaningful pull request to an open source project. Be gentle :)