### PR TITLE
Added support for a detailed LuigiRunResult instead of a plain Boolean

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -713,7 +713,7 @@ If you customize return codes, prefer to set them in range 128 to 255 to avoid
 conflicts. Return codes in range 0 to 127 are reserved for possible future use
 by Luigi contributors.
 
-If you run *luigi.build()/luigi.run()* programmatically, you can enable a detailed response by sending ``detailed_summary=True`` to these functions. This detailed response has an attribute(``response.status``) which is a status code that contains information about the progress. The list of possible status codes can be found `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiStatusCode>`_.
+If you run *luigi.build()/luigi.run()* programmatically, you can enable a detailed response of type :class:`~luigi.execution_summary.LuigiRunResult` by sending ``detailed_summary=True`` to these functions. This detailed response has an attribute(``status``) which is a status code that contains information about the progress. The list of possible status codes can be found in :class:`~luigi.execution_summary.LuigiStatusCode`.
 
 [scalding]
 ----------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -713,6 +713,8 @@ If you customize return codes, prefer to set them in range 128 to 255 to avoid
 conflicts. Return codes in range 0 to 127 are reserved for possible future use
 by Luigi contributors.
 
+If you run *luigi.build()/luigi.run()* programmatically, you can enable a detailed response by sending ``detailed_summary=True`` to these functions. This detailed response has an attribute(``response.status``) which is a status code that contains information about the progress. The list of possible status codes can be found `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiStatusCode>`_.
+
 [scalding]
 ----------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -713,8 +713,6 @@ If you customize return codes, prefer to set them in range 128 to 255 to avoid
 conflicts. Return codes in range 0 to 127 are reserved for possible future use
 by Luigi contributors.
 
-If you run *luigi.build()/luigi.run()* programmatically, you can enable a detailed response of type :class:`~luigi.execution_summary.LuigiRunResult` by sending ``detailed_summary=True`` to these functions. This detailed response has an attribute(``status``) which is a status code that contains information about the progress. The list of possible status codes can be found in :class:`~luigi.execution_summary.LuigiStatusCode`.
-
 [scalding]
 ----------
 

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -113,31 +113,15 @@ In some cases (like task queue) it may be useful.
 Response of luigi.build()/luigi.run()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **Default response** The default response of *luigi.build()* / *luigi.run()* is a Boolean. It is:
+- **Default response** The default response of *luigi.build()* / *luigi.run()* is a Boolean. This response is also the same as the attribute ``LuigiRunResult.scheduling_succeeded``. It is:
 
   * ``True`` : when there were no failed tasks or missing dependencies.
   * ``False`` : when there were failed tasks or scheduling / dependency / permission issues. (NOTE: The response is also *False* even when there were failed tasks, but all of them succeeded in a retry)
 
-- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This response contains detailed information about the jobs like:
-
-  * ``summary`` - One line summary of the progress
-  * ``summary_detailed`` - Detailed summary of the progress
-  * ``task_groups`` - Tasks grouped by their status (*completed, failed, not_run etc.* )
-  * ``worker`` - Worker object
-  * ``status`` - Boolean which is *True* if finally, there were no failed tasks.
-  * ``status_legacy`` - Boolean which is the same as the **Default response** mentioned above.
+- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run* This response contains detailed information about the jobs. Please look at the available attributes in a detailed response `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiRunResult>`_
 
   .. code-block:: python
 
     if __name__ == '__main__':
-         response = luigi.build([MyTask1(x=1)], workers=5, local_scheduler=True)
-         print(response.summary_detailed)
-
-  This type of detailed response can be enabled by setting the config:
-
-  .. code:: ini
-
-      [execution_summary]
-      legacy_run_result=False
-
-  Please check `Configuration Docs <https://github.com/spotify/luigi/blob/master/doc/configuration.rst>`_ for details about adding configuration files.
+         response = luigi.build(..., detailed_summary=True)
+         print(response.summary_text)

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -118,10 +118,10 @@ Response of luigi.build()/luigi.run()
   * ``True`` : when there were no failed tasks or missing dependencies.
   * ``False`` : when there were failed tasks or scheduling / dependency / permission issues. (NOTE: The response is also *False* even when there were failed tasks, but all of them succeeded in a retry)
 
-- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run* This response contains detailed information about the jobs. The available attributes in this kind of response can be found `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiRunResult>`_.
+- **Detailed response** This is a response of type :class:`~luigi.execution_summary.LuigiRunResult`. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run*. This response contains detailed information about the jobs.
 
   .. code-block:: python
 
     if __name__ == '__main__':
-         response = luigi.build(..., detailed_summary=True)
-         print(response.summary_text)
+         luigi_run_result = luigi.build(..., detailed_summary=True)
+         print(luigi_run_result.summary_text)

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -113,10 +113,7 @@ In some cases (like task queue) it may be useful.
 Response of luigi.build()/luigi.run()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **Default response** The default response of *luigi.build()* / *luigi.run()* is a Boolean. This response is also the same as the attribute ``LuigiRunResult.scheduling_succeeded``. It is:
