### PR TITLE
Add a "capture_output" parameter to ExternalProgramTask

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -53,7 +53,13 @@ class ExternalProgramTask(luigi.Task):
     and you can optionally override :py:meth:`program_environment` if you want to
     control the environment variables (see :py:class:`ExternalPythonProgramTask`
     for an example).
+
+    By default, the output (stdout and stderr) of the run external program
+    is being captured and displayed after the execution has ended. This
+    behaviour can be overriden by passing ``--capture-output False``
     """
+
+    capture_output = luigi.BoolParameter(default=True, significant=False)
 
     def program_args(self):
         """
@@ -89,13 +95,14 @@ class ExternalProgramTask(luigi.Task):
         args = list(map(str, self.program_args()))
 
         logger.info('Running command: %s', ' '.join(args))
-        tmp_stdout, tmp_stderr = tempfile.TemporaryFile(), tempfile.TemporaryFile()
         env = self.program_environment()
+        kwargs = {'env': env}
+        if self.capture_output:
+            tmp_stdout, tmp_stderr = tempfile.TemporaryFile(), tempfile.TemporaryFile()
+            kwargs.update({'stdout': tmp_stdout, 'stderr': tmp_stderr})
         proc = subprocess.Popen(
             args,
-            env=env,
-            stdout=tmp_stdout,
-            stderr=tmp_stderr
+            **kwargs
         )
 
         try:
@@ -103,22 +110,26 @@ class ExternalProgramTask(luigi.Task):
                 proc.wait()
             success = proc.returncode == 0
 
-            stdout = self._clean_output_file(tmp_stdout)
-            stderr = self._clean_output_file(tmp_stderr)
+            if self.capture_output:
+                stdout = self._clean_output_file(tmp_stdout)
+                stderr = self._clean_output_file(tmp_stderr)
 
-            if stdout:
-                logger.info('Program stdout:\n{}'.format(stdout))
-            if stderr:
-                if self.always_log_stderr or not success:
-                    logger.info('Program stderr:\n{}'.format(stderr))
+                if stdout:
+                    logger.info('Program stdout:\n{}'.format(stdout))
+                if stderr:
+                    if self.always_log_stderr or not success:
+                        logger.info('Program stderr:\n{}'.format(stderr))
+            else:
+                stdout, stderr = None, None
 
             if not success:
                 raise ExternalProgramRunError(
                     'Program failed with return code={}:'.format(proc.returncode),
                     args, env=env, stdout=stdout, stderr=stderr)
         finally:
-            tmp_stderr.close()
-            tmp_stdout.close()
+            if self.capture_output:
+                tmp_stderr.close()
+                tmp_stdout.close()
 
 
 class ExternalProgramRunContext(object):


### PR DESCRIPTION
## Description
A `capture_output` is added to `ExternalProgramTask`, so that
the output is captured only optionally (which is still the default
behaviour).

## Motivation and Context
This change can make debugging long-running tasks easier
by allowing the user to see the output on the fly. The current
behaviour remains unchanged by having the parameter set
to True by default

## Have you tested this? If so, how?
I have been running jobs this way by hot-fixing luigi
in `dist-packages`

Simple usage:

```
In [1]: from luigi.contrib.external_program import ExternalProgramTask

In [2]: class LsTask(ExternalProgramTask):
   ...:     def program_args(self):
   ...:         return ['ls']
   ...:     

In [3]: task = LsTask(capture_output=False)

In [4]: task.run()
bin  codecov.yml  CONTRIBUTING.rst  doc  examples  ISSUE_TEMPLATE.md  LICENSE  luigi  MANIFEST.in  PULL_REQUEST_TEMPLATE.md  README.rst  RELEASE-PROCESS.rst  scripts  setup.py  test  tox.in
```
*Edit*:
in reference to issue #2342