### PR TITLE
fix parameter exposure in error emails

### DIFF
--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -405,7 +405,7 @@ def format_task_error(headline, task, command, formatted_exception=None):
         </html>
         ''')
 
-        str_params = task.to_str_params()
+        str_params = task.to_str_params(only_public=True)
         params = '\n'.join('<tr><th>{}</th><td>{}</td></tr>'.format(*items) for items in str_params.items())
         body = msg_template.format(headline=headline, name=task.task_family, param_rows=params,
                                    command=command, traceback=formatted_exception)
@@ -424,7 +424,7 @@ def format_task_error(headline, task, command, formatted_exception=None):
         {traceback}
         ''')
 
-        str_params = task.to_str_params()
+        str_params = task.to_str_params(only_public=True)
         max_width = max([0] + [len(x) for x in str_params.keys()])
         params = '\n'.join('  {:{width}}: {}'.format(*items, width=max_width) for items in str_params.items())
         body = msg_template.format(headline=headline, name=task.task_family, params=params,

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -544,7 +544,7 @@ class Task(object):
         repr_parts = []
         param_objs = dict(params)
         for param_name, param_value in param_values:
-            if param_objs[param_name].significant and param_objs[param_name].visibility == ParameterVisibility.PUBLIC:
+            if param_objs[param_name].significant:
                 repr_parts.append('%s=%s' % (param_name, param_objs[param_name].serialize(param_value)))
 
         task_str = '{}({})'.format(self.get_task_family(), ', '.join(repr_parts))

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -544,7 +544,7 @@ class Task(object):
         repr_parts = []
         param_objs = dict(params)
         for param_name, param_value in param_values:
-            if param_objs[param_name].significant:
+            if param_objs[param_name].significant and param_objs[param_name].visibility == ParameterVisibility.PUBLIC:
                 repr_parts.append('%s=%s' % (param_name, param_objs[param_name].serialize(param_value)))
 
         task_str = '{}({})'.format(self.get_task_family(), ', '.join(repr_parts))


### PR DESCRIPTION
A task error results in an email sent to associated addresses.  The email currently includes non-public parameters in the subject and body.  That was a problem for us because our HIDDEN and PRIVATE parameters (e.g. passwords) were exposed.

We made two changes to fix the problem:
1. serialize only PUBLIC parameters to the body of the error email
2. serialized only significant and PUBLIC parameters in the task representation, which is used to generate the subject for error emails (e.g. https://github.com/spotify/luigi/blob/865cc4e97540b5adc19898cbb5f31f39bff791de/luigi/worker.py#L686)

Note: #2 makes sense to us because we never want HIDDEN or PRIVATE parameters exposed (e.g. logs, etc).

We've been running this change in production for two weeks: error emails are now as desired and not seeing any regression.
