### PR TITLE
Mark tasks as failed if complete() is false when run finishes

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -458,10 +458,10 @@ class worker(Config):
                                            description='If true, check for completeness of '
                                            'dependencies before running a task')
     check_complete_on_run = BoolParameter(default=False,
-                                           config_path=dict(section='core', name='check-complete-on-run'),
-                                           description='If true, only mark tasks as done after running if they are complete. '
-                                           'Regardless of this setting, the worker will always check if external '
-                                           'tasks are complete before marking them as done.')
+                                          config_path=dict(section='core', name='check-complete-on-run'),
+                                          description='If true, only mark tasks as done after running if they are complete. '
+                                          'Regardless of this setting, the worker will always check if external '
+                                          'tasks are complete before marking them as done.')
     force_multiprocessing = BoolParameter(default=False,
                                           description='If true, use multiprocessing also when '
                                           'running with 1 worker')

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -196,7 +196,7 @@ class TaskProcess(multiprocessing.Process):
                 with self._forward_attributes():
                     new_deps = self._run_get_new_deps()
                 if not new_deps:
-                    if self.complete():
+                    if self.task.complete():
                         status = DONE
                     else:
                         status = FAILED

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -456,7 +456,6 @@ class worker(Config):
                                            description='If true, check for completeness of '
                                            'dependencies before running a task')
     check_complete_on_run = BoolParameter(default=False,
-                                          config_path=dict(section='core', name='check-complete-on-run'),
                                           description='If true, only mark tasks as done after running if they are complete. '
                                           'Regardless of this setting, the worker will always check if external '
                                           'tasks are complete before marking them as done.')

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -124,7 +124,8 @@ class TaskProcess(multiprocessing.Process):
     }
 
     def __init__(self, task, worker_id, result_queue, status_reporter,
-                 use_multiprocessing=False, worker_timeout=0, check_unfulfilled_deps=True):
+                 use_multiprocessing=False, worker_timeout=0, check_unfulfilled_deps=True,
+                 check_complete_on_run=False):
         super(TaskProcess, self).__init__()
         self.task = task
         self.worker_id = worker_id
@@ -134,6 +135,7 @@ class TaskProcess(multiprocessing.Process):
         self.timeout_time = time.time() + self.worker_timeout if self.worker_timeout else None
         self.use_multiprocessing = use_multiprocessing or self.timeout_time is not None
         self.check_unfulfilled_deps = check_unfulfilled_deps
+        self.check_complete_on_run = check_complete_on_run
 
     def _run_get_new_deps(self):
         task_gen = self.task.run()
@@ -196,7 +198,7 @@ class TaskProcess(multiprocessing.Process):
                 with self._forward_attributes():
                     new_deps = self._run_get_new_deps()
                 if not new_deps:
-                    if self.task.complete():
+                    if not self.check_complete_on_run or self.task.complete():
                         status = DONE
                     else:
                         status = FAILED
@@ -455,6 +457,11 @@ class worker(Config):
     check_unfulfilled_deps = BoolParameter(default=True,
                                            description='If true, check for completeness of '
                                            'dependencies before running a task')
+    check_complete_on_run = BoolParameter(default=False,
+                                           config_path=dict(section='core', name='check-complete-on-run'),
+                                           description='If true, only mark tasks as done after running if they are complete. '
+                                           'Regardless of this setting, the worker will always check if external '
+                                           'tasks are complete before marking them as done.')
     force_multiprocessing = BoolParameter(default=False,
                                           description='If true, use multiprocessing also when '
                                           'running with 1 worker')
@@ -1024,6 +1031,7 @@ class Worker(object):
             use_multiprocessing=use_multiprocessing,
             worker_timeout=self._config.timeout,
             check_unfulfilled_deps=self._config.check_unfulfilled_deps,
+            check_complete_on_run=self._config.check_complete_on_run,
         )
 
     def _purge_children(self):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -201,9 +201,7 @@ class TaskProcess(multiprocessing.Process):
                     if not self.check_complete_on_run or self.task.complete():
                         status = DONE
                     else:
-                        status = FAILED
-                        ex = TaskException("Task finished running, but complete() is still returning false.")
-                        expl = self._handle_run_exception(ex)
+                        raise TaskException("Task finished running, but complete() is still returning false.")
                 else:
                     status = PENDING
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -138,6 +138,13 @@ class RunOnceTask(luigi.Task):
         self.comp = True
 
 
+# string subclass that matches arguments containing the specified substring
+# for use in mock 'called_with' assertions
+class StringContaining(str):
+    def __eq__(self, other_str):
+        return self in other_str
+
+
 class LuigiTestCase(unittest.TestCase):
     """
     Tasks registred within a test case will get unregistered in a finalizer

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -103,7 +103,7 @@ class TaskProcessTest(LuigiTestCase):
                 FAILED,
                 StringContaining("finished running, but complete() is still returning false"),
                 [],
-                []
+                None
             ))
 
     def test_cleanup_children_on_terminate(self):

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -18,7 +18,7 @@ import multiprocessing
 from subprocess import check_call
 import sys
 
-from helpers import LuigiTestCase
+from helpers import LuigiTestCase, StringContaining
 import mock
 from psutil import Process
 from time import sleep
@@ -86,6 +86,26 @@ class TaskProcessTest(LuigiTestCase):
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()
             mock_put.assert_called_once_with((task.task_id, FAILED, "test failure expl", [], []))
+
+    def test_fail_on_false_complete(self):
+        class NeverCompleteTask(luigi.Task):
+            def complete(self):
+                return False
+
+        task = NeverCompleteTask()
+        result_queue = multiprocessing.Queue()
+        task_process = TaskProcess(task, 1, result_queue, mock.Mock())
+
+        with mock.patch.object(result_queue, 'put') as mock_put:
+            task_process.run()
+            mock_put.assert_called_once_with((
+                task.task_id,
+                FAILED,
+                StringContaining("finished running, but complete() is still returning false"),
+                [],
+                []
+            ))
+
 
     def test_cleanup_children_on_terminate(self):
         """

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -106,7 +106,6 @@ class TaskProcessTest(LuigiTestCase):
                 []
             ))
 
-
     def test_cleanup_children_on_terminate(self):
         """
         Subprocesses spawned by tasks should be terminated on terminate

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -94,7 +94,7 @@ class TaskProcessTest(LuigiTestCase):
 
         task = NeverCompleteTask()
         result_queue = multiprocessing.Queue()
-        task_process = TaskProcess(task, 1, result_queue, mock.Mock())
+        task_process = TaskProcess(task, 1, result_queue, mock.Mock(), check_complete_on_run=True)
 
         with mock.patch.object(result_queue, 'put') as mock_put:
             task_process.run()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `check_complete_on_run` setting to workers, which changes the logic used to determine job status in `TaskProcess` to mark a task as FAILED if its `run()` method executes successfully but its `complete()` method still returns false. This setting is false by default, to avoid breaking existing workflows.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, if a task runs but does not create all of its outputs (or does not satisfy its custom complete() method), it is marked as DONE, but tasks that depend on it later fail with a cryptic "missing dependency" error. This associates the failure with the responsible task rather than marking dependent tasks that were unable to begin execution as failed. Additionally, this greatly simplifies detecting whether root tasks (i.e. tasks upon which no other tasks depend) have actually completed successfully. Without this change, they are marked as DONE and there is no built-in method to detect that their outputs have not been created.
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
I have included unit tests.
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
