### PR TITLE
this feels more like a warning than error

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -141,7 +141,8 @@ class RemoteScheduler(object):
             except self._fetcher.raises as e:
                 last_exception = e
                 if log_exceptions:
-                    logger.exception("Failed connecting to remote scheduler %r", self._url)
+                    logger.warning("Failed connecting to remote scheduler %r", self._url,
+                                   exc_info=True)
                 continue
         else:
             raise RPCError(


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Log exception as warning when retrying communicating with remote scheduler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since this happens during retrying, a warning seems to be more suitable.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Tested it manually.
```
import logging
from logging import getLogger

logging.basicConfig(level=logging.INFO)
logger = getLogger('test')

try:
    10 / 0
except Exception as exp:
    logger.exception("an error with exception")
    logger.warning("a warning with exception" , exc_info=True)
```
```
python test.py
ERROR:test:an error with exception
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    10 / 0
ZeroDivisionError: integer division or modulo by zero
WARNING:test:a warning with exception
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    10 / 0
ZeroDivisionError: integer division or modulo by zero
```
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->

@dlstadther PTAL Does this make sense?