### PR TITLE
Interpolate environment variables in .cfg config files

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -5,7 +5,7 @@ All configuration can be done by adding configuration files.
 
 Supported config parsers:
 
-* ``cfg`` (default), based on Python's standard ConfigParser_. Option values may refer to environment variables using ``${ENVVAR}`` syntax.
+* ``cfg`` (default), based on Python's standard ConfigParser_. Values may refer to environment variables using ``${ENVVAR}`` syntax.
 * ``toml``
 
 .. _ConfigParser: https://docs.python.org/3/library/configparser.html

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -4,8 +4,11 @@ Configuration
 All configuration can be done by adding configuration files.
 
 Supported config parsers:
-* ``cfg`` (default)
+
+* ``cfg`` (default), based on Python's standard ConfigParser_. Option values may refer to environment variables using ``${ENVVAR}`` syntax.
 * ``toml``
+
+.. _ConfigParser: https://docs.python.org/3.6/library/configparser.html
 
 You can choose right parser via ``LUIGI_CONFIG_PARSER`` environment variable. For example, ``LUIGI_CONFIG_PARSER=toml``.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -8,7 +8,7 @@ Supported config parsers:
 * ``cfg`` (default), based on Python's standard ConfigParser_. Option values may refer to environment variables using ``${ENVVAR}`` syntax.
 * ``toml``
 
-.. _ConfigParser: https://docs.python.org/3.6/library/configparser.html
+.. _ConfigParser: https://docs.python.org/3/library/configparser.html
 
 You can choose right parser via ``LUIGI_CONFIG_PARSER`` environment variable. For example, ``LUIGI_CONFIG_PARSER=toml``.
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ install_requires = [
     'tornado>=4.0,<5',
     'python-daemon<3.0',
 ]
+if sys.version_info.major == 2:
+    install_requires.append('configparser>=3.5.0')
 
 if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ install_requires = [
     'tornado>=4.0,<5',
     'python-daemon<3.0',
 ]
-if sys.version_info.major == 2:
-    install_requires.append('configparser>=3.5.0')
 
 if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla

--- a/test/config_env_test.py
+++ b/test/config_env_test.py
@@ -19,7 +19,7 @@ import os
 from luigi.configuration import LuigiConfigParser, get_config
 from luigi.configuration.cfg_parser import InterpolationMissingEnvvarError
 
-from helpers import LuigiTestCase
+from helpers import LuigiTestCase, with_config
 
 
 class ConfigParserTest(LuigiTestCase):
@@ -44,22 +44,26 @@ class ConfigParserTest(LuigiTestCase):
         for key, value in self.environ_backup:
             os.environ[key] = value
 
+    @with_config({"test": {
+        "a": "testval",
+        "b": "%(a)s",
+        "c": "%(a)s%(a)s",
+    }})
     def test_basic_interpolation(self):
         # Make sure the default ConfigParser behaviour is not broken
         config = get_config()
-        config.set("test", "a", "testval")
-        config.set("test", "b", "%(a)s")
-        config.set("test", "c", "%(a)s%(a)s")
 
         self.assertEqual(config.get("test", "b"), config.get("test", "a"))
         self.assertEqual(config.get("test", "c"), 2 * config.get("test", "a"))
 
+    @with_config({"test": {
+        "a": "${TESTVAR}",
+        "b": "${TESTVAR} ${TESTVAR}",
+        "c": "${TESTVAR} %(a)s",
+        "d": "${NONEXISTING}",
+    }})
     def test_env_interpolation(self):
         config = get_config()
-        config.set("test", "a", "${TESTVAR}")
-        config.set("test", "b", "${TESTVAR} ${TESTVAR}")
-        config.set("test", "c", "${TESTVAR} %(a)s")
-        config.set("test", "d", "${NONEXISTING}")
 
         self.assertEqual(config.get("test", "a"), "1")
         self.assertEqual(config.getint("test", "a"), 1)

--- a/test/config_env_test.py
+++ b/test/config_env_test.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Vote inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+from luigi.configuration import LuigiConfigParser, get_config
+from luigi.configuration.cfg_parser import InterpolationMissingEnvvarError
+
+from helpers import LuigiTestCase
+
+
+class ConfigParserTest(LuigiTestCase):
+
+    environ = {
+        "TESTVAR": "1",
+    }
+
+    def setUp(self):
+        self.environ_backup = {
+            os.environ[key] for key in self.environ
+            if key in os.environ
+        }
+        for key, value in self.environ.items():
+            os.environ[key] = value
+        LuigiConfigParser._instance = None
+        super(ConfigParserTest, self).setUp()
+
+    def tearDown(self):
+        for key in self.environ:
+            os.environ.pop(key)
+        for key, value in self.environ_backup:
+            os.environ[key] = value
+
+    def test_basic_interpolation(self):
+        # Make sure the default ConfigParser behaviour is not broken
+        config = get_config()
+        config.set("test", "a", "testval")
+        config.set("test", "b", "%(a)s")
+        config.set("test", "c", "%(a)s%(a)s")
+
+        self.assertEqual(config.get("test", "b"), config.get("test", "a"))
+        self.assertEqual(config.get("test", "c"), 2 * config.get("test", "a"))
+
+    def test_env_interpolation(self):
+        config = get_config()
+        config.set("test", "a", "${TESTVAR}")
+        config.set("test", "b", "${TESTVAR} ${TESTVAR}")
+        config.set("test", "c", "${TESTVAR} %(a)s")
+        config.set("test", "d", "${NONEXISTING}")
+
+        self.assertEqual(config.get("test", "a"), "1")
+        self.assertEqual(config.getint("test", "a"), 1)
+        self.assertEqual(config.getboolean("test", "a"), True)
+
+        self.assertEqual(config.get("test", "b"), "1 1")
+
+        self.assertEqual(config.get("test", "c"), "1 1")
+
+        with self.assertRaises(InterpolationMissingEnvvarError):
+            config.get("test", "d")


### PR DESCRIPTION
## Description
Added possibility to refer to environment variables in the config files using `${variable_name}` syntax.

In Python 3 the feature is implemented by changing the default interpolation in `LuigiConfigParser`. In Python 2 `ConfigParser` does not support custom interpolations, so instead the `LuigiConfigParser` overrides the `_interpolate` method from the parent class.

## Motivation and Context
Addresses issue #2354. A typical use case is to include secrets in the config file, for example:

```ini
[database]
host=someserver.com
uid=someuser
pwd=${DATABASE_PASSWORD}
```

An alternative implementation of this feature exists in PR #2038 (not merged), which uses the `%(variable_name)s` syntax. However, that implementation is not backward compatible because it changes the default behavior of `ConfigParser` (and therefore `LuigiConfigParser`) where the same syntax is used to refer to other options in the same config section.

## Have you tested this? If so, how?
I have included unit tests.