### PR TITLE
Make CmdlineParser available during execution summary (#2411)

### DIFF
--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -80,9 +80,10 @@ def run_with_retcodes(argv):
         logger.exception("Uncaught exception in luigi")
         sys.exit(retcodes.unhandled_exception)
 
-    task_sets = luigi.execution_summary._summary_dict(worker)
-    root_task = luigi.execution_summary._root_task(worker)
-    non_empty_categories = {k: v for k, v in task_sets.items() if v}.keys()
+    with luigi.cmdline_parser.CmdlineParser.global_instance(argv):
+        task_sets = luigi.execution_summary._summary_dict(worker)
+        root_task = luigi.execution_summary._root_task(worker)
+        non_empty_categories = {k: v for k, v in task_sets.items() if v}.keys()
 
     def has(status):
         assert status in luigi.execution_summary._ORDERED_STATUSES

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -90,6 +90,24 @@ class ATaskThatFails(luigi.Task):
         raise ValueError()
 
 
+class RequiredConfig(luigi.Config):
+    required_test_param = luigi.Parameter()
+
+
+class TaskThatRequiresConfig(luigi.WrapperTask):
+    def requires(self):
+        if RequiredConfig().required_test_param == 'A':
+            return SubTaskThatFails()
+
+
+class SubTaskThatFails(luigi.Task):
+    def complete(self):
+        return False
+
+    def run(self):
+        raise Exception()
+
+
 class CmdlineTest(unittest.TestCase):
 
     def setUp(self):
@@ -338,6 +356,17 @@ class InvokeOverCmdlineTest(unittest.TestCase):
 
         self.assertFalse(stdout.find(b"run() got an unexpected keyword argument 'tracking_url_callback'") != -1)
         self.assertFalse(stdout.find(b'During handling of the above exception, another exception occurred') != -1)
+
+    def test_cmd_line_params_are_available_for_execution_summary(self):
+        """
+        Test that config parameters specified on the command line are available while generating the execution summary.
+        """
+        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', 'TaskThatRequiresConfig', '--RequiredConfig-required-test-param', 'A', '--local-scheduler', '--no-lock'])
+        print(stdout)
+        print(stderr)
+
+        self.assertNotEquals(returncode, 1)
+        self.assertFalse(b'required_test_param' in stderr)
 
 
 if __name__ == '__main__':

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -361,7 +361,10 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         """
         Test that config parameters specified on the command line are available while generating the execution summary.
         """
-        returncode, stdout, stderr = self._run_cmdline(['./bin/luigi', '--module', 'cmdline_test', 'TaskThatRequiresConfig', '--RequiredConfig-required-test-param', 'A', '--local-scheduler', '--no-lock'])
+        returncode, stdout, stderr = self._run_cmdline([
+            './bin/luigi', '--module', 'cmdline_test', 'TaskThatRequiresConfig', '--local-scheduler', '--no-lock'
+            '--RequiredConfig-required-test-param', 'A',
+        ])
         print(stdout)
         print(stderr)
 


### PR DESCRIPTION
## Description
Wrapping the call to _summary_dict in a CmdlineParser context manager makes command line params available to Task/Config objects in e.g. `requires` which may be invoked while generating the execution summary.
 
## Motivation and Context
Fixes #2411

## Have you tested this? If so, how?
Tested in cmdline_tests.py
