### PR TITLE
Only send public params to datadog

### DIFF
--- a/luigi/contrib/datadog_metric.py
+++ b/luigi/contrib/datadog_metric.py
@@ -109,7 +109,7 @@ class DatadogMetricsCollector(MetricsCollector):
 
     def _format_task_params_to_tags(self, task):
         params = []
-        for key, value in task.params.items():
+        for key, value in task.public_params.items():
             params.append("{key}:{value}".format(key=key, value=value))
 
         return params

--- a/test/contrib/datadog_metric_test.py
+++ b/test/contrib/datadog_metric_test.py
@@ -6,11 +6,14 @@ import time
 
 from luigi.contrib.datadog_metric import DatadogMetricsCollector
 from luigi.metrics import MetricsCollectors
+from luigi.parameter import ParameterVisibility
 from luigi.scheduler import Scheduler
+from nose.plugins.attrib import attr
 
 WORKER = 'myworker'
 
 
+@attr('contrib')
 class DatadogMetricTest(unittest.TestCase):
     def setUp(self):
         self.mockDatadog()
@@ -149,3 +152,13 @@ class DatadogMetricTest(unittest.TestCase):
         self.mock_gauge.assert_called_once_with('luigi.task.execution_time', 0, tags=['task_name:DDTaskName',
                                                                                       'environment:development',
                                                                                       'application:luigi'])
+
+    def test_format_task_params_to_tags(self):
+        task = task = self.startTask()
+        task.set_params({'test_param': 'test_value'})
+        self.assertEqual(self.collector._format_task_params_to_tags(task), ['test_param:test_value'])
+
+    def test_format_task_params_to_tags_hidden(self):
+        task = self.startTask()
+        with mock.patch.object(task, 'param_visibilities', {'test_param': ParameterVisibility.HIDDEN}):
+            self.assertEqual(self.collector._format_task_params_to_tags(task), [])


### PR DESCRIPTION
* Update DatadogMetricsCollector to respect HIDDEN and PRIVATE param visibility

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the DatadogMetricsCollector to respect HIDDEN and PRIVATE params and _not_ send those as tags to Datadog.

Debatably, params should not be used as tags at all (or at least not by default) as params tend to have high cardinality (dates, ids, etc) which is not recommended by datadog: https://docs.datadoghq.com/tagging/#defining-tags (see item 6)

## Motivation and Context
Per my reported issue: https://github.com/spotify/luigi/issues/2738 using the datadog metrics collector has the potential to leak secrets to datadog as tags

## Have you tested this? If so, how?
* Added unit tests