### PR TITLE
Send messages from scheduler to tasks

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -276,6 +276,11 @@ force_multiprocessing
   the number of workers.
   Defaults to false.
 
+receive_messages
+  If true, workers can receive messages sent by the scheduler and dispatch them
+  to running tasks.
+  Defaults to true.
+
 
 [elasticsearch]
 ---------------
@@ -725,6 +730,11 @@ worker_disconnect_delay
 pause_enabled
   If false, disables pause/unpause operations and hides the pause toggle from
   the visualiser.
+
+send_messages
+  When true, the scheduler is allowed to send messages to running tasks and
+  the central scheduler provides a simple prompt per task to send messages.
+  Defaults to true.
 
 
 [sendgrid]

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -276,11 +276,6 @@ force_multiprocessing
   the number of workers.
   Defaults to false.
 
-receive_messages
-  If true, workers can receive messages sent by the scheduler and dispatch them
-  to running tasks.
-  Defaults to true.
-
 
 [elasticsearch]
 ---------------

--- a/doc/luigi_patterns.rst
+++ b/doc/luigi_patterns.rst
@@ -334,7 +334,7 @@ messages:
         ...
 
         # configure the task to accept all incoming messages
-        accepted_messages = True
+        accepts_messages = True
 
         def run(self):
             # this example runs some loop and listens for the

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1264,12 +1264,15 @@ class Scheduler(object):
             'tracking_url': getattr(task, "tracking_url", None),
             'status_message': getattr(task, "status_message", None),
             'progress_percentage': getattr(task, "progress_percentage", None),
-            'enabled_scheduler_messages': self._config.send_messages,
+            'enabled_scheduler_messages': False,
         }
         if task.status == DISABLED:
             ret['re_enable_able'] = task.scheduler_disable_time is not None
         if include_deps:
             ret['deps'] = list(task.deps if deps is None else deps)
+        if self._config.send_messages and task.status == RUNNING and task.worker_running:
+            worker = self._state.get_worker(task.worker_running)
+            ret['enabled_scheduler_messages'] = worker.info.get('receive_messages', False)
         return ret
 
     @rpc_method()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -952,7 +952,6 @@ class Scheduler(object):
         if self._state.has_task(task_id):
             task = self._state.get_task(task_id)
             task.scheduler_message_responses[message_id] = response
-        print task.scheduler_message_responses
 
     @rpc_method()
     def get_scheduler_message_response(self, task_id, message_id):

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -280,7 +280,7 @@ class OrderedSet(collections.MutableSet):
 
 class Task(object):
     def __init__(self, task_id, status, deps, resources=None, priority=0, family='', module=None,
-                 params=None, accepted_messages=False, tracking_url=None, status_message=None,
+                 params=None, accepts_messages=False, tracking_url=None, status_message=None,
                  progress_percentage=None, retry_policy='notoptional'):
         self.id = task_id
         self.stakeholders = set()  # workers ids that are somehow related to this task (i.e. don't prune while any of these workers are still active)
@@ -303,7 +303,7 @@ class Task(object):
         self.module = module
         self.params = _get_default(params, {})
 
-        self.accepted_messages = accepted_messages
+        self.accepts_messages = accepts_messages
         self.retry_policy = retry_policy
         self.failures = Failures(self.retry_policy.disable_window)
         self.tracking_url = tracking_url
