### PR TITLE
Use passed password when create a redis connection

### DIFF
--- a/luigi/contrib/redis_store.py
+++ b/luigi/contrib/redis_store.py
@@ -68,6 +68,7 @@ class RedisTarget(Target):
         self.redis_client = redis.StrictRedis(
             host=self.host,
             port=self.port,
+            password=self.password,
             db=self.db,
             socket_timeout=self.socket_timeout,
         )


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Use passed password when create a redis connection
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, password is ignored when creating a RedisTarget, but in some cases there is a needance in secured connection
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
There is no new logic, so, existing tests should cover it
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
