### PR TITLE
Configuration documentation: remove deprecated/wrong [core]max_reschedules entry

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -168,12 +168,6 @@ log_level
 logging_conf_file
   Location of the logging configuration file.
 
-max_reschedules
-  The maximum number of times that a job can be automatically
-  rescheduled by a worker before it will stop trying. Workers will
-  reschedule a job if it is found to not be done when attempting to run
-  a dependent job. This defaults to 1.
-
 max_shown_tasks
   .. versionadded:: 1.0.20
 
@@ -320,8 +314,10 @@ max_keep_alive_idle_duration
   Default: 0 (Indefinitely)
 
 max_reschedules
-  Maximum number of times to reschedule a failed task.
-  Default: 1
+  The maximum number of times that a job can be automatically
+  rescheduled by a worker before it will stop trying. Workers will
+  reschedule a job if it is found to not be done when attempting to run
+  a dependent job. This defaults to 1.
 
 retry_external_tasks
   If true, incomplete external tasks (i.e. tasks where the `run()` method is


### PR DESCRIPTION

The configration doc contains entry on `[core]max_reschedules`,
which is not only deprecated (in favor of `[worker]max_reschedules`)
but also wrong: the correct (but deprecated) config key is
`[core]worker-max-reschedules`.
Better get rid of this all together and just keep `[worker]max_reschedules`
