### PR TITLE
Fix azureblob splitfilepath to work for windows file paths

### DIFF
--- a/luigi/contrib/azureblob.py
+++ b/luigi/contrib/azureblob.py
@@ -164,7 +164,10 @@ class AzureBlobClient(FileSystem):
 
     @staticmethod
     def splitfilepath(filepath):
-        splitpath = filepath.split("/")
+        if ("/" in filepath):
+            splitpath = filepath.split("/")
+        else:
+            splitpath = filepath.split("\\")
         container = splitpath[0]
         blobsplit = splitpath[1:]
         blob = None if not blobsplit else "/".join(blobsplit)

--- a/test/contrib/azureblob_test.py
+++ b/test/contrib/azureblob_test.py
@@ -51,6 +51,11 @@ class AzureBlobClientTest(unittest.TestCase):
         self.assertEqual(container, "abc")
         self.assertEqual(blob, "cde")
 
+    def test_splitfilepath_blob_windowspath(self):
+        container, blob = self.client.splitfilepath("abc\\cde")
+        self.assertEqual(container, "abc")
+        self.assertEqual(blob, "cde")
+
     def test_splitfilepath_blob_nested(self):
         container, blob = self.client.splitfilepath("abc/cde/xyz.txt")
         self.assertEqual(container, "abc")


### PR DESCRIPTION
## Description
Just a small change to the splitfilepath function so it will now also work with file paths that have backslashes. 

## Motivation and Context
The splitfilepath function would not work with windows file paths with '\\' in them. 

## Have you tested this? If so, how?
I have ran my own jobs with this change and have also included a test for paths with a backslash.
