### PR TITLE
add beam_dataflow_task to luigi/contrib

### DIFF
--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -218,7 +218,7 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
     dataflow_params = None
     output_uris = None
 
-    def __init(self):
+    def __init__(self):
         if not isinstance(self.dataflow_params, DataflowParams):
             raise ValueError("dataflow_params must be of type DataflowParams")
 

--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -215,7 +215,6 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
 
     cmd_line_runner = _CmdLineRunner
     dataflow_params = None
-    output_uris = None
 
     def __init__(self):
         if not isinstance(self.dataflow_params, DataflowParamKeys):
@@ -462,13 +461,10 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
             raise ValueError(
                 "Task output must be a Target or a dict from String to Target")
 
-        self.output_uris = {}
         output_args = []
 
         for (name, target) in job_output.items():
             uri = self.get_target_path(target)
-
-            self.output_uris[name] = uri
             output_args.append("--%s=%s" % (name, uri))
 
         return output_args

--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -18,6 +18,7 @@
 import abc
 from abc import abstractmethod, abstractproperty, ABCMeta
 import logging
+import json
 import os
 import subprocess
 
@@ -375,7 +376,7 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
         if self.service_account:
             output.append(f(self.dataflow_params.service_account, self.service_account))
         if self.labels:
-            output.append(f(self.dataflow_params.labels, self.labels))
+            output.append(f(self.dataflow_params.labels, json.dumps(self.labels)))
 
         return output
 

--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -429,14 +429,14 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
         elif not isinstance(job_output, dict):
             raise ValueError("Input (requires()) must be dict type")
 
-        self.output_uris = []
+        self.output_uris = {}
         output_args = []
 
         for (name, target) in job_output.items():
             getter = self._targets_to_uri_getter.get(target.__class__)
             uri = getter(target)
 
-            self.output_uris.append(uri)
+            self.output_uris[name] = uri
             output_args.append("--%s=%s" % (name, uri))
 
         return output_args

--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -241,6 +241,13 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
         """
         return []
 
+    def before_run(self):
+        """
+        Hook that gets called right before the Dataflow job is launched.
+        Can be used to setup any temporary files/tables, validate input, etc.
+        """
+        pass
+
     def on_successful_run(self):
         """
         Callback that gets called right after the Dataflow job has finished
@@ -285,10 +292,11 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
         cmd_line = self._mk_cmd_line()
         logger.info(' '.join(cmd_line))
 
+        self.before_run()
+
         try:
             self.cmd_line_runner.run(cmd_line, self)
         except subprocess.CalledProcessError as e:
-
             logger.error(e, exc_info=True)
             self.cleanup_on_error()
             """
@@ -297,6 +305,7 @@ class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
             https://github.com/spotify/styx/blob/master/doc/design-overview.md#workflow-state-graph
             """
             os._exit(e.returncode)
+
         self.on_successful_run()
 
         if self.validate_output():

