### PR TITLE
Use task_id in Task.__eq__ comparison

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -541,7 +541,7 @@ class Task(object):
         return task_str
 
     def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.param_kwargs == other.param_kwargs
+        return self.__class__ == other.__class__ and self.task_id == other.task_id
 
     def complete(self):
         """


### PR DESCRIPTION
## Description, Motivation and Context

Currently, `Task.__eq__` works like this:

https://github.com/spotify/luigi/blob/1192003388c7e661962a76102e7668256a67022d/luigi/task.py#L543-L544

`param_kwargs` is a dictionary, so task comparison might be slow for tasks with many parameters. It should be safe to just compare the `task_id` which is computed in the task init based on all parameters and therefore is a valid hash for task comparison.

(originally added in #2446)

## Have you tested this? If so, how?

No new feature was added, so the existing tests should completely cover the code changes.