@@ -778,7 +778,7 @@ class Scheduler(object):
     @rpc_method()
     def add_task(self, task_id=None, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
-                 priority=0, family='', module=None, params=None, accepted_messages=False,
+                 priority=0, family='', module=None, params=None, accepts_messages=False,
                  assistant=False, tracking_url=None, worker=None, batchable=None,
                  batch_id=None, retry_policy_dict=None, owners=None, **kwargs):
         """
@@ -803,7 +803,7 @@ class Scheduler(object):
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
                 priority=priority, family=family, module=module, params=params,
-                accepted_messages=accepted_messages,
+                accepts_messages=accepts_messages,
             )
         else:
             _default_task = None
@@ -1292,7 +1292,7 @@ class Scheduler(object):
         if include_deps:
             ret['deps'] = list(task.deps if deps is None else deps)
         if self._config.send_messages and task.status == RUNNING:
-            ret['accepted_messages'] = task.accepted_messages
+            ret['accepts_messages'] = task.accepts_messages
         return ret
 
     @rpc_method()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -962,7 +962,7 @@ class Scheduler(object):
         if self._state.has_task(task_id):
             task = self._state.get_task(task_id)
             response = task.scheduler_message_responses.pop(message_id, None)
-        return {"taskId": task_id, "response": response}
+        return {"response": response}
 
     @rpc_method()
     def is_pause_enabled(self):

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -41,7 +41,7 @@
                   {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                   {{/progressPercentage}}
                 {{/statusMessage}}
-                {{#enabledSchedulerMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>{{/enabledSchedulerMessages}}
+                {{#acceptedMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>{{/acceptedMessages}}
             </div>
         </script>
         <script type="text/template" name="errorTemplate">
@@ -230,8 +230,8 @@
                             {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                             {{/progressPercentage}}
                           {{/statusMessage}}
-                          {{#enabledSchedulerMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>
-                          {{/enabledSchedulerMessages}}
+                          {{#acceptedMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>
+                          {{/acceptedMessages}}
                         </td>
                       </tr>
                       {{/tasks}}

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -41,7 +41,7 @@
                   {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                   {{/progressPercentage}}
                 {{/statusMessage}}
-                {{#acceptedMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>{{/acceptedMessages}}
+                {{#acceptsMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>{{/acceptsMessages}}
             </div>
         </script>
         <script type="text/template" name="errorTemplate">
@@ -230,8 +230,8 @@
                             {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                             {{/progressPercentage}}
                           {{/statusMessage}}
-                          {{#acceptedMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>
-                          {{/acceptedMessages}}
+                          {{#acceptsMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>
+                          {{/acceptsMessages}}
                         </td>
                       </tr>
                       {{/tasks}}

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -41,6 +41,7 @@
                   {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                   {{/progressPercentage}}
                 {{/statusMessage}}
+                {{#enabledSchedulerMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>{{/enabledSchedulerMessages}}
             </div>
         </script>
         <script type="text/template" name="errorTemplate">
@@ -77,6 +78,28 @@
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
               </div>
+            </div>
+          </div>
+        </script>
+        <script type="text/template" name="schedulerMessageTemplate">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="myModalLabel">Send message to {{displayName}}</h4>
+              </div>
+              <div class="modal-body">
+                  <form>
+                    <div class="form-group">
+                      <label for="schedulerMessageInput">Message:</label>
+                      <input type="text" class="form-control" id="schedulerMessageInput" placeholder="">
+                    </div>
+                  </form>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                  <button type="button" id="schedulerMessageButton" data-dismiss="modal" class="btn btn-primary">Send</button>
+                </div>
             </div>
           </div>
         </script>
@@ -198,6 +221,8 @@
                             {{#progressPercentage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>
                             {{/progressPercentage}}
                           {{/statusMessage}}
+                          {{#enabledSchedulerMessages}}<button class="btn btn-success btn-xs schedulerMessage" title="Send message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}" data-worker="{{workerIdRunning}}"><i class="fa fa-paper-plane"></i></button>
+                          {{/enabledSchedulerMessages}}
                         </td>
                       </tr>
                       {{/tasks}}
@@ -325,6 +350,8 @@
         <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         </div>
         <div class="modal fade" id="statusMessageModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        </div>
+        <div class="modal fade" id="schedulerMessageModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
         </div>
 
         <div class="wrapper">

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -94,7 +94,16 @@
                       <label for="schedulerMessageInput">Message:</label>
                       <input type="text" class="form-control" id="schedulerMessageInput" placeholder="">
                     </div>
+                    <div class="form-group">
+                      <input type="checkbox" class="form-check-input" id="schedulerMessageAwaitResponse">
+                      <label class="form-check-label" for="schedulerMessageAwaitResponse">Await response</label>
+                    </div>
                   </form>
+                  <div class="form-group" id="schedulerMessageResponse" style="display: none;">
+                    <hr />
+                    <label>Response:</label>
+                    <pre class="pre-scrollable"><i class="fa fa-spinner fa-pulse" id="schedulerMessageSpinner"></i><div></div></pre>
+                  </div>
                 </div>
                 <div class="modal-footer">
                   <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -158,9 +158,20 @@ var LuigiAPI = (function() {
         });
     };
 
-    LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, message) {
+    LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, message, callback) {
         var data = {worker: workerId, task: taskId, message: message};
-        jsonRPC(this.urlRoot + "/send_scheduler_message", data);
+        jsonRPC(this.urlRoot + "/send_scheduler_message", data, function(response) {
+            if (callback) {
+                callback(response.response.messageId);
+            }
+        });
+    };
+
+    LuigiAPI.prototype.getSchedulerMessageResponse = function(taskId, messageId, callback) {
+        var data = {task_id: taskId, message_id: messageId};
+        jsonRPC(this.urlRoot + "/get_scheduler_message_response", data, function(response) {
+            callback(response.response.response);
+        });
     };
 
     LuigiAPI.prototype.isPauseEnabled = function(callback) {

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -158,6 +158,11 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, message) {
+        var data = {worker: workerId, task: taskId, message: message};
+        jsonRPC(this.urlRoot + "/send_scheduler_message", data);
+    };
+
     LuigiAPI.prototype.isPauseEnabled = function(callback) {
         jsonRPC(this.urlRoot + '/is_pause_enabled', {}, function(response) {
             callback(response.response.enabled);

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -158,11 +158,11 @@ var LuigiAPI = (function() {
         });
     };
 
-    LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, message, callback) {
-        var data = {worker: workerId, task: taskId, message: message};
+    LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, content, callback) {
+        var data = {worker: workerId, task: taskId, content: content};
         jsonRPC(this.urlRoot + "/send_scheduler_message", data, function(response) {
             if (callback) {
-                callback(response.response.messageId);
+                callback(response.response.message_id);
             }
         });
     };

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -76,7 +76,7 @@ function visualiserApp(luigi) {
             re_enable: task.status == "DISABLED" && task.re_enable_able,
             statusMessage: task.status_message,
             progressPercentage: task.progress_percentage,
-            enabledSchedulerMessages: task.enabled_scheduler_messages,
+            acceptedMessages: task.accepted_messages,
             workerIdRunning: task.worker_running,
         };
     }
@@ -348,14 +348,14 @@ function visualiserApp(luigi) {
         });
 
         $send.on("click", function($event) {
-            var message = $input.val();
+            var content = $input.val();
             var awaitResponse = $awaitResponse.prop("checked");
-            if (message && data.worker) {
+            if (content && data.worker) {
                 if (awaitResponse) {
                     $responseContainer.show();
                     $responseSpinner.show();
                     $responseContent.empty();
-                    luigi.sendSchedulerMessage(data.worker, data.taskId, message, function(messageId) {
+                    luigi.sendSchedulerMessage(data.worker, data.taskId, content, function(messageId) {
                         var interval = window.setInterval(function() {
                             luigi.getSchedulerMessageResponse(data.taskId, messageId, function(response) {
                                 if (response != null) {
@@ -369,7 +369,7 @@ function visualiserApp(luigi) {
                     $event.stopPropagation();
                 } else {
                     $responseContainer.hide();
-                    luigi.sendSchedulerMessage(data.worker, data.taskId, message);
+                    luigi.sendSchedulerMessage(data.worker, data.taskId, content);
                 }
             }
         });

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -76,7 +76,7 @@ function visualiserApp(luigi) {
             re_enable: task.status == "DISABLED" && task.re_enable_able,
             statusMessage: task.status_message,
             progressPercentage: task.progress_percentage,
-            acceptedMessages: task.accepted_messages,
+            acceptsMessages: task.accepts_messages,
             workerIdRunning: task.worker_running,
         };
     }

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -76,7 +76,7 @@ function visualiserApp(luigi) {
             re_enable: task.status == "DISABLED" && task.re_enable_able,
             statusMessage: task.status_message,
             progressPercentage: task.progress_percentage,
-            enabledSchedulerMessages: task.status == "RUNNING" && task.enabled_scheduler_messages,
+            enabledSchedulerMessages: task.enabled_scheduler_messages,
             workerIdRunning: task.worker_running,
         };
     }

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -280,10 +280,10 @@ class Task(object):
                     logger.exception("Error in event callback for %r", event)
 
     @property
-    def accepted_messages(self):
+    def accepts_messages(self):
         """
