### PR TITLE
Fix S3Client.remove - add max batch size

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -191,6 +191,9 @@ class S3Client(FileSystem):
     def remove(self, path, recursive=True):
         """
         Remove a file or directory from S3.
+        :param path: File or directory to remove
+        :param recursive: Boolean indicator to remove object and children
+        :return: Boolean indicator denoting success of the removal of 1 or more files
         """
         if not self.exists(path):
             logger.debug('Could not delete %s; path does not exist', path)

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -218,7 +218,9 @@ class S3Client(FileSystem):
             delete_key_list.append({'Key': '{}{}'.format(key, S3_DIRECTORY_MARKER_SUFFIX_0)})
 
         if len(delete_key_list) > 0:
-            self.s3.meta.client.delete_objects(Bucket=bucket, Delete={'Objects': delete_key_list})
+            n = 1000
+            for i in range(0, len(delete_key_list), n):
+                self.s3.meta.client.delete_objects(Bucket=bucket, Delete={'Objects': delete_key_list[i: i + n]})
             return True
 
         return False

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -441,6 +441,15 @@ class TestS3Client(unittest.TestCase):
         self.assertTrue(s3_client.remove('s3://mybucket/removemedir'))
         self.assertFalse(s3_client.exists('s3://mybucket/removemedir_$folder$'))
 
+    def test_remove_dir_batch(self):
+        create_bucket()
+        s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)
+
+        for i in range(0, 2000):
+            s3_client.put(self.tempFilePath, 's3://mybucket/removemedir/file{i}'.format(i=i))
+        self.assertTrue(s3_client.remove('s3://mybucket/removemedir/'))
+        self.assertFalse(s3_client.exists('s3://mybucket/removedir/'))
+
     @skipOnTravis("passes and fails intermitantly, suspecting it's a race condition not handled by moto")
     def test_copy_multiple_parts_non_exact_fit(self):
         """


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Update `S3Client.remove()` to call `delete_objects()` on batches of 1000 (max).

## Description
<!--- Describe your changes -->
[Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.delete_objects) denotes that `delete_objects()` can be provided up to 1000 keys. We were passing it however many keys were in  `delete_key_list` with no maximum limit.

This patch implements a max of 1000 keys per batch to send to `delete_objects()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Began receiving errors when attempting to recursively delete a lot of files with the following error message:
```shell
Runtime error:
Traceback (most recent call last):
  File "/opt/venv/local/lib/python2.7/site-packages/luigi/worker.py", line 205, in run
    new_deps = self._run_get_new_deps()
  File "/opt/venv/local/lib/python2.7/site-packages/luigi/worker.py", line 142, in _run_get_new_deps
    task_gen = self.task.run()
  File "/opt/luigi/my_file.py", line 1028, in run
   self.client.remove(self.prefix, recursive=True)
  File "/opt/venv/local/lib/python2.7/site-packages/luigi/contrib/s3.py", line 221, in remove
    self.s3.meta.client.delete_objects(Bucket=bucket, Delete={'Objects': delete_key_list})
  File "/opt/venv/local/lib/python2.7/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/opt/venv/local/lib/python2.7/site-packages/botocore/client.py", line 612, in _make_api_call
    raise error_class(parsed_response, operation_name)
ClientError: An error occurred (MalformedXML) when calling the DeleteObjects operation: The XML you provided was not well-formed or did not validate against our published schema
```
I then looked at boto3 documentation and found the 1000 key limit. Adding this patch's batching has prevented this MalformedXML error.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Existing tests refactored and new test added. (Was unable to force the error to occur with boto/moto)

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
