### PR TITLE
Use status.get to prevent KeyError in KubernetesJobTask (fixes #2432)

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -273,7 +273,7 @@ class KubernetesJobTask(luigi.Task):
                     assert wr == 'ContainerCreating', "Pod %s %s. Logs: `kubectl logs pod/%s`" % (
                         pod.name, wr, pod.name)
 
-            for cond in status['conditions']:
+            for cond in status.get('conditions', []):
                 if 'message' in cond:
                     if cond['reason'] == 'ContainersNotReady':
                         return False


### PR DESCRIPTION
## Description
Use `status.get('conditions', [])` instead of `status['conditions']` to prevent `KeyError` in some rare cases.

## Motivation and Context
Fix #2432.
