### PR TITLE
set upper bound of python-daemon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ with open('README.rst') as fobj:
 
 install_requires = [
     'tornado>=4.0,<5',
-    'python-daemon<3.0',
+    # https://pagure.io/python-daemon/issue/18
+    'python-daemon<2.2.0',
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Set upper bound of `python-daemon` to `2.2.0` exclusively.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to #2494 and #2525, `2.2.0` seems to be a problematic version and the progress of the community is very slow.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
It had been working before `2.2.0` release.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
