### PR TITLE
Fix durations in D3 graph (fixes #2620)

### DIFF
--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -719,20 +719,19 @@ function visualiserApp(luigi) {
                         if (taskIdMap[task.inputQueue[i]] !== undefined) {
                             if (task.status === "DONE") {
                                 var durations = getDurations(tasks, task.inputQueue);
-                                var duration = durations[task.inputQueue[i]]
-                                var oneDayInMilliseconds = 24 * 60 * 60 * 1000
+                                var duration = durations[task.inputQueue[i]];
+                                var oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+                                var durationLabel;
                                 if (duration.getTime() < oneDayInMilliseconds) {
-                                    // Label task duration in stripped ISO format (hh:mm:ss:f)
-                                    g.setEdge(task.inputQueue[i], task.taskId, {
-                                        label: duration.toISOString().substr(11, 12),
-                                        width: 40
-                                    });
+                                    // Label task duration in stripped ISO format (hh:mm:ss.f)
+                                    durationLabel = duration.toISOString().substr(11, 12);
                                 } else {
-                                    g.setEdge(task.inputQueue[i], task.taskId, {
-                                        label: "> 24h",
-                                        width: 40
-                                    });
+                                    durationLabel = "> 24h";
                                 }
+                                g.setEdge(task.inputQueue[i], task.taskId, {
+                                    label: durationLabel,
+                                    width: 40
+                                });
                             } else {
                                 g.setEdge(task.inputQueue[i], task.taskId, {
                                     width: 40


### PR DESCRIPTION
Fixes the duration calculation. Both date objects `startTime` and
`finishTime` are in milliseconds, so the additional multiplication with
1000 was wrong.

Also, the duration is now calculated with:
```
duration = last_updated - time_running
```
as it is done also in https://github.com/spotify/luigi/blob/eadf7ab8a487740e38e6fe9f63b3cba6e31e6caf/luigi/contrib/datadog_metric.py#L83

The display format was also problematic, because it only displayed the
seconds of the `Date` object, i.e. always less than 60 seconds. Now it
uses the `hh:mm:ss:f` format.

I decided to not display the time if the duration is longer than a day,
because then it gets messy with the Date objects (would require a
conversion to day of year, not day of month).

