### PR TITLE
Add schema to DB if not exists for Redshift

### DIFF
--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -184,6 +184,48 @@ class TestS3CopyToTable(unittest.TestCase):
 
         return
 
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_schema_exist", return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_to_missing_schema(self, mock_redshift_target, mock_does_exist):
+        task = DummyS3CopyToTableKey(table='schema.table_with_schema')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+        executed_query = mock_cursor.execute.call_args_list[0][0][0]
+        assert executed_query.startswith("CREATE SCHEMA IF NOT EXISTS schema")
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_schema_exist", return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_to_missing_schema_with_no_schema(self, mock_redshift_target, mock_does_exist):
+        task = DummyS3CopyToTableKey(table='table_with_no_schema')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+        executed_query = mock_cursor.execute.call_args_list[0][0][0]
+        assert not executed_query.startswith("CREATE SCHEMA IF NOT EXISTS")
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_schema_exist", return_value=True)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_s3_copy_to_existing_schema_with_schema(self, mock_redshift_target, mock_does_exist):
+        task = DummyS3CopyToTableKey(table='schema.table_with_schema')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+        executed_query = mock_cursor.execute.call_args_list[0][0][0]
+        assert not executed_query.startswith("CREATE SCHEMA IF NOT EXISTS")
+
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.does_table_exist",
                 return_value=False)
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")


### PR DESCRIPTION
## Description
This adds the functionality to allow for the schema to be created if we
find a schema as part of the table name.

## Motivation and Context
Based on the current implementation, code exists to create the table if
it doesn't exist. It's a fair assumption that we would like to have the
same behavior for schemas.

Without this feature, the task could potentially crash and throw an error
saying that it cannot create the table under the related schema if a
schema is specified in the table name and that it doesn't exist.

## Have you tested this? If so, how?
Tested this feature manually in a test database + added a few specs to make sure that the core behavior works.
