### PR TITLE
add callback to metric collector

### DIFF
--- a/luigi/contrib/prometheus_metric.py
+++ b/luigi/contrib/prometheus_metric.py
@@ -1,4 +1,4 @@
-from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest, CONTENT_TYPE_LATEST
 from luigi.metrics import MetricsCollector
 
 
@@ -58,3 +58,6 @@ class PrometheusMetricsCollector(MetricsCollector):
         # time_running can be `None` if task was already complete
         if task.time_running is not None:
             self.task_execution_time.labels(family=task.family).set(task.updated - task.time_running)
+
+    def configure_http_handler(self, http_handler):
+        http_handler.set_header('Content-Type', CONTENT_TYPE_LATEST)

--- a/luigi/metrics.py
+++ b/luigi/metrics.py
@@ -53,6 +53,9 @@ class MetricsCollector(object):
     def generate_latest(self):
         return
 
+    def configure_http_handler(self, http_handler):
+        pass
+
 
 class NoMetricsCollector(MetricsCollector):
     """Empty MetricsCollector when no collector is being used

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -45,7 +45,6 @@ import sys
 import time
 
 import pkg_resources
-from prometheus_client import CONTENT_TYPE_LATEST
 import tornado.httpserver
 import tornado.ioloop
 import tornado.netutil
@@ -282,8 +281,8 @@ class MetricsHandler(tornado.web.RequestHandler):
     def get(self):
         metrics = self._scheduler._state._metrics_collector.generate_latest()
         if metrics:
+            metrics.configure_http_handler(self)
             self.write(metrics)
-            self.set_header('Content-Type', CONTENT_TYPE_LATEST)
 
 
 def app(scheduler):

--- a/test/contrib/prometheus_metric_test.py
+++ b/test/contrib/prometheus_metric_test.py
@@ -1,5 +1,7 @@
 from helpers import unittest
 from nose.plugins.attrib import attr
+from mock import MagicMock
+from prometheus_client import CONTENT_TYPE_LATEST
 
 from luigi.contrib.prometheus_metric import PrometheusMetricsCollector
 from luigi.metrics import MetricsCollectors
@@ -68,3 +70,8 @@ class PrometheusMetricTest(unittest.TestCase):
 
         assert self.collector.registry.get_sample_value(counter_name, labels=labels) == 1
         assert self.collector.registry.get_sample_value(gauge_name, labels=labels) == task.updated - task.time_running
+
+    def test_configure_http_handler(self):
+        mock_http_handler = MagicMock()
+        self.collector.configure_http_handler(mock_http_handler)
+        mock_http_handler.set_header.assert_called_once_with('Content-Type', CONTENT_TYPE_LATEST)

--- a/test/contrib/prometheus_metric_test.py
+++ b/test/contrib/prometheus_metric_test.py
@@ -1,11 +1,16 @@
 from helpers import unittest
 from nose.plugins.attrib import attr
-from mock import MagicMock
 from prometheus_client import CONTENT_TYPE_LATEST
 
 from luigi.contrib.prometheus_metric import PrometheusMetricsCollector
 from luigi.metrics import MetricsCollectors
 from luigi.scheduler import Scheduler
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 
 WORKER = 'myworker'
 TASK_ID = 'TaskID'
@@ -72,6 +77,6 @@ class PrometheusMetricTest(unittest.TestCase):
         assert self.collector.registry.get_sample_value(gauge_name, labels=labels) == task.updated - task.time_running
 
     def test_configure_http_handler(self):
-        mock_http_handler = MagicMock()
+        mock_http_handler = mock.MagicMock()
         self.collector.configure_http_handler(mock_http_handler)
         mock_http_handler.set_header.assert_called_once_with('Content-Type', CONTENT_TYPE_LATEST)

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -22,7 +22,6 @@ import signal
 import time
 import tempfile
 from helpers import unittest, skipOnTravis
-import mock
 import luigi.rpc
 import luigi.server
 import luigi.cmdline

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -22,6 +22,7 @@ import signal
 import time
 import tempfile
 from helpers import unittest, skipOnTravis
+import mock
 import luigi.rpc
 import luigi.server
 import luigi.cmdline
@@ -448,3 +449,27 @@ class INETLuigidDaemonServerTest(_INETServerTest):
         shutil.rmtree(self.server_client.tempdir)
 
     server_client_class = ServerClient
+
+
+class MetricsHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_scheduler = mock.MagicMock()
+        self.handler = luigi.server.MetricsHandler(tornado.web.Application(), mock.MagicMock(),
+                                                   scheduler=self.mock_scheduler)
+
+    def test_initialize(self):
+        self.assertIs(self.handler._scheduler, self.mock_scheduler)
+
+    def test_get(self):
+        mock_metrics = mock.MagicMock()
+        self.mock_scheduler._state._metrics_collector.generate_latest.return_value = mock_metrics
+        with mock.patch.object(self.handler, 'write') as patched_write:
+            self.handler.get()
+            patched_write.assert_called_once_with(mock_metrics)
+            mock_metrics.configure_http_handler.assert_called_once_with(self.handler)
+
+    def test_get_no_metrics(self):
+        self.mock_scheduler._state._metrics_collector.generate_latest.return_value = None
+        with mock.patch.object(self.handler, 'write') as patched_write:
+            self.handler.get()
+            patched_write.assert_not_called()


### PR DESCRIPTION
So that they can configure http handler. This is to fix #2628.

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
#2628 introduced dependency of `prometheus_client` and that breaks `server.py`. This PR
adds a callback for the metrics collector to further customise http handler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm not entirely sure exposing http handler to contrib is a good idea, but this is to avoid pulling
in dependency or hardcoding a header value only for the sake of a certain metrics collector.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