-
-  * ``True`` : when there were no failed tasks or missing dependencies.
-  * ``False`` : when there were failed tasks or scheduling / dependency / permission issues. (NOTE: The response is also *False* even when there were failed tasks, but all of them succeeded in a retry)
+- **Default response** By default *luigi.build()/luigi.run()* returns True if there were no scheduling errors. This is the same as the attribute ``LuigiRunResult.scheduling_succeeded``.
 
 - **Detailed response** This is a response of type :class:`~luigi.execution_summary.LuigiRunResult`. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run*. This response contains detailed information about the jobs.
 

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -118,7 +118,7 @@ Response of luigi.build()/luigi.run()
   * ``True`` : when there were no failed tasks or missing dependencies.
   * ``False`` : when there were failed tasks or scheduling / dependency / permission issues. (NOTE: The response is also *False* even when there were failed tasks, but all of them succeeded in a retry)
 
-- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run* This response contains detailed information about the jobs. Please look at the available attributes in a detailed response `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiRunResult>`_
+- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This is obtained by passing a keyword argument ``detailed_summary=True`` to *build/run* This response contains detailed information about the jobs. The available attributes in this kind of response can be found `here <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiRunResult>`_.
 
   .. code-block:: python
 

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -109,3 +109,35 @@ which will return your worker and/or scheduler implementations:
         luigi.build([MyTask1(x=1)], worker_scheduler_factory=MyFactory())
 
 In some cases (like task queue) it may be useful.
+
+Response of luigi.build()/luigi.run()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Default response** The default response of *luigi.build()* / *luigi.run()* is a Boolean. It is:
+
+  * ``True`` : when there were no failed tasks or missing dependencies.
+  * ``False`` : when there were failed tasks or scheduling / dependency / permission issues. (NOTE: The response is also *False* even when there were failed tasks, but all of them succeeded in a retry)
+
+- **Detailed response** This is a response of type ``luigi.execution_summary.LuigiRunResult``. This response contains detailed information about the jobs like:
+
+  * ``summary`` - One line summary of the progress
+  * ``summary_detailed`` - Detailed summary of the progress
+  * ``task_groups`` - Tasks grouped by their status (*completed, failed, not_run etc.* )
+  * ``worker`` - Worker object
+  * ``status`` - Boolean which is *True* if finally, there were no failed tasks.
+  * ``status_legacy`` - Boolean which is the same as the **Default response** mentioned above.
+
+  .. code-block:: python
+
+    if __name__ == '__main__':
+         response = luigi.build([MyTask1(x=1)], workers=5, local_scheduler=True)
+         print(response.summary_detailed)
+
+  This type of detailed response can be enabled by setting the config:
+
+  .. code:: ini
+
+      [execution_summary]
+      legacy_run_result=False
+
+  Please check `Configuration Docs <https://github.com/spotify/luigi/blob/master/doc/configuration.rst>`_ for details about adding configuration files.

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -43,6 +43,7 @@ from luigi import configuration
 
 from luigi import interface
 from luigi.interface import run, build
+from luigi.execution_summary import LuigiStatusCode
 
 from luigi import event
 from luigi.event import Event
@@ -59,5 +60,5 @@ __all__ = [
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
-    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter'
+    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'LuigiStatusCode'
 ]

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -81,10 +81,6 @@ class LuigiRunResult(object):
         self.one_line_summary = _create_one_line_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
 
-    # This function makes this class subscriptable like a dictionary for backwards compatibility.
-    def __getitem__(self, key):
-        return getattr(self, key, None)
-
     def __str__(self):
         return "LuigiRunResult with status {0}".format(self.status)
 

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -60,7 +60,7 @@ class LuigiStatusCode(enum.Enum):
     MISSING_EXT = (":|", "there were missing external dependencies")
 
 
-class LuigiRunResult:
+class LuigiRunResult(object):
     """
     Result of the execution (build/run) will be of type LuigiRunResult instead of
     the regular Boolean response if the keyword argument ``detailed_summary=True`` is passed to
@@ -78,7 +78,7 @@ class LuigiRunResult:
     def __init__(self, worker, worker_add_run_status=True):
         self.worker = worker
         summary_dict = _summary_dict(worker)
-        self.summary_text = summary(worker, summary_dict)
+        self.summary_text = _summary_wrap(_summary_format(summary_dict, worker))
         self.status = _tasks_status(summary_dict)
         self.summary_text_one_line = _progress_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
@@ -89,7 +89,7 @@ class LuigiRunResult:
         return getattr(self, key, None)
 
     def __str__(self):
-        return "STATUS: {0}".format(self.status, self.summary_text_one_line)
+        return "STATUS: {0}".format(self.status)
 
     def __repr__(self):
         return self.__str__()
@@ -486,12 +486,10 @@ def _summary_wrap(str_output):
     """).format(str_output=str_output)
 
 
-def summary(worker, summary_dict=None):
+def summary(worker):
     """
     Given a worker, return a human readable summary of what the worker have
     done.
     """
