### PR TITLE
Refactor/s3 copy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ script:
   - tox --version
   - ./scripts/ci/conditional_tox.sh
 
-#branches:
-#  only:
-#    - master
+branches:
+  only:
+    - master
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ script:
   - tox --version
   - ./scripts/ci/conditional_tox.sh
 
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 
 notifications:
   email: false

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -295,7 +295,8 @@ class S3Client(FileSystem):
         self.s3.meta.client.upload_fileobj(
             Fileobj=open(local_path, 'rb'), Bucket=bucket, Key=key, Config=transfer_config, ExtraArgs=kwargs)
 
-    def copy(self, source_path, destination_path, threads=100, start_time=None, end_time=None, part_size=8388608, **kwargs):
+    def copy(self, source_path, destination_path, threads=100, start_time=None, end_time=None, part_size=8388608,
+             **kwargs):
         """
         Copy object(s) from one S3 location to another. Works for individual keys or entire directories.
         When files are larger than `part_size`, multipart uploading will be used.
@@ -320,61 +321,60 @@ class S3Client(FileSystem):
 
         transfer_config = TransferConfig(max_concurrency=threads, multipart_chunksize=part_size)
         total_keys = 0
-        total_size_bytes = 0
 
         if self.isdir(source_path):
-            copy_jobs = []
-            management_pool = ThreadPool(processes=threads)
-
-            (bucket, key) = self._path_to_bucket_and_key(source_path)
-            key_path = self._add_path_delimiter(key)
-            key_path_len = len(key_path)
-            src_prefix = self._add_path_delimiter(src_key)
-            dst_prefix = self._add_path_delimiter(dst_key)
-
-            for item in self.list(source_path, start_time=start_time, end_time=end_time, return_key=True):
-                path = item.key[key_path_len:]
-                # prevents copy attempt of empty key in folder
-                if path != '' and path != '/':
-                    total_keys += 1
-                    total_size_bytes += item.size
-                    copy_source = {
-                        'Bucket': src_bucket,
-                        'Key': src_prefix + path
-                    }
-
-                    the_kwargs = {'Config': transfer_config, 'ExtraArgs': kwargs}
-                    job = management_pool.apply_async(self.s3.meta.client.copy,
-                                                      args=(copy_source, dst_bucket, dst_prefix + path),
-                                                      kwds=the_kwargs)
-                    copy_jobs.append(job)
-
-            # Wait for the pools to finish scheduling all the copies
-            management_pool.close()
-            management_pool.join()
-
-            # Raise any errors encountered in any of the copy processes
-            for result in copy_jobs:
-                result.get()
-
-            end = datetime.datetime.now()
-            duration = end - start
-            logger.info('%s : Complete : %s total keys copied in %s' %
-                        (datetime.datetime.now(), total_keys, duration))
+            return self._copy_dir(src_bucket, src_key, dst_bucket, dst_key, end_time, source_path, start,
+                                  start_time, threads, total_keys, transfer_config, **kwargs)
 
         # If the file isn't a directory just perform a simple copy
         else:
-            total_keys += 1
-            copy_source = {
-                'Bucket': src_bucket,
-                'Key': src_key
-            }
-            item = self.get_key(source_path)
-            total_size_bytes += item.size
-            self.s3.meta.client.copy(
-                copy_source, dst_bucket, dst_key, Config=transfer_config, ExtraArgs=kwargs)
+            self._copy_file(src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs)
 
+    def _copy_file(self, src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs):
+        copy_source = {
+            'Bucket': src_bucket,
+            'Key': src_key
+        }
+        self.s3.meta.client.copy(copy_source, dst_bucket, dst_key, Config=transfer_config, ExtraArgs=kwargs)
+
+    def _copy_dir(self, dst_bucket, dst_key, end_time, source_path, src_bucket, src_key, start, start_time,
+                  threads, total_keys, transfer_config, **kwargs):
+        copy_jobs = []
+        management_pool = ThreadPool(processes=threads)
+        (bucket, key) = self._path_to_bucket_and_key(source_path)
+        key_path = self._add_path_delimiter(key)
+        key_path_len = len(key_path)
+        src_prefix = self._add_path_delimiter(src_key)
+        dst_prefix = self._add_path_delimiter(dst_key)
+        total_size_bytes = 0
+        for item in self.list(source_path, start_time=start_time, end_time=end_time, return_key=True):
+            path = item.key[key_path_len:]
+            # prevents copy attempt of empty key in folder
+            if path != '' and path != '/':
+                total_keys += 1
+                total_size_bytes += item.size
+                copy_source = {
+                    'Bucket': src_bucket,
+                    'Key': src_prefix + path
+                }
+
+                the_kwargs = {'Config': transfer_config, 'ExtraArgs': kwargs}
+                job = management_pool.apply_async(self.s3.meta.client.copy,
+                                                  args=(copy_source, dst_bucket, dst_prefix + path),
+                                                  kwds=the_kwargs)
+                copy_jobs.append(job)
+        # Wait for the pools to finish scheduling all the copies
+        management_pool.close()
+        management_pool.join()
+        # Raise any errors encountered in any of the copy processes
+        for result in copy_jobs:
+            result.get()
+        end = datetime.datetime.now()
+        duration = end - start
+        logger.info('%s : Complete : %s total keys copied in %s' %
+                    (datetime.datetime.now(), total_keys, duration))
         return total_keys, total_size_bytes
+
 
     def get(self, s3_path, destination_local_path):
         """

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -327,13 +327,16 @@ class S3Client(FileSystem):
 
         # If the file isn't a directory just perform a simple copy
         else:
