### PR TITLE
Support 'b' flag in open() by setting the correct default format lazily

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -652,7 +652,7 @@ class S3Target(FileSystemTarget, LazyFormatMixin):
         super(S3Target, self).__init__(path)
 
         self.path = path
-        self._format = format
+        self.format = format
         self.fs = client or S3Client()
         self.s3_options = kwargs
 

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -513,8 +513,10 @@ Bzip2 = Bzip2Format()
 MixedUnicodeBytes = MixedUnicodeBytesFormat()
 
 
-def get_default_format():
+def get_default_format(mode=None):
     if six.PY3:
+        if mode and 'b' in mode:
+            return Nop
         return Text
     elif os.linesep == '\n':
         return Nop

--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -137,7 +137,7 @@ class LocalTarget(FileSystemTarget, LazyFormatMixin):
                 raise Exception('path or is_tmp must be set')
             path = os.path.join(tempfile.gettempdir(), 'luigi-tmp-%09d' % random.randint(0, 999999999))
         super(LocalTarget, self).__init__(path)
-        self._format = format
+        self.format = format
         self.is_tmp = is_tmp
 
     def makedirs(self):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -27,6 +27,7 @@ import tempfile
 import logging
 import warnings
 from luigi import six
+from luigi.format import get_default_format
 
 logger = logging.getLogger('luigi-interface')
 
@@ -348,3 +349,20 @@ class AtomicLocalFile(io.BufferedWriter):
         if exc_type:
             return
         return super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)
+
+
+class LazyFormatMixin:
+    @property
+    def format(self):
+        if self._format is None:
+            self._set_default_format()
+        return self._format
+
+    def _set_default_format(self, mode=None):
+        if self._format is None:
+            self._format = get_default_format(mode)
+
+    def set_format(self, format):
+        if self._format is not None:
+            raise Exception("Cannot change format once set")
+        self._format = format

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -352,17 +352,20 @@ class AtomicLocalFile(io.BufferedWriter):
 
 
 class LazyFormatMixin:
+    _format = None
+
     @property
     def format(self):
         if self._format is None:
             self._set_default_format()
         return self._format
 
-    def _set_default_format(self, mode=None):
-        if self._format is None:
-            self._format = get_default_format(mode)
-
-    def set_format(self, format):
+    @format.setter
+    def format(self, format):
         if self._format is not None:
             raise Exception("Cannot change format once set")
         self._format = format
+
+    def _set_default_format(self, mode=None):
+        if self._format is None:
+            self._format = get_default_format(mode)

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -243,6 +243,22 @@ class FileSystemTargetTestMixin(object):
         test_obj = pickle.loads(read_string)
         self.assertEqual(obj, test_obj)
 
+    def test_lazy_format_backwards_compat(self):
+        # in case someone accessed the format before calling open
+        # it should remain the same
+        t = self.create_target()
+        modeless_default = luigi.format.get_default_format()  # no mode
+        self.assertIs(t.format, modeless_default)
+        if six.PY3:
+            self.assertIs(t.format, luigi.format.Text)
+
+        fake_string = "luigi"
+        # since the previous .format access set format to Text
+        # strings will still work
+        with self.assertWarnsRegex(UserWarning, "does not support 'b'"):
+            with t.open('wb') as f:
+                f.write(fake_string)
+
     def test_writelines(self):
         t = self.create_target()
         with t.open('w') as f:

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -197,6 +197,34 @@ class FileSystemTargetTestMixin(object):
 
         self.assertEqual(c, b'a\xf2\xf3\r\nfd')
 
+    def test_lazy_format_binary(self):
+        t = self.create_target()
+        with t.open('wb') as f:
+            f.write(b'a\xf2\xf3\r\nfd')
+
+        with t.open('r') as f:
+            c = f.read()
+
+        self.assertEqual(c, b'a\xf2\xf3\r\nfd')
+
+    def test_lazy_format_binary_pickle(self):
+        import pickle
+
+        obj = {
+            'bob': 123,
+            'mario': ['luigi']
+        }
+
+        t = self.create_target()
+        with t.open('wb') as f:
+            f.write(pickle.dumps(obj))
+
+        with t.open('rb') as f:
+            c = f.read()
+            test_obj = pickle.loads(c)
+
+        self.assertEqual(obj, test_obj)
+
     def test_writelines(self):
         t = self.create_target()
         with t.open('w') as f:

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -20,6 +20,8 @@ from helpers import unittest, skipOnTravis
 from mock import Mock
 import re
 import random
+import pickle
+import six
 
 import luigi.target
 import luigi.format
@@ -210,7 +212,6 @@ class FileSystemTargetTestMixin(object):
         self.assertEqual(c, byte_string)
 
     def test_lazy_format_binary_pickle(self):
-        import pickle
 
         def target_write_read(t, byte_string, wmode, rmode='rb'):
             # util to write string then read it back
@@ -228,9 +229,13 @@ class FileSystemTargetTestMixin(object):
         byte_string = pickle.dumps(obj)
 
         # first test original broken condition
+        # only happens on python 3
         t = self.create_target()
-        self.assertRaises(TypeError,
-                          lambda: target_write_read(t, byte_string, 'w'))
+        if six.PY3:
+            self.assertRaises(TypeError,
+                              lambda: target_write_read(t, byte_string, 'w'))
+        else:
+            target_write_read(t, byte_string, 'w')  # should not error
 
         # test that we're respecting open(mode='wb')
         t = self.create_target()

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -252,9 +252,12 @@ class FileSystemTargetTestMixin(object):
         if six.PY3:
             self.assertIs(t.format, luigi.format.Text)
 
-        fake_string = "luigi"
         # since the previous .format access set format to Text
         # strings will still work
+        if not six.PY3:  # assertWarnsRegex was introduced in Python 3.2
+            return
+
+        fake_string = "luigi"
         with self.assertWarnsRegex(UserWarning, "does not support 'b'"):
             with t.open('wb') as f:
                 f.write(fake_string)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When `format` is `None`, do not set it to the default format in the Constructor, but wait until `open()` is called. If we find the 'b' flag, then use `Nop` so format doesn't muck with binary data.

## Motivation and Context

#1647

## Have you tested this? If so, how?
Included tests and on personal Tasks.

So this might not admittedly be *the* way. The format/mode juggling is tricky since they were designed to be independent of each other and `mode` isn't really the builtin `open`'s mode since the format really decides whether we're writing bytes or str.