### PR TITLE
bugfix bigquery bulk complete failing when argument is a generator

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -420,11 +420,10 @@ class MixinBigQueryBulkComplete(object):
 
     @classmethod
     def bulk_complete(cls, parameter_tuples):
-        if len(parameter_tuples) < 1:
-            return
-
         # Instantiate the tasks to inspect them
         tasks_with_params = [(cls(p), p) for p in parameter_tuples]
+        if not tasks_with_params:
+            return
 
         # Grab the set of BigQuery datasets we are interested in
         datasets = {t.output().table.dataset for t, p in tasks_with_params}

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -135,6 +135,14 @@ class BigQueryTest(unittest.TestCase):
         complete = list(TestRunQueryTask.bulk_complete(parameters))
         self.assertEqual(complete, ['table2'])
 
+        # Test that bulk_complete accepts lazy sequences in addition to lists
+        def parameters_gen():
+            yield 'table1'
+            yield 'table2'
+
+        complete = list(TestRunQueryTask.bulk_complete(parameters_gen()))
+        self.assertEqual(complete, ['table2'])
+
     def test_dataset_doesnt_exist(self):
         client = MagicMock()
         client.dataset_exists.return_value = False


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
This change fixes a bug that prevents BigQuery tasks from working as ranged tasks (RangeDaily, et. al.) in python 3.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
RangeDaily tasks are broken for big query tasks in python3, because the big query bulk_complete method is invoked, with the return value of a call to map, as an argument.  In python 3, map returns a generator, while in python 2 it returns a list.

The MixinBigQueryBulkComplete.bulk_complete method invokes len() on this argument, and so fails if that argument is a generator.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Current unit tests pass for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->