### PR TITLE
Rename _requires

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -754,7 +754,7 @@ class BaseHadoopJobTask(luigi.Task):
     def input_hadoop(self):
         return luigi.task.getpaths(self.requires_hadoop())
 
-    def deps(self):
+    def process_requires(self):
         # Overrides the default implementation
         return luigi.task.flatten(self.requires_hadoop()) + luigi.task.flatten(self.requires_local())
 

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -141,7 +141,7 @@ def _depth_first_search(set_tasks, current_task, visited):
         upstream_missing_dependency = False
         upstream_run_by_other_worker = False
         upstream_scheduling_error = False
-        for task in current_task._requires():
+        for task in current_task.process_requires():
             if task not in visited:
                 _depth_first_search(set_tasks, task, visited)
             if task in set_tasks["ever_failed"] or task in set_tasks["upstream_failure"]:

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -613,16 +613,25 @@ class Task(object):
         """
         return []  # default impl
 
-    def _requires(self):
+    def process_requires(self):
         """
         Override in "template" tasks which themselves are supposed to be
         subclassed and thus have their requires() overridden (name preserved to
         provide consistent end-user experience), yet need to introduce
         (non-input) dependencies.
 
-        Must return an iterable which among others contains the _requires() of
+        Must return an iterable which among others contains the process_requires() of
         the superclass.
         """
+
+        _requires = getattr(self, '_requires', None)
+        if callable(_requires):
+            warnings.warn("Use of _requires has been deprecated. To customize "
+                          "dependencies in a child class, use `process_requires`.",
+                          DeprecationWarning)
+
+            return _requires()
+
         return flatten(self.requires())  # base impl
 
     def process_resources(self):
@@ -651,7 +660,7 @@ class Task(object):
         Returns the flattened list of requires.
         """
         # used by scheduler
-        return flatten(self._requires())
+        return flatten(self.process_requires())
 
     def run(self):
         """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -653,15 +653,6 @@ class Task(object):
         """
         return getpaths(self.requires())
 
-    def deps(self):
-        """
-        Internal method used by the scheduler.
-
-        Returns the flattened list of requires.
-        """
-        # used by scheduler
-        return flatten(self.process_requires())
-
     def run(self):
         """
         The task run method, to be overridden in a subclass.

--- a/luigi/util.py
+++ b/luigi/util.py
@@ -407,9 +407,9 @@ def delegates(task_that_delegates):
     @task._task_wraps(task_that_delegates)
     class Wrapped(task_that_delegates):
 
-        def deps(self):
+        def process_requires(self):
             # Overrides method in base class
-            return task.flatten(self.requires()) + task.flatten([t.deps() for t in task.flatten(self.subtasks())])
+            return task.flatten(self.requires()) + task.flatten([t.process_requires() for t in task.flatten(self.subtasks())])
 
         def run(self):
             for t in task.flatten(self.subtasks()):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -176,7 +176,7 @@ class TaskProcess(multiprocessing.Process):
             # checking completeness of self.task so outputs of dependencies are
             # irrelevant.
             if self.check_unfulfilled_deps and not _is_external(self.task):
-                missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]
+                missing = [dep.task_id for dep in self.task.process_requires() if not dep.complete()]
                 if missing:
                     deps = 'dependency' if len(missing) == 1 else 'dependencies'
                     raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing)))
@@ -641,7 +641,7 @@ class Worker(object):
         logger.warning(log_msg)
 
     def _log_dependency_error(self, task, tb):
-        log_msg = "Will not run {task} or any dependencies due to error in deps() method:\n{tb}".format(task=task, tb=tb)
+        log_msg = "Will not run {task} or any dependencies due to error in process_requires() method:\n{tb}".format(task=task, tb=tb)
         logger.warning(log_msg)
 
     def _log_unexpected_error(self, task):
@@ -675,7 +675,7 @@ class Worker(object):
         if self._config.send_failure_email:
             self._email_error(task, formatted_traceback,
                               subject="Luigi: {task} failed scheduling. Host: {host}",
-                              headline="Will not run {task} or any dependencies due to error in deps() method",
+                              headline="Will not run {task} or any dependencies due to error in process_requires() method",
                               )
 
     def _email_unexpected_error(self, task, formatted_traceback):
@@ -821,7 +821,7 @@ class Worker(object):
 
             else:
                 try:
-                    deps = task.deps()
+                    deps = task.process_requires()
                     self._add_task_batcher(task)
                 except Exception as ex:
                     formatted_traceback = traceback.format_exc()

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -1044,7 +1044,7 @@ class MonthInstantiationTest(LuigiTestCase):
                                   start=datetime.date(2015, 12, 1),
                                   stop=datetime.date(2016, 1, 1))
         expected_task = MyTask(month_param=datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_month_cli_instantiation(self):
         """
@@ -1082,7 +1082,7 @@ class MonthInstantiationTest(LuigiTestCase):
                                   stop=datetime.date(2016, 1, 1),
                                   param_name='month_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_param_name_with_inferred_fs(self):
         class MyTask(luigi.Task):
@@ -1098,7 +1098,7 @@ class MonthInstantiationTest(LuigiTestCase):
                                   stop=datetime.date(2016, 1, 1),
                                   param_name='month_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_of_param_distinction(self):
         class MyTask(luigi.Task):
@@ -1465,7 +1465,7 @@ class RangeInstantiationTest(LuigiTestCase):
                                     start=datetime.date(2015, 12, 1),
                                     stop=datetime.date(2015, 12, 2))
         expected_task = MyTask(date_param=datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_cli_instantiation(self):
         """
@@ -1503,7 +1503,7 @@ class RangeInstantiationTest(LuigiTestCase):
                                     stop=datetime.date(2015, 12, 2),
                                     param_name='date_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_param_name_with_inferred_fs(self):
         class MyTask(luigi.Task):
@@ -1519,7 +1519,7 @@ class RangeInstantiationTest(LuigiTestCase):
                                 stop=datetime.date(2015, 12, 2),
                                 param_name='date_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
-        self.assertEqual(expected_task, list(range_task._requires())[0])
+        self.assertEqual(expected_task, list(range_task.process_requires())[0])
 
     def test_of_param_distinction(self):
         class MyTask(luigi.Task):

--- a/test/worker_external_task_test.py
+++ b/test/worker_external_task_test.py
@@ -180,7 +180,7 @@ class WorkerExternalTaskTest(unittest.TestCase):
         test_task = TestTask(tempdir=self.tempdir, complete_after=3)
         test_task.run = NotImplemented
 
-        assert len(test_task.deps()) > 0
+        assert len(test_task.process_requires()) > 0
 
         # split up scheduling task and running to simulate runtime scenario
         with self._make_worker() as w:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -510,7 +510,7 @@ class WorkerTest(LuigiTestCase):
 
         # For b to be done, we must have rescheduled its dependencies to run them twice
         self.assertTrue(b.complete())
-        self.assertTrue(all(a.complete() for a in b.deps()))
+        self.assertTrue(all(a.complete() for a in b.process_requires()))
 
     def test_interleaved_workers(self):
         class A(DummyTask):


### PR DESCRIPTION
This is a part of #2657. 

1. Rename `_requires` to `process_requires` to be consistent with other similar methods.
2. Replace calls to `deps` with `process_requires`. Based on previous discussions, it was never meant to be a public method and it's only duplicating the same function as `process_requires`.