### PR TITLE
Fix logging via toml

### DIFF
--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -40,7 +40,7 @@ class BaseLogging(object):
         """Get logging settings from config file section "logging"."""
         try:
             logging_config = cls.config['logging']
-        except (TypeError, KeyError, NoSectionError):
+        except (TypeError, KeyError, NoSectionError, AttributeError):
             return False
         logging.config.dictConfig(logging_config)
         return True

--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -22,7 +22,7 @@ workers via command line arguments and options from config files.
 import logging
 import logging.config
 import os.path
-from luigi.configuration import get_config
+from luigi.configuration import get_config, LuigiConfigParser
 
 # In python3 ConfigParser was renamed
 # https://stackoverflow.com/a/41202010
@@ -38,9 +38,11 @@ class BaseLogging(object):
     @classmethod
     def _section(cls, opts):
         """Get logging settings from config file section "logging"."""
+        if isinstance(cls.config, LuigiConfigParser):
+            return False
         try:
             logging_config = cls.config['logging']
-        except (TypeError, KeyError, NoSectionError, AttributeError):
+        except (TypeError, KeyError, NoSectionError):
             return False
         logging.config.dictConfig(logging_config)
         return True

--- a/test/setup_logging_test.py
+++ b/test/setup_logging_test.py
@@ -1,5 +1,5 @@
 from luigi.setup_logging import DaemonLogging, InterfaceLogging
-from luigi.configuration import LuigiTomlParser, get_config
+from luigi.configuration import LuigiTomlParser, LuigiConfigParser, get_config
 from helpers import unittest
 
 
@@ -39,6 +39,11 @@ class TestDaemonLogging(unittest.TestCase):
         self.assertTrue(result)
 
         self.cls.config = {}
+        result = self.cls._section(None)
+        self.assertFalse(result)
+
+    def test_section_cfg(self):
+        self.cls.config = LuigiConfigParser.instance()
         result = self.cls._section(None)
         self.assertFalse(result)
 


### PR DESCRIPTION
## Description

Wrap AttributeError when try to configure logging via config section. Cfg file doesn't support inheritance enough for logging configuring, so we can skip logging configuring via config section when cfg-based config used.

## Motivation and Context

Fix #2592

## Have you tested this? If so, how?

Test included. Failed before fix, success after

<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
