### PR TITLE
Add metadata columns to the RDBMS contrib

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -326,6 +326,8 @@ class CopyToTable(rdbms.CopyToTable):
                 self.init_copy(connection)
                 self.copy(cursor, tmp_file)
                 self.post_copy(connection)
+                if self.enable_metadata_columns:
+                    self.post_copy_metacolumns(cursor)
             except psycopg2.ProgrammingError as e:
                 if e.pgcode == psycopg2.errorcodes.UNDEFINED_TABLE and attempt == 0:
                     # if first attempt fails with "relation not found", try creating table

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -28,7 +28,8 @@ logger = logging.getLogger('luigi-interface')
 
 
 class _MetadataColumnsMixin(object):
-    """
+    """Provice an additinal behavior that adds columns and values to tables
+
     This mixin is used to provide an additional behavior that allow a task to
     add generic metadata columns to every table created for both PSQL and
     Redshift.
@@ -49,7 +50,9 @@ class _MetadataColumnsMixin(object):
     def enable_metadata_columns(self):
         return False
 
-    def _add_metadata_columns(self, cursor):
+    def _add_metadata_columns(self, connection):
+        cursor = connection.cursor()
+
         for column in self.metadata_columns:
             if len(column) == 0:
                 logger.info('Unable to infer column information from column {column} for {table}'.format(column=column, table=self.table))
@@ -65,11 +68,11 @@ class _MetadataColumnsMixin(object):
             schema, table = self.table.split('.')
             query = "SELECT 1 AS column_exists " \
                     "FROM information_schema.columns " \
-                    "WHERE table_schema = LOWER('{0}') AND table_name = LOWER('{1}') AND column_name = LOWER('{2}') LIMIT 1".format(schema, table, column_name)
+                    "WHERE table_schema = LOWER('{0}') AND table_name = LOWER('{1}') AND column_name = LOWER('{2}') LIMIT 1;".format(schema, table, column_name)
         else:
             query = "SELECT 1 AS column_exists " \
                     "FROM information_schema.columns " \
-                    "WHERE table_name = LOWER('{0}') AND column_name = LOWER('{1}') LIMIT 1".format(table, column_name)
+                    "WHERE table_name = LOWER('{0}') AND column_name = LOWER('{1}') LIMIT 1;".format(self.table, column_name)
 
         cursor.execute(query)
         result = cursor.fetchone()
@@ -79,13 +82,18 @@ class _MetadataColumnsMixin(object):
         if len(column) == 1:
             raise ValueError("_add_column_to_table() column type not specified for {column}".format(column=column[0]))
         elif len(column) == 2:
-            query = "ALTER TABLE {table} ADD COLUMN {column}".format(table=self.table, column=' '.join(column))
+            query = "ALTER TABLE {table} ADD COLUMN {column};".format(table=self.table, column=' '.join(column))
         elif len(column) == 3:
-            query = "ALTER TABLE {table} ADD COLUMN {column} ENCODE {encoding}".format(table=self.table, column=' '.join(column[0:2]), encoding=column[3])
+            query = "ALTER TABLE {table} ADD COLUMN {column} ENCODE {encoding};".format(table=self.table, column=' '.join(column[0:2]), encoding=column[2])
         else:
             raise ValueError("_add_column_to_table() found no matching behavior for {column}".format(column=column))
 
         cursor.execute(query)
+
+    def post_copy_metacolumns(self, cursor):
+        logger.info('Executing post copy metadata queries')
+        for query in self.metadata_queries:
+            cursor.execute(query)
 
 
 class CopyToTable(luigi.task.MixinNaiveBulkComplete, _MetadataColumnsMixin, luigi.Task):

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -27,7 +27,68 @@ import luigi.task
 logger = logging.getLogger('luigi-interface')
 
 
