### PR TITLE
PySparkTask: handle special characters in name (#2778)

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -299,9 +299,9 @@ class PySparkTask(SparkSubmitTask):
         return [self.app, pickle_loc] + self.app_options()
 
     def run(self):
-        name = re.sub(r'[^\w]', '_', self.name)
-        self.run_path = tempfile.mkdtemp(prefix=name)
-        self.run_pickle = os.path.join(self.run_path, '.'.join([name, 'pickle']))
+        path_name_fragment = re.sub(r'[^\w]', '_', self.name)
+        self.run_path = tempfile.mkdtemp(prefix=path_name_fragment)
+        self.run_pickle = os.path.join(self.run_path, '.'.join([path_name_fragment, 'pickle']))
         with open(self.run_pickle, 'wb') as fd:
             # Copy module file to run path.
             module_path = os.path.abspath(inspect.getfile(self.__class__))

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import re
 import sys
 import tempfile
 import shutil
@@ -298,8 +299,9 @@ class PySparkTask(SparkSubmitTask):
         return [self.app, pickle_loc] + self.app_options()
 
     def run(self):
-        self.run_path = tempfile.mkdtemp(prefix=self.name)
-        self.run_pickle = os.path.join(self.run_path, '.'.join([self.name.replace(' ', '_'), 'pickle']))
+        name = re.sub(r'[^\w]', '_', self.name)
+        self.run_path = tempfile.mkdtemp(prefix=name)
+        self.run_pickle = os.path.join(self.run_path, '.'.join([name, 'pickle']))
         with open(self.run_pickle, 'wb') as fd:
             # Copy module file to run path.
             module_path = os.path.abspath(inspect.getfile(self.__class__))

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -97,6 +97,10 @@ class TestPySparkTask(PySparkTask):
         sc.textFile(self.input().path).saveAsTextFile(self.output().path)
 
 
+class MessyNamePySparkTask(TestPySparkTask):
+    name = 'AppName(a,b,c,1:2,3/4)'
+
+
 @attr('apache')
 class SparkSubmitTaskTest(unittest.TestCase):
     ss = 'ss-stub'
@@ -289,3 +293,10 @@ class PySparkTaskTest(unittest.TestCase):
 
         sc.textFile.assert_called_with('input')
         sc.textFile.return_value.saveAsTextFile.assert_called_with('output')
+
+    @patch('luigi.contrib.external_program.subprocess.Popen')
+    def test_name_cleanup(self, proc):
+        setup_run_process(proc)
+        job = MessyNamePySparkTask()
+        job.run()
+        assert 'AppName_a_b_c_1_2_3_4_' in job.run_path


### PR DESCRIPTION
Fixes #2778 

## Description
It cleans _name_ property before it is used to derive _run_path_ and _run_pickle_ properties.

## Motivation and Context
If name property contains some special characters PySparkTask fails: #2778 

## Have you tested this? If so, how?
Unit test is included
