### PR TITLE
Import collections ABCs from collections.abc, not collections

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -26,7 +26,11 @@ import warnings
 from enum import IntEnum
 import json
 from json import JSONEncoder
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import operator
 import functools
 from ast import literal_eval

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -22,6 +22,10 @@ See :doc:`/central_scheduler` for more info.
 """
 
 import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 import json
 
 from luigi.batch_notifier import BatchNotifier
@@ -208,7 +212,7 @@ def _get_default(x, default):
         return default
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     """
     Standard Python OrderedSet recipe found at http://code.activestate.com/recipes/576694/
 


### PR DESCRIPTION
This fixes a DeprecationWarning which would have broken in Python 3.8:

```
/home/ben/.virtualenvs/monitoring/lib/python3.7/site-packages/luigi/parameter.py:29
  /home/ben/.virtualenvs/monitoring/lib/python3.7/site-packages/luigi/parameter.py:29: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import OrderedDict, Mapping

/home/ben/.virtualenvs/monitoring/lib/python3.7/site-packages/luigi/scheduler.py:211
  /home/ben/.virtualenvs/monitoring/lib/python3.7/site-packages/luigi/scheduler.py:211: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class OrderedSet(collections.MutableSet):
```