### PR TITLE
Check if the GCS directory object exists

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -136,13 +136,13 @@ class GCSClient(luigi.target.FileSystem):
 
     def _obj_exists(self, bucket, obj):
         try:
-            self.client.objects().get(bucket=bucket, object=obj).execute()
+            objects = self.client.objects().get(bucket=bucket, object=obj).execute()
         except errors.HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
         else:
-            return True
+            return obj in objects
 
     def _list_iter(self, bucket, prefix):
         request = self.client.objects().list(bucket=bucket, prefix=prefix)


### PR DESCRIPTION
## Description
`_obj_exists` lists all the objects with given prefix, so in case if you have those objects in your bucket:
```
gs://bucket/dir/obj1
```
And you ask if `gs://bucket/dir/` exists it'll return `True` while no `gs://bucket/dir/` object is present. This broke `mkdir` method, as it would not create directory object if some contents already had been present inside of it.

This fixes that behaviour checking if literal path is present in the list.

## Have you tested this? If so, how?
```
# Create file in the bucket
$ python
>>> from luigi.contrib.gcs import GCSClient
>>> gcs_client = GCSClient()
>>> gcs_client.put_string(b"", "gs://bucket/testsomething5/test", mimetype='text/plain')

# Verify that only file is there
$ gsutil ls gs://bucket/testsomething5/
gs://bucket/testsomething5/test

# Try to create directory
>>> gcs_client.mkdir("gs://bucket/testsomething5/")

# Nothing happen, still only file object is there
$ gsutil ls gs://bucket/testsomething5/
gs://bucket/testsomething5/test

# Why does it fail? Because this directory already "exists"
>>> gcs_client.exists("gs://bucket/testsomething5/")
True
```