--- a/luigi/contrib/beam_dataflow.py
+++ b/luigi/contrib/beam_dataflow.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import abc
+from abc import abstractmethod, abstractproperty, ABCMeta
+import logging
+import os
+import subprocess
+
+import luigi
+from luigi import six
+from luigi.contrib import bigquery, gcs
+from luigi.task import MixinNaiveBulkComplete
+
+logger = logging.getLogger('luigi-interface')
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DataflowParams(object):
+    """
+    Defines the naming conventions for Dataflow params specified in:
+        https://cloud.google.com/dataflow/docs/guides/specifying-exec-params
+
+    For example, the Java api expects param names in lower camel case, whereas
+    the Python implementation expects snake case.
+    """
+    @abstractproperty
+    def runner(self):
+        pass
+
+    @abstractproperty
+    def project(self):
+        pass
+
+    @abstractproperty
+    def zone(self):
+        pass
+
+    @abstractproperty
+    def region(self):
+        pass
+
+    @abstractproperty
+    def staging_location(self):
+        pass
+
+    @abstractproperty
+    def temp_location(self):
+        pass
+
+    @abstractproperty
+    def gcp_temp_location(self):
+        pass
+
+    @abstractproperty
+    def num_workers(self):
+        pass
+
+    @abstractproperty
+    def autoscaling_algorithm(self):
+        pass
+
+    @abstractproperty
+    def max_num_workers(self):
+        pass
+
+    @abstractproperty
+    def disk_size_gb(self):
+        pass
+
+    @abstractproperty
+    def worker_machine_type(self):
+        pass
+
+    @abstractproperty
+    def worker_disk_type(self):
+        pass
+
+    @abstractproperty
+    def job_name(self):
+        pass
+
+    @abstractproperty
+    def service_account(self):
+        pass
+
+    @abstractproperty
+    def network(self):
+        pass
+
+    @abstractproperty
+    def subnetwork(self):
+        pass
+
+    @abstractproperty
+    def labels(self):
+        pass
+
+
+class _CmdLineRunner(object):
+    """
+    Executes a given command line class in a subprocess, logging its output.
+    If more complex monitoring/logging is desired, user can implement their
+    own launcher class and set it in BeamDataflowJobTask.cmd_line_runner.
+    """
+    @staticmethod
+    def run(cmd, task=None):
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            close_fds=True
+        )
+        output_lines = []
+        while True:
+            line = process.stdout.readline()
+            if not line:
+                break
+            line = line.decode("utf-8")
+            output_lines += [line]
+            logger.info(line.rstrip("\n"))
+        process.stdout.close()
+        exit_code = process.wait()
+        if exit_code:
+            output = "".join(output_lines)
+            raise subprocess.CalledProcessError(exit_code, cmd, output=output)
+        return exit_code
+
+
+@six.add_metaclass(ABCMeta)
+class BeamDataflowJobTask(MixinNaiveBulkComplete, luigi.Task):
+    """
+    Luigi wrapper for a Dataflow job. Must be overridden for each Beam SDK
+    with that SDK's dataflow_executable().
+
+    The following required Dataflow properties must be set:
+
+    project                 # GCP project ID
+    temp_location           # Cloud storage path for temporary files
+
+    The following optional Dataflow properties can be set:
+
+    runner                  # PipelineRunner implementation for your Beam job.
+                              Default: DirectRunner
+    num_workers             # The number of workers to start the task with
+                              Default: Determined by Dataflow service
+    autoscaling_algorithm   # The Autoscaling mode for the Dataflow job
+                              Default: `THROUGHPUT_BASED`
+    max_num_workers         # Used if the autoscaling is enabled
+                              Default: Determined by Dataflow service
+    network                 # Network in GCE to be used for launching workers
+                              Default: a network named "default"
+    subnetwork              # Subnetwork in GCE to be used for launching workers
+                              Default: Determined by Dataflow service
+    disk_size_gb            # Remote worker disk size. Minimum value is 30GB
+                              Default: set to 0 to use GCP project default
+    worker_machine_type     # Machine type to create Dataflow worker VMs. If unset,
+                              the Dataflow service will choose a reasonable default
+                              Default: Determined by Dataflow service
+    job_name                # Custom job name, must be unique across project's active jobs
+    worker_disk_type        # Specify SSD for local disk or defaults to hard disk
+                              as a full URL of disk type resource
+                              Default: Determined by Dataflow service.
+    service_account         # Service account of Dataflow VMs/workers
+                              Default: active GCE service account
+    region                  # Region to deploy Dataflow job to
+                              Default: us-central1
+    zone                    # Availability zone for launching workers instances
+                              Default: an available zone in the specified region
+    staging_location        # Cloud Storage bucket for Dataflow to stage binary files
+                              Default: the value of temp_location
+    gcp_temp_location       # Cloud Storage path for Dataflow to stage temporary files
+                              Default: the value of temp_location
+    labels = {}             # Custom GCP labels attached to the Dataflow job
+
+    For more documentation, see:
+    https://cloud.google.com/dataflow/docs/guides/specifying-exec-params
+
+    :Example:
+    class AwesomeJob(BeamDataflowJobTask):
+        project = 'some-project'
+        temp_location = 'gs://some-project/user/bob/tmp'
+        max_num_workers = 20
+        region = 'europe-west1'
+        service_account = 'some-account@scio-playground.iam.gserviceaccount.com'
+        gcp_labels = {'user': 'bob'}
+        def output(self):
+                    ...
+    """
+
+    project = None
+    runner = None
+    temp_location = None
+    staging_location = None
+    gcp_temp_location = None
+    num_workers = None
+    autoscaling_algorithm = None
+    max_num_workers = None
+    network = None
+    subnetwork = None
+    disk_size_gb = None
+    worker_machine_type = None
+    job_name = None
+    worker_disk_type = None
+    service_account = None
+    zone = None
+    region = None
+    labels = {}
+
+    cmd_line_runner = _CmdLineRunner
+    dataflow_params = None
+    output_uris = None
+
+    def __init(self):
+        if not isinstance(self.dataflow_params, DataflowParams):
+            raise ValueError("dataflow_params must be of type DataflowParams")
+        else:
+            self.dataflow_params = self.dataflow_params
+
+    @abstractmethod
+    def dataflow_executable(self):
+        """ Command representing the Dataflow executable to be run.
+
+        Example:
+            java com.spotify.luigi.MyClass '-Xmx256m'
+        or:
+            python /path/to/python_script
+        """
+        pass
+
+    def args(self):
+        """ Extra String arguments that will be passed to your Dataflow job.
+
+        Example:
+                return [
+                    '--setup_file=setup.py'
+                ]
+        """
+        return []
+
+    def on_successful_run(self):
+        """ Callback that gets called right after the Dataflow job has finished
+        successfully but before validate_output is run.
+        """
+        pass
+
+    def validate_output(self):
+        """ Callback that can be used to validate your output before it is moved to
+        its final location. Returning false here will cause the job to fail, and
+        output to be removed instead of published.
+        """
+        return True
+
+    def file_pattern(self):
+        """ If one/some of the input target files are not in the pattern of part-*,
+        we can add the key of the required target and the correct file pattern
+        that should be appended in the command line here. If the input target key is not found
+        in this dict, the file pattern will be assumed to be part-* for that target.
+
+        :return A dictionary of overriden file pattern that is not part-* for the inputs
+        :rtype: Dict of String to String
+        """
+        return {}
+
+    def on_output_validation(self):
+        """ Callback that gets called after the Dataflow job has finished
+        successfully if validate_output returns True.
+        """
+        pass
+
+    def cleanup_on_error(self):
+        """ Callback that gets called after the Dataflow job has finished
+        unsuccessfully, or validate_output returns False.
+        """
+        pass
+
+    def run(self):
+        cmd_line = self._mk_cmd_line()
+        logger.info(' '.join(cmd_line))
+
+        try:
+            self.cmd_line_runner.run(cmd_line, self)
+        except subprocess.CalledProcessError as e:
+
+            logger.error(e, exc_info=True)
+            self.cleanup_on_error()
+            # Exit Luigi with the same exit code as the Dataflow job process, so
+            # users can easily exit the job with code 50 to avoid Styx retries
+            # https://github.com/spotify/styx/blob/master/doc/design-overview.md#workflow-state-graph
+            os._exit(e.returncode)
+        self.on_successful_run()
+
+        if self.validate_output():
+            self.on_output_validation()
+        else:
+            self.cleanup_on_error()
+            raise ValueError("Output validation failed")
+
+    def _mk_cmd_line(self):
+        cmd_line = self.dataflow_executable()
+
+        cmd_line.extend(self._get_dataflow_args())
+        cmd_line.extend(self.args())
+        cmd_line.extend(self._format_input_args())
+        cmd_line.extend(self._format_output_args())
+        return cmd_line
+
+    def _get_runner(self):
+        if self.runner in [
+            "DataflowRunner",
+            "DirectRunner"
+        ]:
+            return self.runner
+
+        elif self.runner in [
+            "InProcessPipelineRunner",
+            "BlockingDataflowPipelineRunner"
+        ]:
+            logger.warning("Using deprecated runner %s. Consider upgrading to "
+                           "Beam 2.x." % self.runner)
+            return self.runner
+
+        else:
+            logger.warning("Found unsupported runner %s. Defaulting to "
+                           "DirectRunner." % self.runner)
+            return "DirectRunner"
+
+    def _get_dataflow_args(self):
+        def f(key, value):
+            return '--{}={}'.format(key, value)
+
+        output = []
+
+        runner = self._get_runner()
+        if runner:
+            output.append(f(self.dataflow_params.runner, runner))
+        if self.project:
+            output.append(f(self.dataflow_params.project, self.project))
+        if self.zone:
+            output.append(f(self.dataflow_params.zone, self.zone))
+        if self.region:
+            output.append(f(self.dataflow_params.region, self.region))
+        if self.staging_location:
+            output.append(f(self.dataflow_params.staging_location, self.staging_location))
+        if self.temp_location:
+            output.append(f(self.dataflow_params.temp_location, self.temp_location))
+        if self.gcp_temp_location:
+            output.append(f(self.dataflow_params.gcp_temp_location, self.gcp_temp_location))
+        if self.num_workers:
+            output.append(f(self.dataflow_params.num_workers, self.num_workers))
+        if self.autoscaling_algorithm:
+            output.append(f(self.dataflow_params.autoscaling_algorithm, self.autoscaling_algorithm))
+        if self.max_num_workers:
+            output.append(f(self.dataflow_params.max_num_workers, self.max_num_workers))
+        if self.disk_size_gb:
+            output.append(f(self.dataflow_params.disk_size_gb, self.disk_size_gb))
+        if self.worker_machine_type:
+            output.append(f(self.dataflow_params.worker_machine_type, self.worker_machine_type))
+        if self.worker_disk_type:
+            output.append(f(self.dataflow_params.worker_disk_type, self.worker_disk_type))
+        if self.network:
+            output.append(f(self.dataflow_params.network, self.network))
+        if self.subnetwork:
+            output.append(f(self.dataflow_params.subnetwork, self.subnetwork))
+        if self.job_name:
+            output.append(f(self.dataflow_params.job_name, self.job_name))
+        if self.service_account:
+            output.append(f(self.dataflow_params.service_account, self.service_account))
+        if self.labels:
+            output.append(f(self.dataflow_params.labels, self.labels))
+
+        return output
+
+    def _format_input_args(self):
+        job_input = self.input()
+        if isinstance(job_input, luigi.Target):
+            job_input = {"input": job_input}
+        elif not isinstance(job_input, dict):
+            raise ValueError("Input (requires()) must be dict type")
+
+        if not isinstance(self.file_pattern(), dict):
+            raise ValueError('file_pattern() must return a dict type')
+
+        input_args = []
+
+        for (name, targets) in job_input.items():
+            uri_targets = luigi.task.flatten(targets)
+            uris = [self._targets_to_uri_getter.get(
+                uri_target.__class__)(uri_target) for uri_target in uri_targets]
+            if isinstance(targets, dict):
+                # If targets is a dict that means it had multiple outputs.
+                #  Make the input args in that case "<input key>-<task output key>"
+                names = ["%s-%s" % (name, key) for key in targets.keys()]
+            else:
+                names = [name] * len(uris)
+            for (arg_name, uri) in zip(names, uris):
+                pattern = self.file_pattern().get(name, 'part-*')
+                input_args.append(
+                    "--%s=%s" %
+                    (arg_name, uri.rstrip('/') + '/' + pattern)
+                )
+
+        return input_args
+
+    def _format_output_args(self):
+        job_output = self.output()
+        if isinstance(job_output, luigi.Target):
+            job_output = {"output": job_output}
+        elif not isinstance(job_output, dict):
+            raise ValueError("Input (requires()) must be dict type")
+
+        self.output_uris = []
+        output_args = []
+
+        for (name, target) in job_output.items():
+            getter = self._targets_to_uri_getter.get(target.__class__)
+            uri = getter(target)
+
+            self.output_uris.append(uri)
+            output_args.append("--%s=%s" % (name, uri))
+
+        return output_args
+
+    @property
+    def _targets_to_uri_getter(self):
+        """
+        This should be overridden for custom target types.
+        """
+        return dict([
+            (luigi.LocalTarget, lambda t: t.path),
+            (gcs.GCSTarget, lambda t: t.path),
+            (bigquery.BigQueryTarget, lambda t: "{}:{}.{}".format(
+                t.project_id, t.dataset_id, t.table_id))
+        ])

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -24,77 +24,24 @@ import unittest
 
 
 class TestDataflowParams(beam_dataflow.DataflowParams):