-        Configures which scheduler messages can be received and returns them. When falsy, this tasks
-        does not accept any message. When True, all messages are accepted.
+        For configuring which scheduler messages can be received. When falsy, this tasks does not
+        accept any message. When True, all messages are accepted.
         """
         return False
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -687,7 +687,7 @@ class Task(object):
                         pickle.dumps(self)
 
         """
-        unpicklable_properties = tuple(luigi.worker.TaskProcess.forward_reporter_callbacks.values())
+        unpicklable_properties = tuple(luigi.worker.TaskProcess.forward_reporter_attributes.values())
         reserved_properties = {}
         for property_name in unpicklable_properties:
             if hasattr(self, property_name):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -280,6 +280,14 @@ class Task(object):
                     logger.exception("Error in event callback for %r", event)
 
     @property
+    def accepted_messages(self):
+        """
+        Configures which scheduler messages can be received and returns them. When falsy, this tasks
+        does not accept any message. When True, all messages are accepted.
+        """
+        return False
+
+    @property
     def task_module(self):
         ''' Returns what Python module to import to get access to this class. '''
         # TODO(erikbern): we should think about a language-agnostic mechanism

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -420,6 +420,7 @@ class worker(Config):
                                           description='If true, use multiprocessing also when '
                                           'running with 1 worker')
 
