### PR TITLE
Enable automatic URL tracking for Spark applications

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -54,7 +54,7 @@ class SparkSubmitTask(ExternalProgramTask):
     # Only log stderr if spark fails (since stderr is normally quite verbose)
     always_log_stderr = False
     # Spark applications write its logs into stderr
-    track_url_in_stderr = True
+    stream_for_searching_tracking_url = 'stderr'
 
     def run(self):
         if self.deploy_mode == "cluster":


### PR DESCRIPTION
## Description
https://github.com/spotify/luigi/pull/2661 has provided the mechanism of tracking URL in external programs.
So now we can enable it for Spark applications:
If spark application is run in cluster mode, the string matching the pattern `tracking URL: (https?://.*)\s` is searched.
If spark application is run in client mode, the string matching the pattern `Bound (?:.*) to (?:.*), and started at (https?://.*)\s` is searched.
In both cases the searching is performed in `stderr` stream.

## Motivation and Context
To enable URL tracking in Spark applications.

## Have you tested this? If so, how?
The PR contains some new unit tests + existing tests were run locally