### PR TITLE
[luigi.contrib.spark] pyspark python options added

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -97,7 +97,7 @@ class SparkSubmitTask(ExternalProgramTask):
 
     @property
     def hadoop_user_name(self):
-        return os.getlogin()
+        return None
 
     @property
     def spark_version(self):

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -35,6 +35,12 @@ from luigi import configuration
 
 logger = logging.getLogger('luigi-interface')
 
+_DEFINED_SYSTEM_SETTINGS = (
+    'HADOOP_CONF_DIR',
+    'HADOOP_USER_NAME',
+    'PYSPARK_PYTHON',
+    'PYSPARK_DRIVER_PYTHON'
+)
 
 class SparkSubmitTask(ExternalProgramTask):
     """
@@ -72,6 +78,24 @@ class SparkSubmitTask(ExternalProgramTask):
 
         """
         return []
+
+    def _upd_env_if_not_none(self, env, prop):
+        # type: (SparkSubmitTask, dict, str) -> None
+        var = getattr(self, prop.lower(), None)
+        if var:
+            env[prop] = var
+
+    @property
+    def pyspark_python(self):
+        return None
+
+    @property
+    def pyspark_driver_python(self):
+        return None
+
+    @property
+    def hadoop_user_name(self):
+        return os.getlogin()
 
     @property
     def spark_version(self):
@@ -170,9 +194,8 @@ class SparkSubmitTask(ExternalProgramTask):
 
     def get_environment(self):
         env = os.environ.copy()
-        hadoop_conf_dir = self.hadoop_conf_dir
-        if hadoop_conf_dir:
-            env['HADOOP_CONF_DIR'] = hadoop_conf_dir
+        for prop in _DEFINED_SYSTEM_SETTINGS:
+            self._upd_env_if_not_none(env, prop)
         return env
 
     def program_environment(self):

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import collections
 import logging
 import os
 import re
@@ -123,7 +124,7 @@ class SparkSubmitTask(ExternalProgramTask):
 
     @property
     def _conf(self):
-        conf = self.conf or {}
+        conf = collections.OrderedDict(self.conf or {})
         if self.pyspark_python:
             conf['spark.pyspark.python'] = self.pyspark_python
         if self.pyspark_driver_python:

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -62,6 +62,7 @@ class SparkSubmitTask(ExternalProgramTask):
 
     # Only log stderr if spark fails (since stderr is normally quite verbose)
     always_log_stderr = False
+
     # Spark applications write its logs into stderr
     stream_for_searching_tracking_url = 'stderr'
 

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -83,7 +83,6 @@ class SparkSubmitTask(ExternalProgramTask):
         return []
 
     def _upd_env_if_not_none(self, env, prop):
-        # type: (SparkSubmitTask, dict, str) -> None
         var = getattr(self, prop.lower(), None)
         if var:
             env[prop] = var

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -24,6 +24,7 @@ import shutil
 import importlib
 import tarfile
 import inspect
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -41,6 +42,7 @@ _DEFINED_SYSTEM_SETTINGS = (
     'PYSPARK_PYTHON',
     'PYSPARK_DRIVER_PYTHON'
 )
