### PR TITLE
Reenables true multithreaded s3 copy

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -30,6 +30,8 @@ import os
 import os.path
 import warnings
 
+from multiprocessing.pool import ThreadPool
+
 import botocore
 
 try:
@@ -323,6 +325,9 @@ class S3Client(FileSystem):
         total_keys = 0
 
         if self.isdir(source_path):
+            copy_jobs = []
+            management_pool = ThreadPool(processes=threads)
+
             (bucket, key) = self._path_to_bucket_and_key(source_path)
             key_path = self._add_path_delimiter(key)
             key_path_len = len(key_path)
@@ -340,8 +345,19 @@ class S3Client(FileSystem):
                         'Key': src_prefix + path
                     }
 
-                    self.s3.meta.client.copy(
-                        copy_source, dst_bucket, dst_prefix + path, Config=transfer_config, ExtraArgs=kwargs)
+                    the_kwargs = {'Config': transfer_config, 'ExtraArgs': kwargs}
+                    job = management_pool.apply_async(self.s3.meta.client.copy,
+                                                      args=(copy_source, dst_bucket, dst_prefix + path),
+                                                      kwds=the_kwargs)
+                    copy_jobs.append(job)
+
+            # Wait for the pools to finish scheduling all the copies
+            management_pool.close()
+            management_pool.join()
+
+            # Raise any errors encountered in any of the copy processes
+            for result in copy_jobs:
+                result.get()
 
             end = datetime.datetime.now()
             duration = end - start


### PR DESCRIPTION
Boto3 update removed multithreaded file copy in favor of multithreaded multipart file copy.

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Re-enables true multithreaded file copy. (Logic taken directly from pre-boto3 s3.py)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Boto3's `TransferConfig` appears to enable multithreaded copy capabilities for multipart files, but not for the copying of many small files.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I've run with test code. Other than that, i'm letting travis test it.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
