### PR TITLE
Added TTL to keep_alive

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -308,6 +308,12 @@ wait_jitter
   workers do not ask the scheduler for another job at the same time.
   Default: 5.0
 
+max_keep_alive_idle_duration
+  .. versionadded:: 2.8.4
+
+  Maximum duration to keep worker alive while in idle state.
+  Default: 0 (Indefinitely)
+
 max_reschedules
   Maximum number of times to reschedule a failed task.
   Default: 1

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -29,6 +29,7 @@ ways between versions. The exception is the exception types and the
 """
 
 import collections
+import datetime
 import getpass
 import importlib
 import logging
@@ -61,7 +62,7 @@ from luigi.target import Target
 from luigi.task import Task, flatten, getpaths, Config
 from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
-from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter
+from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, TimeDeltaParameter
 
 try:
     import simplejson as json
@@ -411,6 +412,8 @@ class worker(Config):
                                    config_path=dict(section='core', name='worker-ping-interval'))
     keep_alive = BoolParameter(default=False,
                                config_path=dict(section='core', name='worker-keep-alive'))
+    keep_alive_ttl = TimeDeltaParameter(default=datetime.timedelta(0),
+                                        config_path=dict(section='core', name='worker-keep-alive-ttl'))
     count_uniques = BoolParameter(default=False,
                                   config_path=dict(section='core', name='worker-count-uniques'),
                                   description='worker-count-uniques means that we will keep a '
@@ -549,6 +552,7 @@ class Worker(object):
         # Keep info about what tasks are running (could be in other processes)
         self._task_result_queue = multiprocessing.Queue()
         self._running_tasks = {}
+        self._idle_since = None
 
         # Stuff for execution_summary
         self._add_task_history = []
@@ -1039,6 +1043,7 @@ class Worker(object):
            will be rescheduled and dependencies added,
         3. child process dies: we need to catch this separately.
         """
+        self._idle_since = None
         while True:
             self._purge_children()  # Deal with subprocess failures
 
@@ -1127,8 +1132,16 @@ class Worker(object):
             return get_work_response.n_pending_last_scheduled > 0
         elif self._config.count_uniques:
             return get_work_response.n_unique_pending > 0
+        elif get_work_response.n_pending_tasks <= 0:
+            return False
+        elif not self._config.keep_alive_ttl:
+            return True
+        elif not self._idle_since:
+            return True
         else:
-            return get_work_response.n_pending_tasks > 0
+            time_to_shutdown = self._idle_since + self._config.keep_alive_ttl - datetime.datetime.now()
+            logger.debug("%s until shutdown", time_to_shutdown)
+            return time_to_shutdown > datetime.timedelta(0)
 
     def handle_interrupt(self, signum, _):
         """
@@ -1170,6 +1183,7 @@ class Worker(object):
                 if not self._stop_requesting_work:
                     self._log_remote_tasks(get_work_response)
                 if len(self._running_tasks) == 0:
+                    self._idle_since = self._idle_since or datetime.datetime.now()
                     if self._keep_alive(get_work_response):
                         six.next(sleeper)
                         continue


### PR DESCRIPTION
## Description
This adds an additional parameter `keep_alive_ttl` which determines how long a worker is kept alive for new tasks to be available. 

## Motivation and Context
This will prevent a worker from waiting indefinitely when another worker is running the pending tasks and this one has nothing else to do.

## Have you tested this? If so, how?
We have been using these changes in our production for a while now. The code paths around the changes are a little too hairy to be sure we got all edge cases correctly.
