### PR TITLE
[luigi.six.itervalues] usage removed

### DIFF
--- a/luigi/batch_notifier.py
+++ b/luigi/batch_notifier.py
@@ -170,9 +170,9 @@ class BatchNotifier(object):
             return body
 
     def _send_email(self, fail_counts, disable_counts, scheduling_counts, fail_expls, owner):
-        num_failures = sum(six.itervalues(fail_counts))
-        num_disables = sum(six.itervalues(disable_counts))
-        num_scheduling_failures = sum(six.itervalues(scheduling_counts))
+        num_failures = sum(fail_counts.values())
+        num_disables = sum(disable_counts.values())
+        num_scheduling_failures = sum(scheduling_counts.values())
         subject_parts = [
             _plural_format('{} failure{}', num_failures),
             _plural_format('{} disable{}', num_disables),

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -490,16 +490,16 @@ class SimpleTaskState(object):
 
             self.set_state(state)
             self._status_tasks = collections.defaultdict(dict)
-            for task in six.itervalues(self._tasks):
+            for task in self._tasks.values():
                 self._status_tasks[task.status][task.id] = task
         else:
             logger.info("No prior state file exists at %s. Starting with empty state", self._state_path)
 
     def get_active_tasks(self):
-        return six.itervalues(self._tasks)
+        return self._tasks.values()
 
     def get_active_tasks_by_status(self, *statuses):
-        return itertools.chain.from_iterable(six.itervalues(self._status_tasks[status]) for status in statuses)
+        return itertools.chain.from_iterable(self._status_tasks[status].values() for status in statuses)
 
     def get_active_task_count_for_status(self, status):
         if status:
@@ -645,7 +645,7 @@ class SimpleTaskState(object):
             self._status_tasks[task_obj.status].pop(task)
 
     def get_active_workers(self, last_active_lt=None, last_get_work_gt=None):
-        for worker in six.itervalues(self._active_workers):
+        for worker in self._active_workers.values():
             if last_active_lt is not None and worker.last_active >= last_active_lt:
                 continue
             last_get_work = worker.last_get_work

--- a/luigi/six.py
+++ b/luigi/six.py
@@ -37,6 +37,11 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 PY34 = sys.version_info[0:2] >= (3, 4)
 
+
+class SixUsageException(Exception):
+    pass
+
+
 if PY3:
     string_types = str,
     integer_types = int,
@@ -575,7 +580,7 @@ if PY3:
         return iter(d.keys(**kw))
 
     def itervalues(d, **kw):
-        return iter(d.values(**kw))
+        raise SixUsageException()
 
     def iteritems(d, **kw):
         return iter(d.items(**kw))
@@ -593,7 +598,7 @@ else:
         return d.iterkeys(**kw)
 
     def itervalues(d, **kw):
-        return d.itervalues(**kw)
+        raise SixUsageException()
 
     def iteritems(d, **kw):
         return d.iteritems(**kw)

--- a/luigi/six.py
+++ b/luigi/six.py
@@ -37,11 +37,6 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 PY34 = sys.version_info[0:2] >= (3, 4)
 
-
-class SixUsageException(Exception):
-    pass
-
-
 if PY3:
     string_types = str,
     integer_types = int,
@@ -579,9 +574,6 @@ if PY3:
     def iterkeys(d, **kw):
         return iter(d.keys(**kw))
 
-    def itervalues(d, **kw):
-        raise SixUsageException()
-
     def iteritems(d, **kw):
         return iter(d.items(**kw))
 
@@ -597,9 +589,6 @@ else:
     def iterkeys(d, **kw):
         return d.iterkeys(**kw)
 
-    def itervalues(d, **kw):
-        raise SixUsageException()
-
     def iteritems(d, **kw):
         return d.iteritems(**kw)
 
@@ -613,7 +602,6 @@ else:
     viewitems = operator.methodcaller("viewitems")
 
 _add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
-_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
 _add_doc(iteritems,
          "Return an iterator over the (key, value) pairs of a dictionary.")
 _add_doc(iterlists,


### PR DESCRIPTION
## Description
- py27 tests removed from `.travis.yml`
- `luigi.six.itervalues` eliminated
- `luigi.six.itervalues` now raises exception on invocation to be sure it's not called

## Motivation and Context
#2830 

## Have you tested this? If so, how?
tests are okay