-    @property
-    def runner(self):
-        return "runner"
-
-    @property
-    def project(self):
-        return "project"
-
-    @property
-    def zone(self):
-        return "zone"
-
-    @property
-    def region(self):
-        return "region"
-
-    @property
-    def staging_location(self):
-        return "stagingLocation"
-
-    @property
-    def temp_location(self):
-        return "tempLocation"
-
-    @property
-    def gcp_temp_location(self):
-        return "gcpTempLocation"
-
-    @property
-    def num_workers(self):
-        return "numWorkers"
-
-    @property
-    def autoscaling_algorithm(self):
-        return "autoscalingAlgorithm"
-
-    @property
-    def max_num_workers(self):
-        return "maxNumWorkers"
-
-    @property
-    def disk_size_gb(self):
-        return "diskSizeGb"
-
-    @property
-    def worker_machine_type(self):
-        return "workerMachineType"
-
-    @property
-    def worker_disk_type(self):
-        return "workerDiskType"
-
-    @property
-    def job_name(self):
-        return "jobName"
-
-    @property
-    def service_account(self):
-        return "serviceAccount"
-
-    @property
-    def network(self):
-        return "network"
-
-    @property
-    def subnetwork(self):
-        return "subnetwork"
-
-    @property
-    def labels(self):
-        return "labels"
+    runner = "runner"
+    project = "project"
+    zone = "zone"
+    region = "region"
+    staging_location = "stagingLocation"
+    temp_location = "tempLocation"
+    gcp_temp_location = "gcpTempLocation"
+    num_workers = "numWorkers"
+    autoscaling_algorithm = "autoscalingAlgorithm"
+    max_num_workers = "maxNumWorkers"
+    disk_size_gb = "diskSizeGb"
+    worker_machine_type = "workerMachineType"
+    worker_disk_type = "workerDiskType"
+    job_name = "jobName"
+    service_account = "serviceAccount"
+    network = "network"
+    subnetwork = "subnetwork"
+    labels = "labels"
 
 
 class TestRequires(luigi.ExternalTask):

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -181,7 +181,6 @@ class BeamDataflowTest(unittest.TestCase):
 
         self.assertEqual(json.loads(cmd_line_args[19][9:]), {'k1': 'v1'})
         self.assertEqual(cmd_line_args, expected)