+            item = self.get_key(source_path)
             self._copy_file(src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs)
+            return 1, item.size
 
     def _copy_file(self, src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs):
         copy_source = {
             'Bucket': src_bucket,
             'Key': src_key
         }
+
         self.s3.meta.client.copy(copy_source, dst_bucket, dst_key, Config=transfer_config, ExtraArgs=kwargs)
 
     def _copy_dir(self, src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config,
@@ -372,7 +375,6 @@ class S3Client(FileSystem):
         logger.info('%s : Complete : %s total keys copied in %s' %
                     (datetime.datetime.now(), total_keys, duration))
         return total_keys, total_size_bytes
-
 
     def get(self, s3_path, destination_local_path):
         """

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -354,11 +354,14 @@ class S3Client(FileSystem):
             if path != '' and path != '/':
                 total_keys += 1
                 total_size_bytes += item.size
-                extra_args = {'ExtraArgs': kwargs} if kwargs else {}
-                job = management_pool.apply_async(self._copy_file,
-                                                  args=(src_bucket, src_prefix + path, dst_bucket, dst_prefix + path,
-                                                        transfer_config),
-                                                  kwds=extra_args)
+                copy_source = {
+                    'Bucket': src_bucket,
+                    'Key': src_prefix + path
+                }
+                the_kwargs = {'Config': transfer_config, 'ExtraArgs': kwargs}
+                job = management_pool.apply_async(self.s3.meta.client.copy,
+                                                  args=(copy_source, dst_bucket, dst_prefix + path),
+                                                  kwds=the_kwargs)
                 copy_jobs.append(job)
         # Wait for the pools to finish scheduling all the copies
         management_pool.close()

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -94,6 +94,8 @@ class S3Client(FileSystem):
     """
 
     _s3 = None
+    DEFAULT_PART_SIZE = 8388608
+    DEFAULT_THREADS = 100
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  **kwargs):
@@ -271,7 +273,7 @@ class S3Client(FileSystem):
         self.s3.meta.client.put_object(
             Key=key, Bucket=bucket, Body=content, **kwargs)
 
-    def put_multipart(self, local_path, destination_s3_path, part_size=8388608, **kwargs):
+    def put_multipart(self, local_path, destination_s3_path, part_size=DEFAULT_PART_SIZE, **kwargs):
         """
         Put an object stored locally to an S3 path
         using S3 multi-part upload (for files > 8Mb).
@@ -295,7 +297,8 @@ class S3Client(FileSystem):
         self.s3.meta.client.upload_fileobj(
             Fileobj=open(local_path, 'rb'), Bucket=bucket, Key=key, Config=transfer_config, ExtraArgs=kwargs)
 
-    def copy(self, source_path, destination_path, threads=100, start_time=None, end_time=None, part_size=8388608, **kwargs):
+    def copy(self, source_path, destination_path, threads=DEFAULT_THREADS, start_time=None, end_time=None,
+             part_size=DEFAULT_PART_SIZE, **kwargs):
         """
         Copy object(s) from one S3 location to another. Works for individual keys or entire directories.
         When files are larger than `part_size`, multipart uploading will be used.
@@ -320,7 +323,7 @@ class S3Client(FileSystem):
         else:
             return self._copy_file(source_path, destination_path, threads=threads, part_size=part_size, **kwargs)
 
-    def _copy_file(self, source_path, destination_path, threads=100, part_size=8388608, **kwargs):
+    def _copy_file(self, source_path, destination_path, threads=DEFAULT_THREADS, part_size=DEFAULT_PART_SIZE, **kwargs):
         src_bucket, src_key = self._path_to_bucket_and_key(source_path)
         dst_bucket, dst_key = self._path_to_bucket_and_key(destination_path)
         transfer_config = TransferConfig(max_concurrency=threads, multipart_chunksize=part_size)
@@ -334,8 +337,8 @@ class S3Client(FileSystem):
 
         return 1, item.size
 
-    def _copy_dir(self, source_path, destination_path, threads=100,
-                  start_time=None, end_time=None, part_size=8388608, **kwargs):
+    def _copy_dir(self, source_path, destination_path, threads=DEFAULT_THREADS,
+                  start_time=None, end_time=None, part_size=DEFAULT_PART_SIZE, **kwargs):
         start = datetime.datetime.now()
         copy_jobs = []
         management_pool = ThreadPool(processes=threads)

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -324,17 +324,18 @@ class S3Client(FileSystem):
 
         # If the file isn't a directory just perform a simple copy
         else:
