### PR TITLE
aws batch : job queue as parameter

### DIFF
--- a/luigi/contrib/batch.py
+++ b/luigi/contrib/batch.py
@@ -200,6 +200,7 @@ class BatchTask(luigi.Task):
     """
     job_definition = luigi.Parameter()
     job_name = luigi.OptionalParameter(default=None)
+    job_queue = luigi.OptionalParameter(default=None)
     poll_time = luigi.IntParameter(default=POLL_TIME)
 
     def run(self):
@@ -207,7 +208,8 @@ class BatchTask(luigi.Task):
         job_id = bc.submit_job(
             self.job_definition,
             self.parameters,
-            job_name=self.job_name)
+            job_name=self.job_name,
+            queue=self.job_queue)
         bc.wait_on_job(job_id)
 
     @property

--- a/luigi/contrib/batch.py
+++ b/luigi/contrib/batch.py
@@ -196,7 +196,7 @@ class BatchTask(luigi.Task):
 
     :param job_definition (str): name of pre-registered jobDefinition
     :param job_name: name of specific job, for tracking in the queue and logs.
-    :param job_queue: name of job queue where job is going to be submitted. This is optional, if not specified, one queue whose state is VALID and ENABLED is going to be automatically selected.
+    :param job_queue: name of job queue where job is going to be submitted.
 
     """
     job_definition = luigi.Parameter()

--- a/luigi/contrib/batch.py
+++ b/luigi/contrib/batch.py
@@ -196,6 +196,7 @@ class BatchTask(luigi.Task):
 
     :param job_definition (str): name of pre-registered jobDefinition
     :param job_name: name of specific job, for tracking in the queue and logs.
+    :param job_queue: name of job queue where job is going to be submitted. This is optional, if not specified, one queue whose state is VALID and ENABLED is going to be automatically selected.
 
     """
     job_definition = luigi.Parameter()

--- a/test/contrib/batch_test.py
+++ b/test/contrib/batch_test.py
@@ -129,6 +129,23 @@ class BatchClientTest(unittest.TestCase):
             job_name='test_job')
         self.assertEqual(job_id, 'abcd')
 
+    def test_submit_job_specific_queue(self):
+        job_id = self.bc.submit_job(
+            'test_job_def',
+            {'param1': 'foo', 'param2': 'bar'},
+            job_name='test_job',
+            queue='test_queue')
+        self.assertEqual(job_id, 'abcd')
+
+    def test_submit_job_non_existant_queue(self):
+        with self.assertRaises(Exception):
+            job_id = self.bc.submit_job(
+                'test_job_def',
+                {'param1': 'foo', 'param2': 'bar'},
+                job_name='test_job',
+                queue='non_existant_queue')
+
+
     def test_wait_on_job(self):
         job_id = self.bc.submit_job(
             'test_job_def',

--- a/test/contrib/batch_test.py
+++ b/test/contrib/batch_test.py
@@ -139,12 +139,11 @@ class BatchClientTest(unittest.TestCase):
 
     def test_submit_job_non_existant_queue(self):
         with self.assertRaises(Exception):
-            job_id = self.bc.submit_job(
+            self.bc.submit_job(
                 'test_job_def',
                 {'param1': 'foo', 'param2': 'bar'},
                 job_name='test_job',
                 queue='non_existant_queue')
-
 
     def test_wait_on_job(self):
         job_id = self.bc.submit_job(


### PR DESCRIPTION
## Description
allowing batch tasks to pass `job_queue` as a parameter when scheduling a task.
default behaviour is left untouched.

## Motivation and Context
- in environments with multiple compute engines and job queues this is a useful parameter.

## Have you tested this? If so, how?
- locally scheduled a task in a particular queue


