### PR TITLE
Add Python version-agnostic get_writer_schema.

### DIFF
--- a/luigi/contrib/bigquery_avro.py
+++ b/luigi/contrib/bigquery_avro.py
@@ -1,7 +1,7 @@
 """Specialized tasks for handling Avro data in BigQuery from GCS.
 """
 import logging
-import sys
+import six
 
 from luigi.contrib.bigquery import BigQueryLoadTask, SourceFormat
 from luigi.contrib.gcs import GCSClient
@@ -77,10 +77,10 @@ class BigQueryLoadAvro(BigQueryLoadTask):
 
     @staticmethod
     def get_writer_schema(datum_reader):
-        if sys.version_info >= (3, 0):
-            return datum_reader.writer_schema
-        else:
+        if six.PY2:
             return datum_reader.writers_schema
+        else:
+            return datum_reader.writer_schema
 
     def _set_output_doc(self, avro_schema):
         bq_client = self.output().client.client

--- a/luigi/contrib/bigquery_avro.py
+++ b/luigi/contrib/bigquery_avro.py
@@ -61,7 +61,7 @@ class BigQueryLoadAvro(BigQueryLoadTask):
             # requiring the remainder of the file...
             try:
                 reader = avro.datafile.DataFileReader(fp, avro.io.DatumReader())
-                schema[:] = [self.get_writer_schema(reader.datum_reader)]
+                schema[:] = [BigQueryLoadAvro._get_writer_schema(reader.datum_reader)]
             except Exception as e:
                 # Save but assume benign unless schema reading ultimately fails. The benign
                 # exception in case of insufficiently big downloaded file part seems to be:
@@ -76,7 +76,15 @@ class BigQueryLoadAvro(BigQueryLoadTask):
         return schema[0]
 
     @staticmethod
-    def get_writer_schema(datum_reader):
+    def _get_writer_schema(datum_reader):
+        """Python-version agnostic getter for datum_reader writer(s)_schema attribute
+        
+        Parameters:
+        datum_reader (avro.io.DatumReader): DatumReader
+
+        Returns:
+        Returning correct attribute name depending on Python version.
+        """
         if six.PY2:
             return datum_reader.writers_schema
         else:

--- a/luigi/contrib/bigquery_avro.py
+++ b/luigi/contrib/bigquery_avro.py
@@ -20,8 +20,8 @@ except ImportError:
 class BigQueryLoadAvro(BigQueryLoadTask):
     """A helper for loading specifically Avro data into BigQuery from GCS.
 
-    Copies table level description from Avro schema doc, BigQuery internally will copy field-level descriptions
-    to the table.
+    Copies table level description from Avro schema doc,
+    BigQuery internally will copy field-level descriptions to the table.
 
     Suitable for use via subclassing: override requires() to return Task(s) that output
     to GCS Targets; their paths are expected to be URIs of .avro files or URI prefixes
@@ -78,7 +78,7 @@ class BigQueryLoadAvro(BigQueryLoadTask):
     @staticmethod
     def _get_writer_schema(datum_reader):
         """Python-version agnostic getter for datum_reader writer(s)_schema attribute
-        
+
         Parameters:
         datum_reader (avro.io.DatumReader): DatumReader
 

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -23,7 +23,9 @@ import unittest
 from avro.io import DatumReader
 from luigi.contrib.bigquery_avro import BigQueryLoadAvro
 
+from nose.plugins.attrib import attr
 
+@attr('gcloud')
 class BigQueryAvroTest(unittest.TestCase):
 
     def test_writer_schema_method_existence(self):

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -19,8 +19,10 @@
 These are the unit tests for the BigQueryLoadAvro class.
 """
 
+import six
 import unittest
 import avro
+import avro.schema
 from luigi.contrib.bigquery_avro import BigQueryLoadAvro
 from nose.plugins.attrib import attr
 
@@ -29,7 +31,7 @@ from nose.plugins.attrib import attr
 class BigQueryAvroTest(unittest.TestCase):
 
     def test_writer_schema_method_existence(self):
-        avro_schema = """
+        schema_json = """
         {
             "namespace": "example.avro",
             "type": "record",
@@ -41,8 +43,15 @@ class BigQueryAvroTest(unittest.TestCase):
             ]
         }
         """
