### PR TITLE
Reconcile underscore/dash config style handling (#2688)

### DIFF
--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -162,7 +162,18 @@ class LuigiConfigParser(BaseParser, ConfigParser):
         Raises an exception if the default value is not None and doesn't match the expected_type.
         """
         try:
-            return method(self, section, option, **kwargs)
+            try:
+                # Underscore-style is the recommended configuration style
+                option = option.replace('-', '_')
+                return method(self, section, option, **kwargs)
+            except (NoOptionError, NoSectionError):
+                # Support dash-style option names (with deprecation warning).
+                option_alias = option.replace('_', '-')
+                value = method(self, section, option_alias, **kwargs)
+                warn = 'Configuration [{s}] {o} (with dashes) should be avoided. Please use underscores: {u}.'.format(
+                    s=section, o=option_alias, u=option)
+                warnings.warn(warn, DeprecationWarning)
+                return value
         except (NoOptionError, NoSectionError):
             if default is LuigiConfigParser.NO_DEFAULT:
                 raise

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -217,9 +217,6 @@ class Parameter(object):
             found = getattr(cp_parser.known_args, dest, None)
             yield (self._parse_or_no_value(found), None)
         yield (self._get_value_from_config(task_name, param_name), None)
-        yield (self._get_value_from_config(task_name, param_name.replace('_', '-')),
-               'Configuration [{}] {} (with dashes) should be avoided. Please use underscores.'.format(
-                   task_name, param_name))
         if self._config_path:
             yield (self._get_value_from_config(self._config_path['section'], self._config_path['name']),
                    'The use of the configuration [{}] {} is deprecated. Please use [{}] {}'.format(

--- a/test/config_env_test.py
+++ b/test/config_env_test.py
@@ -75,3 +75,23 @@ class ConfigParserTest(LuigiTestCase):
 
         with self.assertRaises(InterpolationMissingEnvvarError):
             config.get("test", "d")
+
+    @with_config({"test": {
+        "foo-bar": "fob",
+        "baz_qux": "bax",
+    }})
+    def test_underscore_vs_dash_style(self):
+        config = get_config()
+        self.assertEqual(config.get("test", "foo-bar"), "fob")
+        self.assertEqual(config.get("test", "foo_bar"), "fob")
+        self.assertEqual(config.get("test", "baz-qux"), "bax")
+        self.assertEqual(config.get("test", "baz_qux"), "bax")
+
+    @with_config({"test": {
+        "foo-bar": "fob",
+        "foo_bar": "bax",
+    }})
+    def test_underscore_vs_dash_style_priority(self):
+        config = get_config()
+        self.assertEqual(config.get("test", "foo-bar"), "bax")
+        self.assertEqual(config.get("test", "foo_bar"), "bax")

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -595,6 +595,11 @@ class TestRemoveGlobalParameters(LuigiTestCase):
         self.assertEqual(MyConfigWithoutSection().mc_r, 555)
         self.assertEqual(MyConfigWithoutSection().mc_s, 888)
 
+    @with_config({"MyConfig": {"mc_p": "555", "mc-p": "666", "mc-q": "777"}})
+    def test_configuration_style(self):
+        self.assertEqual(MyConfig().mc_p, 555)
+        self.assertEqual(MyConfig().mc_q, 777)
+
     def test_misc_1(self):
         class Dogs(luigi.Config):
             n_dogs = luigi.IntParameter()
@@ -1005,7 +1010,7 @@ class OverrideEnvStuff(LuigiTestCase):
     @with_config({"core": {"scheduler-port": '6544'}})
     def testOverrideSchedulerPort2(self):
         if six.PY3:
-            with self.assertWarnsRegex(DeprecationWarning, r'scheduler_port \(with dashes\) should be avoided'):
+            with self.assertWarnsRegex(DeprecationWarning, r'scheduler-port \(with dashes\) should be avoided'):
                 env_params = luigi.interface.core()
         else:
             env_params = luigi.interface.core()


### PR DESCRIPTION


As discussed in #2688:
Underscore config style is recommended Luigi, but `luigi.task.Config` also  helpfully allows dash style in configuration files (with a deprecation warning).

In a lot of places in contrib modules however, `configuration.get_config().get()`  is used, with dash-style e.g. in the spark contrib module:
```
    return configuration.get_config().get(self.spark_version, "deploy-mode", None)
```
`configuration.get_config().get()` does not provide the dash/underscore translation feature, so one is forced to use `deploy-mode` in their config file. Using the seemingly recommended `deploy_mode` alias will not work. This leads to inconsistently styled and confusing configuration files.


This PR reconciles the underscore/dash handling of `luigi.task.Config` and `configuration.get_config().get()`, so that both use the same logic: both underscores and dashes are allowed, but dash-style triggers a DeprecationWarning.

## Have you tested this? If so, how?
Added some tests about this too.
