### PR TITLE
Allow python-daemon >= 2.2.0 if not on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ install_requires = ['python-dateutil>=2.7.5,<3']
 # Can't use python-daemon>=2.2.0 if on windows
 #     See https://pagure.io/python-daemon/issue/18
 if sys.platform == 'nt':
-    insall_requires.append('python-daemon<2.2.0')
+    install_requires.append('python-daemon<2.2.0')
 else:
-    insall_requires.append('python-daemon')
+    install_requires.append('python-daemon')
 
 # Tornado >=5 requires updated ssl module so we only allow it for recent enough
 # versions of python (3.4+ and 2.7.9+).
@@ -65,7 +65,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
     install_requires.append('sqlalchemy')
     # readthedocs don't like python-daemon, see #1342
-    install_requires = [x for x install_requires if not x.startswith('python-daemon')
+    install_requires = [x for x in install_requires if not x.startswith('python-daemon')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
     install_requires.append('sqlalchemy')
     # readthedocs don't like python-daemon, see #1342
-    install_requires = [x for x in install_requires if not x.startswith('python-daemon')
+    install_requires = [x for x in install_requires if not x.startswith('python-daemon')]
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,14 @@ readme_note = """\
 with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
-install_requires = [
-    # https://pagure.io/python-daemon/issue/18
-    'python-daemon<2.2.0',
-    'python-dateutil>=2.7.5,<3',
-]
+install_requires = ['python-dateutil>=2.7.5,<3']
+
+# Can't use python-daemon>=2.2.0 if on windows
+#     See https://pagure.io/python-daemon/issue/18
+if sys.platform == 'nt':
+    insall_requires.append('python-daemon<2.2.0')
+else:
+    insall_requires.append('python-daemon')
 
 # Tornado >=5 requires updated ssl module so we only allow it for recent enough
 # versions of python (3.4+ and 2.7.9+).
@@ -62,7 +65,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
     install_requires.append('sqlalchemy')
     # readthedocs don't like python-daemon, see #1342
-    install_requires.remove('python-daemon<2.2.0')
+    install_requires = [x for x install_requires if not x.startswith('python-daemon')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 setup(


### PR DESCRIPTION
It looks like the `python-daemon<2.2.0` dependency was created to specifically address an issue with windows. (See [#2525](https://github.com/spotify/luigi/issues/2525)) This patch loosens the requirement so that only windows requires `python-daemon<2.2.0` and all other platforms can use any `python-daemon`.

I have **NOT** tested this pull request, and am relying on crashing my way through the CIs...