### PR TITLE
luigi.contrib.sqla - add `use_marker_table` parameter to make marker table optional

### DIFF
--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -233,9 +233,9 @@ class SQLAlchemyTarget(luigi.Target):
                                                 inserted=datetime.datetime.now())
                 else:
                     ins = table.update().where(sqlalchemy.and_(table.c.update_id == self.update_id,
-                                                            table.c.target_table == self.target_table)).\
+                                                               table.c.target_table == self.target_table)).\
                         values(update_id=self.update_id, target_table=self.target_table,
-                            inserted=datetime.datetime.now())
+                               inserted=datetime.datetime.now())
                 conn.execute(ins)
         assert self.exists()
 

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -32,6 +32,7 @@ from luigi.contrib import sqla
 from luigi.mock import MockTarget
 from nose.plugins.attrib import attr
 from helpers import skipOnTravis
+import mock
 
 if six.PY3:
     unicode = str
@@ -236,6 +237,25 @@ class TestSQLA(unittest.TestCase):
         self.assertFalse(target.exists())
         target.touch()
         self.assertTrue(target.exists())
+
+    def test_touch_when_not_use_marker_table(self):
+        """
+        Test case to ensure touch() behaves the same when use_marker_table is set as False.
+        """
+        target = sqla.SQLAlchemyTarget(self.connection_string, "test_table", "12312123", use_marker_table=False)
+        self.assertRaises(NotImplementedError, target.create_marker_table())
+        self.assertFalse(target.exists())
+        target.touch()
+        self.assertTrue(target.exists())
+    
+    @mock.patch("luigi.contrib.sqla.SQLAlchemyTarget.create_marker_table", new_callable=mock.PropertyMock)
+    def test_no_marker_table_created(self, mock_create_marker_table):
+        """
+        Test case to ensure no marker table is created when use_marker_table is set as False
+        """
+        target = sqla.SQLAlchemyTarget(self.connection_string, "test_table", "12312123", use_marker_table=False)
+        target.touch()
+        self.assertFalse(mock_create_marker_table.called)
 
     def test_row_overload(self):
         """Overload the rows method and we should be able to insert data into database"""

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -247,7 +247,7 @@ class TestSQLA(unittest.TestCase):
         self.assertFalse(target.exists())
         target.touch()
         self.assertTrue(target.exists())
-    
+
     @mock.patch("luigi.contrib.sqla.SQLAlchemyTarget.create_marker_table", new_callable=mock.PropertyMock)
     def test_no_marker_table_created(self, mock_create_marker_table):
         """


### PR DESCRIPTION
## Description
Add `use_marker_table` parameter to `luigi.contrib.sqla.SQLAlchemyTarget` and `luigi.contrib.sqla.CopyToTable`.

## Motivation and Context
The current implementation of `luigi.contrib.sqla.SQLAlchemyTarget` and `luigi.contrib.sqla.CopyToTable` make it compulsory to use marker table to check if `output.exists()`. While marker table can provide more metadata to the database write, sometimes the Writer may not be always granted access right to create new table.

With the `CopyToTable.use_marker_table` to be set as `False`, user can write to database without creating a marker table, while keeping the existing behaviors.

## Have you tested this? If so, how?
I have included unit tests.