-        self.assertEqual(full_test_task.output_uris, {"output": "some-output.txt"})
 
     def test_dataflow_with_file_patterns(self):
         cmd_line_args = FilePatternsTestTask()._mk_cmd_line()

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import luigi
+from luigi.contrib import beam_dataflow
+from luigi import local_target
+from mock import MagicMock, patch
+
+
+class TestDataflowParams(beam_dataflow.DataflowParams):
+    @property
+    def runner(self):
+        return "runner"
+
+    @property
+    def project(self):
+        return "project"
+
+    @property
+    def zone(self):
+        return "zone"
+
+    @property
+    def region(self):
+        return "region"
+
+    @property
+    def staging_location(self):
+        return "stagingLocation"
+
+    @property
+    def temp_location(self):
+        return "tempLocation"
+
+    @property
+    def gcp_temp_location(self):
+        return "gcpTempLocation"
+
+    @property
+    def num_workers(self):
+        return "numWorkers"
+
+    @property
+    def autoscaling_algorithm(self):
+        return "autoscalingAlgorithm"
+
+    @property
+    def max_num_workers(self):
+        return "maxNumWorkers"
+
+    @property
+    def disk_size_gb(self):
+        return "diskSizeGb"
+
+    @property
+    def worker_machine_type(self):
+        return "workerMachineType"
+
+    @property
+    def worker_disk_type(self):
+        return "workerDiskType"
+
+    @property
+    def job_name(self):
+        return "jobName"
+
+    @property
+    def service_account(self):
+        return "serviceAccount"
+
+    @property
+    def network(self):
+        return "network"
+
+    @property
+    def subnetwork(self):
+        return "subnetwork"
+
+    @property
+    def labels(self):
+        return "labels"
+
+
+class TestRequires(luigi.ExternalTask):
+    def output(self):
+        return luigi.LocalTarget(path='some-input-dir')
+
+
+class SimpleTestTask(beam_dataflow.BeamDataflowJobTask):
+    dataflow_params = TestDataflowParams()
+
+    def requires(self):
+        return TestRequires()
+
+    def output(self):
+        return local_target.LocalTarget(path='some-output.txt')
+
+    def dataflow_executable(self):
+        return ['java', 'com.spotify.luigi.SomeJobClass']
+
+
+class FullTestTask(beam_dataflow.BeamDataflowJobTask):
+    project = 'some-project'
+    runner = 'DirectRunner'
+    temp_location = 'some-temp'
+    staging_location = 'some-staging'
+    gcp_temp_location = 'some-gcp-temp'
+    num_workers = 1
+    autoscaling_algorithm = 'THROUGHPUT_BASED'
+    max_num_workers = 2
+    network = 'some-network'
+    subnetwork = 'some-subnetwork'
+    disk_size_gb = 5
+    worker_machine_type = 'n1-standard-4'
+    job_name = 'SomeJobName'
+    worker_disk_type = 'compute.googleapis.com/projects//zones//diskTypes/pd-ssd'
+    service_account = 'some-service-account@google.com'
+    zone = 'europe-west1-c'
+    region = 'europe-west1'
+    labels = {'k1': 'v1'}
+
+    dataflow_params = TestDataflowParams()
+
+    def requires(self):
+        return TestRequires()
+
+    def output(self):
+        return {'output': luigi.LocalTarget(path='some-output.txt')}
+
+    def args(self):
+        return ['--extraArg=present']
+
+    def dataflow_executable(self):
+        return ['java', 'com.spotify.luigi.SomeJobClass']
+
+
+class FilePatternsTestTask(beam_dataflow.BeamDataflowJobTask):
+    dataflow_params = TestDataflowParams()
+
+    def requires(self):
+        return {
+            'input1': TestRequires(),
+            'input2': TestRequires()
+        }
+
+    def file_pattern(self):
+        return {'input2': '*.some-ext'}
+
+    def output(self):
+        return {'output': luigi.LocalTarget(path='some-output.txt')}
+
+    def dataflow_executable(self):
+        return ['java', 'com.spotify.luigi.SomeJobClass']
+
+
+class DummyCmdLineTestTask(beam_dataflow.BeamDataflowJobTask):
+    dataflow_params = TestDataflowParams()
+
+    def dataflow_executable(self):
+        pass
+
+    def requires(self):
+        return {}
+
+    def output(self):
+        return {}
+
+    def _mk_cmd_line(self):
+        return ['echo', '"hello world"']
+
+
+class BeamDataflowTest(unittest.TestCase):
+
+    def test_dataflow_simple_cmd_line_args(self):
+        cmd_line_args = SimpleTestTask()._mk_cmd_line()
+
+        expected = [
+            'java',
+            'com.spotify.luigi.SomeJobClass',
+            '--runner=DirectRunner',
+            '--input=some-input-dir/part-*',
+            '--output=some-output.txt'
+        ]
+
+        self.assertEqual(cmd_line_args, expected)
+
+    def test_dataflow_full_cmd_line_args(self):
+        task = FullTestTask()
+        cmd_line_args = task._mk_cmd_line()
+
+        expected = [
+            'java',
+            'com.spotify.luigi.SomeJobClass',
+            '--runner=DirectRunner',
+            '--project=some-project',
+            '--zone=europe-west1-c',
+            '--region=europe-west1',
+            '--stagingLocation=some-staging',
+            '--tempLocation=some-temp',
+            '--gcpTempLocation=some-gcp-temp',
+            '--numWorkers=1',
+            '--autoscalingAlgorithm=THROUGHPUT_BASED',
+            '--maxNumWorkers=2',
+            '--diskSizeGb=5',
+            '--workerMachineType=n1-standard-4',
+            '--workerDiskType=compute.googleapis.com/projects//zones//diskTypes/pd-ssd',
+            '--network=some-network',
+            '--subnetwork=some-subnetwork',
+            '--jobName=SomeJobName',
+            '--serviceAccount=some-service-account@google.com',
+            '--labels={\'k1\': \'v1\'}',
+            '--extraArg=present',
+            '--input=some-input-dir/part-*',
+            '--output=some-output.txt'
+        ]
+
+        self.assertEqual(cmd_line_args, expected)
+        self.assertEqual(task.output_uris, ["some-output.txt"])
+
+    def test_dataflow_with_file_patterns(self):
+        cmd_line_args = FilePatternsTestTask()._mk_cmd_line()
+
+        self.assertIn('--input1=some-input-dir/part-*', cmd_line_args)
+        self.assertIn('--input2=some-input-dir/*.some-ext', cmd_line_args)
+
+    def test_dataflow_with_invalid_file_patterns(self):
+        task = FilePatternsTestTask()
+        task.file_pattern = MagicMock(return_value='notadict')
+        with self.assertRaises(ValueError):
+            task._mk_cmd_line()
+
+    def test_dataflow_runner_resolution(self):
+        task = SimpleTestTask()
+        # Test that supported runners are passed through
+        for runner in ["DirectRunner", "BlockingDataflowPipelineRunner",
+                       "InProcessPipelineRunner", "DataflowRunner"]:
+            task.runner = runner
+            self.assertEqual(task._get_runner(), runner)
+
+        # Test that unsupported runners default to DirectRunner
+        task.runner = "UnsupportedRunner"
+        self.assertEqual(task._get_runner(), "DirectRunner")
+
+    def test_dataflow_successful_run_callbacks(self):
+        task = DummyCmdLineTestTask()
+
+        task.validate_output = MagicMock()
+        task.on_successful_run = MagicMock()
+        task.on_output_validation = MagicMock()
+        task.cleanup_on_error = MagicMock()
+
+        task.run()
+
+        task.validate_output.assert_called_once_with()
+        task.cleanup_on_error.assert_not_called()
+        task.on_successful_run.assert_called_once_with()
+        task.on_output_validation.assert_called_once_with()
+
+    def test_dataflow_successful_run_invalid_output_callbacks(self):
+        task = DummyCmdLineTestTask()
+
+        task.validate_output = MagicMock(return_value=False)
+        task.on_successful_run = MagicMock()
+        task.on_output_validation = MagicMock()
+        task.cleanup_on_error = MagicMock()
+
+        with self.assertRaises(ValueError):
+            task.run()
+
+        task.validate_output.assert_called_once_with()
+        task.cleanup_on_error.assert_called_once_with()
+        task.on_successful_run.assert_called_once_with()
+        task.on_output_validation.assert_not_called()
+
+    @patch('luigi.contrib.beam_dataflow.subprocess.Popen.wait', return_value=1)
+    @patch('luigi.contrib.beam_dataflow.os._exit', side_effect=OSError)
+    def test_dataflow_failed_run_callbacks(self, popen, os_exit):
+        task = DummyCmdLineTestTask()
+
+        task.validate_output = MagicMock()
+        task.on_successful_run = MagicMock()
+        task.on_output_validation = MagicMock()
+        task.cleanup_on_error = MagicMock()
+
+        with self.assertRaises(OSError):
+            task.run()
+
+        task.validate_output.assert_not_called()
+        task.cleanup_on_error.assert_called_once_with()
+        task.on_successful_run.assert_not_called()
+        task.on_output_validation.assert_not_called()

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -261,6 +261,7 @@ class BeamDataflowTest(unittest.TestCase):
     def test_dataflow_successful_run_callbacks(self):
         task = DummyCmdLineTestTask()
 
