### PR TITLE
Changed to buffered reads when using GCSTarget

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -32,6 +32,7 @@ from luigi.contrib import gcp
 import luigi.target
 from luigi import six
 from luigi.six.moves import xrange
+from luigi.format import FileWrapper
 
 logger = logging.getLogger('luigi-interface')
 
@@ -473,7 +474,8 @@ class GCSTarget(luigi.target.FileSystemTarget):
 
     def open(self, mode='r'):
         if mode == 'r':
-            return self.format.pipe_reader(self.fs.download(self.path))
+            return self.format.pipe_reader(
+                FileWrapper(io.BufferedReader(self.fs.download(self.path))))
         elif mode == 'w':
             return self.format.pipe_writer(AtomicGCSFile(self.path, self.fs))
         else:


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Buffers the file read operation after downloading a GCS file to the local file system.

## Motivation and Context
Reading unbuffered files can be veery slow.
This change is consistent with how the reading is implement in luigi.contrib.ftp.RemoteTarget.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
