### PR TITLE
Minor improvements to single-worker-timeout support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -300,10 +300,8 @@ timeout
 
   Number of seconds after which to kill a task which has been running
   for too long. This provides a default value for all tasks, which can
-  be overridden by setting the worker-timeout property in any task. This
-  only works when using multiple workers, as the timeout is implemented
-  by killing worker subprocesses. Default value is 0, meaning no
-  timeout.
+  be overridden by setting the worker-timeout property in any task.
+  Default value is 0, meaning no timeout.
 
 wait_interval
   Number of seconds for the worker to wait before asking the scheduler

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -188,8 +188,7 @@ class Task(object):
 
     #: Number of seconds after which to time out the run function.
     #: No timeout if set to 0.
-    #: Defaults to 0 or worker-timeout value in config file
-    #: Only works when using multiple workers.
+    #: Defaults to 0 or worker-timeout value in config
     worker_timeout = None
 
     #: Maximum number of tasks to run together as a batch. Infinite by default

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -130,9 +130,8 @@ class TaskProcess(multiprocessing.Process):
         self.worker_id = worker_id
         self.result_queue = result_queue
         self.status_reporter = status_reporter
-        if task.worker_timeout is not None:
-            worker_timeout = task.worker_timeout
-        self.timeout_time = time.time() + worker_timeout if worker_timeout else None
+        self.worker_timeout = task.worker_timeout or worker_timeout
+        self.timeout_time = time.time() + self.worker_timeout if self.worker_timeout else None
         self.use_multiprocessing = use_multiprocessing or self.timeout_time is not None
         self.check_unfulfilled_deps = check_unfulfilled_deps
 
@@ -1026,7 +1025,7 @@ class Worker(object):
                 p.task.trigger_event(Event.PROCESS_FAILURE, p.task, error_msg)
             elif p.timeout_time is not None and time.time() > float(p.timeout_time) and p.is_alive():
                 p.terminate()
-                error_msg = 'Task {} timed out after {} seconds and was terminated.'.format(task_id, p.task.worker_timeout)
+                error_msg = 'Task {} timed out after {} seconds and was terminated.'.format(task_id, p.worker_timeout)
                 p.task.trigger_event(Event.TIMEOUT, p.task, error_msg)
             else:
                 continue

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1863,6 +1863,26 @@ class WorkerPurgeEventHandlerTest(unittest.TestCase):
 
         self.assertEqual(result, [task])
 
+    @mock.patch('luigi.worker.time')
+    def test_timeout_handler_single_worker(self, mock_time):
+        result = []
+
+        @HangTheWorkerTask.event_handler(Event.TIMEOUT)
+        def store_task(t, error_msg):
+            self.assertTrue(error_msg)
+            result.append(t)
+
+        w = Worker(wait_interval=0.01, timeout=5)
+        mock_time.time.return_value = 0
+        task = HangTheWorkerTask(worker_timeout=1)
+        w.add(task)
+        w._run_task(task.task_id)
+
+        mock_time.time.return_value = 3
+        w._handle_next_task()
+
+        self.assertEqual(result, [task])
+
 
 class PerTaskRetryPolicyBehaviorTest(LuigiTestCase):
     def setUp(self):


### PR DESCRIPTION
## Description
PR #1860 by @daveFNbuck gives us support for `worker-timeout` support 
in single-worker configuration. 

## Motivation and Context
- Currently the documentation states that `worker-timeout` setting
  only applies when using multiple workers. This is no longer true 
  after PR #1860. This PR updates the documentation to clarify.
- Add test to ensure/prove timeout feature works without
  multiple workers
- Currently, for single-worker setups, the error message
  related to timeout is missing the actual timeout seconds
  in the error message. 
```
Task TimeoutThing__99914b932b timed out after None seconds and was terminated.
```
The issue is `None seconds` is invalid. The PR addresses that issue
by ensuring worker_timeout is a property of TaskProcess.

## Have you tested this? If so, how?
I have tested this on my own workflows in python 2/3 environments. 
Also I've locally executed the tests as outlined in the contributing guideline.