### PR TITLE
Add support to process dynamic dependencies in template tasks

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -625,6 +625,18 @@ class Task(object):
         """
         return flatten(self.requires())  # base impl
 
+    def process_dynamic_deps(self, deps):
+        """
+        Override in "template" tasks which themselves are supposed to be
+        subclassed and thus have their dynamic dependencies modified.
+
+        Takes a flattened list of dynamic dependencies.
+
+        Must return an iterable which among others contains the original
+        dynamic dependencies the superclass.
+        """
+        return deps
+
     def process_resources(self):
         """
         Override in "template" tasks which provide common resource functionality

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -151,7 +151,7 @@ class TaskProcess(multiprocessing.Process):
             except StopIteration:
                 return None
 
-            new_req = flatten(requires)
+            new_req = flatten(self.task.process_dynamic_deps(requires))
             if all(t.complete() for t in new_req):
                 next_send = getpaths(requires)
             else:


### PR DESCRIPTION
This is a different take on #2657. 

Instead of going for a single template function, This creates a new template function to handle dynamic dependencies. If a user wants to apply some logic to both deps, he'll have to override both methods.

```py
class TemplateTask(Task):
    def process_requires(self):
        return do_common_processing(self.requires())
    def process_dynamic_deps(self, deps):
        return do_common_processing(deps)
```