### PR TITLE
Fix issue #2392

### DIFF
--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -113,7 +113,9 @@ class LuigiConfigParser(ConfigParser):
 
     def getintdict(self, section):
         try:
-            return dict((key, int(value)) for key, value in self.items(section))
+            # Exclude keys from [DEFAULT] section because in general they do not hold int values
+            return dict((key, int(value)) for key, value in self.items(section)
+                        if key not in {k for k, _ in self.items('DEFAULT')})
         except NoSectionError:
             return {}
 


### PR DESCRIPTION
## Description
When casting config values to int, exclude any values from `[DEFAULT]`
section. This will be the case when reading int values from [resources].

## Motivation and Context
`luigid` won't start. It errors out when casting everything in `[DEFAULTS]` to int.

## Have you tested this? If so, how?
Tested in my environment, ran `tox -e flake8`.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
