### PR TITLE
Add Jodel in list of companies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,6 +184,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Whizar <https://www.whizar.com/>`_
 * `xtream <https://www.xtreamers.io/>`_
 * `Skyscanner <https://www.skyscanner.net/>`_
+* `Jodel <https://www.jodel.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION
## Description
Add Jodel in the list of companies which are using Luigi.

## Motivation and Context
Jodel has been using Luigi for its ETL for about 2 years and would love to have its name on the list of companies using it.
