### PR TITLE
Provide automatic URL tracking for Spark applications

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -53,8 +53,17 @@ class SparkSubmitTask(ExternalProgramTask):
 
     # Only log stderr if spark fails (since stderr is normally quite verbose)
     always_log_stderr = False
-    # For automatic detection of urls in Spark applications
-    tracking_url_pattern = r"Bound (?:.*) to (?:.*), and started at (https?://.*)\s"
+    # Spark applications write its logs into stderr
+    track_url_in_stderr = True
+
+    def run(self):
+        if self.deploy_mode == "cluster":
+            # in cluster mode client only receives application status once a period of time
+            self.tracking_url_pattern = r"tracking URL: (https?://.*)\s"
+        else:
+            self.tracking_url_pattern = r"Bound (?:.*) to (?:.*), and started at (https?://.*)\s"
+
+        super(SparkSubmitTask, self).run()
 
     def app_options(self):
         """

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -53,6 +53,8 @@ class SparkSubmitTask(ExternalProgramTask):
 
     # Only log stderr if spark fails (since stderr is normally quite verbose)
     always_log_stderr = False
+    # For automatic detection of urls in Spark applications
+    tracking_url_pattern = r"Bound (?:.*) to (?:.*), and started at (https?://.*)\s"
 
     def app_options(self):
         """


### PR DESCRIPTION
## Description
A new string parameter `tracking_url_pattern` was added to `ExternalProgramTask` task in order to provide a mechanism for parsing the task output and update tracking URL in Luigi web UI on the run. Also the new parameter is set for `SparkSubmitTask` according to the log message structure: https://github.com/apache/spark/blob/0a4c03f7d084f1d2aa48673b99f3b9496893ce8d/core/src/main/scala/org/apache/spark/ui/WebUI.scala#L133

## Motivation and Context
One of the most missing things to me in Luigi, while I'm working with Spark applications, is automatic detection of the link for Spark Web UI. It is very uncomfortable to look for Spark jobs e.g. in Yarn UI among thousands of other jobs, having only the name of the Luigi task plus it's parameters.
The existence of such feature in Luigi would hugely simplify the process of tracking Spark jobs that are running at the moment.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.
