### PR TITLE
Update postgres.py

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -392,5 +392,6 @@ class PostgresQuery(rdbms.Query):
             user=self.user,
             password=self.password,
             table=self.table,
-            update_id=self.update_id
+            update_id=self.update_id,
+            port=self.port
         )

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -48,6 +48,7 @@ class DummyPostgresImporter(luigi.contrib.postgres.CopyToTable):
     date = luigi.DateParameter()
 
     host = 'dummy_host'
+    port = 1234
     database = 'dummy_database'
     user = 'dummy_user'
     password = 'dummy_password'
@@ -87,6 +88,7 @@ class DummyPostgresQuery(luigi.contrib.postgres.PostgresQuery):
     date = luigi.DateParameter()
 
     host = 'dummy_host'
+    port = 1234
     database = 'dummy_database'
     user = 'dummy_user'
     password = 'dummy_password'


### PR DESCRIPTION
added port to `PostgresTarget`

## Description
<!--- Describe your changes --> 
added port to the postgres.Query

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
was required to use `postgres.Query` to connect to a postgres db that did not use the default port
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
 "I ran my jobs with this code and it works for me." 

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