-    if summary_dict is None:
-        summary_dict = _summary_dict(worker)
-    return _summary_wrap(_summary_format(summary_dict, worker))
+    return _summary_wrap(_summary_format(_summary_dict(worker), worker))
 # 5

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -34,8 +34,21 @@ class execution_summary(luigi.Config):
 
 class LuigiRetCodes:
     """
-    All possible retcodes for luigi.run(..., detailed_summary=True) or
-    luigi.build(..., detailed_summary=True).
+    All possible return codes for **LuigiRunResult.status** when the argument ``detailed_summary=True`` in
+    *luigi.run() / luigi.build*. Here are the codes and what they mean:
+
+    =============================  =====  ========================================================== 
+    Return Code Name               Value  Meaning 
+    =============================  =====  ========================================================== 
+    SUCCESS                        0      There were no failed tasks or missing dependencies 
+    SUCCESS_WITH_RETRY             1      There were failed tasks but they all succeeded in a retry 
+    FAILED                         2      There were failed tasks
+    FAILED_AND_SCHEDULING_FAILED   3      There were failed tasks and tasks whose scheduling failed
+    SCHEDULING_FAILED              4      There were tasks whose scheduling failed
+    NOT_RUN                        5      There were tasks that were not granted run permission by the scheduler
+    MISSING_EXT                    6      There were missing external dependencies
+    =============================  =====  ==========================================================
+    
     """
     SUCCESS = 0
     SUCCESS_WITH_RETRY = 1
@@ -60,8 +73,19 @@ class LuigiRetCodes:
 class LuigiRunResult:
     """
     Result of the execution (build/run) will be of type LuigiRunResult instead of
-    the regular Boolean response if the keyword argument `detailed_summary=True` in
-    build/run.
+    the regular Boolean response if the keyword argument ``detailed_summary=True`` is passed to
+    build/run. A response of type **LuigiRunResult** has the following attributes:
+
+    Attributes:
+        * **summary_text_one_line** - One line summary of the progress.
+        * **summary_text** - Detailed summary of the progress.
+        * **status** - Integer Return Code. See \
+        `LuigiRetCodes <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiRetCodes>`_ \
+        for what these codes mean.
+        * **worker** - Worker object.
+        * **execution_succeeded** - Boolean which is *True* if finally, there were no failed tasks.
+        * **scheduling_succeeded** - Boolean which is *True* if all the tasks were scheduled without errors.
+
     """
     def __init__(self, worker, worker_add_run_status=True):
         self.worker = worker
@@ -72,7 +96,16 @@ class LuigiRunResult:
                                             self.status is LuigiRetCodes.SUCCESS_WITH_RETRY
                                     else False)
 
-    def response(self, detailed_summary = False):
+    def _response(self, detailed_summary = False):
+        """ This function returns an object of type **LuigiRunResult** or a **Boolean**
+        based on the value passed for the parameter.
+
+        Args:
+            *detailed_summary*: Enables/disables a response of type **LuigiRunResult**.
+
+        Returns:
+            A response of type **LuigiRunResult** if *detailed_summary* is True, Boolean otherwise.
+        """
         if detailed_summary is True:
             return self
         else:

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -85,7 +85,7 @@ class LuigiRunResult(object):
         return "LuigiRunResult with status {0}".format(self.status)
 
     def __repr__(self):
-        return "LuigiRunResult(status=%r,worker=%r,scheduling_succeeded=%r)" % (self.status, self.worker, self.scheduling_succeeded)
+        return "LuigiRunResult(status={0!r},worker={1!r},scheduling_succeeded={2!r})".format(self.status, self.worker, self.scheduling_succeeded)
 
 
 def _partition_tasks(worker):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -70,7 +70,6 @@ class LuigiRunResult(object):
         - summary_text (str): Detailed summary of the progress.
         - status (LuigiStatusCode): Luigi Status Code. See :class:`~luigi.execution_summary.LuigiStatusCode` for what these codes mean.
         - worker (luigi.worker.worker): Worker object. See :class:`~luigi.worker.worker`.
