### PR TITLE
Documentation: Running Luigi on Windows

### DIFF
--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -127,16 +127,17 @@ Response of luigi.build()/luigi.run()
          print(luigi_run_result.summary_text)
 
 
-Running Luigi on Windows
-^^^^^^^^^^^^^^^^^^^^^^^^
+Luigi on Windows
+^^^^^^^^^^^^^^^^
 
 Most Luigi functionality works on Windows. Exceptions:
 
-- Specifying multiple worker processes using the `workers` argument for `luigi.build`,
-  or using `--workers` on the command line. (Similarly for specifying
-  `--worker-force-multiprocessing`). For most programs, this will result in
-  failure (a common sight is `BrokenPipeError`). The reason is that worker processes
-  are assumed to be forked from the main process. Forking is [not possible](https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods)
+- Specifying multiple worker processes using the ``workers`` argument for
+  ``luigi.build``, or using the ``--workers`` command line argument. (Similarly,
+  specifying ``--worker-force-multiprocessing``). For most programs, this will
+  result in failure (a common sight is ``BrokenPipeError``). The reason is that
+  worker processes are assumed to be forked from the main process. Forking is
+  `not possible <https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods>`_
   on Windows.
-- Running the Luigi central scheduling server as a daemon (i.e. with `--background`).
+- Running the Luigi central scheduling server as a daemon (i.e. with ``--background``).
   Again, a Unix-only concept.

--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -1,4 +1,5 @@
-.. _RunningLuigi:
+Running Luigi
+-------------
 
 Running from the Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,6 +111,8 @@ which will return your worker and/or scheduler implementations:
 
 In some cases (like task queue) it may be useful.
 
+
+
 Response of luigi.build()/luigi.run()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -122,3 +125,18 @@ Response of luigi.build()/luigi.run()
     if __name__ == '__main__':
          luigi_run_result = luigi.build(..., detailed_summary=True)
          print(luigi_run_result.summary_text)
+
+
+Running Luigi on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most Luigi functionality works on Windows. Exceptions:
+
+- Specifying multiple worker processes using the `workers` argument for `luigi.build`,
+  or using `--workers` on the command line. (Similarly for specifying
+  `--worker-force-multiprocessing`). For most programs, this will result in
+  failure (a common sight is `BrokenPipeError`). The reason is that worker processes
+  are assumed to be forked from the main process. Forking is [not possible](https://docs.python.org/dev/library/multiprocessing.html#contexts-and-start-methods)
+  on Windows.
+- Running the Luigi central scheduling server as a daemon (i.e. with `--background`).
+  Again, a Unix-only concept.


### PR DESCRIPTION
## Description
- Added section "Running on Windows" to `doc/running_luigi.rst`
- Made "Running Luigi" a proper item in the documentation side-nav, with sub-items.
  (Before, all subsections of the `doc/running_luigi.rst` file appeared separately as top-level items in the side-nav. This became too long).

## Motivation and Context
I test [my Luigi-based software](https://github.com/tfiers/sharp/) locally on Windows (for later deployment on Linux). That's how I discovered these Windows issues.
I have spent a little time figuring out these issues.
This will spare other Luigi users the same puzzlement.

A simple test to show the multiprocessing issue on Windows:
```py
import luigi

class Burrito(luigi.WrapperTask):
    def requires(self):
        return (Madamme(prot=put) for put in range(30))


class Madamme(luigi.Task):
    prot = luigi.IntParameter()

    def output(self):
        return luigi.LocalTarget(f"{self.prot}.txt")

    def run(self):
        with self.output().open('w') as f:
            f.write('prot ' * self.prot)

luigi.build([Burrito()], local_scheduler=True, workers=2)
```
Works on Unix, but on Windows only when `workers=1`

## Have you tested this? If so, how?
Tested locally with `tox -e docs`


