### PR TITLE
Fix SendGrid email API documentation.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -363,7 +363,7 @@ check_unfulfilled_deps
 
 force_multiprocessing
   By default, luigi uses multiprocessing when *more than one* worker process is
-  requested. Whet set to true, multiprocessing is used independent of the
+  requested. When set to true, multiprocessing is used independent of the
   the number of workers.
   Defaults to false.
 
@@ -405,8 +405,8 @@ method
   config files or run Luigi on an EC2 instance with proper instance
   profile.
 
-  In order to use sendgrid, fill in your sendgrid username and password
-  in the `[sendgrid]`_ section.
+  In order to use sendgrid, fill in your sendgrid API key in the
+  `[sendgrid]`_ section.
 
   In order to use smtp, fill in the appropriate fields in the `[smtp]`_
   section.
@@ -834,11 +834,8 @@ metrics_collector
 
 These parameters control sending error e-mails through SendGrid.
 
-password
-  Password used for sendgrid login
-
-username
-  Name of the user for the sendgrid login
+apikey
+  API key of the SendGrid account.
 
 
 [smtp]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the SendGrid documentation to mention the API key instead of username/password combination. Closes #2741 .
<!--- Describe your changes -->

## Motivation and Context
After PR #2715 , which updated the usage of SendGrid to comply with the new API format, the documentation was forgotten. This fixes the RST file.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
No tests required.
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
