### PR TITLE
Add google-auth-httplib2 as dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps=
   py27-gcloud: avro
   py33-gcloud,py34-gcloud,py35-gcloud,py36-gcloud: avro-python3
   gcloud: google-auth==1.4.1
+  gcloud: google-auth-httplib2==0.0.3
   google-compute-engine
   coverage>=4.1,<4.2
   codecov>=1.4.0


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adding a new dependency.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed here https://github.com/spotify/luigi/pull/2361#issuecomment-378661375

This is used by https://github.com/google/google-api-python-client/blob/v1.6.6/googleapiclient/discovery.py#L371

Another option is to fix `luigi.contrib.bigquery` somehow.
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Manually installing this package worked for me.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
