### PR TITLE
Change task result parameter value to TEXT

### DIFF
--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -256,4 +256,7 @@ def _upgrade_schema(engine):
         conn.execute('CREATE INDEX ix_task_id ON tasks (task_id)')
 
     # Upgrade 2. Alter value column to be TEXT, note that this is idempotent so no if-guard
-    conn.execute('ALTER TABLE task_parameters ALTER COLUMN value TYPE TEXT')
+    if engine.dialect == 'mysqldb':
+        conn.execute('ALTER TABLE task_parameters MODIFY COLUMN value value TEXT')
+    elif engine.dialect == 'psycopg2':
+        conn.execute('ALTER TABLE task_parameters ALTER COLUMN value TYPE TEXT')

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -196,7 +196,7 @@ class TaskParameter(Base):
     __tablename__ = 'task_parameters'
     task_id = sqlalchemy.Column(sqlalchemy.Integer, sqlalchemy.ForeignKey('tasks.id'), primary_key=True)
     name = sqlalchemy.Column(sqlalchemy.String(128), primary_key=True)
-    value = sqlalchemy.Column(sqlalchemy.String(256))
+    value = sqlalchemy.Column(sqlalchemy.Text())
 
     def __repr__(self):
         return "TaskParameter(task_id=%d, name=%s, value=%s)" % (self.task_id, self.name, self.value)
@@ -254,3 +254,6 @@ def _upgrade_schema(engine):
         logger.warn('Upgrading DbTaskHistory schema: Adding tasks.task_id')
         conn.execute('ALTER TABLE tasks ADD COLUMN task_id VARCHAR(200)')
         conn.execute('CREATE INDEX ix_task_id ON tasks (task_id)')
+    
+    # Upgrade 2. Alter value column to be TEXT, note that this is idempotent so no if-guard
+    conn.execute('ALTER TABLE task_parameters ALTER COLUMN value TYPE TEXT')

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -254,6 +254,6 @@ def _upgrade_schema(engine):
         logger.warn('Upgrading DbTaskHistory schema: Adding tasks.task_id')
         conn.execute('ALTER TABLE tasks ADD COLUMN task_id VARCHAR(200)')
         conn.execute('CREATE INDEX ix_task_id ON tasks (task_id)')
-    
+
     # Upgrade 2. Alter value column to be TEXT, note that this is idempotent so no if-guard
     conn.execute('ALTER TABLE task_parameters ALTER COLUMN value TYPE TEXT')


### PR DESCRIPTION
This is a manual rebase of #2241 onto master with one additional commit.

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Parameter values longer than 256 characters currently fail to be written to the SQL result store. This changes the task value column to TEXT to avoid the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2240
Fixes #1885

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I've tested this against a PostgreSQL setup, both a new database and existing database, and it works.  I have not tested any other dialects (help plz). The existing tests **should** cover MySQL and SQLite? Marking WIP until I can confirm this works with the required dialects.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
