### PR TITLE
Fix example of "summary_length"

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -979,7 +979,7 @@ db_connection
 
 Parameters controlling execution summary of a worker
 
-summary-length
+summary_length
   Maximum number of tasks to show in an execution summary.  If the value is 0,
   then all tasks will be displayed.  Default value is 5.
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Fix name of parameter `summary_length` from `[execution_summary]` section in documentation.
From `summary-length --> summary_length`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to have correct usage example in description.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Not required. Only documentation change.
Already tested in [/test/execution_summary_test.py](https://github.com/spotify/luigi/blob/master/test/execution_summary_test.py):
```python
@with_config({'execution_summary': {'summary_length': '1'}})
    def test_config_summary_limit(self):
        class Bar(luigi.Task):
...
```
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
