### PR TITLE
Add `target_table` to `PostgresTarget.exists()`

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -169,10 +169,9 @@ class PostgresTarget(luigi.Target):
         cursor = connection.cursor()
         try:
             cursor.execute("""SELECT 1 FROM {marker_table}
-                WHERE update_id = %s
+                WHERE (update_id, target_table) = (%s, %s)
                 LIMIT 1""".format(marker_table=self.marker_table),
-                           (self.update_id,)
-                           )
+                           (self.update_id, self.table))
             row = cursor.fetchone()
         except psycopg2.ProgrammingError as e:
             if e.pgcode == psycopg2.errorcodes.UNDEFINED_TABLE:


### PR DESCRIPTION
## Description
Adding `target_table` to the `exists` method of PostgresTarget checks if a specific `update_id` exists for a specific table, rather than any table.

## Motivation and Context
This way, one can use a "general" `update_id` (e.g. update_id = '2018-05-01', if a Pipeline has to be executed on a daily basis) for every task involved in this Pipeline.
Since a `PostgresTarget` can only point to one specific table anyway, it makes sense to constraint its `exists` method to check for an `update_id` of this specific table.

In the current implementation, every task in a Pipeline has to have a specific `update_id`. 
This often results in the table name being integrated to the `update_id` (e.g.: 'table-a-2018-05-01', 'table-b-2018-05-01', ...), which brings redundancy, since the table name is in the column `target_table` anyway.
