### PR TITLE
Make logging of RPC retries configurable

### DIFF
--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from helpers import unittest
+from helpers import unittest, with_config
 try:
     from unittest import mock
 except ImportError:
@@ -52,7 +52,7 @@ class RemoteSchedulerTest(unittest.TestCase):
         scheduler = ShorterWaitRemoteScheduler('http://zorg.com', 42)
 
         with mock.patch.object(scheduler, '_fetcher') as fetcher:
-            fetcher.raises = socket.timeout
+            fetcher.raises = socket.timeout, socket.gaierror
             fetcher.fetch.side_effect = fetcher_side_effect
             return scheduler.get_work("fake_worker")
 
@@ -71,6 +71,36 @@ class RemoteSchedulerTest(unittest.TestCase):
 
         fetch_results = [socket.timeout, socket.timeout, socket.timeout]
         self.assertRaises(luigi.rpc.RPCError, self.get_work, fetch_results)
+
+    @mock.patch('luigi.rpc.logger')
+    def test_log_rpc_retries_enabled(self, mock_logger):
+        """
+        Tests that each retry of an RPC method is logged
+        """
+
+        fetch_results = [socket.timeout, socket.timeout, '{"response":{}}']
+        self.get_work(fetch_results)
+        self.assertEqual([
+            mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
+            mock.call.info('Retrying attempt 2 of 3 (max)'),
+            mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
+            mock.call.info('Retrying attempt 3 of 3 (max)'),
+        ], mock_logger.mock_calls)
+
+    @with_config({'core': {'rpc-log-retries': 'false'}})
+    @mock.patch('luigi.rpc.logger')
+    def test_log_rpc_retries_disabled(self, mock_logger):
+        """
+        Tests that retries of an RPC method are not logged
+        """
+
+        fetch_results = [socket.timeout, socket.timeout, socket.gaierror]
+        try:
+            self.get_work(fetch_results)
+            self.fail("get_work should have thrown RPCError")
+        except luigi.rpc.RPCError as e:
+            self.assertTrue(isinstance(e.sub_exception, socket.gaierror))
+        self.assertEqual([], mock_logger.mock_calls)
 
     def test_get_work_retries_on_null(self):
         """


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Logging of intermittent RPC exceptions and retries as they happen makes logs spammy and obscures other errors, so we want a way to disable it. If the exceptions persist, the final RPCError does log the last exception anyway.

Especially when long running (hanging, even) tasks are considered, with periods of silence in the logs, any intermittent "Failed connecting to remote scheduler" logging from KeepAliveThread looks very flashy and misleads troubleshooting often, in our experience.

The health of communication channels (presence of intermittent failures) probably should be easy to  monitor through dedicated tooling, as opposed to logging it interspersed with task logs.

## Have you tested this? If so, how?
Ought to be covered with unit tests.
