### PR TITLE
Accept date_interval classes as arguments for relevant parameter types.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     from configparser import NoOptionError, NoSectionError
 
+from luigi import date_interval
 from luigi import task_register
 from luigi import six
 from luigi import configuration
@@ -423,6 +424,9 @@ class DateParameter(_DateParameterBase):
         if value is None:
             return None
 
+        if isinstance(value, date_interval.Date):
+            value = value.date_a
+
         if isinstance(value, datetime.datetime):
             value = value.date()
 
@@ -460,6 +464,9 @@ class MonthParameter(DateParameter):
         if value is None:
             return None
 
+        if isinstance(value, date_interval.Month):
+            value = value.date_a
+
         months_since_start = (value.year - self.start.year) * 12 + (value.month - self.start.month)
         months_since_start -= months_since_start % self.interval
 
@@ -482,6 +489,9 @@ class YearParameter(DateParameter):
     def normalize(self, value):
         if value is None:
             return None
+
+        if isinstance(value, date_interval.Year):
+            value = value.date_a
 
         delta = (value.year - self.start.year) % self.interval
         return datetime.date(year=value.year - delta, month=1, day=1)

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -424,9 +424,6 @@ class DateParameter(_DateParameterBase):
         if value is None:
             return None
 
-        if isinstance(value, date_interval.Date):
-            value = value.date_a
-
         if isinstance(value, datetime.datetime):
             value = value.date()
 
@@ -440,7 +437,7 @@ class MonthParameter(DateParameter):
     (day of :py:class:`~datetime.date` is "rounded" to first of the month).
 
     A MonthParameter is a Date string formatted ``YYYY-MM``. For example, ``2013-07`` specifies
-    July of 2013.
+    July of 2013. Task objects constructed from code also accept :py:class:`~luigi.date_interval.Month`.
     """
 
     date_format = '%Y-%m'
@@ -478,7 +475,8 @@ class YearParameter(DateParameter):
     Parameter whose value is a :py:class:`~datetime.date`, specified to the year
     (day and month of :py:class:`~datetime.date` is "rounded" to first day of the year).
 
-    A YearParameter is a Date string formatted ``YYYY``.
+    A YearParameter is a Date string formatted ``YYYY``. Task objects constructed from code also accept
+    :py:class:`~luigi.date_interval.Year`.
     """
 
     date_format = '%Y'

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -437,7 +437,8 @@ class MonthParameter(DateParameter):
     (day of :py:class:`~datetime.date` is "rounded" to first of the month).
 
     A MonthParameter is a Date string formatted ``YYYY-MM``. For example, ``2013-07`` specifies
-    July of 2013. Task objects constructed from code also accept :py:class:`~luigi.date_interval.Month`.
+    July of 2013. Task objects constructed from code accept :py:class:`~datetime.date` (ignoring the day value) or
+    :py:class:`~luigi.date_interval.Month`.
     """
 
     date_format = '%Y-%m'
@@ -475,8 +476,8 @@ class YearParameter(DateParameter):
     Parameter whose value is a :py:class:`~datetime.date`, specified to the year
     (day and month of :py:class:`~datetime.date` is "rounded" to first day of the year).
 
-    A YearParameter is a Date string formatted ``YYYY``. Task objects constructed from code also accept
-    :py:class:`~luigi.date_interval.Year`.
+    A YearParameter is a Date string formatted ``YYYY``. Task objects constructed from code accept
+    :py:class:`~datetime.date` (ignoring the month and day values) or :py:class:`~luigi.date_interval.Year`.
     """
 
     date_format = '%Y'

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -52,17 +52,6 @@ class DateParameterTest(unittest.TestCase):
         d = luigi.DateParameter().parse('2015-04-03')
         self.assertEqual(d, datetime.date(2015, 4, 3))
 
-    def test_construct_date_interval(self):
-        m = DateTask(luigi.date_interval.Date(2015, 4, 8))
-        self.assertEqual(m.day, datetime.date(2015, 4, 8))
-
-    def test_date_interval_default(self):
-        class DateDefaultTask(luigi.task.Task):
-            day = luigi.DateParameter(default=luigi.date_interval.Date(2015, 4, 8))
-
-        m = DateDefaultTask()
-        self.assertEqual(m.day, datetime.date(2015, 4, 8))
-
     def test_serialize(self):
         d = luigi.DateParameter().serialize(datetime.date(2015, 4, 3))
         self.assertEqual(d, '2015-04-03')

--- a/test/date_parameter_test.py
+++ b/test/date_parameter_test.py
@@ -52,6 +52,17 @@ class DateParameterTest(unittest.TestCase):
         d = luigi.DateParameter().parse('2015-04-03')
         self.assertEqual(d, datetime.date(2015, 4, 3))
 
+    def test_construct_date_interval(self):
+        m = DateTask(luigi.date_interval.Date(2015, 4, 8))
+        self.assertEqual(m.day, datetime.date(2015, 4, 8))
+
+    def test_date_interval_default(self):
+        class DateDefaultTask(luigi.task.Task):
+            day = luigi.DateParameter(default=luigi.date_interval.Date(2015, 4, 8))
+
+        m = DateDefaultTask()
+        self.assertEqual(m.day, datetime.date(2015, 4, 8))
+
     def test_serialize(self):
         d = luigi.DateParameter().serialize(datetime.date(2015, 4, 3))
         self.assertEqual(d, '2015-04-03')
@@ -144,6 +155,17 @@ class MonthParameterTest(unittest.TestCase):
         m = luigi.MonthParameter().parse('2015-04')
         self.assertEqual(m, datetime.date(2015, 4, 1))
 
+    def test_construct_month_interval(self):
+        m = MonthTask(luigi.date_interval.Month(2015, 4))
+        self.assertEqual(m.month, datetime.date(2015, 4, 1))
+
+    def test_month_interval_default(self):
+        class MonthDefaultTask(luigi.task.Task):
+            month = luigi.MonthParameter(default=luigi.date_interval.Month(2015, 4))
+
+        m = MonthDefaultTask()
+        self.assertEqual(m.month, datetime.date(2015, 4, 1))
+
     def test_serialize(self):
         m = luigi.MonthParameter().serialize(datetime.date(2015, 4, 3))
         self.assertEqual(m, '2015-04')
@@ -161,6 +183,17 @@ class YearParameterTest(unittest.TestCase):
     def test_parse(self):
         year = luigi.YearParameter().parse('2015')
         self.assertEqual(year, datetime.date(2015, 1, 1))
+
+    def test_construct_year_interval(self):
+        y = YearTask(luigi.date_interval.Year(2015))
+        self.assertEqual(y.year, datetime.date(2015, 1, 1))
+
+    def test_year_interval_default(self):
+        class YearDefaultTask(luigi.task.Task):
+            year = luigi.YearParameter(default=luigi.date_interval.Year(2015))
+
+        m = YearDefaultTask()
+        self.assertEqual(m.year, datetime.date(2015, 1, 1))
 
     def test_serialize(self):
         year = luigi.YearParameter().serialize(datetime.date(2015, 4, 3))


### PR DESCRIPTION
## Description

Allow date_interval.{Month,Year} to be used as arguments for {Month,Year}Parameter.

## Motivation and Context

The date_interval classes are useful for date arithmetic. Allowing them to be used to fill parameter values saves a confusing '.date_a' when using them for calculating values in requires().

## Have you tested this? If so, how?

Added unit tests. Ran tests locally. No additional test failures.