### PR TITLE
Silence warning: String parameter must have string default value.

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -446,7 +446,7 @@ class worker(Config):
     force_multiprocessing = BoolParameter(default=False,
                                           description='If true, use multiprocessing also when '
                                           'running with 1 worker')
-    task_process_context = Parameter(default=None,
+    task_process_context = Parameter(default='',
                                      description='If set to a fully qualified class name, the class will '
                                      'be instantiated with a TaskProcess as its constructor parameter and '
                                      'applied as a context manager around its run() call, so this can be '


### PR DESCRIPTION
## Description

Silence a warning caused by luigi code.

## Have you tested this? If so, how?

No new test failures on my machine. The change itself did not seem worthy a test. The value is only read with "if self.context:" at https://github.com/spotify/luigi/blob/master/luigi/worker.py#L276
