### PR TITLE
s3client check for deprecated host keyword and raise error with the details

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -518,12 +518,18 @@ class S3Client(FileSystem):
     @staticmethod
     def _check_deprecated_argument(**kwargs):
         """
-        If `encrypt_key` is part of the arguments raise an exception
+        If `encrypt_key` or `host` is part of the arguments raise an exception
         :return: None
         """
         if 'encrypt_key' in kwargs:
             raise DeprecatedBotoClientException(
                 'encrypt_key deprecated in boto3. Please refer to boto3 documentation for encryption details.')
+        if 'host' in kwargs:
+            raise DeprecatedBotoClientException(
+                'host keyword deprecated and is replaced by region_name in boto3.\n'
+                'example: region_name=us-west-1\n'
+                'For region names, refer to the amazon S3 region documentation\n'
+                'https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region')
 
     def _validate_bucket(self, bucket_name):
         exists = True

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -168,6 +168,10 @@ class TestS3Client(unittest.TestCase):
         sts_mock.client.assume_role.called_with(
             RoleArn='role', RoleSessionName='name')
 
+    def test_client_host_deprecated(self):
+        with self.assertRaises(DeprecatedBotoClientException):
+            S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY, host='us-east-1')
+
     def test_put(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -168,10 +168,6 @@ class TestS3Client(unittest.TestCase):
         sts_mock.client.assume_role.called_with(
             RoleArn='role', RoleSessionName='name')
 
-    def test_client_host_deprecated(self):
-        with self.assertRaises(DeprecatedBotoClientException):
-            S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY).s3
-
     def test_put(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
@@ -204,7 +200,7 @@ class TestS3Client(unittest.TestCase):
         with self.assertRaises(DeprecatedBotoClientException):
             s3_client.put('SOMESTRING',
                           's3://mybucket/putMe', encrypt_key=True)
-  
+
     def test_put_string_host_deprecated(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -170,7 +170,7 @@ class TestS3Client(unittest.TestCase):
 
     def test_client_host_deprecated(self):
         with self.assertRaises(DeprecatedBotoClientException):
-            S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY, host='us-east-1')
+            S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY).s3
 
     def test_put(self):
         create_bucket()
@@ -185,6 +185,13 @@ class TestS3Client(unittest.TestCase):
             s3_client.put(self.tempFilePath,
                           's3://mybucket/putMe', encrypt_key=True)
 
+    def test_put_host_deprecated(self):
+        create_bucket()
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(DeprecatedBotoClientException):
+            s3_client.put(self.tempFilePath,
+                          's3://mybucket/putMe', host='us-east-1')
+
     def test_put_string(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
@@ -197,6 +204,13 @@ class TestS3Client(unittest.TestCase):
         with self.assertRaises(DeprecatedBotoClientException):
             s3_client.put('SOMESTRING',
                           's3://mybucket/putMe', encrypt_key=True)
+  
+    def test_put_string_host_deprecated(self):
+        create_bucket()
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(DeprecatedBotoClientException):
+            s3_client.put('SOMESTRING',
+                          's3://mybucket/putMe', host='us-east-1')
 
     @skipOnTravis("passes and fails intermitantly, suspecting it's a race condition not handled by moto")
     def test_put_multipart_multiple_parts_non_exact_fit(self):
@@ -222,6 +236,11 @@ class TestS3Client(unittest.TestCase):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
         with self.assertRaises(DeprecatedBotoClientException):
             s3_client.put_multipart('path', 'path', encrypt_key=True)
+
+    def test_put_multipart_multiple_parts_with_host_deprecated(self):
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(DeprecatedBotoClientException):
+            s3_client.put_multipart('path', 'path', host='us-east-1')
 
     def test_put_multipart_empty_file(self):
         """


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
host keyword has been deprecated and replaced by region_name for S3.
Raising deprecated error and test included


## Motivation and Context
Closes New boto3 client usage in 2.7.6 throws error #2484

## Have you tested this? If so, how?
I have included a unit test