### PR TITLE
Fix tasklist history graph y-axis labels

### DIFF
--- a/luigi/templates/history.html
+++ b/luigi/templates/history.html
@@ -87,13 +87,15 @@
 			.showMaxMin(false)
 			.ticks(refined_failed_data.values.length+refined_done_data.values.length)
 			.tickFormat(function(d, i) {
-					var dx = (merged_data[0].values[d] && merged_data[0].values[d][0]) || (merged_data[1].values[d] && merged_data[1].values[d][0]);
-					return d3.time.format('%x %X')(new Date(dx));
+				var dx = (merged_data[0].values[d] && merged_data[0].values[d][0]) || (merged_data[1].values[d] && merged_data[1].values[d][0]);
+				return d3.time.format('%x %X')(new Date(dx));
 			});
 			chart.yAxis
 			.axisLabel("Processing Time (H:M:S)")
 			.tickFormat(function(d) {
-				return d3.time.format('%X')(new Date(d - 32400000));
+				var dy = new Date();
+				dy.setHours(0, 0, 0, d);
+				return d3.time.format('%X')(dy);
 			});
 			chart.tooltipContent(function(key, x, y, e, graph) {
 				tooltip_str = '<center><b>Result status: '+key+'</b></center>'+'<center>processing time: '+y+'</center><center> on '+x+'</center>';


### PR DESCRIPTION
## Description
Fix the y-axis labels of the chart available at `{base_url}/tasklist/{task_name}`.
![image](https://user-images.githubusercontent.com/5764201/57893101-f0d1cf00-7841-11e9-8db5-f38c46fea2bf.png)

## Motivation and Context
This chart is showing the historical running time of a task but the y-axis was shifted by x hours depending on your timezone.
It was using some hardcoded time shift which I guess was accounting for the timezone of the contributor.

The simple fix is to create a date and set the the time to `d` milliseconds (the running time).

This should fix #2651 

## Have you tested this? If so, how?
Tested locally
