### PR TITLE
Add support for specifying kubernetes namespace

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -59,7 +59,7 @@ class kubernetes(luigi.Config):
     max_retrials = luigi.IntParameter(
         default=0,
         description="Max retrials in event of job failure")
-    kubernetes_namespace = luigi.Parameter(
+    kubernetes_namespace = luigi.OptionalParameter(
         default=None,
         description="K8s namespace in which the job will run")
 

--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -59,6 +59,9 @@ class kubernetes(luigi.Config):
     max_retrials = luigi.IntParameter(
         default=0,
         description="Max retrials in event of job failure")
+    kubernetes_namespace = luigi.Parameter(
+        default=None,
+        description="K8s namespace in which the job will run")
 
 
 class KubernetesJobTask(luigi.Task):
@@ -106,6 +109,17 @@ class KubernetesJobTask(luigi.Task):
         http://kubernetes.io/docs/user-guide/kubeconfig-file
         """
         return self.kubernetes_config.kubeconfig_path
+
+    @property
+    def kubernetes_namespace(self):
+        """
+        Namespace in Kubernetes where the job will run.
+        It defaults to the default namespace in Kubernetes
+
+        For more details, please refer to:
+        https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+        """
+        return self.kubernetes_config.kubernetes_namespace
 
     @property
     def name(self):
@@ -225,13 +239,13 @@ class KubernetesJobTask(luigi.Task):
         pass
 
     def __get_pods(self):
-        pod_objs = Pod.objects(self.__kube_api) \
+        pod_objs = Pod.objects(self.__kube_api, namespace=self.kubernetes_namespace) \
             .filter(selector="job-name=" + self.uu_name) \
             .response['items']
         return [Pod(self.__kube_api, p) for p in pod_objs]
 
     def __get_job(self):
-        jobs = Job.objects(self.__kube_api) \
+        jobs = Job.objects(self.__kube_api, namespace=self.kubernetes_namespace) \
             .filter(selector="luigi_task_id=" + self.job_uuid) \
             .response['items']
         assert len(jobs) == 1, "Kubernetes job " + self.uu_name + " not found"
@@ -338,6 +352,8 @@ class KubernetesJobTask(luigi.Task):
                 }
             }
         }
+        if self.kubernetes_namespace is not None:
+            job_json['metadata']['namespace'] = self.kubernetes_namespace
         if self.active_deadline_seconds is not None:
             job_json['spec']['activeDeadlineSeconds'] = \
                 self.active_deadline_seconds


### PR DESCRIPTION

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for specifying kubernetes namespace

## Motivation and Context
This change will allow users to submit jobs to a specific namespace in a k8s cluster rather than having them all run in the default namespace.


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
I ran my jobs with this code and it works for me.  The current unit tests for this module don't cover any different parameters so I don't think additional tests are needed for this change.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
