### PR TITLE
Wildcard support in GCSClient.exists

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -193,6 +193,11 @@ class GCSClient(luigi.target.FileSystem):
         return response
 
     def exists(self, path):
+        if '*' in path:
+            for _ in self.list_wildcard(path):
+                return True
+            return False
+
         bucket, obj = self._path_to_bucket_and_key(path)
         if self._obj_exists(bucket, obj):
             return True

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -86,6 +86,11 @@ class GCSClientTest(_GCSBaseTestCase):
         self.assertTrue(self.client.exists(bucket_url('exists_test')))
         self.assertFalse(self.client.isdir(bucket_url('exists_test')))
 
+    def test_exists_wildcard(self):
+        self.client.put_string('hello', bucket_url('exists_test'))
+        self.assertTrue(self.client.exists(bucket_url('exists_*')))
+        self.assertFalse(self.client.exists(bucket_url('does_not_exist_*')))
+
     def test_mkdir(self):
         self.client.mkdir(bucket_url('exists_dir_test'))
         self.assertTrue(self.client.exists(bucket_url('exists_dir_test')))


### PR DESCRIPTION
## Description

Add wildcard support to `GCSClient.exists`.

## Motivation and Context

To be able to use wildcards in the last part of the `GCSTargets` path, e.g.:
```
def output(self):
    return GCSTarget('gs://my_bucket_id/my_dir/*.txt.gz')
```

## Have you tested this? If so, how?

I've tested this change by calling `GCSClient.exists` from the python console and also by running a simple pipeline with one `ExternalTask` with a wildcard `GCSTarget` output. 