-class CopyToTable(luigi.task.MixinNaiveBulkComplete, luigi.Task):
+class _MetadataColumnsMixin(object):
+    """
+    This mixin is used to provide an additional behavior that allow a task to
+    add generic metadata columns to every table created for both PSQL and
+    Redshift.
+    """
+    @property
+    def metadata_columns(self):
+        """Returns the default metadata columns.
+
+        Those columns are columns that we want each tables to have by default.
+        """
+        return []
+
+    @property
+    def metadata_queries(self):
+        return []
+
+    @property
+    def enable_metadata_columns(self):
+        return False
+
+    def _add_metadata_columns(self, cursor):
+        for column in self.metadata_columns:
+            if len(column) == 0:
+                logger.info('Unable to infer column information from column {column} for {table}'.format(column=column, table=self.table))
+                break
+
+            column_name = column[0]
+            if not self._column_exists(cursor, column_name):
+                logger.info('Adding missing metadata column {column} to {table}'.format(column=column, table=self.table))
+                self._add_column_to_table(cursor, column)
+
+    def _column_exists(self, cursor, column_name):
+        if '.' in self.table:
+            schema, table = self.table.split('.')
+            query = "SELECT 1 AS column_exists " \
+                    "FROM information_schema.columns " \
+                    "WHERE table_schema = LOWER('{0}') AND table_name = LOWER('{1}') AND column_name = LOWER('{2}') LIMIT 1".format(schema, table, column_name)
+        else:
+            query = "SELECT 1 AS column_exists " \
+                    "FROM information_schema.columns " \
+                    "WHERE table_name = LOWER('{0}') AND column_name = LOWER('{1}') LIMIT 1".format(table, column_name)
+
+        cursor.execute(query)
+        result = cursor.fetchone()
+        return bool(result)
+
+    def _add_column_to_table(self, cursor, column):
+        if len(column) == 1:
+            raise ValueError("_add_column_to_table() column type not specified for {column}".format(column=column[0]))
+        elif len(column) == 2:
+            query = "ALTER TABLE {table} ADD COLUMN {column}".format(table=self.table, column=' '.join(column))
+        elif len(column) == 3:
+            query = "ALTER TABLE {table} ADD COLUMN {column} ENCODE {encoding}".format(table=self.table, column=' '.join(column[0:2]), encoding=column[3])
+        else:
+            raise ValueError("_add_column_to_table() found no matching behavior for {column}".format(column=column))
+
+        cursor.execute(query)
+
+
+class CopyToTable(luigi.task.MixinNaiveBulkComplete, _MetadataColumnsMixin, luigi.Task):
     """
     An abstract task for inserting a data set into RDBMS.
 
@@ -119,6 +180,9 @@ class CopyToTable(luigi.task.MixinNaiveBulkComplete, luigi.Task):
         # clear_table attribtue will have noticed it doesn't work anymore
         if hasattr(self, "clear_table"):
             raise Exception("The clear_table attribute has been removed. Override init_copy instead!")
+
+        if self.enable_metadata_columns:
+            self._add_metadata_columns(connection.cursor())
 
     def post_copy(self, connection):
         """

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -104,8 +104,8 @@ class _MetadataColumnsMixin(object):
 
         for column in self.metadata_columns:
             if len(column) == 0:
-                logger.info('Unable to infer column information from column {column} for {table}'.format(column=column, table=self.table))
-                break
+                raise ValueError("_add_metadata_columns is unable to infer column information from column {column} for {table}".format(column=column,
+                                                                                                                                       table=self.table))
 
             column_name = column[0]
             if not self._column_exists(cursor, column_name):

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -37,6 +37,66 @@ except ImportError:
                    "Will crash at runtime if postgres functionality is used.")
 
 
+class _MetadataColumnsMixin(object):
+    """
+    This mixin is used to provide an additional behavior that allow a task to
+    add generic metadata columns to every table created for Redshift.
+    """
+    @property
+    def metadata_columns(self):
+        """Returns the default metadata columns.
+
+        Those columns are columns that we want each tables to have by default.
+        """
+        return []
+
+    @property
+    def metadata_queries(self):
+        return []
+
+    @property
+    def enable_metadata_columns(self):
+        return False
+
+    def _add_metadata_columns(self, cursor):
+        for column in self.metadata_columns:
+            if len(column) == 0:
+                logger.info('Unable to infer column information from column {column} for {table}'.format(column=column, table=self.table))
+                break
+
+            column_name = column[0]
+            if not self._column_exists(cursor, column_name):
+                logger.info('Adding missing metadata column {column} to {table}'.format(column=column, table=self.table))
+                self._add_column_to_table(cursor, column)
+
+    def _column_exists(self, cursor, column_name):
+        if '.' in self.table:
+            schema, table = self.table.split('.')
+            query = "SELECT 1 AS column_exists " \
+                    "FROM information_schema.columns " \
+                    "WHERE table_schema = LOWER('{0}') AND table_name = LOWER('{1}') AND column_name = LOWER('{2}') LIMIT 1".format(schema, table, column_name)
+        else:
+            query = "SELECT 1 AS column_exists " \
+                    "FROM information_schema.columns " \
+                    "WHERE table_name = LOWER('{0}') AND column_name = LOWER('{1}') LIMIT 1".format(table, column_name)
+
+        cursor.execute(query)
+        result = cursor.fetchone()
+        return bool(result)
+
+    def _add_column_to_table(self, cursor, column):
+        if len(column) == 1:
+            raise ValueError("_add_column_to_table() column type not specified for {column}".format(column=column[0]))
+        elif len(column) == 2:
+            query = "ALTER TABLE {table} ADD COLUMN {column}".format(table=self.table, column=' '.join(column))
+        elif len(column) == 3:
+            query = "ALTER TABLE {table} ADD COLUMN {column} ENCODE {encoding}".format(table=self.table, column=' '.join(column[0:2]), encoding=column[3])
+        else:
+            raise ValueError("_add_column_to_table() found no matching behavior for {column}".format(column=column))
+
+        cursor.execute(query)
+
+
 class _CredentialsMixin():
     """
     This mixin is used to provide the same credential properties
@@ -141,7 +201,7 @@ class RedshiftTarget(postgres.PostgresTarget):
     use_db_timestamps = False
 
 
-class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
+class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin, _MetadataColumnsMixin):
     """
     Template task for inserting a data set into Redshift from s3.
 
