### PR TITLE
append is vulnerable of xss

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -382,7 +382,7 @@ function visualiserApp(luigi) {
                 }
             } else {
                 $("#searchError").addClass("alert alert-error");
-                $("#searchError").append("Couldn't find task " + taskId);
+                $("#searchError").text("Couldn't find task " + taskId);
             }
             drawGraphETL(dependencyGraph, paint);
             bindGraphEvents();
@@ -402,7 +402,7 @@ function visualiserApp(luigi) {
                 bindGraphEvents();
             } else {
                 $("#searchError").addClass("alert alert-error");
-                $("#searchError").append("Couldn't find task " + taskId);
+                $("#searchError").text("Couldn't find task " + taskId);
             }
         }
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Fix cross-site-scripting issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
http://api.jquery.com/append/ points out that `append` can introduce
cross-site-scripting (XSS) vulnerabilities.

In this particular case, we have identified an XSS issue as following:

Spin up a Luigi instance and navigate to /static/visualiser/index.html#tab=graph&visType=svg&taskId=%3Cscript%3Ealert(1)%3C%2Fscript%3E.
You should see an alert box pop up displaying 1.

Use `text` instead of `append` should fix it.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I tested it locally manually.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