+
 class KeepAliveThread(threading.Thread):
     """
     Periodically tell the scheduler that the worker still lives.

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -822,7 +822,7 @@ class Worker(object):
             module=task.task_module,
             batchable=task.batchable,
             retry_policy_dict=_get_retry_policy_dict(task),
-            accepted_messages=task.accepted_messages,
+            accepts_messages=task.accepts_messages,
         )
 
     def _validate_dependency(self, dependency):
@@ -963,7 +963,7 @@ class Worker(object):
             task_process.run()
 
     def _create_task_process(self, task):
-        message_queue = multiprocessing.Queue() if task.accepted_messages else None
+        message_queue = multiprocessing.Queue() if task.accepts_messages else None
         reporter = TaskStatusReporter(self._scheduler, task.task_id, self._id, message_queue)
         use_multiprocessing = self._config.force_multiprocessing or bool(self.worker_processes > 1)
         return TaskProcess(

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -453,16 +453,16 @@ class Worker(object):
         if scheduler is None:
             scheduler = Scheduler()
 
+        self._config = worker(**kwargs)
+
+        assert self._config.wait_interval >= _WAIT_INTERVAL_EPS, "[worker] wait_interval must be positive"
+        assert self._config.wait_jitter >= 0.0, "[worker] wait_jitter must be equal or greater than zero"
+
         self.worker_processes = int(worker_processes)
         self._worker_info = self._generate_worker_info()
 
         if not worker_id:
             worker_id = 'Worker(%s)' % ', '.join(['%s=%s' % (k, v) for k, v in self._worker_info])
-
-        self._config = worker(**kwargs)
-
-        assert self._config.wait_interval >= _WAIT_INTERVAL_EPS, "[worker] wait_interval must be positive"
-        assert self._config.wait_jitter >= 0.0, "[worker] wait_jitter must be equal or greater than zero"
 
         self._id = worker_id
         self._scheduler = scheduler
@@ -546,7 +546,8 @@ class Worker(object):
         # Generate as much info as possible about the worker
         # Some of these calls might not be available on all OS's
         args = [('salt', '%09d' % random.randrange(0, 999999999)),
-                ('workers', self.worker_processes)]
+                ('workers', self.worker_processes),
+                ('receive_messages', self._config.receive_messages)]
         try:
             args += [('host', socket.gethostname())]
         except BaseException:

--- a/test/scheduler_message_test.py
+++ b/test/scheduler_message_test.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import time
+import tempfile
+
+from helpers import LuigiTestCase, RunOnceTask
+
+import luigi
+import luigi.scheduler
+import luigi.worker
+
+
+def fast_worker(scheduler, **kwargs):
+    kwargs.setdefault("ping_interval", 0.5)
+    kwargs.setdefault("force_multiprocessing", True)
+    return luigi.worker.Worker(scheduler=scheduler, **kwargs)
+
+
+class WriteMessageToFile(luigi.Task):
+
+    path = luigi.Parameter()
+
+    def output(self):
+        return luigi.LocalTarget(self.path)
+
+    def run(self):
+        msg = ""
+
+        time.sleep(0.5)
+        if not self.scheduler_messages.empty():
+            msg = self.scheduler_messages.get()
+
+        with self.output().open("w") as f:
+            f.write(msg + "\n")
+
+
+class SchedulerMessageTest(LuigiTestCase):
+
+    def test_receive_messsage(self):
+        sch = luigi.scheduler.Scheduler(send_messages=True)
+        with fast_worker(sch, receive_messages=True) as w:
+            with tempfile.NamedTemporaryFile() as tmp:
+                if os.path.exists(tmp.name):
+                    os.remove(tmp.name)
+
+                task = WriteMessageToFile(path=tmp.name)
+                w.add(task)
+
+                sch.send_scheduler_message(w._id, task.task_id, "test")
+                w.run()
+
+                self.assertTrue(os.path.exists(tmp.name))
+                with open(tmp.name, "r") as f:
+                    self.assertEqual(str(f.read()).strip(), "test")
+
+    def test_receive_messages_disabled(self):
+        sch = luigi.scheduler.Scheduler(send_messages=True)
+        with fast_worker(sch, receive_messages=False, force_multiprocessing=False) as w:
+                class MyTask(RunOnceTask):
+                    def run(self):
+                        self.had_queue = self.scheduler_messages is not None
+                        super(MyTask, self).run()
+
+                task = MyTask()
+                w.add(task)
+
+                sch.send_scheduler_message(w._id, task.task_id, "test")
+                w.run()
+
+                self.assertFalse(task.had_queue)
+
+    def test_send_messages_disabled(self):
+        sch = luigi.scheduler.Scheduler(send_messages=False)
+        with fast_worker(sch, receive_messages=True) as w:
+            with tempfile.NamedTemporaryFile() as tmp:
+                if os.path.exists(tmp.name):
+                    os.remove(tmp.name)
+
+                task = WriteMessageToFile(path=tmp.name)
+                w.add(task)
+
+                sch.send_scheduler_message(w._id, task.task_id, "test")
+                w.run()
+
+                self.assertTrue(os.path.exists(tmp.name))
+                with open(tmp.name, "r") as f:
+                    self.assertEqual(str(f.read()).strip(), "")

--- a/test/scheduler_message_test.py
+++ b/test/scheduler_message_test.py
@@ -36,7 +36,7 @@ class WriteMessageToFile(luigi.Task):
 
     path = luigi.Parameter()
 
-    accepted_messages = True
+    accepts_messages = True
 
     def output(self):
         return luigi.LocalTarget(self.path)

--- a/test/scheduler_message_test.py
+++ b/test/scheduler_message_test.py
@@ -35,7 +35,7 @@ def fast_worker(scheduler, **kwargs):
 class WriteMessageToFile(luigi.Task):
 
     path = luigi.Parameter()
-    
+
     accepted_messages = True
 
     def output(self):

--- a/test/scheduler_message_test.py
+++ b/test/scheduler_message_test.py
@@ -35,6 +35,8 @@ def fast_worker(scheduler, **kwargs):
 class WriteMessageToFile(luigi.Task):
 
     path = luigi.Parameter()
+    
+    accepted_messages = True
 
     def output(self):
         return luigi.LocalTarget(self.path)
@@ -54,7 +56,7 @@ class SchedulerMessageTest(LuigiTestCase):
 
     def test_receive_messsage(self):
         sch = luigi.scheduler.Scheduler(send_messages=True)
-        with fast_worker(sch, receive_messages=True) as w:
+        with fast_worker(sch) as w:
             with tempfile.NamedTemporaryFile() as tmp:
                 if os.path.exists(tmp.name):
                     os.remove(tmp.name)
@@ -71,7 +73,7 @@ class SchedulerMessageTest(LuigiTestCase):
 
     def test_receive_messages_disabled(self):
         sch = luigi.scheduler.Scheduler(send_messages=True)
-        with fast_worker(sch, receive_messages=False, force_multiprocessing=False) as w:
+        with fast_worker(sch, force_multiprocessing=False) as w:
                 class MyTask(RunOnceTask):
                     def run(self):
                         self.had_queue = self.scheduler_messages is not None
@@ -87,7 +89,7 @@ class SchedulerMessageTest(LuigiTestCase):
 
     def test_send_messages_disabled(self):
         sch = luigi.scheduler.Scheduler(send_messages=False)
-        with fast_worker(sch, receive_messages=True) as w:
+        with fast_worker(sch) as w:
             with tempfile.NamedTemporaryFile() as tmp:
                 if os.path.exists(tmp.name):
                     os.remove(tmp.name)

--- a/test/scheduler_message_test.py
+++ b/test/scheduler_message_test.py
@@ -42,9 +42,9 @@ class WriteMessageToFile(luigi.Task):
     def run(self):
         msg = ""
 
-        time.sleep(0.5)
+        time.sleep(1)
         if not self.scheduler_messages.empty():
-            msg = self.scheduler_messages.get()
+            msg = self.scheduler_messages.get().content
 
         with self.output().open("w") as f:
             f.write(msg + "\n")


### PR DESCRIPTION
## Description

This PR enables the scheduler to send messages to particular tasks. More precisely, messages are sent to workers via the RPC message system which dispatches them to a specified task. Running tasks 
can access a `multiprocessing.Queue` object (named `scheduler_messages`, set via the `StatusReporter`) which stores incoming messages. Users can implement custom behavior to react to certain messages (see code example below).

The new config `scheduler.send_messages` controls whether a scheduler is capable of sending messages in the first place. By defining `accepted_messages` a task can define whether it accepts messages, independent of the scheduler the worker is talking to. The message button is only visible in the UI when the scheduler is able to send messages, and the task can receive them (see screenshots).

There is also a simple "respond" mechanism so tasks can immediately respond to incoming messages which is shown in the scheduler.

"Send message" action button:

![Action button](https://www.dropbox.com/s/9q074j4ehseqvas/luigi1.png?raw=1 "Action button")

Message prompt:

![Message prompt](https://www.dropbox.com/s/ubuv3cih9y4l8w0/luigi2.png?raw=1 "Message prompt")

Awaiting response:

![Awaiting response](https://www.dropbox.com/s/aflo2l6snodp07x/luigi3.png?raw=1 "Awaiting response")

Response arrived:

![Response arrived](https://www.dropbox.com/s/co71o0cq8cbblkj/luigi4.png?raw=1 "Response arrived")

When `Await response` is not checked, the prompt closes upon `Send`. Otherwise, the prompt remains open and a response container is shown. This triggers a simple polling to fetch and display the actual response.

## Motivation and Context

There are many use cases when the messaging could be useful. One particular example is machine learning. Our training tasks publish their current results to the scheduler. Although they contain predefined termination criteria, it could be nice to manually trigger *graceful* training termination if the training stagnates:

```python
class Training(luigi.Task):

    def requires(self):
        ...

    def output(self):
        return luigi.LocalTarget("my_ml_model.pb")

    def run(self):
        # setup the training
        model = ...

        for _ in training_loop():
            # training stuff with internal termination criterion
            model.train(...)

            # check messages
            if not self.scheduler_messages.empty():
                msg = self.scheduler_messages.get()
                if msg.content == "terminate":
                    break
                else:
                    msg.respond("unknown message")

        # save the model
        model.save(self.output().path)
```

## Have you tested this? If so, how?

Yep, I added unit tests and docs.
