### PR TITLE
Show task history link in visualizer when recording.

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -993,6 +993,10 @@ class Scheduler(object):
         return {"response": response}
 
     @rpc_method()
+    def has_task_history(self):
+        return self._config.record_task_history
+
+    @rpc_method()
     def is_pause_enabled(self):
         return {'enabled': self._config.pause_enabled}
 

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -361,6 +361,14 @@
           </div>
         </script>
 
+        <script type="text/template" name="topNavbarItem">
+          <li>
+            <a class="js-nav-link" href="{{href}}" {{#dataTab}}data-tab="{{dataTab}}"{{/dataTab}}>
+              {{label}}
+            </a>
+          </li>
+        </script>
+
     </head>
     <body class="skin-green-light fixed">
         <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -387,7 +395,7 @@
                             </button>
                         </div>
                         <div class="collapse navbar-collapse">
-                            <ul class="nav navbar-nav">
+                            <ul class="nav navbar-nav" id="topNavbar">
                                 <li><a class="js-nav-link" href="#tab=tasks" data-tab="taskList">Task List</a></li>
                                 <li><a class="js-nav-link" href="#tab=graph" data-tab="dependencyGraph">Dependency Graph</a></li>
                                 <li><a class="js-nav-link" href="#tab=workers" data-tab="workerList">Workers</a></li>

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -180,6 +180,12 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.hasTaskHistory = function(callback) {
+        jsonRPC(this.urlRoot + '/has_task_history', {}, function(response) {
+            callback(response.response);
+        });
+    };
+
     LuigiAPI.prototype.pause = function() {
         jsonRPC(this.urlRoot + '/pause');
     };

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1126,6 +1126,15 @@ function visualiserApp(luigi) {
     $(document).ready(function() {
         loadTemplates();
 
+        luigi.hasTaskHistory(function(hasTaskHistory) {
+            if (hasTaskHistory) {
+                $('#topNavbar').append(renderTemplate('topNavbarItem', {
+                    label: "History",
+                    href: "../../history",
+                }).children()[0]);
+            }
+        });
+
         luigi.isPauseEnabled(function(enabled) {
             if (enabled) {
                 luigi.isPaused(createPauseToggle);

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -22,6 +22,7 @@ import time
 from helpers import unittest
 
 import luigi.scheduler
+import luigi.configuration
 from helpers import with_config
 
 
@@ -231,8 +232,11 @@ class SchedulerIoTest(unittest.TestCase):
 
     @with_config({'scheduler': {'record_task_history': 'true'}})
     def test_has_task_history(self):
-        s = luigi.scheduler.Scheduler()
-        self.assertTrue(s.has_task_history())
+        cfg = luigi.configuration.get_config()
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=True) as fn:
+            cfg.set('task_history', 'db_connection', 'sqlite:///' + fn.name)
+            s = luigi.scheduler.Scheduler()
+            self.assertTrue(s.has_task_history())
 
     @with_config({'scheduler': {'record_task_history': 'false'}})
     def test_has_no_task_history(self):

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -229,6 +229,16 @@ class SchedulerIoTest(unittest.TestCase):
         task_9.add_failure()
         self.assertTrue(task_9.has_excessive_failures())
 
+    @with_config({'scheduler': {'record_task_history': 'true'}})
+    def test_has_task_history(self):
+        s = luigi.scheduler.Scheduler()
+        self.assertTrue(s.has_task_history())
+
+    @with_config({'scheduler': {'record_task_history': 'false'}})
+    def test_has_no_task_history(self):
+        s = luigi.scheduler.Scheduler()
+        self.assertFalse(s.has_task_history())
+
     @with_config({'scheduler': {'pause_enabled': 'false'}})
     def test_pause_disabled(self):
         s = luigi.scheduler.Scheduler()


### PR DESCRIPTION
## Description

This PR adds a link to the task history page (`/history`) when `record_task_history` is enabled:

![history link](https://www.dropbox.com/s/elrk0463sas7rq5/luigi_history.png?raw=1)

To achieve that I
- added a new rpc method to `Scheduler` that returns the `record_task_history` setting,
- added a template for top navigation items,
- added the link to the top navigation after an initial check using the rpc method.

## Motivation and Context

In some projects, easy browsing of the task history might be an important feature, so having a link in the top navigation bar seems like a good thing.

## Tests

I added two simple tests that invoke the added rpc method and expect either True or False, depending on the `record_task_history` setting.