+        task.before_run = MagicMock()
         task.validate_output = MagicMock()
         task.on_successful_run = MagicMock()
         task.on_output_validation = MagicMock()
@@ -268,6 +269,7 @@ class BeamDataflowTest(unittest.TestCase):
 
         task.run()
 
+        task.before_run.assert_called_once_with()
         task.validate_output.assert_called_once_with()
         task.cleanup_on_error.assert_not_called()
         task.on_successful_run.assert_called_once_with()
@@ -276,6 +278,7 @@ class BeamDataflowTest(unittest.TestCase):
     def test_dataflow_successful_run_invalid_output_callbacks(self):
         task = DummyCmdLineTestTask()
 
+        task.before_run = MagicMock()
         task.validate_output = MagicMock(return_value=False)
         task.on_successful_run = MagicMock()
         task.on_output_validation = MagicMock()
@@ -284,6 +287,7 @@ class BeamDataflowTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             task.run()
 
+        task.before_run.assert_called_once_with()
         task.validate_output.assert_called_once_with()
         task.cleanup_on_error.assert_called_once_with()
         task.on_successful_run.assert_called_once_with()
@@ -294,6 +298,7 @@ class BeamDataflowTest(unittest.TestCase):
     def test_dataflow_failed_run_callbacks(self, popen, os_exit):
         task = DummyCmdLineTestTask()
 
