### PR TITLE
MockTarget mode fixed to accept read and write like r* or w*

### DIFF
--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -131,7 +131,7 @@ class MockTarget(target.FileSystemTarget):
         """
         self.move(*args, **kwargs)
 
-    def open(self, mode):
+    def open(self, mode='r'):
         fn = self.path
         mock_target = self
 
@@ -158,7 +158,7 @@ class MockTarget(target.FileSystemTarget):
                 super(Buffer, self).write(data)
 
             def close(self):
-                if mode == 'w':
+                if mode[0] == 'w':
                     try:
                         mock_target.wrapper.flush()
                     except AttributeError:
@@ -174,15 +174,15 @@ class MockTarget(target.FileSystemTarget):
                 return self
 
             def readable(self):
-                return mode == 'r'
+                return mode[0] == 'r'
 
             def writeable(self):
-                return mode == 'w'
+                return mode[0] == 'w'
 
             def seekable(self):
                 return False
 
-        if mode == 'w':
+        if mode[0] == 'w':
             wrapper = self.format.pipe_writer(Buffer())
             wrapper.set_wrapper(wrapper)
             return wrapper

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -61,11 +61,9 @@ class MockFileTest(unittest.TestCase):
 
     def test_mode_none_error(self):
         t = MockTarget("foo")
-        try:
+        with self.assertRaises(TypeError):
             with t.open(None) as b:
                 b.write("bar")
-        except TypeError:
-            self.assertRaises(TypeError)
 
     # That should work in python2 because of the autocast
     # That should work in python3 because the default format is Text

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -20,6 +20,7 @@ from helpers import unittest
 
 from luigi.mock import MockTarget, MockFileSystem
 from luigi import six
+from luigi.format import Nop
 
 
 class MockFileTest(unittest.TestCase):
@@ -41,6 +42,31 @@ class MockFileTest(unittest.TestCase):
 
         with t.open('r') as b:
             self.assertEqual(list(b), ['bar'])
+
+    def test_bytes(self):
+        t = MockTarget("foo", format=Nop)
+        with t.open('wb') as b:
+            b.write(b"bar")
+
+        with t.open('rb') as b:
+            self.assertEqual(list(b), [b'bar'])
+
+    def test_default_mode_value(self):
+        t = MockTarget("foo")
+        with t.open('w') as b:
+            b.write("bar")
+
+        with t.open() as b:
+            self.assertEqual(list(b), ['bar'])
+
+    def test_mode_none_error(self):
+        t = MockTarget("foo")
+        try:
+            with t.open(None) as b:
+                b.write("bar")
+        except TypeError as error:
+            self.assertIsNotNone(error)
+            self.assertIn("'NoneType' object", str(error))
 
     # That should work in python2 because of the autocast
     # That should work in python3 because the default format is Text

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -64,9 +64,8 @@ class MockFileTest(unittest.TestCase):
         try:
             with t.open(None) as b:
                 b.write("bar")
-        except TypeError as error:
-            self.assertIsNotNone(error)
-            self.assertIn("'NoneType' object", str(error))
+        except TypeError:
+            self.assertRaises(TypeError)
 
     # That should work in python2 because of the autocast
     # That should work in python3 because the default format is Text


### PR DESCRIPTION
## Description
I changed the mock target class to accept open modes such as rb, rt, wb and others

## Motivation and Context
I did it because I am testing some luigi tasks using pickle and the wb wasn't working because of the mode == 'w' instead of mode[0] == 'w' comparation

## Have you tested this? If so, how?
I have included a test for bytearray at mock_test.py
