### PR TITLE
Check for default before warning of "task_process_context" as None

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -258,7 +258,7 @@ class Parameter(object):
         if self.__class__ != Parameter:
             return
         if param_value == self._default:
-            return
+            return        
         if not isinstance(param_value, six.string_types):
             warnings.warn('Parameter "{}" with value "{}" is not of type string.'.format(param_name, param_value))
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -257,6 +257,8 @@ class Parameter(object):
     def _warn_on_wrong_param_type(self, param_name, param_value):
         if self.__class__ != Parameter:
             return
+        if param_value == self._default:
+            return
         if not isinstance(param_value, six.string_types):
             warnings.warn('Parameter "{}" with value "{}" is not of type string.'.format(param_name, param_value))
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes -->
Add a check for default in `Parameter._warn_on_wrong_param_type` before giving out warning by adding an additional if clause to skip the cases of where the parameter is default
```
if param_value == self._default:
    return
```

## Motivation and Context
Currently, the parameter `task_process_context` is being passed as None for default.
However, in the `Parameter._warn_on_wrong_param_type` method, check for string is made and 
if the `param_value` is not a string, the warning is raised.
Therefore, as I was not giving any parameter input for `task_process_context`, every job that I ran displayed this warning, and I thought it would be a good idea to check for default only for the `Parameter` class, to resolve this issue.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs with this code and it works fine for me - without the warning.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->