### PR TITLE
Fix parsing for TupleParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1114,8 +1114,8 @@ class TupleParameter(ListParameter):
         try:
             # loop required to parse tuple of tuples
             return tuple(tuple(x) for x in json.loads(x, object_pairs_hook=_FrozenOrderedDict))
-        except ValueError:
-            return literal_eval(x)  # if this causes an error, let that error be raised.
+        except (ValueError, TypeError):
+            return tuple(literal_eval(x))  # if this causes an error, let that error be raised.
 
 
 class NumericalParameter(Parameter):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -1105,6 +1105,7 @@ class TestSerializeTupleParameter(LuigiTestCase):
 
         self.assertEqual(luigi.TupleParameter().parse(luigi.TupleParameter().serialize(the_tuple)), the_tuple)
 
+
 class NewStyleParameters822Test(LuigiTestCase):
     """
     I bet these tests created at 2015-03-08 are reduntant by now (Oct 2015).

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -1099,6 +1099,12 @@ class TestTaskParameter(LuigiTestCase):
         self.assertTrue(self.run_locally(['MainTask']))
 
 
+class TestSerializeTupleParameter(LuigiTestCase):
+    def testSerialize(self):
+        the_tuple = (1, 2, 3)
+
+        self.assertEqual(luigi.TupleParameter().parse(luigi.TupleParameter().serialize(the_tuple)), the_tuple)
+
 class NewStyleParameters822Test(LuigiTestCase):
     """
     I bet these tests created at 2015-03-08 are reduntant by now (Oct 2015).


### PR DESCRIPTION
## Description

This fixes a bug in the parsing of `TupleParameters`, which led to uncaught errors in dynamic dependencies. 

## Motivation and Context
Fixes #2609 

## Have you tested this? If so, how?
I implemented this fix in a monkey patch within my project, and have also included a test for the desired fix.
