### PR TITLE
Fix the table name when reflect is True in sqla.CopyToTable (#2604)

### DIFF
--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -351,7 +351,7 @@ class CopyToTable(luigi.Task):
                         metadata.create_all(engine)
                     else:
                         full_table = '.'.join([self.schema, self.table]) if self.schema else self.table
-                        metadata.reflect(only=[full_table], bind=engine)
+                        metadata.reflect(only=[self.table], bind=engine)
                         self.table_bound = metadata.tables[full_table]
                 except Exception as e:
                     self._logger.exception(self.table + str(e))


### PR DESCRIPTION
When the schema is specified, MetaData is already parametrized with the right
name. No need to call "meta.reflect" with the name of the schema in this case.