+        task.before_run = MagicMock()
         task.validate_output = MagicMock()
         task.on_successful_run = MagicMock()
         task.on_output_validation = MagicMock()
@@ -302,6 +307,7 @@ class BeamDataflowTest(unittest.TestCase):
         with self.assertRaises(OSError):
             task.run()
 
+        task.before_run.assert_called_once_with()
         task.validate_output.assert_not_called()
         task.cleanup_on_error.assert_called_once_with()
         task.on_successful_run.assert_not_called()

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -249,6 +249,40 @@ class BeamDataflowTest(unittest.TestCase):
         self.assertEqual(task_tuple_input._format_input_args(),
                          ['--some-key=some-input/part-*'])
 
+    def test_task_output_arg_completion(self):
+        class TestCompleteTarget(luigi.Target):
+            def exists(self):
+                return True
+
+        class TestIncompleteTarget(luigi.Target):
+            def exists(self):
+                return False
+
+        class TestTaskDictOfCompleteOutput(SimpleTestTask):
+            def output(self):
+                return {
+                    "output": TestCompleteTarget()
+                }
+
+        self.assertEqual(TestTaskDictOfCompleteOutput().complete(), True)
+
+        class TestTaskDictOfIncompleteOutput(SimpleTestTask):
+            def output(self):
+                return {
+                    "output": TestIncompleteTarget()
+                }
+
+        self.assertEqual(TestTaskDictOfIncompleteOutput().complete(), False)
+
+        class TestTaskDictOfMixedCompleteOutput(SimpleTestTask):
+            def output(self):
+                return {
+                    "output1": TestIncompleteTarget(),
+                    "output2": TestCompleteTarget()
+                }
+
+        self.assertEqual(TestTaskDictOfMixedCompleteOutput().complete(), False)
+
     def test_dataflow_runner_resolution(self):
         task = SimpleTestTask()
         # Test that supported runners are passed through

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -15,12 +15,12 @@
 # limitations under the License.
 #
 
