### PR TITLE
Remove s3 bucket validation prior to file upload

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -264,9 +264,6 @@ class S3Client(FileSystem):
         self._check_deprecated_argument(**kwargs)
         (bucket, key) = self._path_to_bucket_and_key(destination_s3_path)
 
-        # validate the bucket
-        self._validate_bucket(bucket)
-
         # put the file
         self.s3.meta.client.put_object(
             Key=key, Bucket=bucket, Body=content, **kwargs)
@@ -288,9 +285,6 @@ class S3Client(FileSystem):
         transfer_config = TransferConfig(multipart_chunksize=part_size)
 
         (bucket, key) = self._path_to_bucket_and_key(destination_s3_path)
-
-        # validate the bucket
-        self._validate_bucket(bucket)
 
         self.s3.meta.client.upload_fileobj(
             Fileobj=open(local_path, 'rb'), Bucket=bucket, Key=key, Config=transfer_config, ExtraArgs=kwargs)
@@ -534,19 +528,6 @@ class S3Client(FileSystem):
                 'example: region_name=us-west-1\n'
                 'For region names, refer to the amazon S3 region documentation\n'
                 'https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region')
-
-    def _validate_bucket(self, bucket_name):
-        exists = True
-
-        try:
-            self.s3.meta.client.head_bucket(Bucket=bucket_name)
-        except botocore.exceptions.ClientError as e:
-            error_code = e.response['Error']['Code']
-            if error_code in ('404', 'NoSuchBucket'):
-                exists = False
-            else:
-                raise
-        return exists
 
     def _exists(self, bucket, key):
         try:

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -177,6 +177,12 @@ class TestS3Client(unittest.TestCase):
         s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
         self.assertTrue(s3_client.exists('s3://mybucket/putMe'))
 
+    def test_put_no_such_bucket(self):
+        # intentionally don't create bucket
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(s3_client.s3.meta.client.exceptions.NoSuchBucket):
+            s3_client.put(self.tempFilePath, 's3://mybucket/putMe')
+
     def test_put_sse_deprecated(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
@@ -196,6 +202,12 @@ class TestS3Client(unittest.TestCase):
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
         s3_client.put_string("SOMESTRING", 's3://mybucket/putString')
         self.assertTrue(s3_client.exists('s3://mybucket/putString'))
+
+    def test_put_string_no_such_bucket(self):
+        # intentionally don't create bucket
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(s3_client.s3.meta.client.exceptions.NoSuchBucket):
+            s3_client.put_string("SOMESTRING", 's3://mybucket/putString')
 
     def test_put_string_sse_deprecated(self):
         create_bucket()
@@ -258,6 +270,12 @@ class TestS3Client(unittest.TestCase):
         part_size = 8388608
         file_size = 5000
         return self._run_multipart_test(part_size, file_size)
+
+    def test_put_multipart_no_such_bucket(self):
+        # intentionally don't create bucket
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+        with self.assertRaises(s3_client.s3.meta.client.exceptions.NoSuchBucket):
+            s3_client.put_multipart(self.tempFilePath, 's3://mybucket/putMe')
 
     def test_exists(self):
         create_bucket()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

Replaces #2526 

## Description
<!--- Describe your changes -->
Removes bucket validation from s3 PUT operations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
S3 permissions can be very granular. It is possible for them to be such that an IAM Role only has
permissions on a specific subdir within a S3 bucket. In this event, _validate_bucket() may fail due
to a 403, when in fact the permissions exist to put* within the specified path.

It was then determined that the `_validate_bucket()` check provided very little benefit to Luigi. The removal of this staticmethod should not break any code.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Added tests

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
