### PR TITLE
- Create subprocess without preexec_fn or close_fds arguments in Windows

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -23,6 +23,7 @@ import re
 import locale
 import tempfile
 import warnings
+import sys
 
 from luigi import six
 
@@ -94,6 +95,12 @@ class InputPipeProcessWrapper(object):
         """
         http://www.chiark.greenend.org.uk/ucgi/~cjwatson/blosxom/2009-07-02-python-sigpipe.html
         """
+
+        # Windows doesn't support preexec_fn or close_fds arguments.
+        if sys.platform == 'win32':
+            return subprocess.Popen(command,
+                                    stdin=self._input_pipe,
+                                    stdout=subprocess.PIPE)
 
         def subprocess_setup():
             # Python installs a SIGPIPE handler by default. This is usually not what


### PR DESCRIPTION

## Description
Added a check for Windows os when creating a subprocess.

## Motivation and Context
I ran into this problem when trying to use ssh on Windows. The ssh example task will create warnings about Windows not supporting preexec_fn arguments to subprocess.Popen. 

This may fix https://github.com/spotify/luigi/issues/2218

## Have you tested this? If so, how?
These changes will let me run ssh tasks on Windows (ssh and scp both work for me after these changes).
