### PR TITLE
Fix attribute forwarding for tasks with dynamic dependencies

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -257,10 +257,8 @@ class TaskProcess(multiprocessing.Process):
         # forward configured attributes to the task
         for reporter_attr, task_attr in six.iteritems(self.forward_reporter_attributes):
             setattr(self.task, task_attr, getattr(self.status_reporter, reporter_attr))
-
         try:
             yield self
-
         finally:
             # reset attributes again
             for reporter_attr, task_attr in six.iteritems(self.forward_reporter_attributes):

--- a/test/task_forwarded_attributes_test.py
+++ b/test/task_forwarded_attributes_test.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import LuigiTestCase, RunOnceTask
+
+import luigi
+import luigi.scheduler
+import luigi.worker
+
+
+forwarded_attributes = set(luigi.worker.TaskProcess.forward_reporter_attributes.values())
+
+
+class NonYieldingTask(RunOnceTask):
+
+    # need to accept messages in order for the "scheduler_message" attribute to be not None
+    accepts_messages = True
+
+    def gather_forwarded_attributes(self):
+        attrs = set()
+        for attr in forwarded_attributes:
+            if getattr(self, attr, None) is not None:
+                attrs.add(attr)
+        return attrs
+
+    def run(self):
+        self.attributes_while_running = self.gather_forwarded_attributes()
+
+        RunOnceTask.run(self)
+
+
+class YieldingTask(NonYieldingTask):
+
+    def run(self):
+        self.attributes_before_yield = self.gather_forwarded_attributes()
+
+        yield RunOnceTask()
+
+        self.attributes_after_yield = self.gather_forwarded_attributes()
+
+        RunOnceTask.run(self)
+
+
+class TaskForwardedAttributesTest(LuigiTestCase):
+
+    def run_task(self, task):
+        sch = luigi.scheduler.Scheduler()
+        with luigi.worker.Worker(scheduler=sch) as w:
+            w.add(task)
+            w.run()
+        return task
+
+    def test_non_yielding_task(self):
+        task = self.run_task(NonYieldingTask())
+
+        self.assertEqual(task.attributes_while_running, forwarded_attributes)
+
+    def test_yielding_task(self):
+        task = self.run_task(YieldingTask())
+
+        self.assertEqual(task.attributes_before_yield, forwarded_attributes)
+        self.assertEqual(task.attributes_after_yield, forwarded_attributes)


### PR DESCRIPTION
## Description

This PR fixes the forwarding of attributes (mostly callbacks such as `set_status_message`) from `TaskProcess`es to running `Task`s that yield dynamic dependencies within their `run()` method.

## Motivation and Context

Currently, the attributes are forwarded and reset like this:

https://github.com/spotify/luigi/blob/7d2c5574cb53106044a25afdddf151165471a741/luigi/worker.py#L137-L146

However, when the `run` method returns a generator, attributes are reset again before the yielded dependencies are handled (right below the referenced code). Actually, this should happen right before `_run_get_new_deps` returns. I added a context-managed method that handles the attributes so I could place the (only) call to `_run_get_new_deps` in that context.

## Have you tested this?

I added a new test case that checks if attributes are forwarded for tasks that don't yield dependencies and for those who do. The `TaskForwardedAttributesTest.test_yielding_task` test would actually fail in the current implementation, but passes with the proposed change.