### PR TITLE
Fix S3Client's _path_to_bucket_and_key to support keys with question marks

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -507,8 +507,10 @@ class S3Client(FileSystem):
 
     @staticmethod
     def _path_to_bucket_and_key(path):
-        (scheme, netloc, path, query, fragment) = urlsplit(path)
-        path_without_initial_slash = path[1:]
+        (scheme, netloc, path, query, fragment) = urlsplit(path,
+                                                           allow_fragments=False)
+        question_mark_plus_query = '?' + query if query else ''
+        path_without_initial_slash = path[1:] + question_mark_plus_query
         return netloc, path_without_initial_slash
 
     @staticmethod

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -503,6 +503,11 @@ class TestS3Client(unittest.TestCase):
             copy_size = s3_client.get_key(s3_dest + str(i)).size
             self.assertEqual(original_size, copy_size)
 
+    def test__path_to_bucket_and_key(self):
+        self.assertEqual([('bucket', 'noquestionmarkhere'), ('bucket', 'questionmark?here')],
+                         [S3Client._path_to_bucket_and_key('s3://bucket/noquestionmarkhere'),
+                          S3Client._path_to_bucket_and_key('s3://bucket/questionmark?here')])
+
     @mock_s3
     def _run_copy_test(self, put_method, is_multipart=False):
         create_bucket()

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -504,9 +504,10 @@ class TestS3Client(unittest.TestCase):
             self.assertEqual(original_size, copy_size)
 
     def test__path_to_bucket_and_key(self):
-        self.assertEqual([('bucket', 'noquestionmarkhere'), ('bucket', 'questionmark?here')],
-                         [S3Client._path_to_bucket_and_key('s3://bucket/noquestionmarkhere'),
-                          S3Client._path_to_bucket_and_key('s3://bucket/questionmark?here')])
+        self.assertEqual(('bucket', 'key'), S3Client._path_to_bucket_and_key('s3://bucket/key'))
+
+    def test__path_to_bucket_and_key_with_question_mark(self):
+        self.assertEqual(('bucket', 'key?blade'), S3Client._path_to_bucket_and_key('s3://bucket/key?blade'))
 
     @mock_s3
     def _run_copy_test(self, put_method, is_multipart=False):


### PR DESCRIPTION
## Description
Fix S3Client's _path_to_bucket_and_key to support keys with question marks.

## Motivation and Context
Fixes https://github.com/spotify/luigi/issues/2533.

## Have you tested this? If so, how?
Before:
```python
S3Client()._path_to_bucket_and_key('s3://bucket/hello?world') # --> ('bucket', 'hello')
```

After:

```python
S3Client()._path_to_bucket_and_key('s3://bucket/hello?world') # --> ('bucket', 'hello?world')
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
