### PR TITLE
Add autodetect parameter to BigQueryLoadTask (#2363)

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -443,7 +443,6 @@ class MixinBigQueryBulkComplete(object):
 
 class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
     """Load data into BigQuery from GCS."""
-
     @property
     def source_format(self):
         """The source format to use (see :py:class:`SourceFormat`)."""
@@ -465,7 +464,7 @@ class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
     def schema(self):
         """Schema in the format defined at https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load.schema.
 
-        If the value is falsy, it is omitted and inferred by BigQuery, which only works for AVRO and CSV inputs."""
+        If the value is falsy, it is omitted and inferred by BigQuery."""
         return []
 
     @property
@@ -555,6 +554,8 @@ class BigQueryLoadTask(MixinBigQueryBulkComplete, luigi.Task):
 
         if self.schema:
             job['configuration']['load']['schema'] = {'fields': self.schema}
+        else:
+            job['configuration']['load']['autodetect'] = True
 
         bq_client.run_job(output.table.project_id, job, dataset=output.table.dataset)
 


### PR DESCRIPTION
## Description
When schema is not provided try to use `autodetect` parameter.
Removed comment that implicates that it doesn't work for JSON 
(docs linked below explicitly says it works for JSON)

## Motivation and Context
It solves: https://github.com/spotify/luigi/issues/2363

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.
It also matches description of `configuration.load.autodetect`
in docs https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load
