### PR TITLE
Kubernetes: Don't set activeDeadlineSeconds by default

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -186,7 +186,7 @@ class KubernetesJobTask(luigi.Task):
         Time allowed to successfully schedule pods.
         See: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#job-termination-and-cleanup
         """
-        return 100
+        return None
 
     @property
     def kubernetes_config(self):
@@ -329,7 +329,6 @@ class KubernetesJobTask(luigi.Task):
                 }
             },
             "spec": {
-                "activeDeadlineSeconds": self.active_deadline_seconds,
                 "backoffLimit": self.backoff_limit,
                 "template": {
                     "metadata": {
@@ -339,6 +338,9 @@ class KubernetesJobTask(luigi.Task):
                 }
             }
         }
+        if self.active_deadline_seconds is not None:
+            job_json['spec']['activeDeadlineSeconds'] = \
+                self.active_deadline_seconds
         # Update user labels
         job_json['metadata']['labels'].update(self.labels)
         # Add default restartPolicy if not specified


### PR DESCRIPTION
## Description
Don't set the activeDeadlineSeconds key in kubernetes job spec by default.

## Motivation and Context
I assume tasks take longer to finish then 100 seconds (the current default). I also assume you usually  don't know how long the task will take. So not setting this as a default seems reasonable to me. See also #2383

## Have you tested this? If so, how?
Still need to run tests. I have a pipeline which uses this job but in the current release it is broken. I'll try to use this version for next run.
