### PR TITLE
Fix exception when toml lib is not installed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ Run ``pip install luigi`` to install the latest stable version from `PyPI
 <https://pypi.python.org/pypi/luigi>`_. `Documentation for the latest release
 <https://luigi.readthedocs.io/en/stable/>`__ is hosted on readthedocs.
 
+Run ``pip install luigi[toml]`` to install Luigi with `TOML-based configs
+<https://luigi.readthedocs.io/en/stable/configuration.html>`__ support.
+
 For the bleeding edge code, ``pip install
 git+https://github.com/spotify/luigi.git``. `Bleeding edge documentation
 <https://luigi.readthedocs.io/en/latest/>`__ is also available.

--- a/luigi/configuration/core.py
+++ b/luigi/configuration/core.py
@@ -46,12 +46,12 @@ def get_config(parser=PARSER):
 
     parser_class = PARSERS[parser]
     if not parser_class.enabled:
-        logger.error((
-                "Parser not installed yet. "
-                "Please, install luigi with required parser:\n"
-                "pip install luigi[{parser}]"
-            ).format(parser)
+        msg = (
+            "Parser not installed yet. "
+            "Please, install luigi with required parser:\n"
+            "pip install luigi[{parser}]"
         )
+        raise ImportError(msg.format(parser))
 
     return parser_class.instance()
 
@@ -72,12 +72,20 @@ def add_config_path(path):
     parser_class = PARSERS[parser]
 
     if not parser_class.enabled:
-        logger.error((
+        msg = (
                 "Parser not installed yet. "
                 "Please, install luigi with required parser:\n"
                 "pip install luigi[{parser}]"
-            ).format(parser)
+            )
+        raise ImportError(msg.format(parser))
+
+    if parser != PARSER:
+        msg = (
+            "Config for {added} parser added, but used {used} parser. "
+            "Set up right parser via env var: "
+            "export LUIGI_CONFIG_PARSER={added}"
         )
+        warnings.warn(msg.format(added=parser, used=PARSER))
 
     # add config path to parser
     parser_class.add_config_path(path)

--- a/luigi/configuration/core.py
+++ b/luigi/configuration/core.py
@@ -40,11 +40,7 @@ if PARSER not in PARSERS:
     PARSER = DEFAULT_PARSER
 
 
-def get_config(parser=PARSER):
-    """Get configs singleton for parser
-    """
-
-    parser_class = PARSERS[parser]
+def _check_parser(parser_class, parser):
     if not parser_class.enabled:
         msg = (
             "Parser not installed yet. "
@@ -53,6 +49,12 @@ def get_config(parser=PARSER):
         )
         raise ImportError(msg.format(parser=parser))
 
+
+def get_config(parser=PARSER):
+    """Get configs singleton for parser
+    """
+    parser_class = PARSERS[parser]
+    _check_parser(parser_class, parser)
     return parser_class.instance()
 
 
@@ -71,14 +73,7 @@ def add_config_path(path):
         parser = PARSER
     parser_class = PARSERS[parser]
 
-    if not parser_class.enabled:
-        msg = (
-                "Parser not installed yet. "
-                "Please, install luigi with required parser:\n"
-                "pip install luigi[{parser}]"
-            )
-        raise ImportError(msg.format(parser=parser))
-
+    _check_parser(parser_class, parser)
     if parser != PARSER:
         msg = (
             "Config for {added} parser added, but used {used} parser. "

--- a/luigi/configuration/core.py
+++ b/luigi/configuration/core.py
@@ -51,7 +51,7 @@ def get_config(parser=PARSER):
             "Please, install luigi with required parser:\n"
             "pip install luigi[{parser}]"
         )
-        raise ImportError(msg.format(parser))
+        raise ImportError(msg.format(parser=parser))
 
     return parser_class.instance()
 
@@ -77,7 +77,7 @@ def add_config_path(path):
                 "Please, install luigi with required parser:\n"
                 "pip install luigi[{parser}]"
             )
-        raise ImportError(msg.format(parser))
+        raise ImportError(msg.format(parser=parser))
 
     if parser != PARSER:
         msg = (

--- a/luigi/configuration/core.py
+++ b/luigi/configuration/core.py
@@ -66,9 +66,18 @@ def add_config_path(path):
     # select parser by file extension
     _base, ext = os.path.splitext(path)
     if ext and ext[1:] in PARSERS:
-        parser_class = PARSERS[ext[1:]]
+        parser = ext[1:]
     else:
-        parser_class = PARSERS[PARSER]
+        parser = PARSER
+    parser_class = PARSERS[parser]
+
+    if not parser_class.enabled:
+        logger.error((
+                "Parser not installed yet. "
+                "Please, install luigi with required parser:\n"
+                "pip install luigi[{parser}]"
+            ).format(parser)
+        )
 
     # add config path to parser
     parser_class.add_config_path(path)

--- a/test/config_toml_test.py
+++ b/test/config_toml_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018 Cindicator Ltd.
+# Copyright 2018 Vote inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,3 +63,19 @@ class TomlConfigParserTest(LuigiTestCase):
         self.assertEqual(config.get('hdfs', 'client'), 'test')
         config.set('hdfs', 'check', 'test me')
         self.assertEqual(config.get('hdfs', 'check'), 'test me')
+
+
+class HelpersTest(LuigiTestCase):
+    def test_add_without_install(self):
+        enabled = LuigiTomlParser.enabled
+        LuigiTomlParser.enabled = False
+        with self.assertRaises(ImportError):
+            add_config_path('test/testconfig/luigi.toml')
+        LuigiTomlParser.enabled = enabled
+
+    def test_get_without_install(self):
+        enabled = LuigiTomlParser.enabled
+        LuigiTomlParser.enabled = False
+        with self.assertRaises(ImportError):
+            get_config('toml')
+        LuigiTomlParser.enabled = enabled


### PR DESCRIPTION
## Description

Fix issue from comments to #2457 and some related stuff:
1. Add informative message, when `LUIGI_CONFIG_PATH` with `*.toml` file is presented in env vars, but `toml` lib is not installed yet.
1. Raise `ImportError` instead of simple logging, because this is critical issue, that doesn't allow lib works fine.
1. Add warning when `LUIGI_CONFIG_PATH` and `LUIGI_CONFIG_PARSER` point to different parsers.
1. Add info about toml support in `installation` section.

## Have you tested this? If so, how?

Some minimal tests included and works fine.
