### PR TITLE
Build task.param_kwargs dynamically.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -437,9 +437,6 @@ class Task(object):
         for key, value in param_values:
             setattr(self, key, value)
 
-        # Register kwargs as an attribute on the class. Might be useful
-        self.param_kwargs = dict(param_values)
-
         self._warn_on_wrong_param_types()
         self.task_id = task_id_str(self.get_task_family(), self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
@@ -451,7 +448,11 @@ class Task(object):
     @property
     def param_args(self):
         warnings.warn("Use of param_args has been deprecated.", DeprecationWarning)
-        return tuple(self.param_kwargs[k] for k, v in self.get_params())
+        return tuple(self.param_kwargs.values())
+
+    @property
+    def param_kwargs(self):
+        return {param: getattr(self, param) for param, _ in self.get_params()}
 
     def initialized(self):
         """
@@ -526,13 +527,10 @@ class Task(object):
         """
         Build a task representation like `MyTask(param1=1.5, param2='5')`
         """
-        params = self.get_params()
-        param_values = self.get_param_values(params, [], self.param_kwargs)
-
         # Build up task id
         repr_parts = []
-        param_objs = dict(params)
-        for param_name, param_value in param_values:
+        param_objs = dict(self.get_params())
+        for param_name, param_value in self.param_kwargs.items():
             if param_objs[param_name].significant:
                 repr_parts.append('%s=%s' % (param_name, param_objs[param_name].serialize(param_value)))
 
@@ -541,7 +539,7 @@ class Task(object):
         return task_str
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.param_kwargs == other.param_kwargs
+        return self.__class__ == other.__class__ and self.task_id == other.task_id
 
     def complete(self):
         """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -448,7 +448,8 @@ class Task(object):
     @property
     def param_args(self):
         warnings.warn("Use of param_args has been deprecated.", DeprecationWarning)
-        return tuple(self.param_kwargs.values())
+        param_kwargs = self.param_kwargs
+        return tuple(param_kwargs[k] for k, v in self.get_params())
 
     @property
     def param_kwargs(self):


### PR DESCRIPTION
## Description, Motivation and Context

In the [current task constructor](https://github.com/spotify/luigi/blob/bda236d0cf41b849c25a82bda02d5ecbebd2bf6a/luigi/task.py#L441), all task parameters at initialization time are stored in `param_kwargs`:

```python
    def __init__(self, *args, **kwargs):
        params = self.get_params()
        param_values = self.get_param_values(params, args, kwargs)

        # Set all values on class instance
        for key, value in param_values:
            setattr(self, key, value)

        # Register kwargs as an attribute on the class. Might be useful
        self.param_kwargs = dict(param_values)  # <--- set once
```

Dynamic changes of parameter values are not reflected in this dict, which is somewhat dangerous. Consider this example using [util.common_params](https://github.com/spotify/luigi/blob/bda236d0cf41b849c25a82bda02d5ecbebd2bf6a/luigi/util.py#L233) (which uses `param_kwargs`):

```python
class MyTask(luigi.Task):

    weight = luigi.FloatParameter(default=0.)
    unit = luigi.ChoiceParameter(default="g", choices=("g", "kg"))

    def __init__(self, *args, **kwargs):
        super(MyTask, self).__init__(*args, **kwargs)

        # store weight internally as grams
        if self.unit == "kg":
            self.weight *= 1000

    def requires(self):
        required_cls = ... # class of the required task
        common_params = luigi.util.common_params(self, required_class)
        #
        # -> common_params["weight"] will have the wrong value when unit is kg!
        #
        return required_cls(**common_params)
```
(ok, this might not be the best example...imagine a situation where a parameter value changes after `Task.__init__`)

`util.common_params` uses the `param_kwargs` attribute which is not synchronized to the actual task parameters at the time it is called.

This PR makes `param_kwargs` a property so its content becomes dynamic. There is a small implication on `task.__eq__` which currently compares the `param_kwargs` dict between two instances. This might be too inefficient with dynamic properties, but I think it should be safe to compare `task.task_id` instead.


## Have you tested this?

No new feature was added, so the existing tests should completely cover changed code.