### PR TITLE
Docs: Fixed "Github" to fit to the rest of the doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,8 +184,8 @@ External links
 
 * `Mailing List <https://groups.google.com/d/forum/luigi-user/>`_ for discussions and asking questions. (Google Groups)
 * `Releases <https://pypi.python.org/pypi/luigi>`_ (PyPI)
-* `Source code <https://github.com/spotify/luigi>`_ (Github)
-* `Hubot Integration <https://github.com/houzz/hubot-luigi>`_ plugin for Slack, Hipchat, etc (Github)
+* `Source code <https://github.com/spotify/luigi>`_ (GitHub)
+* `Hubot Integration <https://github.com/houzz/hubot-luigi>`_ plugin for Slack, Hipchat, etc (GitHub)
 
 Authors
 -------


### PR DESCRIPTION
Hey, I fixed a typo.

## Description
I changed the word `Github ` -> `GitHub `to fit to the rest of the documentation.

## Motivation and Context
Styling, and consistency.

## Have you tested this? If so, how?
There aren't any code changes, so there shouldn't be any problems with tests, but no I did not test it.