-        - execution_succeeded (bool): Boolean which is *True* if finally, there were no failed tasks.
         - scheduling_succeeded (bool): Boolean which is *True* if all the tasks were scheduled without errors.
 
     """
@@ -82,15 +81,15 @@ class LuigiRunResult(object):
         self.summary_text_one_line = _progress_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
 
-    # This function makes this class subscriptable (self.worker is used at a few places)
+    # This function makes this class subscriptable like a dictionary for backwards compatibility.
     def __getitem__(self, key):
         return getattr(self, key, None)
 
     def __str__(self):
-        return "STATUS: {0}".format(self.status)
+        return "LuigiRunResult with status {0}".format(self.status)
 
     def __repr__(self):
-        return self.__str__()
+        return "LuigiRunResult(status=%r,worker=%r,scheduling_succeeded=%r)" % (self.status, self.worker, self.scheduling_succeeded)
 
 
 def _partition_tasks(worker):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -66,7 +66,7 @@ class LuigiRunResult(object):
     The result of a call to build/run when passing the detailed_summary=True argument.
 
     Attributes:
-        - summary_text_one_line (str): One line summary of the progress.
+        - one_line_summary (str): One line summary of the progress.
         - summary_text (str): Detailed summary of the progress.
         - status (LuigiStatusCode): Luigi Status Code. See :class:`~luigi.execution_summary.LuigiStatusCode` for what these codes mean.
         - worker (luigi.worker.worker): Worker object. See :class:`~luigi.worker.worker`.
@@ -78,7 +78,7 @@ class LuigiRunResult(object):
         summary_dict = _summary_dict(worker)
         self.summary_text = _summary_wrap(_summary_format(summary_dict, worker))
         self.status = _tasks_status(summary_dict)
-        self.summary_text_one_line = _progress_summary(self.status)
+        self.one_line_summary = _create_one_line_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
 
     # This function makes this class subscriptable like a dictionary for backwards compatibility.
@@ -437,19 +437,18 @@ def _summary_format(set_tasks, worker):
         if len(ext_workers) == 0:
             str_output += '\n'
         str_output += 'Did not run any tasks'
-    summary_text_one_line = _progress_summary(_tasks_status(set_tasks))
-    str_output += "\n{0}".format(summary_text_one_line)
+    one_line_summary = _create_one_line_summary(_tasks_status(set_tasks))
+    str_output += "\n{0}".format(one_line_summary)
     if num_all_tasks == 0:
         str_output = 'Did not schedule any tasks'
     return str_output
 
 
-def _progress_summary(status_code):
+def _create_one_line_summary(status_code):
     """
     Given a status_code of type LuigiStatusCode which has a tuple value, returns a one line summary
     """
-    summary_text_one_line = "This progress looks {0} because {1}".format(*status_code.value)
-    return summary_text_one_line
+    return "This progress looks {0} because {1}".format(*status_code.value)
 
 
 def _tasks_status(set_tasks):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -28,6 +28,7 @@ import enum
 
 import luigi
 
+
 class execution_summary(luigi.Config):
     summary_length = luigi.IntParameter(default=5)
 

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -45,7 +45,7 @@ class LuigiRunResult:
         self.summary_detailed = summary(worker)
         self.summary, smiley, _ = self._progress_summary()
         self.status = True if smiley == ":)" else False
-        self.status_legacy = self._legacy_status() & worker_add_run_status
+        self.status_legacy = worker_add_run_status
         self.response = self._response()
 
     def _response(self):
@@ -57,14 +57,6 @@ class LuigiRunResult:
     def _progress_summary(self):
         smiley, reason = _tasks_status(self.task_groups)
         return "The progress looks {0} because {1}".format(smiley, reason), smiley, reason
-
-    def _legacy_status(self):
-        legacyStatus = self.status
-        if (legacyStatus is True and
-                self.task_groups["ever_failed"] and not
-                self.task_groups["failed"]):
-            legacyStatus = False
-        return legacyStatus
 
     def __str__(self):
         return self.summary

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -35,17 +35,17 @@ class execution_summary(luigi.Config):
 
 class LuigiRunResult:
     """
-    Result of the execution (build/run) will be of type LuigiRunResult instead of 
-    the regular Boolean response if [execution_summary]legacy_run_result is set 
+    Result of the execution (build/run) will be of type LuigiRunResult instead of
+    the regular Boolean response if [execution_summary]legacy_run_result is set
     to False in the config.
     """
-    def __init__(self, worker):
+    def __init__(self, worker, worker_add_run_status=True):
         self.worker = worker
         self.task_groups = _summary_dict(worker)
         self.summary_detailed = summary(worker)
         self.summary, smiley, _ = self._progress_summary()
         self.status = True if smiley == ":)" else False
-        self.status_legacy = self._legacy_status()
+        self.status_legacy = self._legacy_status() & worker_add_run_status
         self.response = self._response()
 
     def _response(self):
@@ -60,9 +60,10 @@ class LuigiRunResult:
 
     def _legacy_status(self):
         legacyStatus = self.status
-        if legacyStatus is True and (
-            self.task_groups["ever_failed"] and not self.task_groups["failed"]):
-           legacyStatus = False
+        if (legacyStatus is True and
+                self.task_groups["ever_failed"] and not
+                self.task_groups["failed"]):
+            legacyStatus = False
         return legacyStatus
 
     def __str__(self):
@@ -70,7 +71,6 @@ class LuigiRunResult:
 
     def __repr__(self):
         return self.__str__()
-
 
 
 def _partition_tasks(worker):
@@ -424,6 +424,7 @@ def _summary_format(set_tasks, worker):
         str_output = 'Did not schedule any tasks'
     return str_output
 
+
 def _tasks_status(set_tasks):
     """
     Given a grouped set of tasks, returns a smiley and a readable reason for the expression
@@ -452,6 +453,7 @@ def _tasks_status(set_tasks):
         smiley = ":)"
         reason = "there were no failed tasks or missing dependencies"
     return smiley, reason
