### PR TITLE
Small fix to logging in contrib/ecs.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Big Data <https://bigdata.com.br/>`_
 * `Movio <https://movio.co.nz/>`_
 * `Bonnier News <https://www.bonniernews.se/>`_
+* `Starsky Robotics <https://www.starsky.io/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 

--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -182,6 +182,11 @@ class ECSTask(luigi.Task):
         response = client.run_task(taskDefinition=self.task_def_arn,
                                    overrides=overrides,
                                    cluster=self.cluster)
+
+        if response['failures']:
+            raise Exception(", ".join(["fail to run task {0} reason: {1}".format(failure['arn'], failure['reason'])
+                                       for failure in response['failures']]))
+
         self._task_ids = [task['taskArn'] for task in response['tasks']]
 
         # Wait on task completion


### PR DESCRIPTION
Added check for failures in contrib/ecs.py ECSTask.run() response from run_task boto3 api call. This was causing unhelpful error messages.

Also added Starsky Robotics as "Companies Using Luigi but haven't written about it". Hoping to write about it soon.

## Description
Adds a check for "failures" in the response dict from ECS client.run_task call. This was missed initially in developing this module.

## Motivation and Context
Our tasks were failing with a bizarre "Task ids cannot be empty" error, tracing back through we saw other more readable failures that lead to this. (Our specific failure was an easily-fixed "out of cpu" error). 

Also, I've never contributed to open source and it's time to do so!

## Have you tested this? If so, how?
I ran this with success:
`tox -e py27-nonhdfs test/contrib/ecs_test.py`
