### PR TITLE
[luigi.contrib.hive] WarehouseHiveClient

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -560,11 +560,13 @@ class ExternalHiveTask(luigi.ExternalTask):
 
     def output(self):
         if self.partition:
-            assert self.partition, "partition required"
             return HivePartitionTarget(
+                database=self.database,
                 table=self.table,
                 partition=self.partition,
-                database=self.database
             )
         else:
-            return HiveTableTarget(self.table, self.database)
+            return HiveTableTarget(
+                database=self.database,
+                table=self.table,
+            )

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -486,8 +486,14 @@ class HivePartitionTarget(luigi.Target):
 
     def exists(self):
         try:
-            logger.debug("Checking Hive table '{d}.{t}' for partition {p}".format(d=self.database, t=self.table,
-                                                                                  p=str(self.partition)))
+            logger.debug(
+                "Checking Hive table '{d}.{t}' for partition {p}".format(
+                    d=self.database,
+                    t=self.table,
+                    p=str(self.partition)
+                )
+            )
+
             return self.client.table_exists(self.table, self.database, self.partition)
         except HiveCommandError:
             if self.fail_missing_table:
@@ -521,8 +527,10 @@ class ExternalHiveTask(luigi.ExternalTask):
 
     database = luigi.Parameter(default='default')
     table = luigi.Parameter()
-    partition = luigi.DictParameter(default={},
-                                    description='Python dictionary specifying the target partition e.g. {"date": "2013-01-25"}')
+    partition = luigi.DictParameter(
+        default={},
+        description='Python dictionary specifying the target partition e.g. {"date": "2013-01-25"}'
+    )
 
     def output(self):
         if len(self.partition) != 0:

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -311,10 +311,10 @@ class WarehouseHiveClient(HiveClient):
         path = self.table_location(table, database, partition)
         if self.hdfs_client.exists(path):
             ignored_files = get_ignored_file_masks()
-            filenames = self.hdfs_client.listdir(path)
             if ignored_files is None:
                 return True
 
+            filenames = self.hdfs_client.listdir(path)
             pattern = re.compile(ignored_files)
             for filename in filenames:
                 if not pattern.match(filename):

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -280,7 +280,7 @@ class WarehouseHiveClient(HiveClient):
 
     def table_exists(self, table, database='default', partition=None):
         """
-        We consider tabel/partition as existing if corresponding path in hdfs exists
+        We consider table/partition as existing if corresponding path in hdfs exists
         and contains file except those which match pattern set in  `ignored_file_masks`
         """
         path = self.table_location(table, database, partition)
@@ -299,7 +299,7 @@ class WarehouseHiveClient(HiveClient):
 
     def partition_spec(self, partition):
         return '/'.join([
-            "{0}={1}".format(k, v) for (k, v) in sorted(six.iteritems(partition or {}), key=operator.itemgetter(0))
+            '{}={}'.format(k, v) for (k, v) in six.iteritems(partition or {})
         ])
 
 

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -100,8 +100,8 @@ def run_hive_script(script):
 
 def _validate_partition(partition):
     """
-    If partition is set and it's size more than one and it's not ordered
-    than we're unable to restore its path in warehouse definitely
+    If partition is set and its size is more than one and not ordered,
+    then we're unable to restore its path in the warehouse
     """
     if (
             partition
@@ -294,7 +294,7 @@ class WarehouseHiveClient(HiveClient):
 
     def table_exists(self, table, database='default', partition=None):
         """
-        We consider table/partition as existing if corresponding path in hdfs exists
+        The table/partition is considered existing if corresponding path in hdfs exists
         and contains file except those which match pattern set in  `ignored_file_masks`
         """
         path = self.table_location(table, database, partition)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -98,10 +98,6 @@ def run_hive_script(script):
     return run_hive(['-f', script])
 
 
-class AmbiguousLocationException(Exception):
-    pass
-
-
 def _validate_partition(partition):
     """
     If partition is set and it's size more than one and it's not ordered
@@ -112,7 +108,7 @@ def _validate_partition(partition):
             and len(partition) > 1
             and not isinstance(partition, collections.OrderedDict)
     ):
-        raise AmbiguousLocationException()
+        raise ValueError('Unable to restore table/partition location')
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -117,7 +117,7 @@ def _validate_partition(partition):
     if (
             partition
             and len(partition) > 1
-            and _is_ordered_dict(partition)
+            and not _is_ordered_dict(partition)
     ):
         raise ValueError('Unable to restore table/partition location')
 

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -381,7 +381,7 @@ class WarehouseHiveClientTest(unittest.TestCase):
             )
 
         # act & assert
-        self.assertRaises(luigi.contrib.hive.AmbiguousLocationException, _call_exists)
+        self.assertRaises(ValueError, _call_exists)
 
 
 class MyHiveTask(luigi.contrib.hive.HiveQueryTask):

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -316,7 +316,6 @@ class WarehouseHiveClientTest(unittest.TestCase):
         # assert
         assert exists
         hdfs_client.exists.assert_called_once_with('/apps/hive/warehouse/some_db.db/table_name/a=1/b=2')
-        hdfs_client.listdir.assert_called_once_with('/apps/hive/warehouse/some_db.db/table_name/a=1/b=2')
 
     @mock.patch("luigi.configuration")
     def test_table_exists_without_partition_spec_files_actually_exist(self, warehouse_location):

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -378,6 +378,7 @@ class WarehouseHiveClientTest(unittest.TestCase):
             '.tmp/'
         ]
         warehouse_hive_client = luigi.contrib.hive.WarehouseHiveClient(
+            hdfs_client=hdfs_client,
             warehouse_location='/apps/hive/warehouse'
         )
 


### PR DESCRIPTION
## Description
I've added WarehouseHiveClient which allows to determine if table\partition exists when it's files exist on hdfs

## Motivation and Context
Sometimes it's not enough to have an entry in hive metastore that table\partition exists. 
In particular cases we want to be sure if files for that table/partition actually exists
Using of this client is suitable if you want to be sure that your task doesn't write zero rows.
It can be suitable for tasks like "insert overwrite table (...) partition (...)"

## Have you tested this? If so, how?
I've provided several unit tests for that