### PR TITLE
Fix API documentation by overriding bad inherited docstrings

### DIFF
--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -81,15 +81,19 @@ class LuigiConfigParser(BaseParser, ConfigParser):
             return default
 
     def get(self, section, option, default=NO_DEFAULT, **kwargs):
+        """ Override ConfigParser.get """
         return self._get_with_default(ConfigParser.get, section, option, default, **kwargs)
 
     def getboolean(self, section, option, default=NO_DEFAULT):
+        """ Override ConfigParser.getboolean """
         return self._get_with_default(ConfigParser.getboolean, section, option, default, bool)
 
     def getint(self, section, option, default=NO_DEFAULT):
+        """ Override ConfigParser.getint """
         return self._get_with_default(ConfigParser.getint, section, option, default, int)
 
     def getfloat(self, section, option, default=NO_DEFAULT):
+        """ Override ConfigParser.getfloat """
         return self._get_with_default(ConfigParser.getfloat, section, option, default, float)
 
     def getintdict(self, section):
@@ -101,6 +105,7 @@ class LuigiConfigParser(BaseParser, ConfigParser):
             return {}
 
     def set(self, section, option, value=None):
+        """ Override ConfigParser.set """
         if not ConfigParser.has_section(self, section):
             ConfigParser.add_section(self, section)
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Investigating @jethron 's suggestion on #2464 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Luigi API documentation (e.g [luigi/contrib/redshift](https://luigi.readthedocs.io/en/latest/api/luigi.contrib.redshift.html)) has been broken

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
HTML API docs build locally

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
