### PR TITLE
contrib/ftp: Clean up temporary files

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 #
 """
-This library is a wrapper of ftplib.
-It is convenient to move data from/to FTP.
+This library is a wrapper of ftplib or pysftp.
+It is convenient to move data from/to (S)FTP servers.
 
 There is an example on how to use it (example/ftp_experiment_outputs.py)
 
 You can also find unittest for each class.
 
-Be aware that normal ftp do not provide secure communication.
+Be aware that normal ftp does not provide secure communication.
 """
 
 import datetime
@@ -368,7 +368,8 @@ class RemoteTarget(luigi.target.FileSystemTarget):
     """
     Target used for reading from remote files.
 
-    The target is implemented using ssh commands streaming data over the network.
+    The target is implemented using intermediate files on the local system.
+    On Python2, these files may not be cleaned up.
     """
 
     def __init__(
@@ -407,8 +408,25 @@ class RemoteTarget(luigi.target.FileSystemTarget):
             return self.format.pipe_writer(AtomicFtpFile(self._fs, self.path))
 
         elif mode == 'r':
-            temp_dir = os.path.join(tempfile.gettempdir(), 'luigi-contrib-ftp')
-            self.__tmp_path = temp_dir + '/' + self.path.lstrip('/') + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
+            try:
+                # store reference to the TemporaryDirectory because it will be removed on GC
+                self.__temp_dir = tempfile.TemporaryDirectory(
+                    prefix="luigi-contrib-ftp"
+                )
+            except AttributeError:
+                # TemporaryDirectory only available in Python3, use old behaviour in Python2
+                # this file will not be cleaned up automatically
+                self.__tmp_path = os.path.join(
+                    tempfile.gettempdir(),
+                    'luigi-contrib-ftp',
+                    self.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10),
+                )
+            else:
+                self.__tmp_path = os.path.join(
+                    self.__temp_dir.name,
+                    self.path + "-luigi-tmp-%09d" % random.randrange(0, 1e10),
+                )
+
             # download file to local
             self._fs.get(self.path, self.__tmp_path)
 

--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -408,6 +408,9 @@ class RemoteTarget(luigi.target.FileSystemTarget):
             return self.format.pipe_writer(AtomicFtpFile(self._fs, self.path))
 
         elif mode == 'r':
+            temppath = '{}-luigi-tmp-{:09d}'.format(
+                self.path.lstrip('/'), random.randrange(0, 1e10)
+            )
             try:
                 # store reference to the TemporaryDirectory because it will be removed on GC
                 self.__temp_dir = tempfile.TemporaryDirectory(
@@ -417,15 +420,10 @@ class RemoteTarget(luigi.target.FileSystemTarget):
                 # TemporaryDirectory only available in Python3, use old behaviour in Python2
                 # this file will not be cleaned up automatically
                 self.__tmp_path = os.path.join(
-                    tempfile.gettempdir(),
-                    'luigi-contrib-ftp',
-                    self.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10),
+                    tempfile.gettempdir(), 'luigi-contrib-ftp', temppath
                 )
             else:
-                self.__tmp_path = os.path.join(
-                    self.__temp_dir.name,
-                    self.path + "-luigi-tmp-%09d" % random.randrange(0, 1e10),
-                )
+                self.__tmp_path = os.path.join(self.__temp_dir.name, temppath)
 
             # download file to local
             self._fs.get(self.path, self.__tmp_path)

--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -414,7 +414,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
             try:
                 # store reference to the TemporaryDirectory because it will be removed on GC
                 self.__temp_dir = tempfile.TemporaryDirectory(
-                    prefix="luigi-contrib-ftp"
+                    prefix="luigi-contrib-ftp_"
                 )
             except AttributeError:
                 # TemporaryDirectory only available in Python3, use old behaviour in Python2


### PR DESCRIPTION
## Description
On Python3, the target now stores the temporary files in a [tempfile.TemporaryDirectory](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory); once the target is destroyed/garbage collected the TemporaryDirectory should be too, and remove itself and all its contents, so the temporary files don't hang around any more using disk space. A better solution would be to rewrite the module to actually try and stream the data, but this seemed nontrivial with ftplib (though possibly easier with pysftp's [Connection.getfo()](https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.Connection.getfo)).

## Motivation and Context
I started using the contrib/ftp targets only to discover that it doesn't actually 'stream' data as the documentation implies, but it downloads entire files to a file in /tmp which doesn't get cleaned up automatically, even after tasks complete. That worker's disk filled up and took it down temporarily.

## Have you tested this? If so, how?
I'm running a similar patch and it works for me, but that one didn't keep the old behaviour for Python2 like this one does. Not sure if there's a good solution that easily works for both, but since Py2 is EOL in a few months and this behaviour is already ~5 years old, I didn't bother too much.