### PR TITLE
patch module import functionality for pyspark tasks

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -292,6 +292,9 @@ class PySparkTask(SparkSubmitTask):
         with open(self.run_pickle, 'wb') as fd:
             # Copy module file to run path.
             module_path = os.path.abspath(inspect.getfile(self.__class__))
+            module_folder = os.path.dirname(module_path)
+            module_name = os.path.basename(module_folder)
+            shutil.copytree(module_folder, os.path.join(self.run_path, module_name))
             shutil.copy(module_path, os.path.join(self.run_path, '.'))
             self._dump(fd)
         try:

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -291,11 +291,11 @@ class PySparkTask(SparkSubmitTask):
         self.run_pickle = os.path.join(self.run_path, '.'.join([self.name.replace(' ', '_'), 'pickle']))
         with open(self.run_pickle, 'wb') as fd:
             # Copy module file to run path.
-            module_path = os.path.abspath(inspect.getfile(self.__class__))
-            module_folder = os.path.dirname(module_path)
-            module_name = os.path.basename(module_folder)
-            shutil.copytree(module_folder, os.path.join(self.run_path, module_name))
-            shutil.copy(module_path, os.path.join(self.run_path, '.'))
+            module_file_path = os.path.abspath(inspect.getfile(self.__class__))
+            base_module = self.__class__.__module__.split('.')[0]
+            module_folder_path = module_file_path[:module_file_path.find(base_module) + len(base_module)]
+            shutil.copytree(module_folder_path, os.path.join(self.run_path, base_module))
+            shutil.copy(module_file_path, os.path.join(self.run_path, '.'))
             self._dump(fd)
         try:
             super(PySparkTask, self).run()


### PR DESCRIPTION
## Description
Patch Custom Module Import Error By Copying the Entire Custom Module Over to Temp File

## Motivation and Context
Opened Issue Addressed: [Issue 2501](https://github.com/spotify/luigi/issues/2501)
The last attempt to address this issue can be viewed [here](https://github.com/spotify/luigi/pull/2168/files). This patch only fixed the issue when the imported pipeline is from a file and not from a directory. With this PR, it allows users to import from both a module and a file.

## Have you tested this? If so, how?
I ran this code and it worked for me using the project structure indicated in [Issue 2501](https://github.com/spotify/luigi/issues/2501). There has to be a better way to fix this but this request temporarily addresses the issue.