### PR TITLE
Require at least python-dateutil version 2.7.5 instead of only 2.7.5 …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     'tornado>=4.0,<5',
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
-    'python-dateutil==2.7.5',
+    'python-dateutil>=2.7.5,<3',
 ]
 
 # Note: To support older versions of setuptools, we're explicitly not


### PR DESCRIPTION
Fixes #2662 

## Description
See setup.py diff: replaces `python-dateutil==2.7.5` dependency with `python-dateutil>=2.7.5`.

## Motivation and Context
Luigi as a library should not pin down a dependency on an exact version, but specify an "at least" constraint.

python-dateutil 2.8.0 was released on Feb 5 2019

