### PR TITLE
Add HEAD endpoint to scheduler server for status/health checks

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -273,6 +273,10 @@ class RootPathHandler(BaseTaskHistoryHandler):
     def get(self):
         self.redirect("/static/visualiser/index.html")
 
+    def head(self):
+        self.set_status(204)
+        self.finish()
+
 
 class MetricsHandler(tornado.web.RequestHandler):
     def initialize(self, scheduler):

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -274,6 +274,7 @@ class RootPathHandler(BaseTaskHistoryHandler):
         self.redirect("/static/visualiser/index.html")
 
     def head(self):
+        """HEAD endpoint for health checking the scheduler"""
         self.set_status(204)
         self.finish()
 

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -283,6 +283,10 @@ class ServerTest(ServerTestBase):
 
         self.assertIsNone(headers.get('Access-Control-Allow-Origin'))
 
+    def test_api_allow_head_on_root(self):
+        response = self.fetch('/', method='HEAD')
+        self.assertEqual(response.code, 204)
+
 
 class _ServerTest(unittest.TestCase):
     """


### PR DESCRIPTION
Add status/health endpoint for the luigi scheduler by letting it accept HEAD requests to "/". Issue  described in #2788.