### PR TITLE
Add worker config to force multiprocessing

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -270,6 +270,12 @@ check_unfulfilled_deps
   resource-intensive.
   Defaults to true.
 
+force_multiprocessing
+  By default, luigi uses multiprocessing when *more than one* worker process is
+  requested. Whet set to true, multiprocessing is used independent of the
+  the number of workers.
+  Defaults to false.
+
 
 [elasticsearch]
 ---------------

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -388,6 +388,9 @@ class worker(Config):
     check_unfulfilled_deps = BoolParameter(default=True,
                                            description='If true, check for completeness of '
                                            'dependencies before running a task')
+    force_multiprocessing = BoolParameter(default=False,
+                                          description='If true, use multiprocessing also when '
+                                          'running with 1 worker')
 
 
 class KeepAliveThread(threading.Thread):
@@ -932,9 +935,10 @@ class Worker(object):
 
     def _create_task_process(self, task):
         reporter = TaskStatusReporter(self._scheduler, task.task_id, self._id)
+        use_multiprocessing = self._config.force_multiprocessing or bool(self.worker_processes > 1)
         return TaskProcess(
             task, self._id, self._task_result_queue, reporter,
-            use_multiprocessing=bool(self.worker_processes > 1),
+            use_multiprocessing=use_multiprocessing,
             worker_timeout=self._config.timeout,
             check_unfulfilled_deps=self._config.check_unfulfilled_deps,
         )

--- a/test/worker_multiprocess_test.py
+++ b/test/worker_multiprocess_test.py
@@ -106,3 +106,18 @@ class MultiprocessWorkerTest(unittest.TestCase):
                                                     self.gw_res(0, None)])
 
         self.assertFalse(self.worker.run())
+
+
+class SingleWorkerMultiprocessTest(unittest.TestCase):
+
+    def test_default_multiprocessing_behavior(self):
+        with Worker(worker_processes=1) as worker:
+            task = DummyTask("a")
+            task_process = worker._create_task_process(task)
+            self.assertFalse(task_process.use_multiprocessing)
+
+    def test_force_multiprocessing(self):
+        with Worker(worker_processes=1, force_multiprocessing=True) as worker:
+            task = DummyTask("a")
+            task_process = worker._create_task_process(task)
+            self.assertTrue(task_process.use_multiprocessing)


### PR DESCRIPTION
## Description

At the moment, luigi uses multiprocessing for tasks only when the number of requested workers is > 1. In some situations, it might be helpful if this was also the case for exactly 1 worker (e.g. when the executed code does something nasty with the main process, TensorFlow in our case). I added a worker config `force_multiprocessing` which, when `True`, forces multiprocessing to be used independent of the number of workers. I also added a few lines to the docs.

## Have you tested this? If so, how?

Yup, there are two additional tests now in `test/worker_multiprocess_test.py` that check if the created `TaskProcess` instance received the correct multiprocessing flag.
