### PR TITLE
Allow to inject a context manager around TaskProcess.run

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -259,9 +259,8 @@ class TaskProcess(multiprocessing.Process):
             return super(TaskProcess, self).terminate()
 
 
-# TODO be composable with arbitrarily many custom context managers?
-# Introduce a convention shared for extension points other than TaskProcess?
-# Use https://docs.openstack.org/stevedore?
+# This code and the task_process_context config key currently feels a bit ad-hoc.
+# Discussion on generalizing it into a plugin system: https://github.com/spotify/luigi/issues/1897
 class ContextManagedTaskProcess(TaskProcess):
     def __init__(self, context, *args, **kwargs):
         super(ContextManagedTaskProcess, self).__init__(*args, **kwargs)
@@ -269,7 +268,7 @@ class ContextManagedTaskProcess(TaskProcess):
 
     def run(self):
         if self.context:
-            logger.debug('Instantiating ' + self.context)
+            logger.debug('Importing module and instantiating ' + self.context)
             module_path, class_name = self.context.rsplit('.', 1)
             module = importlib.import_module(module_path)
             cls = getattr(module, class_name)

--- a/test/worker_task_process_test.py
+++ b/test/worker_task_process_test.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import LuigiTestCase, temporary_unloaded_module
+import luigi
+from luigi.worker import Worker
+import multiprocessing
+
+
+class ContextManagedTaskProcessTest(LuigiTestCase):
+
+    def _test_context_manager(self, force_multiprocessing):
+        CONTEXT_MANAGER_MODULE = b'''
+class MyContextManager(object):
+    def __init__(self, task_process):
+        self.task = task_process.task
+    def __enter__(self):
+        assert not self.task.run_event.is_set(), "the task should not have run yet"
+        self.task.enter_event.set()
+        return self
+    def __exit__(self, exc_type=None, exc_value=None, traceback=None):
+        assert self.task.run_event.is_set(), "the task should have run"
+        self.task.exit_event.set()
+'''
+
+        class DummyEventRecordingTask(luigi.Task):
+            def __init__(self, *args, **kwargs):
+                self.enter_event = multiprocessing.Event()
+                self.exit_event = multiprocessing.Event()
+                self.run_event = multiprocessing.Event()
+                super(DummyEventRecordingTask, self).__init__(*args, **kwargs)
+
+            def run(self):
+                assert self.enter_event.is_set(), "the context manager should have been entered"
+                assert not self.exit_event.is_set(), "the context manager should not have been exited yet"
+                assert not self.run_event.is_set(), "the task should not have run yet"
+                self.run_event.set()
+
+            def complete(self):
+                return self.run_event.is_set()
+
+        with temporary_unloaded_module(CONTEXT_MANAGER_MODULE) as module_name:
+            t = DummyEventRecordingTask()
+            w = Worker(task_process_context=module_name + '.MyContextManager',
+                       force_multiprocessing=force_multiprocessing)
+            w.add(t)
+            self.assertTrue(w.run())
+            self.assertTrue(t.complete())
+            self.assertTrue(t.enter_event.is_set())
+            self.assertTrue(t.exit_event.is_set())
+
+    def test_context_manager_without_multiprocessing(self):
+        self._test_context_manager(False)
+
+    def test_context_manager_with_multiprocessing(self):
+        self._test_context_manager(True)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1823,7 +1823,7 @@ class KeyboardInterruptBehaviorTest(LuigiTestCase):
 
 class WorkerPurgeEventHandlerTest(unittest.TestCase):
 
-    @mock.patch('luigi.worker.TaskProcess')
+    @mock.patch('luigi.worker.ContextManagedTaskProcess')
     def test_process_killed_handler(self, task_proc):
         result = []
 


### PR DESCRIPTION
## Description
Adds a configurable context manager around TaskProcess.
<!--- Describe your changes -->

## Motivation and Context
The intent with this is to enable customizable collection of logs per task (stdout and stderr output from any Task's run() method, including any subprocesses spawned by it), as opposed to having to read through the worker's logs where outputs from all the tasks are interspersed.

Inspired by CaptureOutput from the opensource [capturer](https://github.com/xolox/python-capturer) package.

Such configurable context managers could be useful extension points for "plugins" made for other purposes too. (Related: https://github.com/spotify/luigi/issues/1897)

## Have you tested this? If so, how?
Has unittests.