### PR TITLE
Added optional choice for hdfs clients 

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -929,8 +929,8 @@ user
   think twice before setting this parameter.
 
 client_type
-  The type of client to use. Default is the InsecureClient that requires no
-  authentication. The other option is the KerberosClient that uses kerberos
+  The type of client to use. Default is the "insecure" client that requires no
+  authentication. The other option is the "kerberos" client that uses kerberos
   authentication.
 
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -922,10 +922,18 @@ summary-length
 port
   The port to use for webhdfs. The normal namenode port is probably on a
   different port from this one.
+
 user
   Perform file system operations as the specified user instead of $USER.  Since
   this parameter is not honored by any of the other hdfs clients, you should
   think twice before setting this parameter.
+
+client_type
+  The type of client to use. Default is the InsecureClient that requires no
+  authentication. Other hdfs clients are KerberosClient and TokenClient.
+
+token
+  The Hadoop delagation token. Only used when client_type is TokenClient.
 
 
 Per Task Retry-Policy

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -930,8 +930,8 @@ user
 
 client_type
   The type of client to use. Default is the InsecureClient that requires no
-  authentication. The other option is to use kerberos authentication with the
-  KerberosClient.
+  authentication. The other option is the KerberosClient that uses kerberos
+  authentication.
 
 
 Per Task Retry-Policy

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -930,10 +930,8 @@ user
 
 client_type
   The type of client to use. Default is the InsecureClient that requires no
-  authentication. Other hdfs clients are KerberosClient and TokenClient.
-
-token
-  The Hadoop delagation token. Only used when client_type is TokenClient.
+  authentication. The other option is to use kerberos authentication with the
+  KerberosClient.
 
 
 Per Task Retry-Policy

--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -43,9 +43,7 @@ class webhdfs(luigi.Config):
                               description='Port for webhdfs')
     user = luigi.Parameter(default='', description='Defaults to $USER envvar',
                            config_path=dict(section='hdfs', name='user'))
-    client_type = luigi.Parameter(default='insecure',
-                                  description='Type of client to use. One of insecure, kerberos or token')
-    token = luigi.Parameter(default='', description='Hadoop delegation token, only used when client_type="token"')
+    client_type = luigi.Parameter(default='insecure', description='Type of client to use. Can be insecure or kerberos')
 
 
 class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
@@ -56,12 +54,11 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
     <https://hdfscli.readthedocs.io/en/latest/api.html>`__.
     """
 
-    def __init__(self, host=None, port=None, user=None, client_type=None, token=None):
+    def __init__(self, host=None, port=None, user=None, client_type=None):
         self.host = host or hdfs_config.hdfs().namenode_host
         self.port = port or webhdfs().port
         self.user = user or webhdfs().user or os.environ['USER']
         self.client_type = client_type or webhdfs().client_type
-        self.token = token or webhdfs().token
 
     @property
     def url(self):
@@ -84,9 +81,6 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         elif self.client_type == 'kerberos':
             from hdfs.ext.kerberos import KerberosClient
             return KerberosClient(url=self.url)
-        elif self.client_type == 'token':
-            import hdfs
-            return hdfs.TokenClient(url=self.url, token=self.token)
         else:
             raise ValueError("Error: Unknown client type specified in webhdfs client_type"
                              "configuration parameter")

--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -43,8 +43,8 @@ class webhdfs(luigi.Config):
                               description='Port for webhdfs')
     user = luigi.Parameter(default='', description='Defaults to $USER envvar',
                            config_path=dict(section='hdfs', name='user'))
-    client_type = luigi.ChoiceParameter(var_type=str, choices=['InsecureClient', 'KerberosClient'],
-                                        default='InsecureClient', description='Type of hdfs client to use.')
+    client_type = luigi.ChoiceParameter(var_type=str, choices=['insecure', 'kerberos'],
+                                        default='insecure', description='Type of hdfs client to use.')
 
 
 class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
@@ -76,7 +76,7 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         # not urgent to memoize it. Note that it *might* be issues with process
         # forking and whatnot (as the one in the snakebite client) if we
         # memoize it too trivially.
-        if self.client_type == 'KerberosClient':
+        if self.client_type == 'kerberos':
             from hdfs.ext.kerberos import KerberosClient
             return KerberosClient(url=self.url)
         else:

--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -45,6 +45,7 @@ class webhdfs(luigi.Config):
                            config_path=dict(section='hdfs', name='user'))
     client_type = luigi.Parameter(default='insecure',
                                   description='Type of client to use. One of insecure, kerberos or token')
+    token = luigi.Parameter(default=None, description='Hadoop delegation token, only used when client_type="token"')
 
 
 class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
@@ -55,11 +56,12 @@ class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):
     <https://hdfscli.readthedocs.io/en/latest/api.html>`__.
     """
 
