### PR TITLE
Replace Python MapReduce example with Spark example.

### DIFF
--- a/examples/top_artists_spark.py
+++ b/examples/top_artists_spark.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import operator
+import sys
+
+from pyspark.sql import SparkSession
+
+
+def main(argv):
+    input_paths = argv[1].split(',')
+    output_path = argv[2]
+
+    spark = SparkSession.builder.getOrCreate()
+
+    streams = spark.read.option('sep', '\t').csv(input_paths[0])
+    for stream_path in input_paths[1:]:
+        streams.union(spark.read.option('sep', '\t').csv(stream_path))
+
+    # The second field is the artist
+    counts = streams \
+        .map(lambda row: (row[1], 1)) \
+        .reduceByKey(operator.add)
+
+    counts.write.option('sep', '\t').csv(output_path)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Description

Replace the old Python MapReduce example in the docs with something modern and relevant.

Improve formatting consistency in the example while we are touching the file.

## Motivation and Context

Nobody uses Python MapReduce anymore. Having it on the front page is confusing and not helpful.

Meanwhile, newcomers cannot quickly determine how to create typical orchestrations with external programs. Here is an example of a question that we would want to answer with clear documentation: https://groups.google.com/forum/#!topic/luigi-user/n0tC4WYTELk

## Have you tested this? If so, how?

tox -e docs
tox -e flake8
