### PR TITLE
Fix S3Client.copy return value consistency

### DIFF
--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -425,7 +425,6 @@ class TestS3Client(unittest.TestCase):
         self._run_copy_test(self.test_put_multipart_empty_file)
 
     @mock_s3
-    @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/145895385')
     def test_copy_empty_dir(self):
         """
         Test copying an empty dir

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -426,6 +426,26 @@ class TestS3Client(unittest.TestCase):
 
     @mock_s3
     @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/145895385')
+    def test_copy_empty_dir(self):
+        """
+        Test copying an empty dir
+        """
+        create_bucket()
+
+        s3_dir = 's3://mybucket/copydir/'
+
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+
+        s3_client.mkdir(s3_dir)
+        self.assertTrue(s3_client.exists(s3_dir))
+
+        s3_dest = 's3://mybucket/copydir_new/'
+        response = s3_client.copy(s3_dir, s3_dest)
+
+        self._run_copy_response_test(response, expected_num=0, expected_size=0)
+
+    @mock_s3
+    @skipOnTravis('https://travis-ci.org/spotify/luigi/jobs/145895385')
     def test_copy_dir(self):
         """
         Test copying 20 files from one folder to another

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -403,8 +403,7 @@ class TestS3Client(unittest.TestCase):
         Test a multipart put with two parts, where the parts are not exactly the split size.
         """
         # First, put a file into S3
-        self._run_copy_test(
-            self.test_put_multipart_multiple_parts_non_exact_fit)
+        self._run_copy_test(self.test_put_multipart_multiple_parts_non_exact_fit)
 
     @skipOnTravis("passes and fails intermitantly, suspecting it's a race condition not handled by moto")
     def test_copy_multiple_parts_exact_fit(self):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adds support for num/size copy response for single-file copies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
S3Client.copy doesn't return a tuple if not copying a directory. This patch adds support for num/size tuple copy response for non-directories.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Adds assertions for minimum values to existing copy tests.
All s3_test.py tests pass locally.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
