### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -31,15 +31,6 @@ import os.path
 import warnings
 from multiprocessing.pool import ThreadPool
 
-logger = logging.getLogger("luigi-interface")
-
-try:
-    from boto3.s3.transfer import TransferConfig
-    import botocore
-except ImportError:
-    logger.warning("Loading S3 module without the python package boto3. "
-                   "Will crash at runtime if S3 functionality is used.")
-
 try:
     from urlparse import urlsplit
 except ImportError:
@@ -59,6 +50,13 @@ from luigi.target import FileAlreadyExists, FileSystem, FileSystemException, Fil
 from luigi.task import ExternalTask
 
 logger = logging.getLogger('luigi-interface')
+
+try:
+    from boto3.s3.transfer import TransferConfig
+    import botocore
+except ImportError:
+    logger.warning("Loading S3 module without the python package boto3. "
+                   "Will crash at runtime if S3 functionality is used.")
 
 
 # two different ways of marking a directory

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -31,8 +31,14 @@ import os.path
 import warnings
 from multiprocessing.pool import ThreadPool
 
-import botocore
-from boto3.s3.transfer import TransferConfig
+logger = logging.getLogger("luigi-interface")
+
+try:
+    from boto3.s3.transfer import TransferConfig
+    import botocore
+except ImportError:
+    logger.warning("Loading S3 module without the python package boto3. "
+                   "Will crash at runtime if S3 functionality is used.")
 
 try:
     from urlparse import urlsplit

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
     install_requires.append('sqlalchemy')
     # readthedocs don't like python-daemon, see #1342
-    install_requires.remove('python-daemon<3.0')
+    install_requires.remove('python-daemon<2.2.0')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 if sys.version_info < (3, 4):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # the License.
 
 import os
-import sys
 
 from setuptools import setup
 
@@ -41,6 +40,7 @@ install_requires = [
     'tornado>=4.0,<5',
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
+    'enum34>1.1.0;python_version<"3.4"',
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':
@@ -49,9 +49,6 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # readthedocs don't like python-daemon, see #1342
     install_requires.remove('python-daemon<2.2.0')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
-
-if sys.version_info < (3, 4):
-    install_requires.append('enum34>1.1.0')
 
 setup(
     name='luigi',


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix RTD builds that have been broken since 7b06c902a2 and should also fix #2464  

## Motivation and Context
RTD builds fail [since 7b06c902a2](https://readthedocs.org/projects/luigi/builds/7854208/) since RTD tries to remove `python-daemon<3.0` from install_requries but it has been changed to `python-daemon<2.2.0`

Prior to that, AWS modules in contrib were not generating documentation due to ImportErrors on botocore & boto3 as documented in #2464 
This guards the imports so they don't raise the exception in line with the other modules in `contrib` that have 3rd party dependencies.

Also cleans up the dependency on enum34 for older python versions; `install_requires` supports version checks automatically without checking `sys.version_info`.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.

I build the documentation via the process [described on RTD](https://docs.readthedocs.io/en/latest/builds.html) in a Py2 venv and generated complete documentation.