### PR TITLE
Fix __init__ error when using TOML config

### DIFF
--- a/luigi/configuration/toml_parser.py
+++ b/luigi/configuration/toml_parser.py
@@ -78,5 +78,8 @@ class LuigiTomlParser(BaseParser):
             self.data[section] = {}
         self.data[section][option] = value
 
+    def has_option(self, section, option):
+        return section in self.data and option in self.data[section]
+
     def __getitem__(self, name):
         return self.data[name]

--- a/test/config_toml_test.py
+++ b/test/config_toml_test.py
@@ -64,6 +64,12 @@ class TomlConfigParserTest(LuigiTestCase):
         config.set('hdfs', 'check', 'test me')
         self.assertEqual(config.get('hdfs', 'check'), 'test me')
 
+    def test_has_option(self):
+        config = get_config('toml')
+        self.assertTrue(config.has_option('hdfs', 'client'))
+        self.assertFalse(config.has_option('hdfs', 'nope'))
+        self.assertFalse(config.has_option('nope', 'client'))
+
 
 class HelpersTest(LuigiTestCase):
     def test_add_without_install(self):


### PR DESCRIPTION
## Description
This PR adds `LuigiTomlParser.has_option()`.

## Motivation and Context
PR #2656 (included in Luigi v2.8.4) introduced an error on Luigi startup when using a TOML config file.
The offending line:
https://github.com/spotify/luigi/blob/2e4c3737972ff6e995e0d9b66571d6978cea1977/luigi/__init__.py#L64

While `LuigiConfigParser` contains the `has_option()` method (inherited from `ConfigParser`), `LuigiTomlParser` does not.

## Have you tested this? If so, how?

Added `test_has_option` in `test/config_toml_test.py`
(Plus I ran my jobs with this code and it works for me.)
