### PR TITLE
Prevented range-tasks from autoloading

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -127,6 +127,13 @@ section and the parameters available within it.
 These parameters control core Luigi behavior, such as error e-mails and
 interactions between the worker and scheduler.
 
+autoload-range
+  .. versionadded:: 2.8.4
+
+  If false, prevents range tasks from autoloading. They can still be loaded
+  using ``--module luigi.tools.range``. Defaults to true. Setting this to true
+  explicitly disables the deprecation warning.
+
 default-scheduler-host
   Hostname of the machine running the scheduler. Defaults to localhost.
 

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -75,5 +75,5 @@ if not configuration.get_config().has_option('core', 'autoload-range'):
     warnings.warn(warning_message, DeprecationWarning)
 
 if configuration.get_config().getboolean('core', 'autoload-range', True):
-    from .tools import range  # just makes the tool classes available from command line
+    from .tools import range  # noqa: F401    just makes the tool classes available from command line
     __all__.append('range')

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -48,14 +48,11 @@ from luigi.execution_summary import LuigiStatusCode
 from luigi import event
 from luigi.event import Event
 
-from .tools import range  # just makes the tool classes available from command line
-
-
 __all__ = [
     'task', 'Task', 'Config', 'ExternalTask', 'WrapperTask', 'namespace', 'auto_namespace',
     'target', 'Target', 'LocalTarget', 'rpc', 'RemoteScheduler',
     'RPCError', 'parameter', 'Parameter', 'DateParameter', 'MonthParameter',
-    'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'DateSecondParameter', 'range',
+    'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'DateSecondParameter',
     'DateIntervalParameter', 'TimeDeltaParameter', 'IntParameter',
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -48,6 +48,7 @@ from luigi.execution_summary import LuigiStatusCode
 from luigi import event
 from luigi.event import Event
 
+
 __all__ = [
     'task', 'Task', 'Config', 'ExternalTask', 'WrapperTask', 'namespace', 'auto_namespace',
     'target', 'Target', 'LocalTarget', 'rpc', 'RemoteScheduler',
@@ -59,3 +60,20 @@ __all__ = [
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
     'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'LuigiStatusCode'
 ]
+
+if not configuration.get_config().has_option('core', 'autoload-range'):
+    import warnings
+    warning_message = '''
+        Autoloading range tasks by default has been deprecated and will be removed in a future version.
+        To get the behavior now add an option to luigi.cfg:
+
+          [core]
+            autoload-range: false
+
+        Alternately set the option to true to continue with existing behaviour and suppress this warning.
+    '''
+    warnings.warn(warning_message, DeprecationWarning)
+
+if configuration.get_config().getboolean('core', 'autoload-range', True):
+    from .tools import range  # just makes the tool classes available from command line
+    __all__.append('range')


### PR DESCRIPTION
Reopening https://github.com/spotify/luigi/pull/2265

This change makes --help-all a lot less noisy.
Range tasks can be loaded if required through the usual --module
parameter.

Existing behaviour is not changed except for adding a deprecation warning which can be suppressed.