-    def __init__(self, host=None, port=None, user=None, client_type=None):
+    def __init__(self, host=None, port=None, user=None, client_type=None, token=None):
         self.host = host or hdfs_config.hdfs().namenode_host
         self.port = port or webhdfs().port
         self.user = user or webhdfs().user or os.environ['USER']
         self.client_type = client_type or webhdfs().client_type
+        self.token = token or webhdfs().token
 
     @property
     def url(self):

--- a/luigi/contrib/hdfs/webhdfs_client.py
+++ b/luigi/contrib/hdfs/webhdfs_client.py
@@ -45,7 +45,7 @@ class webhdfs(luigi.Config):
                            config_path=dict(section='hdfs', name='user'))
     client_type = luigi.Parameter(default='insecure',
                                   description='Type of client to use. One of insecure, kerberos or token')
-    token = luigi.Parameter(default=None, description='Hadoop delegation token, only used when client_type="token"')
+    token = luigi.Parameter(default='', description='Hadoop delegation token, only used when client_type="token"')
 
 
 class WebHdfsClient(hdfs_abstract_client.HdfsFileSystem):

--- a/test/contrib/hdfs/webhdfs_client_test.py
+++ b/test/contrib/hdfs/webhdfs_client_test.py
@@ -51,12 +51,12 @@ class WebHdfsTargetTest(WebHdfsMiniClusterTestCase, HdfsTargetTestMixin):
 
 class TestWebHdfsClient(unittest.TestCase):
 
-    @with_config({'webhdfs': {'client_type': 'InsecureClient'}})
+    @with_config({'webhdfs': {'client_type': 'insecure'}})
     def test_insecure_client_type(self):
         client = WebHdfsClient(host='localhost').client
         self.assertIsInstance(client, InsecureClient)
 
-    @with_config({'webhdfs': {'client_type': 'KerberosClient'}})
+    @with_config({'webhdfs': {'client_type': 'kerberos'}})
     def test_kerberos_client_type(self):
         client = WebHdfsClient(host='localhost').client
         self.assertIsInstance(client, KerberosClient)

--- a/test/contrib/hdfs/webhdfs_client_test.py
+++ b/test/contrib/hdfs/webhdfs_client_test.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import unittest
 
+from hdfs import InsecureClient
+from hdfs.ext.kerberos import KerberosClient
 from nose.plugins.attrib import attr
 
 from helpers import with_config
@@ -44,3 +47,16 @@ class WebHdfsTargetTest(WebHdfsMiniClusterTestCase, HdfsTargetTestMixin):
 
     # This one fails when run together with the whole test suite
     test_write_cleanup_no_close = None
+
+
+class TestWebHdfsClient(unittest.TestCase):
+
+    @with_config({'webhdfs': {'client_type': 'InsecureClient'}})
+    def test_insecure_client_type(self):
+        client = WebHdfsClient(host='localhost').client
+        self.assertIsInstance(client, InsecureClient)
+
+    @with_config({'webhdfs': {'client_type': 'KerberosClient'}})
+    def test_kerberos_client_type(self):
+        client = WebHdfsClient(host='localhost').client
+        self.assertIsInstance(client, KerberosClient)


### PR DESCRIPTION
## Description
Added optional choice for hdfs clients. Previously only InsecureClient was supported. This PR adds KerberosClient and TokenClient. 

## Motivation and Context
Some hdfs work with kerberos authentication. Mine does... This adds support for those clusters. 

This fixes #2481.

## Have you tested this? If so, how?

I have tested the KerberosClient in practice and it works! (Thousand times faster than hadoopcli :) ) 

Not tested the TokenClient though, because I do not have access to a Hadoop cluster with token authentication. 