@@ -373,6 +433,9 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         self.copy(cursor, path)
         self.post_copy(cursor)
 
+        if self.enable_metadata_columns:
+            self.post_copy_metacolumns(cursor)
+
         # update marker table
         output.touch(connection)
         connection.commit()
@@ -472,6 +535,9 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
             logger.info("Creating table %s", self.table)
             self.create_table(connection)
 
+        if self.enable_metadata_columns:
+            self._add_metadata_columns(connection.cursor())
+
         if self.do_truncate_table:
             logger.info("Truncating table %s", self.table)
             self.truncate_table(connection)
@@ -486,6 +552,14 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
         """
         logger.info('Executing post copy queries')
         for query in self.queries:
+            cursor.execute(query)
+
+    def post_copy_metacolums(self, cursor):
+        """
+        Performs post-copy to fill metadata columns.
+        """
+        logger.info('Executing post copy metadata queries')
+        for query in self.metadata_queries:
             cursor.execute(query)
 
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -476,7 +476,7 @@ class S3CopyToTable(rdbms.CopyToTable, _CredentialsMixin):
             self.create_table(connection)
 
         if self.enable_metadata_columns:
-            self._add_metadata_columns(connection.cursor())
+            self._add_metadata_columns(connection)
 
         if self.do_truncate_table:
             logger.info("Truncating table %s", self.table)

--- a/test/contrib/rdbms_test.py
+++ b/test/contrib/rdbms_test.py
@@ -1,0 +1,255 @@
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+We're using Redshift as the test bed since Redshift implements RDBMS. We could
+have opted for PSQL but we're less familiar with that contrib and there are
+less examples on how to test it.
+"""
+
+import luigi
+import luigi.contrib.redshift
+import mock
+
+import unittest
+
+
+# Fake AWS and S3 credentials taken from `../redshift_test.py`.
+AWS_ACCESS_KEY = 'key'
+AWS_SECRET_KEY = 'secret'
+
+AWS_ACCOUNT_ID = '0123456789012'
+AWS_ROLE_NAME = 'MyRedshiftRole'
+
+BUCKET = 'bucket'
+KEY = 'key'
+
+
+class DummyS3CopyToTableBase(luigi.contrib.redshift.S3CopyToTable):
+    # Class attributes taken from `DummyPostgresImporter` in
+    # `../postgres_test.py`.
+    host = 'dummy_host'
+    database = 'dummy_database'
+    user = 'dummy_user'
+    password = 'dummy_password'
+    table = luigi.Parameter(default='dummy_table')
+    columns = luigi.TupleParameter(
+        default=(
+            ('some_text', 'varchar(255)'),
+            ('some_int', 'int'),
+        )
+    )
+
+    copy_options = ''
+    prune_table = ''
+    prune_column = ''
+    prune_date = ''
+
+    def s3_load_path(self):
+        return 's3://%s/%s' % (BUCKET, KEY)
+
+
+class DummyS3CopyToTableKey(DummyS3CopyToTableBase):
+    aws_access_key_id = AWS_ACCESS_KEY
+    aws_secret_access_key = AWS_SECRET_KEY
+
+
+class TestS3CopyToTableWithMetaColumns(unittest.TestCase):
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_check_meta_columns_to_table_if_exists(self,
+                                                        mock_redshift_target,
+                                                        mock_metadata_columns,
+                                                        mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey(table='my_test_table')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        executed_query = mock_cursor.execute.call_args_list[1][0][0]
+
+        expected_output = "SELECT 1 AS column_exists FROM information_schema.columns " \
+                          "WHERE table_name = LOWER('{table}') " \
+                          "AND column_name = LOWER('{column}') " \
+                          "LIMIT 1;".format(table='my_test_table', column='created_tz')
+
+        self.assertEqual(executed_query, expected_output)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_check_meta_columns_to_schematable_if_exists(self,
+                                                              mock_redshift_target,
+                                                              mock_metadata_columns,
+                                                              mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey(table='test.my_test_table')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        executed_query = mock_cursor.execute.call_args_list[2][0][0]
+
+        expected_output = "SELECT 1 AS column_exists FROM information_schema.columns " \
+                          "WHERE table_schema = LOWER('{schema}') " \
+                          "AND table_name = LOWER('{table}') " \
+                          "AND column_name = LOWER('{column}') " \
+                          "LIMIT 1;".format(schema='test', table='my_test_table', column='created_tz')
+
+        self.assertEqual(executed_query, expected_output)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._add_column_to_table")
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_not_add_if_meta_columns_already_exists(self,
+                                                         mock_redshift_target,
+                                                         mock_add_to_table,
+                                                         mock_columns_exists,
+                                                         mock_metadata_columns,
+                                                         mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey()
+        task.run()
+
+        self.assertFalse(mock_add_to_table.called)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=False)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._add_column_to_table")
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_add_if_meta_columns_not_already_exists(self,
+                                                         mock_redshift_target,
+                                                         mock_add_to_table,
+                                                         mock_columns_exists,
+                                                         mock_metadata_columns,
+                                                         mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey()
+        task.run()
+
+        self.assertTrue(mock_add_to_table.called)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_add_regular_column(self,
+                                     mock_redshift_target,
+                                     mock_columns_exists,
+                                     mock_metadata_columns,
+                                     mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey(table='my_test_table')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        executed_query = mock_cursor.execute.call_args_list[1][0][0]
+
+        expected_output = "ALTER TABLE {table} " \
+                          "ADD COLUMN {column} {type};".format(table='my_test_table', column='created_tz', type='TIMESTAMP')
+
+        self.assertEqual(executed_query, expected_output)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP', 'bytedict')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_add_encoded_column(self,
+                                     mock_redshift_target,
+                                     mock_columns_exists,
+                                     mock_metadata_columns,
+                                     mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey(table='my_test_table')
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        executed_query = mock_cursor.execute.call_args_list[1][0][0]
+
+        expected_output = "ALTER TABLE {table} " \
+                          "ADD COLUMN {column} {type} ENCODE {encoding};".format(table='my_test_table', column='created_tz',
+                                                                                 type='TIMESTAMP',
+                                                                                 encoding='bytedict')
+
+        self.assertEqual(executed_query, expected_output)
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_raise_error_on_no_column_type(self,
+                                                mock_redshift_target,
+                                                mock_columns_exists,
+                                                mock_metadata_columns,
+                                                mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey()
+
+        with self.assertRaises(ValueError):
+            task.run()
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock,
+                return_value=[('created_tz', 'TIMESTAMP', 'bytedict', '42')])
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable._column_exists",  return_value=False)
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_copy_raise_error_on_invalid_column(self,
+                                                mock_redshift_target,
+                                                mock_columns_exists,
+                                                mock_metadata_columns,
+                                                mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey()
+
+        with self.assertRaises(ValueError):
+            task.run()
+
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
+    @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_queries",  new_callable=mock.PropertyMock, return_value=['SELECT 1 FROM X', 'SELECT 2 FROM Y'])
+    @mock.patch("luigi.contrib.redshift.RedshiftTarget")
+    def test_post_copy_metacolumns(self,
+                                   mock_redshift_target,
+                                   mock_metadata_queries,
+                                   mock_metadata_columns_enabled):
+        task = DummyS3CopyToTableKey()
+        task.run()
+
+        mock_cursor = (mock_redshift_target.return_value
+                                           .connect
+                                           .return_value
+                                           .cursor
+                                           .return_value)
+
+        executed_query = mock_cursor.execute.call_args_list[2][0][0]
+        expected_output = "SELECT 1 FROM X"
+        self.assertEqual(executed_query, expected_output)
+
+        executed_query = mock_cursor.execute.call_args_list[3][0][0]
+        expected_output = "SELECT 2 FROM Y"
+        self.assertEqual(executed_query, expected_output)


### PR DESCRIPTION
The goal of this feature is to allow metadata column to exists for
specific tables created for Redshift.

Given the scenario where we would always have to have a `created_tz`
column at the end of every table generated by that contrib we could do
the following:

```python
class UpdateTableTask(redshift.S3CopyToTable):

    def metadata_columns(self):
        return [('created_tz', 'TIMESTAMP')]

    def metadata_queries(self):
        query =  'UPDATE {0} ' \ 
                 'SET created_tz = CURRENT_TIMESTAMP ' \
                 'WHERE created_tz IS NULL'.format(self.table)
        return [query]
```

Adding a layer of abstraction over this feature, you could easily
add many default behavior for specific tables for versioning the table
and more.

This feature is opt-in by default since we don't want this break other
people's pipeline after integrating this.

Do we think that this would be a feature that you guys would be interested in merging? I'm unsure if this becomes too specific for our use-case, but it should help some other people to have that type of behavior if need be.

If that's something that you guys are interested in merging, then I'll spend some time in writing a proper testing suite!

Let me know!
