### PR TITLE
Fix Travis Moto Test Failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ usedevelop = True
 install_command = pip install {opts} {packages}
 deps=
   mock<2.0
-  moto<2.0
+  moto==1.3.6
   HTTPretty==0.8.10
   nose<2.0
   docker>=2.1.0


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
With the release of Moto 1.3.7, our Travis moto-based tests began failing. This patch downgrades Moto back to 1.3.6 to allow passing tests while more time is spent to identify true cause of failures.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows Travis tests to start passing again

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Travis

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
