### PR TITLE
Fix Scheduler.add_task to overwrite accepts_messages attribute.

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -803,7 +803,6 @@ class Scheduler(object):
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
                 priority=priority, family=family, module=module, params=params,
-                accepts_messages=accepts_messages,
             )
         else:
             _default_task = None
@@ -830,6 +829,9 @@ class Scheduler(object):
                 batch_tasks = self._state.get_batch_running_tasks(batch_id)
                 task.resources_running = batch_tasks[0].resources_running.copy()
             task.time_running = time.time()
+
+        if accepts_messages is not None:
+            task.accepts_messages = accepts_messages
 
         if tracking_url is not None or task.status != RUNNING:
             task.tracking_url = tracking_url


### PR DESCRIPTION
## Description

When the scheduler receives tasks via `add_task(**kwargs)`, by default it does not overwrite task properties from `kwargs` when the task already exists. I wasn't aware of that when I implemented the `accepts_messages` flag in #2426. As a consequence, the message feature is only enabled on the triggered default task. This PR provides a fix for that.

## Motivation and Context

When the triggered `default_task` is added, its deps are added as dummy tasks at the end of `add_task` to prevent some race condition during task pruning:

https://github.com/spotify/luigi/blob/459a260032ea1b3df573a5e65b0081a2634b2f7b/luigi/scheduler.py#L897-L901

So when the dependency tasks are added again with their full config via `add_task`, an entry already exists in the task state object. As a result, the `accepts_messages` flag is not updated and sticks to the default value (`False`). For the same reason, other boolean flags like `batchable` are updated manually:

https://github.com/spotify/luigi/blob/459a260032ea1b3df573a5e65b0081a2634b2f7b/luigi/scheduler.py#L840-L841

`accepts_messages` is treated the same way now.