### PR TITLE
Update tornado requirement for new enough python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,18 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'tornado>=4.0,<5',
     # https://pagure.io/python-daemon/issue/18
     'python-daemon<2.2.0',
     'python-dateutil>=2.7.5,<3',
 ]
+
+# Tornado >=5 requires updated ssl module so we only allow it for recent enough
+# versions of python (3.4+ and 2.7.9+).
+if sys.version_info[:2] >= (3, 4) or (sys.version_info[:2] == (2, 7) and
+                                      sys.version_info[2] >= 9):
+    install_requires.append('tornado>=4.0,<6')
+else:
+    install_requires.append('tornado>=4.0,<5')
 
 # Note: To support older versions of setuptools, we're explicitly not
 #   using conditional syntax (i.e. 'enum34>1.1.0;python_version<"3.4"').


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Increase the tornado version requirement to allow tornado 5 but only on systems with python 3.4+ or 2.7.9+

This is a replacement for #2735 

## Motivation and Context

This has been tried before for all supported python version in #2490 but had to be reverted in #2503  due to incompatibilities in the ssl module for old python versions. 

However the latest version of jupyter notebook (starting with 6.0) now requires [tornado >=5](https://github.com/jupyter/notebook/commit/729183b14830fb32063b145348c875ebfef278c7) so it is no longer possible to have one consistent stack with both jupyter and luigi.

## Have you tested this? If so, how?

same changes as tested in #2490 but no additional tests by me
