### PR TITLE
Catch Postgres IntegrityError when creating marker table

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -218,8 +218,8 @@ class PostgresTarget(luigi.Target):
 
         try:
             cursor.execute(sql)
-        except psycopg2.ProgrammingError as e:
-            if e.pgcode == psycopg2.errorcodes.DUPLICATE_TABLE:
+        except (psycopg2.ProgrammingError, psycopg2.IntegrityError) as e:
+            if e.pgcode in [psycopg2.errorcodes.DUPLICATE_TABLE, psycopg2.errorcodes.UNIQUE_VIOLATION]:
                 pass
             else:
                 raise


### PR DESCRIPTION
When running with multiple workers there is a race condition when creating the marker_table which can some times result in the following exception:

psycopg2.IntegrityError: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
DETAIL:  Key (typname, typnamespace)=(table_updates, 26808) already exists.