### PR TITLE
EnumListParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -892,7 +892,9 @@ class EnumParameter(Parameter):
 
 class EnumListParameter(Parameter):
     """
-    A parameter whose value is a comma-separated list of :class:`~enum.Enum`.
+    A parameter whose value is a comma-separated list of :class:`~enum.Enum`. Values should come from the same enum.
+
+    Values are taken to be a list, i.e. order is preserved, duplicates may occur, and empty list is possible.
 
     In the task definition, use
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -892,7 +892,7 @@ class EnumParameter(Parameter):
 
 class EnumListParameter(Parameter):
     """
-    A parameter whose value is a str-separated (default ",") list of :class:`~enum.Enum`.
+    A parameter whose value is a comma-separated list of :class:`~enum.Enum`.
 
     In the task definition, use
 
@@ -913,15 +913,16 @@ class EnumListParameter(Parameter):
 
     """
 
+    _sep = ','
+
     def __init__(self, *args, **kwargs):
         if 'enum' not in kwargs:
             raise ParameterException('An enum class must be specified.')
         self._enum = kwargs.pop('enum')
-        self._delim = kwargs.pop('delim', ',')
         super(EnumListParameter, self).__init__(*args, **kwargs)
 
     def parse(self, s):
-        values = [] if s == '' else s.split(self._delim)
+        values = [] if s == '' else s.split(self._sep)
 
         for i, v in enumerate(values):
             try:
@@ -932,7 +933,7 @@ class EnumListParameter(Parameter):
         return tuple(values)
 
     def serialize(self, enum_values):
-        return self._delim.join([e.name for e in enum_values])
+        return self._sep.join([e.name for e in enum_values])
 
 
 class _DictParamEncoder(JSONEncoder):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -458,6 +458,11 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.EnumListParameter(enum=MyEnum)
         self.assertEqual(hash(Foo(args=(MyEnum.A, MyEnum.C)).args), hash(p.parse('A,C')))
 
+        class FooWithDefault(luigi.Task):
+            args = luigi.parameter.EnumListParameter(enum=MyEnum, default=[MyEnum.C])
+
+        self.assertEqual(FooWithDefault().args, p.parse('C'))
+
     def test_dict(self):
         class Foo(luigi.Task):
             args = luigi.parameter.DictParameter()

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -149,6 +149,7 @@ class NoopTask(luigi.Task):
 
 class MyEnum(enum.Enum):
     A = 1
+    C = 3
 
 
 def _value(parameter):
@@ -296,6 +297,19 @@ class ParameterTest(LuigiTestCase):
     def test_enum_param_missing(self):
         self.assertRaises(ParameterException, lambda: luigi.parameter.EnumParameter())
 
+    def test_enum_list_param_valid(self):
+        p = luigi.parameter.EnumListParameter(enum=MyEnum)
+        self.assertEqual((), p.parse(''))
+        self.assertEqual((MyEnum.A,), p.parse('A'))
+        self.assertEqual((MyEnum.A, MyEnum.C), p.parse('A,C'))
+
+    def test_enum_list_param_invalid(self):
+        p = luigi.parameter.EnumListParameter(enum=MyEnum)
+        self.assertRaises(ValueError, lambda: p.parse('A,B'))
+
+    def test_enum_list_param_missing(self):
+        self.assertRaises(ParameterException, lambda: luigi.parameter.EnumListParameter())
+
     def test_list_serialize_parse(self):
         a = luigi.ListParameter()
         b_list = [1, 2, 3]
@@ -436,6 +450,13 @@ class TestParametersHashability(LuigiTestCase):
 
         p = luigi.parameter.EnumParameter(enum=MyEnum)
         self.assertEqual(hash(Foo(args=MyEnum.A).args), hash(p.parse('A')))
+
+    def test_enum_list(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.EnumListParameter(enum=MyEnum)
+
+        p = luigi.parameter.EnumListParameter(enum=MyEnum)
+        self.assertEqual(hash(Foo(args=(MyEnum.A, MyEnum.C)).args), hash(p.parse('A,C')))
 
     def test_dict(self):
         class Foo(luigi.Task):


### PR DESCRIPTION
## Description

A parameter type complementary to EnumParameter that allows for an arbitrarily sized list (0 to *n*) of enum values in a str-delimited format.

## Motivation and Context

Convenient addition to the Luigi parameter type inventory.

## Have you tested this? If so, how?

I have included unit tests that match the style of existing `EnumParameter` tests.