-import unittest
-
+import json
 import luigi
 from luigi.contrib import beam_dataflow
 from luigi import local_target
 from mock import MagicMock, patch
+import unittest
 
 
 class TestDataflowParams(beam_dataflow.DataflowParams):
@@ -224,12 +224,13 @@ class BeamDataflowTest(unittest.TestCase):
             '--subnetwork=some-subnetwork',
             '--jobName=SomeJobName',
             '--serviceAccount=some-service-account@google.com',
-            '--labels={\'k1\': \'v1\'}',
+            '--labels={"k1": "v1"}',
             '--extraArg=present',
             '--input=some-input-dir/part-*',
             '--output=some-output.txt'
         ]
 
+        self.assertEqual(json.loads(cmd_line_args[19][9:]), {'k1': 'v1'})
         self.assertEqual(cmd_line_args, expected)
         self.assertEqual(task.output_uris, ["some-output.txt"])
 

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -232,7 +232,7 @@ class BeamDataflowTest(unittest.TestCase):
 
         self.assertEqual(json.loads(cmd_line_args[19][9:]), {'k1': 'v1'})
         self.assertEqual(cmd_line_args, expected)
-        self.assertEqual(task.output_uris, ["some-output.txt"])
+        self.assertEqual(task.output_uris, {"output": "some-output.txt"})
 
     def test_dataflow_with_file_patterns(self):
         cmd_line_args = FilePatternsTestTask()._mk_cmd_line()

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -196,27 +196,14 @@ class BeamDataflowTest(unittest.TestCase):
             task._mk_cmd_line()
 
     def test_dataflow_input_arg_formatting(self):
