### PR TITLE
contrib: Add ExternalDailySnapshot

### DIFF
--- a/luigi/contrib/external_daily_snapshot.py
+++ b/luigi/contrib/external_daily_snapshot.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import datetime
+import logging
+
+import luigi
+from luigi import six
+
+if six.PY3:
+    xrange = range
+
+logger = logging.getLogger('luigi-interface')
+
+
+class ExternalDailySnapshot(luigi.ExternalTask):
+    """
+    Abstract class containing a helper method to fetch the latest snapshot.
+
+    Example::
+
+      class MyTask(luigi.Task):
+        def requires(self):
+          return PlaylistContent.latest()
+
+    All tasks subclassing :class:`ExternalDailySnapshot` must have a :class:`luigi.DateParameter`
+    named ``date``.
+
+    You can also provide additional parameters to the class and also configure
+    lookback size.
+
+    Example::
+
+      ServiceLogs.latest(service="radio", lookback=21)
+
+    """
+    date = luigi.DateParameter()
+    __cache = []
+
+    @classmethod
+    def latest(cls, *args, **kwargs):
+        """This is cached so that requires() is deterministic."""
+        date = kwargs.pop("date", datetime.date.today())
+        lookback = kwargs.pop("lookback", 14)
+        # hashing kwargs deterministically would be hard. Let's just lookup by equality
+        key = (cls, args, kwargs, lookback, date)
+        for k, v in ExternalDailySnapshot.__cache:
+            if k == key:
+                return v
+        val = cls.__latest(date, lookback, args, kwargs)
+        ExternalDailySnapshot.__cache.append((key, val))
+        return val
+
+    @classmethod
+    def __latest(cls, date, lookback, args, kwargs):
+        assert lookback > 0
+        t = None
+        for i in xrange(lookback):
+            d = date - datetime.timedelta(i)
+            t = cls(date=d, *args, **kwargs)
+            if t.complete():
+                return t
+        logger.debug("Could not find last dump for %s (looked back %d days)",
+                     cls.__name__, lookback)
+        return t

--- a/test/contrib/external_daily_snapshot_test.py
+++ b/test/contrib/external_daily_snapshot_test.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2013 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import unittest
+import luigi
+from luigi.contrib.external_daily_snapshot import ExternalDailySnapshot
+from luigi.mock import MockTarget
+import datetime
+
+
+class DataDump(ExternalDailySnapshot):
+    param = luigi.Parameter()
+    a = luigi.Parameter(default='zebra')
+    aa = luigi.Parameter(default='Congo')
+
+    def output(self):
+        return MockTarget('data-%s-%s-%s-%s' % (self.param, self.a, self.aa, self.date))
+
+
+class ExternalDailySnapshotTest(unittest.TestCase):
+    def test_latest(self):
+        MockTarget('data-xyz-zebra-Congo-2012-01-01').open('w').close()
+        d = DataDump.latest(date=datetime.date(2012, 1, 10), param='xyz')
+        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+
+    def test_latest_not_exists(self):
+        MockTarget('data-abc-zebra-Congo-2012-01-01').open('w').close()
+        d = DataDump.latest(date=datetime.date(2012, 1, 11), param='abc', lookback=5)
+        self.assertEquals(d.date, datetime.date(2012, 1, 7))
+
+    def test_deterministic(self):
+        MockTarget('data-pqr-zebra-Congo-2012-01-01').open('w').close()
+        d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', a='zebra', aa='Congo')
+        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+
+        MockTarget('data-pqr-zebra-Congo-2012-01-05').open('w').close()
+        d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', aa='Congo', a='zebra')
+        self.assertEquals(d.date, datetime.date(2012, 1, 1))  # Should still be the same


### PR DESCRIPTION
It is common to depend on the latest version of an ExternalTask, but not be concerned with
when that external task was generated.

I think this concern is generic enough to warrant having it upstream.

In addition to unit tests, this has been in wide use at Spotify for several years.

