### PR TITLE
Change GET request to POST requests

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -92,7 +92,7 @@ class RequestsFetcher(object):
 
     def fetch(self, full_url, body, timeout):
         self.check_pid()
-        resp = self.session.get(full_url, data=body, timeout=timeout)
+        resp = self.session.post(full_url, data=body, timeout=timeout)
         resp.raise_for_status()
         return resp.text
 


### PR DESCRIPTION
GET requests should not have http body according to RFC.
Works well with POST here, and fails with GET for some cases:
2019-03-22 20:51:24,589 tornado.application[19] ERROR: Uncaught exception GET /api/add_task ...

Traceback (most recent call last):
  File "contrib/python/tornado/tornado/web.py", line 1510, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "contrib/python/luigi/luigi/server.py", line 120, in get
    result = getattr(self._scheduler, method)(**arguments)
  File "contrib/python/luigi/luigi/scheduler.py", line 819, in add_task
    assert worker is not None
AssertionError


By the way: urllib fetcher uses POST here (urlopen(full_url, body, timeout).)

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.


<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