+
 
 def _summary_wrap(str_output):
     return textwrap.dedent("""

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -35,8 +35,9 @@ class execution_summary(luigi.Config):
 
 class LuigiStatusCode(enum.Enum):
     """
-    All possible status codes for the attribute ``status`` in :class:`~luigi.execution_summary.LuigiRunResult` when the argument ``detailed_summary=True`` in
-    *luigi.run() / luigi.build*. Here are the codes and what they mean:
+    All possible status codes for the attribute ``status`` in :class:`~luigi.execution_summary.LuigiRunResult` when
+    the argument ``detailed_summary=True`` in *luigi.run() / luigi.build*.
+    Here are the codes and what they mean:
 
     =============================  ==========================================================
     Status Code Name               Meaning
@@ -62,9 +63,7 @@ class LuigiStatusCode(enum.Enum):
 
 class LuigiRunResult(object):
     """
-    Result of the execution (build/run) will be of type LuigiRunResult instead of
-    the regular Boolean response if the keyword argument ``detailed_summary=True`` is passed to
-    build/run. A response of type **LuigiRunResult** has the following attributes:
+    The result of a call to build/run when passing the detailed_summary=True argument.
 
     Attributes:
         - summary_text_one_line (str): One line summary of the progress.
@@ -82,7 +81,6 @@ class LuigiRunResult(object):
         self.status = _tasks_status(summary_dict)
         self.summary_text_one_line = _progress_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
-        self.execution_succeeded = self.status in (LuigiStatusCode.SUCCESS, LuigiStatusCode.SUCCESS_WITH_RETRY)
 
     # This function makes this class subscriptable (self.worker is used at a few places)
     def __getitem__(self, key):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -35,7 +35,7 @@ class execution_summary(luigi.Config):
 
 class LuigiStatusCode(enum.Enum):
     """
-    All possible status codes for **LuigiRunResult.status** when the argument ``detailed_summary=True`` in
+    All possible status codes for the attribute ``status`` in :class:`~luigi.execution_summary.LuigiRunResult` when the argument ``detailed_summary=True`` in
     *luigi.run() / luigi.build*. Here are the codes and what they mean:
 
     =============================  ==========================================================
@@ -69,18 +69,17 @@ class LuigiRunResult:
     Attributes:
         - summary_text_one_line (str): One line summary of the progress.
         - summary_text (str): Detailed summary of the progress.
-        - status (LuigiStatusCode): Luigi Status Code. See \
-        `LuigiStatusCode <https://luigi.readthedocs.io/en/latest/api/luigi.execution_summary.html#luigi.execution_summary.LuigiStatusCode>`_ \
-        for what these codes mean.
-        - worker (luigi.worker.worker): Worker object.
+        - status (LuigiStatusCode): Luigi Status Code. See :class:`~luigi.execution_summary.LuigiStatusCode` for what these codes mean.
+        - worker (luigi.worker.worker): Worker object. See :class:`~luigi.worker.worker`.
         - execution_succeeded (bool): Boolean which is *True* if finally, there were no failed tasks.
         - scheduling_succeeded (bool): Boolean which is *True* if all the tasks were scheduled without errors.
 
     """
     def __init__(self, worker, worker_add_run_status=True):
         self.worker = worker
-        self.summary_text = summary(worker)
-        self.status = _tasks_status(_summary_dict(worker))
+        summary_dict = _summary_dict(worker)
+        self.summary_text = summary(worker, summary_dict)
+        self.status = _tasks_status(summary_dict)
         self.summary_text_one_line = _progress_summary(self.status)
         self.scheduling_succeeded = worker_add_run_status
         self.execution_succeeded = self.status in (LuigiStatusCode.SUCCESS, LuigiStatusCode.SUCCESS_WITH_RETRY)
@@ -487,10 +486,12 @@ def _summary_wrap(str_output):
     """).format(str_output=str_output)
 
 
-def summary(worker):
+def summary(worker, summary_dict=None):
     """
     Given a worker, return a human readable summary of what the worker have
     done.
     """
-    return _summary_wrap(_summary_format(_summary_dict(worker), worker))
+    if summary_dict is None:
+        summary_dict = _summary_dict(worker)
+    return _summary_wrap(_summary_format(summary_dict, worker))
 # 5

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -170,7 +170,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
             success &= worker.add(t, env_params.parallel_scheduling, env_params.parallel_scheduling_processes)
         logger.info('Done scheduling tasks')
         success &= worker.run()
-    run_result = LuigiRunResult(worker)
+    run_result = LuigiRunResult(worker, success)
     logger.info(run_result.summary_detailed)
     return run_result.response
 

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -137,7 +137,8 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
     :param worker_scheduler_factory:
     :param override_defaults:
     :return: True if all tasks and their dependencies were successfully run (or already completed);
