### PR TITLE
Added default port behaviour for Redshift

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -106,7 +106,7 @@ class PostgresTarget(luigi.Target):
     """
     marker_table = luigi.configuration.get_config().get('postgres', 'marker-table', 'table_updates')
 
-    #if not supplied, fall back to default Postgres port 
+    # if not supplied, fall back to default Postgres port
     DEFAULT_DB_PORT = 5432
 
     # Use DB side timestamps or client side timestamps in the marker_table

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -106,11 +106,14 @@ class PostgresTarget(luigi.Target):
     """
     marker_table = luigi.configuration.get_config().get('postgres', 'marker-table', 'table_updates')
 
+    #if not supplied, fall back to default Postgres port 
+    DEFAULT_DB_PORT = 5432
+
     # Use DB side timestamps or client side timestamps in the marker_table
     use_db_timestamps = True
 
     def __init__(
-        self, host, database, user, password, table, update_id, port=5432
+        self, host, database, user, password, table, update_id, port=None
     ):
         """
         Args:
@@ -126,7 +129,7 @@ class PostgresTarget(luigi.Target):
             self.host, self.port = host.split(':')
         else:
             self.host = host
-            self.port = port
+            self.port = port or self.DEFAULT_DB_PORT
         self.database = database
         self.user = user
         self.password = password

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -135,9 +135,9 @@ class RedshiftTarget(postgres.PostgresTarget):
         'marker-table',
         'table_updates')
 
-    #if not supplied, fall back to default Redshift port 
+    # if not supplied, fall back to default Redshift port
     DEFAULT_DB_PORT = 5439
-    
+
     use_db_timestamps = False
 
 

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -135,6 +135,9 @@ class RedshiftTarget(postgres.PostgresTarget):
         'marker-table',
         'table_updates')
 
+    #if not supplied, fall back to default Redshift port 
+    DEFAULT_DB_PORT = 5439
+    
     use_db_timestamps = False
 
 


### PR DESCRIPTION
## Description
RedshiftTarget is a subclass of PostgresTarget, for obvious reasons. 

In PostgresTarget, if we do not provide a port, we fallback to 5432, the default Postgres port.
In RedshiftTarget, if we do not provide a port, we still fallback to 5432, even though the default Redshift port is 5439.

This PR fixes this by defining the default port as a static class variable on PostgresTarget, as opposed to a default argument on __init__. This allows RedshiftTarget to override this default, without changing any other behaviour.

## Motivation and Context
From https://github.com/spotify/luigi/issues/2473
I only noticed this behaviour when I started using Redshift. I had been supplying the port in PostgresQuery Tasks, even though this never actually got passed to PostgresTarget! So, when I switched to doing the same with Redshift, nothing worked, because RedshiftTarget wasn't being supplied the port by RedshiftQuery, so RedshiftTarget was defaulting to 5432.

## Have you tested this? If so, how?
I looked 'very hard' at any code which is affected by the change, and can't see any reason it would fail.