### PR TITLE
Expose NoSectionError at package level

### DIFF
--- a/luigi/configuration/__init__.py
+++ b/luigi/configuration/__init__.py
@@ -24,4 +24,5 @@ __all__ = [
     'get_config',
     'LuigiConfigParser',
     'LuigiTomlParser',
+    'NoSectionError'
 ]

--- a/luigi/configuration/__init__.py
+++ b/luigi/configuration/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .cfg_parser import LuigiConfigParser
+from .cfg_parser import LuigiConfigParser, NoSectionError
 from .core import get_config, add_config_path
 from .toml_parser import LuigiTomlParser
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose `NoSectionError` at package level so that `from luigi.configuration import NoSectionError` would work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It used to work like this until https://github.com/spotify/luigi/pull/2457, so we should probably bring it back for backward compatibility.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
TBD
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
