### PR TITLE
give a few default values to opts when setting up logging

### DIFF
--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -22,6 +22,7 @@ workers via command line arguments and options from config files.
 import logging
 import logging.config
 import os.path
+
 from luigi.configuration import get_config, LuigiConfigParser
 
 # In python3 ConfigParser was renamed
@@ -48,7 +49,13 @@ class BaseLogging(object):
         return True
 
     @classmethod
-    def setup(cls, opts):
+    def setup(cls,
+              opts=type('opts', (), {
+                  'background': None,
+                  'logdir': None,
+                  'logging_conf_file': None,
+                  'log_level': 'DEBUG'
+              })):
         """Setup logging via CLI params and config."""
         logger = logging.getLogger('luigi')
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Give default values to `opts` used for setting up logging.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make usage of `setup` a bit simpler.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
