### PR TITLE
Update task.flatten to check if struct is instance of Task or Target

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -40,6 +40,7 @@ from luigi import six
 from luigi import parameter
 from luigi.task_register import Register
 from luigi.parameter import ParameterVisibility
+from luigi.target import Target
 
 Parameter = parameter.Parameter
 logger = logging.getLogger('luigi-interface')
@@ -875,7 +876,7 @@ def flatten(struct):
         for _, result in six.iteritems(struct):
             flat += flatten(result)
         return flat
-    if isinstance(struct, six.string_types):
+    if isinstance(struct, (six.string_types, Task, Target)):
         return [struct]
 
     try:

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -106,12 +106,27 @@ class TaskTest(unittest.TestCase):
         self.assertTrue(hasattr(struct["generator"], "__iter__"))
 
     def test_flatten(self):
+        class TaskWithIter(luigi.Task):
+            def __iter__(self):
+                yield 1
+
+        class TargetWithIter(luigi.Target):
+            def exists(self):
+                return True
+
+            def __iter__(self):
+                yield 1
+
+        task_iter = TaskWithIter()
+        target_iter = TargetWithIter()
         flatten = luigi.task.flatten
         self.assertEqual(sorted(flatten({'a': 'foo', 'b': 'bar'})), ['bar', 'foo'])
         self.assertEqual(sorted(flatten(['foo', ['bar', 'troll']])), ['bar', 'foo', 'troll'])
         self.assertEqual(flatten('foo'), ['foo'])
         self.assertEqual(flatten(42), [42])
         self.assertEqual(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+        self.assertEqual(flatten(task_iter), [task_iter])
+        self.assertEqual(flatten(target_iter), [target_iter])
         self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
 
     def test_externalized_task_picklable(self):


### PR DESCRIPTION
## Description
Change `task.flatten` function to stop recursion when a `Task` or `Target` instance is found.

## Motivation and Context
It allows for `Task` or `Target` to implement `__getitem__` or `__iter__`. I'd like to use this to present a simpler interface for subclasses of `Target`s or `WrappedTask`s. The latter I sometimes use as `subtasks` in downstream `Task`s.

This function is used to create a flat list of `Task`s or `Target`s (depending where it's used) from a structured input of `Task`s or `Target`s.
Currently, it has a section when it tries to convert the input to an iterator, that would yield either `Task`s, `Target`s or another structured input. If a subclass of `Task` or `Target` implements `__getitem__` or `__iter__`, it gets iterated and its items (which wouldn't be `Task`s or `Target`s, in my case) flattened.

## Have you tested this? If so, how?
I did a simple test by checking that `Task._requires()` outputted the same list of `Tasks`,
and checked for uses of flatten in the codebase, which is always used to get a flat list of `Task`s or `Target`s.