### PR TITLE
[contrib.hdfs.target.HdfsFlagTarget] fixed argument forwarding to the…

### DIFF
--- a/luigi/contrib/hdfs/target.py
+++ b/luigi/contrib/hdfs/target.py
@@ -214,7 +214,7 @@ class HdfsFlagTarget(HdfsTarget):
         if path[-1] != "/":
             raise ValueError("HdfsFlagTarget requires the path to be to a "
                              "directory.  It must end with a slash ( / ).")
-        super(HdfsFlagTarget, self).__init__(path, format, client)
+        super(HdfsFlagTarget, self).__init__(path, format, fs=client)
         self.flag = flag
 
     def exists(self):


### PR DESCRIPTION
There is a mismatch between `HdfsTarget.__init__` signature and how it's called from the `HdfsFlagTarget.__init__`