### PR TITLE
Fixed installation error using pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
     'python-dateutil==2.7.5',
-    'enum34>1.1.0;python_version<"3.4"',
+    'enum34>1.1.0;python_version<"3.4"'
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':


### PR DESCRIPTION
## Description
Fixed installation error using pip

## Motivation and Context
Complete output from command python setup.py egg_info:
error in luigi setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected ',' or end-of-list in enum34>1.1.0;python_version<"3.4" at ;python_version<"3.4"
