### PR TITLE
[wip] worker+target: propagate output check to target

### DIFF
--- a/luigi/target.py
+++ b/luigi/target.py
@@ -25,6 +25,7 @@ import os
 import random
 import tempfile
 import logging
+import threading
 import warnings
 from luigi import six
 
@@ -44,12 +45,17 @@ class Target(object):
     is considered complete if and only if each of its output Targets exist.
     """
 
+    _local = threading.local()
+
     @abc.abstractmethod
     def exists(self):
         """
         Returns ``True`` if the :py:class:`Target` exists and ``False`` otherwise.
         """
         pass
+
+    def output(self):
+        return Target._local.output or False
 
 
 class FileSystemException(Exception):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -397,10 +397,16 @@ def check_complete(task, out_queue):
     Checks if task is complete, puts the result to out_queue.
     """
     logger.debug("Checking if %s is complete", task)
+    if _is_external(task):
+        Target._local.output = False
+    else:
+        Target._local.output = True
     try:
         is_complete = task.complete()
     except Exception:
         is_complete = TracebackWrapper(traceback.format_exc())
+    finally:
+        del Target._local.output
     out_queue.put((task, is_complete))
 
 


### PR DESCRIPTION
Allow `Target.exists()` to know whether it is called to check for the
existence of an external dependency (`ExternalTask`) or for the
existence of output for a non-external `Task`.

## Description
The `Worker` propagates whether the `exists()` check is for an `ExternalTask` (which is considered an external input dependency lookup) or a non-external `Task` (i.e. output existence lookup for a task that is being evaluated for execution.)

## Motivation and Context
Our use case is to allow adding overwriting behavior to existing  `Target` implementations. E.g., it should be possible to set a `XYZ_OVERWRITE` flag and `XyzTarget.exists()` should then return `False` for output existence checks but perform normal lookups for external input dependency checks.

## Have you tested this? If so, how?
Testing is TODO
