### PR TITLE
Fix call to message from TypeError not working with Python 3.6 (#2616)

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -162,8 +162,8 @@ class S3Client(FileSystem):
                                       aws_session_token=aws_session_token,
                                       **options)
         except TypeError as e:
-            logger.error(e.message)
-            if 'got an unexpected keyword argument' in e.message:
+            logger.error(e.args[0])
+            if 'got an unexpected keyword argument' in e.args[0]:
                 raise DeprecatedBotoClientException(
                     "Now using boto3. Check that you're passing the correct arguments")
             raise

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -175,6 +175,11 @@ class TestS3Client(unittest.TestCase):
         sts_mock.client.assume_role.called_with(
             RoleArn='role', RoleSessionName='name')
 
+    @patch('boto3.client')
+    def test_init_with_host_deprecated(self, mock):
+        with self.assertRaises(DeprecatedBotoClientException):
+            S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY, host='us-east-1').s3
+
     def test_put(self):
         create_bucket()
         s3_client = S3Client(AWS_ACCESS_KEY, AWS_SECRET_KEY)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
The issue is that the file luigi/contrib/s3.py uses a call to TypeError member e.message which is only available in Python 2 as opposed to e.args which is available in both Python 2 and Python 3.

Here is the code snippet in luigi/contrib/s3.py from Luigi release 2.8.0 causing the issue (in fact, it seems it's the same code for all releases >= 2.7.6):
```python
        # At this stage, if no credentials provided, boto3 would handle their resolution for us
        # For finding out about the order in which it tries to find these credentials
        # please see here details
        # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials

        if not (aws_access_key_id and aws_secret_access_key):
            logger.debug('no credentials provided, delegating credentials resolution to boto3')

        try:
            self._s3 = boto3.resource('s3',
                                      aws_access_key_id=aws_access_key_id,
                                      aws_secret_access_key=aws_secret_access_key,
                                      aws_session_token=aws_session_token,
                                      **options)
        except TypeError as e:
            logger.error(e.message)
            if 'got an unexpected keyword argument' in e.message:
                raise DeprecatedBotoClientException(
                    "Now using boto3. Check that you're passing the correct arguments")
            raise
```

To fix this issue, I propose to use `e.args[0]` instead of `e.message` like so:

```python
except TypeError as e:
    logger.error(e.args[0])
    if 'got an unexpected keyword argument' in e.args[0]:
        raise DeprecatedBotoClientException(
            "Now using boto3. Check that you're passing the correct arguments")
    raise
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change resolves the issue, described in the Description. A link to the original issue: 
[https://github.com/spotify/luigi/issues/2616](https://github.com/spotify/luigi/issues/2616)

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs with this code and it works for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
