### PR TITLE
Add port field for PostgresQuery (fixes #2625)

### DIFF
--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -363,9 +363,6 @@ class PostgresQuery(rdbms.Query):
 
     To customize the query signature as recorded in the database marker table, override the `update_id` property.
     """
-
-    port = None
-
     def run(self):
         connection = self.output().connect()
         connection.autocommit = self.autocommit

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -364,6 +364,8 @@ class PostgresQuery(rdbms.Query):
     To customize the query signature as recorded in the database marker table, override the `update_id` property.
     """
 
+    port = None
+
     def run(self):
         connection = self.output().connect()
         connection.autocommit = self.autocommit

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -288,6 +288,13 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
     def host(self):
         return None
 
+    @property
+    def port(self):
+        """
+        Override to use port separately from host. Used in PostgresQuery.
+        """
+        return None
+
     @abc.abstractproperty
     def database(self):
         return None

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -343,4 +343,3 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
         Override with an RDBMS Target (e.g. PostgresTarget or RedshiftTarget) to record execution in a marker table
         """
         raise NotImplementedError("This method must be overridden")
-

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -277,7 +277,9 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
 
         Optionally override:
 
+        * `port`,
         * `autocommit`
+        * `update_id`
 
         Subclass and override the following methods:
 
@@ -291,7 +293,7 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
     @property
     def port(self):
         """
-        Override to use port separately from host. Used in PostgresQuery.
+        Override to specify port separately from host.
         """
         return None
 

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -283,11 +283,16 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
 
         Subclass and override the following methods:
 
+        * `run`
         * `output`
     """
 
     @abc.abstractproperty
     def host(self):
+        """
+        Host of the RDBMS. Implementation should support `hostname:port`
+        to encode port.
+        """
         return None
 
     @property
@@ -321,6 +326,13 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
     def autocommit(self):
         return False
 
+    @property
+    def update_id(self):
+        """
+        Override to create a custom marker table 'update_id' signature for Query subclass task instances
+        """
+        return self.task_id
+
     @abc.abstractmethod
     def run(self):
         raise NotImplementedError("This method must be overridden")
@@ -332,9 +344,3 @@ class Query(luigi.task.MixinNaiveBulkComplete, luigi.Task):
         """
         raise NotImplementedError("This method must be overridden")
 
-    @property
-    def update_id(self):
-        """
-        Override to create a custom marker table 'update_id' signature for Query subclass task instances
-        """
-        return self.task_id

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -48,7 +48,6 @@ class DummyPostgresImporter(luigi.contrib.postgres.CopyToTable):
     date = luigi.DateParameter()
 
     host = 'dummy_host'
-    port = 1234
     database = 'dummy_database'
     user = 'dummy_user'
     password = 'dummy_password'
@@ -88,7 +87,6 @@ class DummyPostgresQuery(luigi.contrib.postgres.PostgresQuery):
     date = luigi.DateParameter()
 
     host = 'dummy_host'
-    port = 1234
     database = 'dummy_database'
     user = 'dummy_user'
     password = 'dummy_password'

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -134,7 +134,6 @@ class PostgresQueryTest(unittest.TestCase):
         output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
         self.assertEquals(output.port, 1234)
 
-
     def test_port_encoded_in_host(self):
         output = DummyPostgresQueryWithPortEncodedInHost(date=datetime.datetime(1991, 3, 24)).output()
         self.assertEquals(output.port, 1234)

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -136,7 +136,7 @@ class PostgresQueryTest(unittest.TestCase):
 
     def test_port_encoded_in_host(self):
         output = DummyPostgresQueryWithPortEncodedInHost(date=datetime.datetime(1991, 3, 24)).output()
-        self.assertEquals(output.port, 1234)
+        self.assertEquals(output.port, '1234')
 
 
 @attr('postgres')

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -98,6 +98,18 @@ class DummyPostgresQuery(luigi.contrib.postgres.PostgresQuery):
     query = 'SELECT * FROM foo'
 
 
+class DummyPostgresQueryWithPort(luigi.contrib.postgres.PostgresQuery):
+    date = luigi.DateParameter()
+
+    host = 'dummy_host'
+    port = 1234
+    database = 'dummy_database'
+    user = 'dummy_user'
+    password = 'dummy_password'
+    table = 'dummy_table'
+    query = 'SELECT * FROM foo'
+
+
 @attr('postgres')
 class PostgresQueryTest(unittest.TestCase):
     maxDiff = None
@@ -121,6 +133,14 @@ class PostgresQueryTest(unittest.TestCase):
             'DummyPostgresQuery_2015_01_06_f91a47ec40',
         ])
         self.assertFalse(task.complete())
+
+
+@attr('postgres')
+class PostgresQueryWithPortTest(unittest.TestCase):
+
+    def test_query_with_port(self):
+        output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
+        self.assertEquals(output.port, 1234)
 
 
 @attr('postgres')

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -98,16 +98,8 @@ class DummyPostgresQuery(luigi.contrib.postgres.PostgresQuery):
     query = 'SELECT * FROM foo'
 
 
-class DummyPostgresQueryWithPort(luigi.contrib.postgres.PostgresQuery):
-    date = luigi.DateParameter()
-
-    host = 'dummy_host'
+class DummyPostgresQueryWithPort(DummyPostgresQuery):
     port = 1234
-    database = 'dummy_database'
-    user = 'dummy_user'
-    password = 'dummy_password'
-    table = 'dummy_table'
-    query = 'SELECT * FROM foo'
 
 
 @attr('postgres')
@@ -134,11 +126,7 @@ class PostgresQueryTest(unittest.TestCase):
         ])
         self.assertFalse(task.complete())
 
-
-@attr('postgres')
-class PostgresQueryWithPortTest(unittest.TestCase):
-
-    def test_query_with_port(self):
+    def test_override_port(self):
         output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
         self.assertEquals(output.port, 1234)
 

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -102,6 +102,10 @@ class DummyPostgresQueryWithPort(DummyPostgresQuery):
     port = 1234
 
 
+class DummyPostgresQueryWithPortEncodedInHost(DummyPostgresQuery):
+    host = 'dummy_host:1234'
+
+
 @attr('postgres')
 class PostgresQueryTest(unittest.TestCase):
     maxDiff = None
@@ -128,6 +132,11 @@ class PostgresQueryTest(unittest.TestCase):
 
     def test_override_port(self):
         output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
+        self.assertEquals(output.port, 1234)
+
+
+    def test_port_encoded_in_host(self):
+        output = DummyPostgresQueryWithPortEncodedInHost(date=datetime.datetime(1991, 3, 24)).output()
         self.assertEquals(output.port, 1234)
 
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->
<!--- Provide a general summary of your changes in the Title above -->
Addresses https://github.com/spotify/luigi/issues/2625.

## Description
<!--- Describe your changes -->
Init an empty port field for PostgresQuery. This will maintain default behaviour of the PostgresQuery and PostgresTarget classes, and users can keep using it by providing the port only as part of the host string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses https://github.com/spotify/luigi/issues/2625 so as to have a non-breaking version update when using postgres.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Updated existing unit tests and added one more test.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->