### PR TITLE
Remove unnecessary method in ConcurrentRunningResourcesTest.

### DIFF
--- a/test/task_running_resources_test.py
+++ b/test/task_running_resources_test.py
@@ -73,9 +73,6 @@ class LocalRunningResourcesTest(unittest.TestCase):
 
 class ConcurrentRunningResourcesTest(unittest.TestCase):
 
-    def get_app(self):
-        return luigi.server.app(luigi.scheduler.Scheduler())
-
     def setUp(self):
         super(ConcurrentRunningResourcesTest, self).setUp()
 


### PR DESCRIPTION
## Description

This (trivial) PR removes an unnecessary method in `test.task_running_resources_test.ConcurrentRunningResourcesTest`. The test itself might be a good example to show how to use a remote scheduler in unit tests so it's worth cleaning it up.

The change was proposed by @Tarrasch in https://github.com/spotify/luigi/pull/2346#pullrequestreview-110284998. 