### PR TITLE
S3 tomlparser temporary fix

### DIFF
--- a/examples/foo_s3.py
+++ b/examples/foo_s3.py
@@ -1,0 +1,12 @@
+import luigi
+from luigi.contrib.s3 import S3Target
+
+
+class Foo(luigi.Task):
+    task_namespace = 'examples'
+
+    def run(self):
+        print("Running Foo that outputs S3Target")
+
+    def output(self):
+        return S3Target("s3://ryft-public-sample-data/hoge")

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -504,21 +504,23 @@ class S3Client(FileSystem):
 
     @staticmethod
     def _get_s3_config(key=None):
-        defaults = dict(configuration.get_config().defaults())
-        try:
-            config = dict(configuration.get_config().items('s3'))
-        except (NoSectionError, KeyError):
-            return {}
-        # So what ports etc can be read without us having to specify all dtypes
-        for k, v in six.iteritems(config):
+        if os.environ.get("LUIGI_CONFIG_PARSER") != "toml":
+            defaults = dict(configuration.get_config().defaults())
             try:
-                config[k] = int(v)
-            except ValueError:
-                pass
-        if key:
-            return config.get(key)
-        section_only = {k: v for k, v in config.items() if k not in defaults or v != defaults[k]}
-
+                config = dict(configuration.get_config().items('s3'))
+            except (NoSectionError, KeyError):
+                return {}
+            # So what ports etc can be read without us having to specify all dtypes
+            for k, v in six.iteritems(config):
+                try:
+                    config[k] = int(v)
+                except ValueError:
+                    pass
+            if key:
+                return config.get(key)
+            section_only = {k: v for k, v in config.items() if k not in defaults or v != defaults[k]}
+        else:
+            return {}
         return section_only
 
     @staticmethod


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

This PR adds a simple conditional branch to use TOML configuration with S3 Client. Two files are changed:

I modify luigi/contrib/s3.py.
I add examples/foo_s3.py to check the validity of my modification.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is pointed out that S3 Client doesn't work with TOML configuration #2698 .
Fixing the issue would help a lot of users because TOML configuration and S3 Client are useful.
Now I propose to fix the issue by a simple modification.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I do not add any unit tests because there is not test of `S3Client._get_s3_config` method.
Instead of unit tests, I add an example file (examples/foo_s3.py) to check the validity of my modification.
I confirm that my modification worked with S3 Client.
Please note that I have not confirmed that my modification does not cause other unknown errors.
I would be grateful that someone could review this PR.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->

Instead of #2767 , I propose to fix S3Client.
Although this PR might not be the best solution as @orsinium said, it would be a better solution because we can avoid the parsing error temporarily.

## Details of tests

```
********:luigi ************$ LUIGI_CONFIG_PARSER=toml LUIGI_CONFIG_PATH=examples/config.toml PYTHONPATH=. python3 -m luigi --module examples.foo_s3 examples.Foo --local-scheduler
INFO     2019-08-21 15:56:19 setup_logging:86 logging configured via config section
INFO     2019-08-21 15:56:23 worker:595 Informed scheduler that task   examples.Foo__99914b932b   has status   PENDING
INFO     2019-08-21 15:56:23 interface:172 Done scheduling tasks
INFO     2019-08-21 15:56:23 worker:1182 Running Worker with 1 processes
INFO     2019-08-21 15:56:23 worker:165 [pid 61882] Worker Worker(salt=792552536, workers=1, host=********.local, username=************, pid=61882) running   examples.Foo()
Running Foo that outputs S3Target
INFO     2019-08-21 15:56:23 worker:217 [pid 61882] Worker Worker(salt=792552536, workers=1, host=********.local, username=************, pid=61882) done      examples.Foo()
INFO     2019-08-21 15:56:23 worker:595 Informed scheduler that task   examples.Foo__99914b932b   has status   DONE
INFO     2019-08-21 15:56:23 worker:493 Worker Worker(salt=792552536, workers=1, host=********.local, username=************, pid=61882) was stopped. Shutting down Keep-Alive thread
INFO     2019-08-21 15:56:23 interface:175 
===== Luigi Execution Summary =====

Scheduled 1 tasks of which:
* 1 ran successfully:
    - 1 examples.Foo()

This progress looks :) because there were no failed tasks or missing dependencies

===== Luigi Execution Summary =====
```