-             False if any error occurred.
+             False if any error occurred. It will return a detailed response of type LuigiRunResult
+             instead of a boolean if detailed_summary=True in override_defaults.
     """
 
     if worker_scheduler_factory is None:
@@ -177,7 +178,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
         success &= worker.run()
     run_result = LuigiRunResult(worker, success)
     logger.info(run_result.summary_text)
-    return run_result.response(env_params.detailed_summary)
+    return run_result._response(env_params.detailed_summary)
 
 
 class PidLockAlreadyTakenExit(SystemExit):

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -196,7 +196,7 @@ def run(*args, **kwargs):
 
 
 def _run(cmdline_args=None, main_task_cls=None,
-         worker_scheduler_factory=None, use_dynamic_argparse=None, local_scheduler=False):
+         worker_scheduler_factory=None, use_dynamic_argparse=None, local_scheduler=False, detailed_summary=False):
     if use_dynamic_argparse is not None:
         warnings.warn("use_dynamic_argparse is deprecated, don't set it.",
                       DeprecationWarning, stacklevel=2)

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -142,8 +142,7 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
 
     if worker_scheduler_factory is None:
         worker_scheduler_factory = _WorkerSchedulerFactory()
-    if override_defaults is None:
-        override_defaults = {}
+    override_defaults = {} if override_defaults is None else override_defaults
     env_params = core(**override_defaults)
 
     InterfaceLogging.setup(env_params)

--- a/luigi/retcodes.py
+++ b/luigi/retcodes.py
@@ -72,7 +72,7 @@ def run_with_retcodes(argv):
 
     worker = None
     try:
-        worker = luigi.interface._run(argv)['worker']
+        worker = luigi.interface._run(argv).worker
     except luigi.interface.PidLockAlreadyTakenExit:
         sys.exit(retcodes.already_running)
     except Exception:

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -47,7 +47,7 @@ class InterfaceTest(LuigiTestCase):
         self.task_a = NoOpTask("a")
         self.task_b = NoOpTask("b")
 
-    def _create_summary_dict_with(self, updates = {}):
+    def _create_summary_dict_with(self, updates={}):
         summary_dict = {
             'completed': set(),
             'already_done': set(),

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -23,7 +23,7 @@ import luigi.notifications
 from luigi.interface import _WorkerSchedulerFactory
 from luigi.worker import Worker
 from luigi.interface import core
-from luigi.execution_summary import LuigiRetCodes
+from luigi.execution_summary import LuigiStatusCode
 
 from mock import Mock, patch, MagicMock
 from helpers import LuigiTestCase, with_config
@@ -101,7 +101,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=True)
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.SUCCESS)
+        self.assertEqual(ret.status, LuigiStatusCode.SUCCESS)
         self.assertEqual(ret.scheduling_succeeded, True)
         self.assertEqual(ret.execution_succeeded, True)
 
@@ -114,7 +114,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=False)
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.SUCCESS_WITH_RETRY)
+        self.assertEqual(ret.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
         self.assertEqual(ret.scheduling_succeeded, False)
         self.assertEqual(ret.execution_succeeded, True)
 
@@ -128,7 +128,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=False)
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.FAILED)
+        self.assertEqual(ret.status, LuigiStatusCode.FAILED)
         self.assertEqual(ret.scheduling_succeeded, False)
         self.assertEqual(ret.execution_succeeded, False)
 
@@ -144,7 +144,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=False)
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.FAILED_AND_SCHEDULING_FAILED)
+        self.assertEqual(ret.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
         self.assertEqual(ret.scheduling_succeeded, False)
         self.assertEqual(ret.execution_succeeded, False)
 
@@ -158,7 +158,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=True)
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.SCHEDULING_FAILED)
+        self.assertEqual(ret.status, LuigiStatusCode.SCHEDULING_FAILED)
         self.assertEqual(ret.scheduling_succeeded, False)
         self.assertEqual(ret.execution_succeeded, False)
 
@@ -170,7 +170,7 @@ class InterfaceTest(LuigiTestCase):
         fake_summary_dict.return_value = test_dict
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.NOT_RUN)
+        self.assertEqual(ret.status, LuigiStatusCode.NOT_RUN)
         self.assertEqual(ret.execution_succeeded, False)
 
     @patch(_summary_dict_module_path())
@@ -181,9 +181,8 @@ class InterfaceTest(LuigiTestCase):
         fake_summary_dict.return_value = test_dict
         ret = self._run_interface(detailed_summary=True)
 
-        self.assertEqual(ret.status, LuigiRetCodes.MISSING_EXT)
+        self.assertEqual(ret.status, LuigiStatusCode.MISSING_EXT)
         self.assertEqual(ret.execution_succeeded, False)
-    
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()
@@ -201,7 +200,6 @@ class InterfaceTest(LuigiTestCase):
 
         self.assertRaises(AttributeError, self._run_interface)
         self.assertTrue(worker.__exit__.called)
-
 
     def test_just_run_main_task_cls(self):
         class MyTestTask(luigi.Task):

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -23,6 +23,7 @@ import luigi.notifications
 from luigi.interface import _WorkerSchedulerFactory
 from luigi.worker import Worker
 from luigi.interface import core
+from luigi.execution_summary import LuigiRetCodes
 
 from mock import Mock, patch, MagicMock
 from helpers import LuigiTestCase, with_config
@@ -46,23 +47,143 @@ class InterfaceTest(LuigiTestCase):
         self.task_a = NoOpTask("a")
         self.task_b = NoOpTask("b")
 
+    def _empty_summary_dict(self):
+        return {
+            'completed': set(),
+            'already_done': set(),
+            'ever_failed': set(),
+            'failed': set(),
+            'scheduling_error': set(),
+            'still_pending_ext': set(),
+            'still_pending_not_ext': set(),
+            'run_by_other_worker': set(),
+            'upstream_failure': set(),
+            'upstream_missing_dependency': set(),
+            'upstream_run_by_other_worker': set(),
+            'upstream_scheduling_error': set(),
+            'not_run': set()}
+
+    def _summary_dict_module_path():
+        return 'luigi.execution_summary._summary_dict'
+
     def test_interface_run_positive_path(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=True)
-
         self.assertTrue(self._run_interface())
+
+        self.worker.add = Mock(side_effect=[True, True])
+        self.worker.run = Mock(return_value=True)
+        self.assertTrue(self._run_interface(detailed_summary=True).scheduling_succeeded)
 
     def test_interface_run_with_add_failure(self):
         self.worker.add = Mock(side_effect=[True, False])
         self.worker.run = Mock(return_value=True)
-
         self.assertFalse(self._run_interface())
+
+        self.worker.add = Mock(side_effect=[True, False])
+        self.worker.run = Mock(return_value=True)
+        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
 
     def test_interface_run_with_run_failure(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=False)
-
         self.assertFalse(self._run_interface())
+
+        self.worker.add = Mock(side_effect=[True, True])
+        self.worker.run = Mock(return_value=False)
+        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_0(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        # Nothing in failed tasks so, should succeed
+        fake_summary_dict.return_value = test_dict
+        self.worker.run = Mock(return_value=True)
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.SUCCESS)
+        self.assertEqual(ret.scheduling_succeeded, True)
+        self.assertEqual(ret.execution_succeeded, True)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_1(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['ever_failed'].update([self.task_a])
+        # Nothing in failed tasks (only an entry in ever_failed) so, should succeed with retry
+        fake_summary_dict.return_value = test_dict
+        self.worker.run = Mock(return_value=False)
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.SUCCESS_WITH_RETRY)
+        self.assertEqual(ret.scheduling_succeeded, False)
+        self.assertEqual(ret.execution_succeeded, True)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_2(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['ever_failed'].update([self.task_a])
+        test_dict['failed'].update([self.task_a])
+        # Should fail because a task failed
+        fake_summary_dict.return_value = test_dict
+        self.worker.run = Mock(return_value=False)
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.FAILED)
+        self.assertEqual(ret.scheduling_succeeded, False)
+        self.assertEqual(ret.execution_succeeded, False)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_3(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['ever_failed'].update([self.task_a])
+        test_dict['failed'].update([self.task_a])
+        test_dict['scheduling_error'].update([self.task_b])
+        # Failed task and also a scheduling error
+        fake_summary_dict.return_value = test_dict
+        self.worker.add = Mock(side_effect=[True, False])
+        self.worker.run = Mock(return_value=False)
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.FAILED_AND_SCHEDULING_FAILED)
+        self.assertEqual(ret.scheduling_succeeded, False)
+        self.assertEqual(ret.execution_succeeded, False)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_4(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['scheduling_error'].update([self.task_b])
+        # Scheduling error for at least one task
+        fake_summary_dict.return_value = test_dict
+        self.worker.add = Mock(side_effect=[True, False])
+        self.worker.run = Mock(return_value=True)
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.SCHEDULING_FAILED)
+        self.assertEqual(ret.scheduling_succeeded, False)
+        self.assertEqual(ret.execution_succeeded, False)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_5(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['not_run'].update([self.task_a])
+        # At least one of the tasks was not run
+        fake_summary_dict.return_value = test_dict
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.NOT_RUN)
+        self.assertEqual(ret.execution_succeeded, False)
+
+    @patch(_summary_dict_module_path())
+    def test_ret_code_6(self, fake_summary_dict):
+        test_dict = self._empty_summary_dict()
+        test_dict['still_pending_ext'].update([self.task_a])
+        # Missing external dependency for at least one task
+        fake_summary_dict.return_value = test_dict
+        ret = self._run_interface(detailed_summary=True)
+
+        self.assertEqual(ret.status, LuigiRetCodes.MISSING_EXT)
+        self.assertEqual(ret.execution_succeeded, False)
+    
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()
@@ -81,6 +202,7 @@ class InterfaceTest(LuigiTestCase):
         self.assertRaises(AttributeError, self._run_interface)
         self.assertTrue(worker.__exit__.called)
 
+
     def test_just_run_main_task_cls(self):
         class MyTestTask(luigi.Task):
             pass
@@ -94,8 +216,11 @@ class InterfaceTest(LuigiTestCase):
         with patch.object(sys, 'argv', ['my_module.py', '--no-lock', '--my-param', 'my_value', '--local-scheduler']):
             luigi.run(main_task_cls=MyOtherTestTask)
 
-    def _run_interface(self):
-        return luigi.interface.build([self.task_a, self.task_b], worker_scheduler_factory=self.worker_scheduler_factory)
+    def _run_interface(self, **env_params):
+        return luigi.interface.build(
+                                    [self.task_a, self.task_b],
+                                    worker_scheduler_factory=self.worker_scheduler_factory,
+                                    **env_params)
 
 
 class CoreConfigTest(LuigiTestCase):

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -31,6 +31,13 @@ from helpers import LuigiTestCase, with_config
 luigi.notifications.DEBUG = True
 
 
+# Using this updatable dict to make inline dict updates for beautiful tests
+class UpdatableDict(dict):
+    def update(self, *args):
+        dict.update(self, *args)
+        return self
+
+
 class InterfaceTest(LuigiTestCase):
 
     def setUp(self):
@@ -47,8 +54,8 @@ class InterfaceTest(LuigiTestCase):
         self.task_a = NoOpTask("a")
         self.task_b = NoOpTask("b")
 
-    def _empty_summary_dict(self):
-        return {
+    def _create_empty_summary_dict(self):
+        return UpdatableDict({
             'completed': set(),
             'already_done': set(),
             'ever_failed': set(),
@@ -61,7 +68,7 @@ class InterfaceTest(LuigiTestCase):
             'upstream_missing_dependency': set(),
             'upstream_run_by_other_worker': set(),
             'upstream_scheduling_error': set(),
-            'not_run': set()}
+            'not_run': set()})
 
     def _summary_dict_module_path():
         return 'luigi.execution_summary._summary_dict'
@@ -71,6 +78,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=True)
         self.assertTrue(self._run_interface())
 
+    def test_interface_run_positive_path_with_detailed_summary_enabled(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=True)
         self.assertTrue(self._run_interface(detailed_summary=True).scheduling_succeeded)
@@ -80,6 +88,7 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=True)
         self.assertFalse(self._run_interface())
 
+    def test_interface_run_with_add_failure_with_detailed_summary_enabled(self):
         self.worker.add = Mock(side_effect=[True, False])
         self.worker.run = Mock(return_value=True)
         self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
@@ -89,100 +98,74 @@ class InterfaceTest(LuigiTestCase):
         self.worker.run = Mock(return_value=False)
         self.assertFalse(self._run_interface())
 
+    def test_interface_run_with_run_failure_with_detailed_summary_enabled(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=False)
         self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_0(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
+    def test_that_status_is_success(self, fake_summary_dict):
         # Nothing in failed tasks so, should succeed
-        fake_summary_dict.return_value = test_dict
-        self.worker.run = Mock(return_value=True)
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.SUCCESS)
-        self.assertEqual(ret.scheduling_succeeded, True)
-        self.assertEqual(ret.execution_succeeded, True)
+        fake_summary_dict.return_value = self._create_empty_summary_dict()
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_1(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['ever_failed'].update([self.task_a])
+    def test_that_status_is_success_with_retry(self, fake_summary_dict):
         # Nothing in failed tasks (only an entry in ever_failed) so, should succeed with retry
-        fake_summary_dict.return_value = test_dict
-        self.worker.run = Mock(return_value=False)
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
-        self.assertEqual(ret.scheduling_succeeded, False)
-        self.assertEqual(ret.execution_succeeded, True)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'ever_failed': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_2(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['ever_failed'].update([self.task_a])
-        test_dict['failed'].update([self.task_a])
+    def test_that_status_is_failed_when_there_is_one_failed_task(self, fake_summary_dict):
         # Should fail because a task failed
-        fake_summary_dict.return_value = test_dict
-        self.worker.run = Mock(return_value=False)
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.FAILED)
-        self.assertEqual(ret.scheduling_succeeded, False)
-        self.assertEqual(ret.execution_succeeded, False)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'ever_failed': [self.task_a],
+            'failed': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_3(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['ever_failed'].update([self.task_a])
-        test_dict['failed'].update([self.task_a])
-        test_dict['scheduling_error'].update([self.task_b])
+    def test_that_status_is_failed_with_scheduling_failure(self, fake_summary_dict):
         # Failed task and also a scheduling error
-        fake_summary_dict.return_value = test_dict
-        self.worker.add = Mock(side_effect=[True, False])
-        self.worker.run = Mock(return_value=False)
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
-        self.assertEqual(ret.scheduling_succeeded, False)
-        self.assertEqual(ret.execution_succeeded, False)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'ever_failed': [self.task_a],
+            'failed': [self.task_a],
+            'scheduling_error': [self.task_b]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_4(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['scheduling_error'].update([self.task_b])
+    def test_that_status_is_scheduling_failed_with_one_scheduling_error(self, fake_summary_dict):
         # Scheduling error for at least one task
-        fake_summary_dict.return_value = test_dict
-        self.worker.add = Mock(side_effect=[True, False])
-        self.worker.run = Mock(return_value=True)
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.SCHEDULING_FAILED)
-        self.assertEqual(ret.scheduling_succeeded, False)
-        self.assertEqual(ret.execution_succeeded, False)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'scheduling_error': [self.task_b]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SCHEDULING_FAILED)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_5(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['not_run'].update([self.task_a])
+    def test_that_status_is_not_run_with_one_task_not_run(self, fake_summary_dict):
         # At least one of the tasks was not run
-        fake_summary_dict.return_value = test_dict
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.NOT_RUN)
-        self.assertEqual(ret.execution_succeeded, False)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'not_run': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.NOT_RUN)
 
     @patch(_summary_dict_module_path())
-    def test_ret_code_6(self, fake_summary_dict):
-        test_dict = self._empty_summary_dict()
-        test_dict['still_pending_ext'].update([self.task_a])
+    def test_that_status_is_missing_ext_with_one_task_with_missing_external_dependency(self, fake_summary_dict):
         # Missing external dependency for at least one task
-        fake_summary_dict.return_value = test_dict
-        ret = self._run_interface(detailed_summary=True)
-
-        self.assertEqual(ret.status, LuigiStatusCode.MISSING_EXT)
-        self.assertEqual(ret.execution_succeeded, False)
+        fake_summary_dict.return_value = self._create_empty_summary_dict().update({
+            'still_pending_ext': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.MISSING_EXT)
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()


### PR DESCRIPTION
## Description
This PR was inspired by the discussion in #2577 

## Motivation and Context
Currently `luigi.run()` and `luigi.build()` respond with a boolean which is not a good indicator of the progress of the workflow. (For example: If there are failed tasks that succeeded in a retry, it can be argued that the response boolean should be a `True` instead of the `False` in the existing implementation) 

## What all did I change ?
- Created a new config variable that would enable this new response: `legacy_run_result`
- Created a new class `LuigiRunResult` and placed it in `luigi/execution_summary.py` for now.
- Added relevant changes to the `build` and `run` functions in `luigi/interface.py`

---
Does my approach look alright ? If not, could you point me in the right direction ? 😸 
I would love to contribute!
PS: I am new to luigi and any form of suggestions/criticism are welcome 🕺