+
 
 class SparkSubmitTask(ExternalProgramTask):
     """
@@ -192,14 +194,11 @@ class SparkSubmitTask(ExternalProgramTask):
     def hadoop_conf_dir(self):
         return configuration.get_config().get(self.spark_version, "hadoop-conf-dir", None)
 
-    def get_environment(self):
-        env = os.environ.copy()
+    def program_environment(self):
+        env = super(SparkSubmitTask, self).program_environment()
         for prop in _DEFINED_SYSTEM_SETTINGS:
             self._upd_env_if_not_none(env, prop)
         return env
-
-    def program_environment(self):
-        return self.get_environment()
 
     def program_args(self):
         return self.spark_command() + self.app_command()

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -192,13 +192,16 @@ class SparkSubmitTask(ExternalProgramTask):
     def hadoop_conf_dir(self):
         return configuration.get_config().get(self.spark_version, "hadoop-conf-dir", None)
 
-    def program_environment(self):
-        env = super(SparkSubmitTask, self).program_environment()
+    def get_environment(self):
+        env = os.environ.copy()
         for prop in ('HADOOP_CONF_DIR', 'HADOOP_USER_NAME'):
             var = getattr(self, prop.lower(), None)
             if var:
                 env[prop] = var
         return env
+
+    def program_environment(self):
+        return self.get_environment()
 
     def program_args(self):
         return self.spark_command() + self.app_command()

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -71,6 +71,7 @@ class TestSparkSubmitTask(SparkSubmitTask):
     archives = ["archive1", "archive2"]
     app = "file"
     pyspark_python = '/a/b/c'
+    pyspark_driver_python = '/b/c/d'
     hadoop_user_name = 'luigiuser'
 
     def app_options(self):
@@ -119,7 +120,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
                          ['ss-stub', '--master', 'yarn-client', '--deploy-mode', 'client', '--name', 'AppName',
                           '--class', 'org.test.MyClass', '--jars', 'jars/my.jar', '--py-files', 'file1.py,file2.py',
                           '--files', 'file1,file2', '--archives', 'archive1,archive2', '--conf', 'Prop=Value',
-                          '--conf', 'spark.pyspark.python=/a/b/c',
+                          '--conf', 'spark.pyspark.python=/a/b/c', '--conf', 'spark.pyspark.driver.python=/b/c/d',
                           '--properties-file', 'conf/spark-defaults.conf', '--driver-memory', '4G',
                           '--driver-java-options', '-Xopt',
                           '--driver-library-path', 'library/path', '--driver-class-path', 'class/path',
@@ -137,7 +138,8 @@ class SparkSubmitTaskTest(unittest.TestCase):
 
         assert job._conf == {
             'Prop': 'Value',
-            'spark.pyspark.python': '/a/b/c'
+            'spark.pyspark.python': '/a/b/c',
+            'spark.pyspark.driver.python': '/b/c/d'
         }
         assert job.program_environment()['HADOOP_USER_NAME'] == 'luigiuser'
         self.assertIn('HADOOP_CONF_DIR', proc.call_args[1]['env'])

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -71,7 +71,6 @@ class TestSparkSubmitTask(SparkSubmitTask):
     archives = ["archive1", "archive2"]
     app = "file"
     pyspark_python = '/a/b/c'
-    pyspark_driver_python = '/a/b/d'
     hadoop_user_name = 'luigiuser'
 
     def app_options(self):
@@ -108,7 +107,8 @@ class MessyNamePySparkTask(TestPySparkTask):
 class SparkSubmitTaskTest(unittest.TestCase):
     ss = 'ss-stub'
 
-    @with_config({'spark': {'spark-submit': ss, 'master': "yarn-client", 'hadoop-conf-dir': 'path', 'deploy-mode': 'client'}})
+    @with_config(
+        {'spark': {'spark-submit': ss, 'master': "yarn-client", 'hadoop-conf-dir': 'path', 'deploy-mode': 'client'}})
     @patch('luigi.contrib.external_program.subprocess.Popen')
     def test_run(self, proc):
         setup_run_process(proc)
@@ -119,9 +119,13 @@ class SparkSubmitTaskTest(unittest.TestCase):
                          ['ss-stub', '--master', 'yarn-client', '--deploy-mode', 'client', '--name', 'AppName',
                           '--class', 'org.test.MyClass', '--jars', 'jars/my.jar', '--py-files', 'file1.py,file2.py',
                           '--files', 'file1,file2', '--archives', 'archive1,archive2', '--conf', 'Prop=Value',
-                          '--properties-file', 'conf/spark-defaults.conf', '--driver-memory', '4G', '--driver-java-options', '-Xopt',
-                          '--driver-library-path', 'library/path', '--driver-class-path', 'class/path', '--executor-memory', '8G',
-                          '--driver-cores', '8', '--supervise', '--total-executor-cores', '150', '--executor-cores', '10',
+                          '--conf', 'spark.pyspark.python=/a/b/c',
+                          '--properties-file', 'conf/spark-defaults.conf', '--driver-memory', '4G',
+                          '--driver-java-options', '-Xopt',
+                          '--driver-library-path', 'library/path', '--driver-class-path', 'class/path',
+                          '--executor-memory', '8G',
+                          '--driver-cores', '8', '--supervise', '--total-executor-cores', '150', '--executor-cores',
+                          '10',
                           '--queue', 'queue', '--num-executors', '2', 'file', 'arg1', 'arg2'])
 
     @with_config({'spark': {'hadoop-conf-dir': 'path'}})
@@ -131,14 +135,17 @@ class SparkSubmitTaskTest(unittest.TestCase):
         job = TestSparkSubmitTask()
         job.run()
 
-        assert job.program_environment()['PYSPARK_PYTHON'] == '/a/b/c'
-        assert job.program_environment()['PYSPARK_DRIVER_PYTHON'] == '/a/b/d'
+        assert job._conf == {
+            'Prop': 'Value',
+            'spark.pyspark.python': '/a/b/c'
+        }
         assert job.program_environment()['HADOOP_USER_NAME'] == 'luigiuser'
         self.assertIn('HADOOP_CONF_DIR', proc.call_args[1]['env'])
         self.assertEqual(proc.call_args[1]['env']['HADOOP_CONF_DIR'], 'path')
 
-    @with_config({'spark': {'spark-submit': ss, 'master': 'spark://host:7077', 'conf': 'prop1=val1', 'jars': 'jar1.jar,jar2.jar',
-                            'files': 'file1,file2', 'py-files': 'file1.py,file2.py', 'archives': 'archive1'}})
+    @with_config(
+        {'spark': {'spark-submit': ss, 'master': 'spark://host:7077', 'conf': 'prop1=val1', 'jars': 'jar1.jar,jar2.jar',
+                   'files': 'file1,file2', 'py-files': 'file1.py,file2.py', 'archives': 'archive1'}})
     @patch('luigi.contrib.external_program.subprocess.Popen')
     def test_defaults(self, proc):
         proc.return_value.returncode = 0
@@ -246,7 +253,9 @@ class PySparkTaskTest(unittest.TestCase):
         job = TestPySparkTask()
         job.run()
         proc_arg_list = proc.call_args[0][0]
-        self.assertEqual(proc_arg_list[0:7], ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'client', '--name', 'TestPySparkTask'])
+        self.assertEqual(proc_arg_list[0:7],
+                         ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'client', '--name',
+                          'TestPySparkTask'])
         self.assertTrue(os.path.exists(proc_arg_list[7]))
         self.assertTrue(proc_arg_list[8].endswith('TestPySparkTask.pickle'))
 
@@ -258,7 +267,9 @@ class PySparkTaskTest(unittest.TestCase):
         luigi.build([job], local_scheduler=True)
         self.assertEqual(proc.call_count, 1)
         proc_arg_list = proc.call_args[0][0]
-        self.assertEqual(proc_arg_list[0:7], ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'client', '--name', 'TestPySparkTask'])
+        self.assertEqual(proc_arg_list[0:7],
+                         ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'client', '--name',
+                          'TestPySparkTask'])
         self.assertTrue(os.path.exists(proc_arg_list[7]))
         self.assertTrue(proc_arg_list[8].endswith('TestPySparkTask.pickle'))
 
@@ -269,7 +280,9 @@ class PySparkTaskTest(unittest.TestCase):
         job = TestPySparkTask()
         job.run()
         proc_arg_list = proc.call_args[0][0]
-        self.assertEqual(proc_arg_list[0:8], ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'cluster', '--name', 'TestPySparkTask', '--files'])
+        self.assertEqual(proc_arg_list[0:8],
+                         ['ss-stub', '--master', 'spark://host:7077', '--deploy-mode', 'cluster', '--name',
+                          'TestPySparkTask', '--files'])
         self.assertTrue(proc_arg_list[8].endswith('TestPySparkTask.pickle'))
         self.assertTrue(os.path.exists(proc_arg_list[9]))
         self.assertEqual('TestPySparkTask.pickle', proc_arg_list[10])

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -70,6 +70,9 @@ class TestSparkSubmitTask(SparkSubmitTask):
     num_executors = 2
     archives = ["archive1", "archive2"]
     app = "file"
+    pyspark_python = '/a/b/c'
+    pyspark_driver_python = '/a/b/d'
+    hadoop_user_name = 'luigiuser'
 
     def app_options(self):
         return ["arg1", "arg2"]
@@ -128,6 +131,9 @@ class SparkSubmitTaskTest(unittest.TestCase):
         job = TestSparkSubmitTask()
         job.run()
 
+        assert job.program_environment()['PYSPARK_PYTHON'] == '/a/b/c'
+        assert job.program_environment()['PYSPARK_DRIVER_PYTHON'] == '/a/b/d'
+        assert job.program_environment()['HADOOP_USER_NAME'] == 'luigiuser'
         self.assertIn('HADOOP_CONF_DIR', proc.call_args[1]['env'])
         self.assertEqual(proc.call_args[1]['env']['HADOOP_CONF_DIR'], 'path')
 

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -208,7 +208,8 @@ class SparkSubmitTaskTest(unittest.TestCase):
                 val.value += 1
 
         def Popen_wrap(args, **kwargs):
-            return Popen('>&2 echo "INFO SparkUI: Bound SparkUI to 0.0.0.0, and started at http://10.66.76.155:4040"', shell=True, **kwargs)
+            return Popen('>&2 echo "INFO SparkUI: Bound SparkUI to 0.0.0.0, and started at http://10.66.76.155:4040"',
+                         shell=True, **kwargs)
 
         task = TestSparkSubmitTask()
         with mock.patch('luigi.contrib.external_program.subprocess.Popen', wraps=Popen_wrap):


### PR DESCRIPTION
## Description
Added `hadoop_user_name`, `pyspark_python`, `pyspark_driver_python` options for SparkSubmitTask

## Motivation and Context
It's a usual usecase when you want to submit your spark application with a specific python environment on spark workers or under specific user


## Have you tested this? If so, how?
I have included a unit test for that
That approach works under my production environment

