### PR TITLE
Bump tornado dependency to >=5.0,<6 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'tornado>=4.0,<5',
+    "tornado>=5,<6",
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
     'python-dateutil>=2.7.5,<3',


### PR DESCRIPTION
## Description
Bump of tornado version because there is a dependency mismatch when  installing this in `jupyter/minimal-notebook:d4cbf2f80a2a` docker image. 

## Have you tested this? If so, how?
Tested using `tox -e py37`. Nevertheless more tests needed, 
