### PR TITLE
override timestamp type for mssql connections

### DIFF
--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -50,6 +50,8 @@ import sqlalchemy.ext.declarative
 import sqlalchemy.orm
 import sqlalchemy.orm.collections
 from sqlalchemy.engine import reflection
+from sqlalchemy.ext.compiler import compiles
+
 Base = sqlalchemy.ext.declarative.declarative_base()
 
 logger = logging.getLogger('luigi-interface')
@@ -214,6 +216,11 @@ class TaskEvent(Base):
 
     def __repr__(self):
         return "TaskEvent(task_id=%s, event_name=%s, ts=%s" % (self.task_id, self.event_name, self.ts)
+
+
+@compiles(sqlalchemy.TIMESTAMP, "mssql")
+def compile_timestamp_mssql(type_, compiler, **kw):
+    return "DATETIME2"
 
 
 class TaskRecord(Base):

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -165,7 +165,6 @@ class DbTaskHistory(task_history.TaskHistory):
             return session.query(TaskRecord).\
                 join(TaskEvent).\
                 filter(TaskEvent.ts >= yesterday).\
-                group_by(TaskRecord.id, TaskEvent.event_name, TaskEvent.ts).\
                 order_by(TaskEvent.ts.desc()).\
                 all()
 


### PR DESCRIPTION
## Description
Overriding the TIMESTAMP type because mssql uses a completely different type.
***This assumes that you will never want to use mssqls [timestamp](https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-2017)*** which is probably a safe assumption IMO

https://docs.sqlalchemy.org/en/13/core/custom_types.html#overriding-type-compilation

## Motivation and Context
https://github.com/spotify/luigi/issues/2769#issue-482514807

## Have you tested this? If so, how?
I have tested that the decorated function correctly creates a datetime2 column. 
I still need to rebuild the package and do an end to end test tomorrow. 

Update: 
See linked issue for update