### PR TITLE
Fix inspect.getargspec() DeprecationWarning in PY3 (#2578)

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -22,7 +22,6 @@ See :doc:`/central_scheduler` for more info.
 """
 
 import collections
-import inspect
 import json
 
 from luigi.batch_notifier import BatchNotifier
@@ -97,7 +96,7 @@ def rpc_method(**request_args):
     def _rpc_method(fn):
         # If request args are passed, return this function again for use as
         # the decorator function with the request args attached.
-        fn_args = inspect.getargspec(fn)
+        fn_args = six.getargspec(fn)
 
         assert not fn_args.varargs
         assert fn_args.args[0] == 'self'

--- a/luigi/six.py
+++ b/luigi/six.py
@@ -866,3 +866,18 @@ if sys.meta_path:
     del i, importer
 # Finally, add the importer to the meta path import hook.
 sys.meta_path.append(_importer)
+
+# luigi specific additions
+if PY3:
+    import inspect
+
+    def getargspec(func):
+        args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, ann = inspect.getfullargspec(func)
+        if kwonlyargs or ann:
+            raise ValueError("Function has keyword-only parameters or annotations"
+                             ", use getfullargspec() API which can support them")
+        return inspect.ArgSpec(args, varargs, varkw, defaults)
+else:
+    import inspect
+
+    getargspec = inspect.getargspec

--- a/luigi/six.py
+++ b/luigi/six.py
@@ -868,6 +868,9 @@ if sys.meta_path:
 sys.meta_path.append(_importer)
 
 # luigi specific additions
+
+# When support for PY2 is dropped getargspec below can be dropped from six.py and
+# instead we should switch to using inspect.getfullargspec directly
 if PY3:
     import inspect
 


### PR DESCRIPTION
Adding a custom getargspec function to luigi.six (essentially the same as inspect.getargspec but without the warning being raised) and using that over inspect.getargspec if PY3
