### PR TITLE
Add configuration to enable/disable the pause button

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -716,6 +716,10 @@ worker_disconnect_delay
   scheduler before removing it and marking all of its running tasks as
   failed. Defaults to 60.
 
+pause_enabled
+  If false, disables pause/unpause operations and hides the pause toggle from
+  the visualiser.
+
 
 [sendgrid]
 ----------

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -147,6 +147,8 @@ class scheduler(Config):
 
     prune_on_get_work = parameter.BoolParameter(default=False)
 
+    pause_enabled = parameter.BoolParameter(default=True)
+
     def _get_retry_policy(self):
         return RetryPolicy(self.retry_count, self.disable_hard_timeout, self.disable_window)
 
@@ -931,16 +933,22 @@ class Scheduler(object):
         self._state.get_worker(worker).add_rpc_message('set_worker_processes', n=n)
 
     @rpc_method()
+    def is_pause_enabled(self):
+        return {'enabled': self._config.pause_enabled}
+
+    @rpc_method()
     def is_paused(self):
         return {'paused': self._paused}
 
     @rpc_method()
     def pause(self):
-        self._paused = True
+        if self._config.pause_enabled:
+            self._paused = True
 
     @rpc_method()
     def unpause(self):
-        self._paused = False
+        if self._config.pause_enabled:
+            self._paused = False
 
     @rpc_method()
     def update_resources(self, **resources):

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -158,6 +158,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.isPauseEnabled = function(callback) {
+        jsonRPC(this.urlRoot + '/is_pause_enabled', {}, function(response) {
+            callback(response.response.enabled);
+        });
+    };
+
     LuigiAPI.prototype.pause = function() {
         jsonRPC(this.urlRoot + '/pause');
     };

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1011,7 +1011,11 @@ function visualiserApp(luigi) {
     $(document).ready(function() {
         loadTemplates();
 
-        luigi.isPaused(createPauseToggle);
+        luigi.isPauseEnabled(function(enabled) {
+            if (enabled) {
+                luigi.isPaused(createPauseToggle);
+            }
+        });
 
         luigi.getWorkerList(function(workers) {
             $("#workerList").append(renderWorkers(workers));

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -229,6 +229,14 @@ class SchedulerIoTest(unittest.TestCase):
         task_9.add_failure()
         self.assertTrue(task_9.has_excessive_failures())
 
+    @with_config({'scheduler': {'pause_enabled': 'false'}})
+    def test_pause_disabled(self):
+        s = luigi.scheduler.Scheduler()
+        self.assertFalse(s.is_pause_enabled()['enabled'])
+        self.assertFalse(s.is_paused()['paused'])
+        s.pause()
+        self.assertFalse(s.is_paused()['paused'])
+
 
 class SchedulerWorkerTest(unittest.TestCase):
     def get_pending_ids(self, worker, state):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a new config value which, when set to false, will turn disable the functionality of the pause/unpause RPC methods and also hide the pause toggle from the visualiser.

## Motivation and Context
We wish to have the ability to disable this functionality because curious engineers may click the button without knowing what it does and accidentally pause all tasks.

## Have you tested this? If so, how?
I ensured that when the config is set to false, the button is hidden from the visualiser.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
