### PR TITLE
Make it so we can do from luigi.contrib.hdfs import HdfsFlagTarget

### DIFF
--- a/luigi/contrib/hdfs/__init__.py
+++ b/luigi/contrib/hdfs/__init__.py
@@ -75,3 +75,4 @@ CompatibleHdfsFormat = hdfs_format.CompatibleHdfsFormat
 
 # target.py
 HdfsTarget = hdfs_target.HdfsTarget
+HdfsFlagTarget = hdfs_target.HdfsFlagTarget


### PR DESCRIPTION

## Description

https://github.com/spotify/luigi/pull/2559 added support for HdfsFlagTarget but the authors neglected to add a reference to this class in `luigi/luigi/contrib/hdfs/__init__.py`

## Motivation and Context

Make it so i can do `from luigi.contrib.hdfs import HdfsFlagTarget`

## Have you tested this? If so, how?

Works on my pc (tm)
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
