### PR TITLE
ChoiceParameter should raise an error when passed invalid choice

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1201,8 +1201,11 @@ class ChoiceParameter(Parameter):
 
     def parse(self, s):
         var = self._var_type(s)
+        return self.normalize(var)
+
+    def normalize(self, var):
         if var in self._choices:
             return var
         else:
-            raise ValueError("{s} is not a valid choice from {choices}".format(
-                s=s, choices=self._choices))
+            raise ValueError("{var} is not a valid choice from {choices}".format(
+                var=var, choices=self._choices))

--- a/test/choice_parameter_test.py
+++ b/test/choice_parameter_test.py
@@ -53,3 +53,8 @@ class ChoiceParameterTest(unittest.TestCase):
         a = luigi.ChoiceParameter(var_type=str, choices=["1", "2", "3"])
         b = "3"
         self.assertEqual(b, a.parse(a.serialize(b)))
+
+    def test_invalid_choice_task(self):
+        class Foo(luigi.Task):
+            args = luigi.ChoiceParameter(var_type=str, choices=["1", "2", "3"])
+        self.assertRaises(ValueError, lambda: Foo(args="4"))


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Validates `ChoiceParameter` when initializing a task by moving the logic from `.parse` to `.normalize`. Currently this validation only runs when calling from the command line, when the method `.parse` is called. Moving it to `.normalize` ensure it always runs

## Motivation and Context
I was having an issue where I was requiring a task with an invalid ChoiceParameter but no ValueError was raising at task init time. 

```
class Foo(luigi.Task):
     args = luigi.ChoiceParameter(var_type=str, choices=["1", "2", "3"])

Foo(args="bar") #should raise an Error
```

## Have you tested this? If so, how?
Added tests
