### PR TITLE
Check for `autoload_range` istead of `autoload-range`

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -61,19 +61,19 @@ __all__ = [
     'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'LuigiStatusCode'
 ]
 
-if not configuration.get_config().has_option('core', 'autoload-range'):
+if not configuration.get_config().has_option('core', 'autoload_range'):
     import warnings
     warning_message = '''
         Autoloading range tasks by default has been deprecated and will be removed in a future version.
         To get the behavior now add an option to luigi.cfg:
 
           [core]
-            autoload-range: false
+            autoload_range: false
 
         Alternately set the option to true to continue with existing behaviour and suppress this warning.
     '''
     warnings.warn(warning_message, DeprecationWarning)
 
-if configuration.get_config().getboolean('core', 'autoload-range', True):
+if configuration.get_config().getboolean('core', 'autoload_range', True):
     from .tools import range  # noqa: F401    just makes the tool classes available from command line
     __all__.append('range')

--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -182,6 +182,28 @@ class LuigiConfigParser(BaseParser, ConfigParser):
                 raise
             return default
 
+    def has_option(self, section, option):
+        """modified has_option
+        Check for the existence of a given option in a given section. If the
+        specified 'section' is None or an empty string, DEFAULT is assumed. If
+        the specified 'section' does not exist, returns False.
+        """
+
+        # Underscore-style is the recommended configuration style
+        option = option.replace('-', '_')
+        if ConfigParser.has_option(self, section, option):
+            return True
+
+        # Support dash-style option names (with deprecation warning).
+        option_alias = option.replace('_', '-')
+        if ConfigParser.has_option(self, section, option_alias):
+            warn = 'Configuration [{s}] {o} (with dashes) should be avoided. Please use underscores: {u}.'.format(
+                s=section, o=option_alias, u=option)
+            warnings.warn(warn, DeprecationWarning)
+            return True
+
+        return False
+
     def get(self, section, option, default=NO_DEFAULT, **kwargs):
         return self._get_with_default(ConfigParser.get, section, option, default, **kwargs)
 


### PR DESCRIPTION
Using the cfg parser would either cause a deprecation warning without specifying

```
[core]
autoload-range=false
```

or shout at you for using a dash instead of an underscore.

This fix let's you specify autoload_range.

Resolves https://github.com/spotify/luigi/issues/2756