### PR TITLE
[luigi.contrib.spark] tracking_url_pattern as a property

### DIFF
--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -24,6 +24,7 @@ import shutil
 import importlib
 import tarfile
 import inspect
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -57,14 +58,13 @@ class SparkSubmitTask(ExternalProgramTask):
     # Spark applications write its logs into stderr
     stream_for_searching_tracking_url = 'stderr'
 
-    def run(self):
+    @property
+    def tracking_url_pattern(self):
         if self.deploy_mode == "cluster":
             # in cluster mode client only receives application status once a period of time
-            self.tracking_url_pattern = r"tracking URL: (https?://.*)\s"
+            return r"tracking URL: (https?://.*)\s"
         else:
-            self.tracking_url_pattern = r"Bound (?:.*) to (?:.*), and started at (https?://.*)\s"
-
-        super(SparkSubmitTask, self).run()
+            return r"Bound (?:.*) to (?:.*), and started at (https?://.*)\s"
 
     def app_options(self):
         """


### PR DESCRIPTION
## Description
`tracking_url_pattern` setting took out from method `run` and was redefined as a property


## Motivation and Context
It's normally no a very good practice to put a variable setting logic inside other method
So I took it out

## Have you tested this? If so, how?
All tests are passed in `test/contrib/spark_test.py`
Particularly `test_tracking_url_is_found_in_stderr_cluster_mode` tests correctness of `tracking_url_pattern` work
