### PR TITLE
Fixing comparison in update_status when task.retry is None #2749

### DIFF
--- a/luigi/contrib/prometheus_metric.py
+++ b/luigi/contrib/prometheus_metric.py
@@ -46,12 +46,16 @@ class PrometheusMetricsCollector(MetricsCollector):
         self.task_execution_time.labels(family=task.family)
 
     def handle_task_failed(self, task):
-        self.task_failed_counter.labels(family=task.family).inc()
-        self.task_execution_time.labels(family=task.family).set(task.updated - task.time_running)
+        # time_running can be `None` if task was already complete
+        if task.time_running is not None:
+            self.task_failed_counter.labels(family=task.family).inc()
+            self.task_execution_time.labels(family=task.family).set(task.updated - task.time_running)
 
     def handle_task_disabled(self, task, config):
-        self.task_disabled_counter.labels(family=task.family).inc()
-        self.task_execution_time.labels(family=task.family).set(task.updated - task.time_running)
+        # time_running can be `None` if task was already complete
+        if task.time_running is not None:
+            self.task_disabled_counter.labels(family=task.family).inc()
+            self.task_execution_time.labels(family=task.family).set(task.updated - task.time_running)
 
     def handle_task_done(self, task):
         self.task_done_counter.labels(family=task.family).inc()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -630,7 +630,7 @@ class SimpleTaskState(object):
                 self.re_enable(task, config)
 
         # Reset FAILED tasks to PENDING if max timeout is reached, and retry delay is >= 0
-        if task.status == FAILED and config.retry_delay >= 0 and task.retry < time.time():
+        if task.status == FAILED and config.retry_delay >= 0 and (False if task.retry is None else task.retry < time.time()):
             self.set_status(task, PENDING, config)
 
     def may_prune(self, task):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
This PR addresses a carry-over code from Python 2 that fails in Python 3; namely, `None` cannot be compared to `Float` and hence the test results in an exception that stops luigi daemon and stalls tasks depending on it.

I also addressed another similar `None` case in `prometheus_metrics` that stops luigi daemon when tasks are already done and hence `task.time_running` is `None`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Quick test for `task.retry` and `task.time_running` -- which are `None` by default.
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs with this code and it works for me. 
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
