### PR TITLE
Adapt SendGrid integration to use the updated libraries.

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -232,20 +232,21 @@ def send_email_ses(sender, subject, message, recipients, image_png):
 def send_email_sendgrid(sender, subject, message, recipients, image_png):
     import sendgrid as sendgrid_lib
     client = sendgrid_lib.SendGridAPIClient(sendgrid().apikey)
+
+    to_send = sendgrid_lib.Mail(
+            from_email=sender,
+            to_emails=recipients,
+            subject=subject)
+
     if email().format == 'html':
-        to_send = sendgrid_lib.Mail(from_email=sender,
-            to_emails=recipients,
-            subject=subject,
-            html_content=message)
+        to_send.add_content(message,'text/html')
     else:
-        to_send = sendgrid_lib.Mail(from_email=sender,
-            to_emails=recipients,
-            subject=subject,
-            plain_text_content=message)
+        to_send.add_content(message,'text/plain')
+
     if image_png:
         to_send.add_attachment(image_png)
 
-    response = client.send(to_send)
+    client.send(to_send)
 
 
 def _email_disabled_reason():

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -239,9 +239,9 @@ def send_email_sendgrid(sender, subject, message, recipients, image_png):
             subject=subject)
 
     if email().format == 'html':
-        to_send.add_content(message,'text/html')
+        to_send.add_content(message, 'text/html')
     else:
-        to_send.add_content(message,'text/plain')
+        to_send.add_content(message, 'text/plain')
 
     if image_png:
         to_send.add_attachment(image_png)

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -312,7 +312,7 @@ class TestSendgridEmail(unittest.TestCase, NotificationFixture):
     def tearDown(self):
         del sys.modules['sendgrid']
 
-    @with_config({"sendgrid": {"apikey":"456abcdef123"}})
+    @with_config({"sendgrid": {"apikey": "456abcdef123"}})
     def test_sends_sendgrid_email(self):
         """
         Call notifications.send_email_sendgrid with fixture parameters

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -312,19 +312,18 @@ class TestSendgridEmail(unittest.TestCase, NotificationFixture):
     def tearDown(self):
         del sys.modules['sendgrid']
 
-    @with_config({"sendgrid": {"username": "Nikola",
-                               "password": "jahuS"}})
+    @with_config({"sendgrid": {"apikey":"456abcdef123"}})
     def test_sends_sendgrid_email(self):
         """
         Call notifications.send_email_sendgrid with fixture parameters
-        and check that SendGridClient is properly called.
+        and check that SendGridAPIClient is properly called.
         """
 
-        with mock.patch('sendgrid.SendGridClient') as SendgridClient:
+        with mock.patch('sendgrid.SendGridAPIClient') as SendGridAPIClient:
             notifications.send_email_sendgrid(*self.notification_args)
 
-            SendgridClient.assert_called_once_with("Nikola", "jahuS", raise_errors=True)
-            self.assertTrue(SendgridClient.return_value.send.called)
+            SendGridAPIClient.assert_called_once_with("456abcdef123", raise_errors=True)
+            self.assertTrue(SendGridAPIClient.return_value.send.called)
 
 
 class TestSESEmail(unittest.TestCase, NotificationFixture):

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -322,7 +322,7 @@ class TestSendgridEmail(unittest.TestCase, NotificationFixture):
         with mock.patch('sendgrid.SendGridAPIClient') as SendGridAPIClient:
             notifications.send_email_sendgrid(*self.notification_args)
 
-            SendGridAPIClient.assert_called_once_with("456abcdef123", raise_errors=True)
+            SendGridAPIClient.assert_called_once_with("456abcdef123")
             self.assertTrue(SendGridAPIClient.return_value.send.called)
 
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
SendGrid changed their API about three years ago to use API tokens instead of username/password combos. The `sendgrid` library adapted, but Luigi's code that depends on SendGrid did not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This re-instates SendGrid integration for sending out emails when Luigi Tasks fail. It solves #2714 and #1956 (since they are duplicate issues).

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran a simple Task that force-failed by calling `sys.exit()`, together with a config file using an `apikey` value in `[sendgrid]` and a `method=sendgrid` on `[email]`. I received the "Task failed" emails, even with multiple email addresses set up.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
