### PR TITLE
Make capture_output non-positional in ExternalProgramTask

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -59,7 +59,7 @@ class ExternalProgramTask(luigi.Task):
     behaviour can be overriden by passing ``--capture-output False``
     """
 
-    capture_output = luigi.BoolParameter(default=True, significant=False)
+    capture_output = luigi.BoolParameter(default=True, significant=False, positional=False)
 
     def program_args(self):
         """


### PR DESCRIPTION
## Description

Make the `capture_output` parameter of `ExternalProgamTask` non-positional, so that it doesn't catch parameters from sub-classes.

## Motivation and Context

Imagine the following task

```python
class MyTask(ExternalProgamTask):
    foo = luigi.Parameter()
    ...
```
When this task is instantiated via `MyTask("bar")` the supplied argument will be catched by `capture_output` and won't be assigned to `foo`. This behaviour is surprising. 

In my case it led to a failing pipeline: we were using `PySparkTask`, which is derived from `ExternalProgramTask`. After the introduction of the `capture_output` parameter in the recent release (2.7.9), `capture_output` catched a positional parameter of a deriving task and the pipeline failed with `MissingParameterException`.

PS: We had the luigi version pinned in our `requirements.txt` in the following way: `luigi==2.7.*`, with the intention to get only bugfixes through new patch versions. The introduction of `capture_output` seems more like a new feature to me and hence I would have expected the minor version to be incremented. Does luigi follow semantic versioning?