+        avro_schema = self._parse_schema(schema_json)
         reader = avro.io.DatumReader(avro_schema, avro_schema)
         actual_schema = BigQueryLoadAvro._get_writer_schema(reader)
         self.assertEqual(actual_schema, avro_schema, 
                          "writer(s) avro_schema attribute not found")
         # otherwise AttributeError is thrown
+
+    def _parse_schema(self, schema_json):
+        if six.PY2:
+            return avro.schema.parse(schema_json)
+        else:
+            return avro.schema.Parse(schema_json)

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2015 Twitter Inc
+# Copyright 2019 Spotify AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -24,10 +24,8 @@ import unittest
 import avro
 import avro.schema
 from luigi.contrib.bigquery_avro import BigQueryLoadAvro
-from nose.plugins.attrib import attr
 
 
-@attr('gcloud')
 class BigQueryAvroTest(unittest.TestCase):
 
     def test_writer_schema_method_existence(self):
@@ -46,7 +44,7 @@ class BigQueryAvroTest(unittest.TestCase):
         avro_schema = self._parse_schema(schema_json)
         reader = avro.io.DatumReader(avro_schema, avro_schema)
         actual_schema = BigQueryLoadAvro._get_writer_schema(reader)
-        self.assertEqual(actual_schema, avro_schema, 
+        self.assertEqual(actual_schema, avro_schema,
                          "writer(s) avro_schema attribute not found")
         # otherwise AttributeError is thrown
 

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -20,16 +20,29 @@ These are the unit tests for the BigQueryLoadAvro class.
 """
 
 import unittest
-from avro.io import DatumReader
+import avro
 from luigi.contrib.bigquery_avro import BigQueryLoadAvro
-
 from nose.plugins.attrib import attr
+
 
 @attr('gcloud')
 class BigQueryAvroTest(unittest.TestCase):
 
     def test_writer_schema_method_existence(self):
-        reader = DatumReader(None, None)
-        schema = BigQueryLoadAvro.get_writer_schema(reader)
-        self.assertEqual(schema, None, "writer(s) schema attribute not found")
+        avro_schema = """
+        {
+            "namespace": "example.avro",
+            "type": "record",
+            "name": "User",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "favorite_number",  "type": ["int", "null"]},
+                {"name": "favorite_color", "type": ["string", "null"]}
+            ]
+        }
+        """
+        reader = avro.io.DatumReader(avro_schema, avro_schema)
+        actual_schema = BigQueryLoadAvro._get_writer_schema(reader)
+        self.assertEqual(actual_schema, avro_schema, 
+                         "writer(s) avro_schema attribute not found")
         # otherwise AttributeError is thrown

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2015 Twitter Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+These are the unit tests for the BigQueryLoadAvro class.
+"""
+
+import unittest
+from avro.io import DatumReader
+from luigi.contrib.bigquery_avro import BigQueryLoadAvro
+
+
+class BigQueryAvroTest(unittest.TestCase):
+
+    def test_writer_schema_method_existence(self):
+        reader = DatumReader(None, None)
+        schema = BigQueryLoadAvro.get_writer_schema(reader)
+        self.assertEqual(schema, None, "writer(s) schema attribute not found")
+        # otherwise AttributeError is thrown

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ deps =
     postgres: psycopg2<3.0
     mysql-connector-python>=8.0.12
     gcloud: google-api-python-client>=1.4.0,<2.0
-    py27-gcloud: avro
-    py33-gcloud,py34-gcloud,py35-gcloud,py36-gcloud: avro-python3
+    py27: avro
+    py33,py34,py35,py36,py37: avro-python3
     gcloud: google-auth==1.4.1
     gcloud: google-auth-httplib2==0.0.3
     google-compute-engine


### PR DESCRIPTION
We got an error while running with Python3: ```AttributeError("'DatumReader' object has no attribute 'writers_schema'",)```

## Description
The name of the attribute is changed between versions 2 & 3.
[PY2](https://github.com/apache/avro/blob/master/lang/py/src/avro/io.py#L634)
[PY3](https://github.com/apache/avro/blob/master/lang/py3/avro/io.py#L421)
```
-def __init__(self, writers_schema=None, readers_schema=None):
+def __init__(self, writer_schema=None, reader_schema=None):
```
## Motivation and Context
Programs calling BigQueryLoadAvro fails.

## Have you tested this? If so, how?
Added a unit-test.