### PR TITLE
Raise correct Batch exception when job fails before start

### DIFF
--- a/luigi/contrib/batch.py
+++ b/luigi/contrib/batch.py
@@ -164,7 +164,13 @@ class BatchClient(object):
                 job_str = json.dumps(jobs, indent=4)
                 logger.debug('Job details:\n' + job_str)
 
-                log_stream_name = jobs[0]['attempts'][0]['container']['logStreamName']
+                job_attempt = jobs[0]['attempts'][-1]
+                if job_attempt['statusReason'] == 'Task failed to start':
+                    raise BatchJobException('Job {} failed: {}'.format(
+                        job_id, job_attempt['container']['reason']
+                    ))
+
+                log_stream_name = job_attempt['container']['logStreamName']
                 logs = self.get_logs(log_stream_name)
                 raise BatchJobException('Job {} failed: {}'.format(
                     job_id, logs))


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

  - Use the container reason from the Batch job attempt if the statusReason is `Task failed to start`
  - Use the most recent attempt when evaluating errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If a Batch job fails to start (due to an invalid task definition for example) no log group is created for that task so the actual Exception raised by the BatchClient is 

```
ResourceNotFoundException
An error occurred (ResourceNotFoundException) when calling the GetLogEvents operation: The specified log stream does not exist.
```

This change fixes it so that if the task has failed to start the reason from the container is used instead. This makes the actual Exception raised by the Batch client:

```
BatchJobException
Job [REDACTED] failed: CannotPullContainerError: Error response from daemon: manifest for [REDACTED] not found
````

Additionally the Batch client was only looking at the first container attempt. This change uses the latest container attempt in any status reason or log gathering.

<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I have included an additional unit test for this case and have also run both the original version and my fixed version with a broken Batch task definition (results above).

(Note that the existing `test_submit_job_non_existant_queue` test case always fails for me in both the original and new version)

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