-            item = self.get_key(source_path)
-            self._copy_file(src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs)
-            return 1, item.size
+            return self._copy_file(src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config, **kwargs)
 
-    def _copy_file(self, src_bucket, src_key, dst_bucket, dst_key, transfer_config, **kwargs):
+    def _copy_file(self, src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config, **kwargs):
+        item = self.get_key(source_path)
         copy_source = {
             'Bucket': src_bucket,
             'Key': src_key
         }
 
         self.s3.meta.client.copy(copy_source, dst_bucket, dst_key, Config=transfer_config, ExtraArgs=kwargs)
+
+        return 1, item.size
 
     def _copy_dir(self, src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config,
                   threads=100, start_time=None, end_time=None, **kwargs):

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -295,8 +295,7 @@ class S3Client(FileSystem):
         self.s3.meta.client.upload_fileobj(
             Fileobj=open(local_path, 'rb'), Bucket=bucket, Key=key, Config=transfer_config, ExtraArgs=kwargs)
 
-    def copy(self, source_path, destination_path, threads=100, start_time=None, end_time=None, part_size=8388608,
-             **kwargs):
+    def copy(self, source_path, destination_path, threads=100, start_time=None, end_time=None, part_size=8388608, **kwargs):
         """
         Copy object(s) from one S3 location to another. Works for individual keys or entire directories.
         When files are larger than `part_size`, multipart uploading will be used.
@@ -353,14 +352,9 @@ class S3Client(FileSystem):
             if path != '' and path != '/':
                 total_keys += 1
                 total_size_bytes += item.size
-                copy_source = {
-                    'Bucket': src_bucket,
-                    'Key': src_prefix + path
-                }
-
                 the_kwargs = {'Config': transfer_config, 'ExtraArgs': kwargs}
-                job = management_pool.apply_async(self.s3.meta.client.copy,
-                                                  args=(copy_source, dst_bucket, dst_prefix + path),
+                job = management_pool.apply_async(self._copy_file,
+                                                  args=(src_bucket,  src_prefix + path, dst_bucket, dst_prefix + path),
                                                   kwds=the_kwargs)
                 copy_jobs.append(job)
         # Wait for the pools to finish scheduling all the copies

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -324,9 +324,10 @@ class S3Client(FileSystem):
 
         # If the file isn't a directory just perform a simple copy
         else:
-            return self._copy_file(src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config, **kwargs)
+            return self._copy_file(source_path, dst_bucket, dst_key, transfer_config, **kwargs)
 
-    def _copy_file(self, src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config, **kwargs):
+    def _copy_file(self, source_path, dst_bucket, dst_key, transfer_config, **kwargs):
+        src_bucket, src_key = self._path_to_bucket_and_key(source_path)
         item = self.get_key(source_path)
         copy_source = {
             'Bucket': src_bucket,

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -309,8 +309,6 @@ class S3Client(FileSystem):
         :returns tuple (number_of_files_copied, total_size_copied_in_bytes)
         """
 
-        start = datetime.datetime.now()
-
         (src_bucket, src_key) = self._path_to_bucket_and_key(source_path)
         (dst_bucket, dst_key) = self._path_to_bucket_and_key(destination_path)
 
@@ -322,8 +320,7 @@ class S3Client(FileSystem):
 
         if self.isdir(source_path):
             return self._copy_dir(src_bucket, src_key, dst_bucket, dst_key, source_path,
-                                  transfer_config, threads=100, start_time=start_time, end_time=end_time,
-                                  start=start, **kwargs)
+                                  transfer_config, threads=100, start_time=start_time, end_time=end_time, **kwargs)
 
         # If the file isn't a directory just perform a simple copy
         else:
@@ -340,9 +337,8 @@ class S3Client(FileSystem):
         self.s3.meta.client.copy(copy_source, dst_bucket, dst_key, Config=transfer_config, ExtraArgs=kwargs)
 
     def _copy_dir(self, src_bucket, src_key, dst_bucket, dst_key, source_path, transfer_config,
-                  threads=100, start_time=None, end_time=None, start=None, **kwargs):
-        if not start:
-            start = datetime.datetime.now()
+                  threads=100, start_time=None, end_time=None, **kwargs):
+        start = datetime.datetime.now()
         copy_jobs = []
         management_pool = ThreadPool(processes=threads)
         (bucket, key) = self._path_to_bucket_and_key(source_path)


### PR DESCRIPTION
## Description
Extract copy directory and copy file logic out of copy function in S3 client.

## Motivation and Context
Is just a small refactor over copy function for having more readability and reuse copy file logic also in copy directory. 
The idea came by reviewing this PR: https://github.com/spotify/luigi/pull/2488

## Have you tested this? If so, how?
I didn't change any behaviour so tests remain the same.