-        class TestTaskListInput(SimpleTestTask):
-            class TestRequiresList(luigi.ExternalTask):
-                def output(self):
-                    return [luigi.LocalTarget(path='some-input-1'),
-                            luigi.LocalTarget(path='some-input-2')]
-
-            def requires(self):
-                return self.TestRequiresList()
-
-        task_list_input = TestTaskListInput()
-        self.assertEqual(task_list_input._format_input_args(),
-                         ['--input=some-input-1/part-*,some-input-2/part-*'])
-
         class TestTaskListOfTargetsInput(SimpleTestTask):
-            class TestRequiresList(luigi.ExternalTask):
+            class TestRequiresListOfTargets(luigi.ExternalTask):
                 def output(self):
                     return [luigi.LocalTarget(path='some-input-1'),
                             luigi.LocalTarget(path='some-input-2')]
 
             def requires(self):
-                return self.TestRequiresList()
+                return self.TestRequiresListOfTargets()
 
         task_list_input = TestTaskListOfTargetsInput()
         self.assertEqual(task_list_input._format_input_args(),


### PR DESCRIPTION
#2665 

Adds a task for Beam Dataflow jobs to luigi/contrib, mostly as a wrapper for [DF execution params](https://cloud.google.com/dataflow/docs/guides/specifying-exec-params) and formatting of input/output URIs, with callbacks on successful/unsuccessful execution. Also provides an (overridable) runner to monitor job execution after submitting the job.

CC @daikeshi