### PR TITLE
Add pod_creation_wait_interal

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -66,6 +66,7 @@ class kubernetes(luigi.Config):
 
 class KubernetesJobTask(luigi.Task):
     __DEFAULT_POLL_INTERVAL = 5  # see __track_job
+    __DEFAULT_POD_CREATION_INTERVAL = 5
     _kubernetes_config = None  # Needs to be loaded at runtime
 
     def _init_kubernetes(self):
@@ -215,8 +216,8 @@ class KubernetesJobTask(luigi.Task):
 
     @property
     def pod_creation_wait_interal(self):
-        """Delay for initial pod creation for just submitted job"""
-        return 5
+        """Delay for initial pod creation for just submitted job in seconds"""
+        return self.__DEFAULT_POD_CREATION_INTERVAL
 
     def __track_job(self):
         """Poll job status while active"""
@@ -286,6 +287,7 @@ class KubernetesJobTask(luigi.Task):
                 'No pods found for {}, waiting for cluster state to match the job definition', self.uu_name
             )
             time.sleep(self.pod_creation_wait_interal)
+            pods = self.__get_pods()
 
         assert len(pods) > 0, "No pod scheduled by " + self.uu_name
         for pod in pods:

--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -284,7 +284,7 @@ class KubernetesJobTask(luigi.Task):
         pods = self.__get_pods()
         if not pods:
             self.__logger.debug(
-                'No pods found for {}, waiting for cluster state to match the job definition', self.uu_name
+                'No pods found for %s, waiting for cluster state to match the job definition' % self.uu_name
             )
             time.sleep(self.pod_creation_wait_interal)
             pods = self.__get_pods()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Add pod_creation_wait_interal property to give Kubernetes cluster some time to create pods for Job.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/spotify/luigi/issues/2570, also aimed to replace abandoned https://github.com/spotify/luigi/pull/2664

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs with this code and it works for me.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
