### PR TITLE
Add parallel_scheduling default value description

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -154,6 +154,7 @@ parallel_scheduling
   If true, the scheduler will compute complete functions of tasks in
   parallel using multiprocessing. This can significantly speed up
   scheduling, but requires that all tasks can be pickled.
+  Defaults to false.
 
 parallel-scheduling-processes
   The number of processes to use for parallel scheduling. If not specified


### PR DESCRIPTION
## Description
Adds the default value of parallel_scheduling (`False`) to the documentation of the configuration.

## Motivation and Context
When looking for the default value of parallel_scheduling, I had to go to the source code. This PR adds it to the documentation.