### PR TITLE
[luigi.mock.MockFile] removed

### DIFF
--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -24,7 +24,6 @@ import multiprocessing
 from io import BytesIO
 
 import sys
-import warnings
 
 from luigi import six
 from luigi import target

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -188,9 +188,3 @@ class MockTarget(target.FileSystemTarget):
             return wrapper
         else:
             return self.format.pipe_reader(Buffer(self.fs.get_all_data()[fn]))
-
-
-class MockFile(MockTarget):
-    def __init__(self, *args, **kwargs):
-        warnings.warn("MockFile has been renamed MockTarget", DeprecationWarning, stacklevel=2)
-        super(MockFile, self).__init__(*args, **kwargs)

--- a/test/mock_test.py
+++ b/test/mock_test.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from helpers import unittest
 
 from luigi.mock import MockTarget, MockFileSystem
-from luigi import six
 from luigi.format import Nop
 
 
@@ -116,14 +115,3 @@ class MockFileSystemTest(unittest.TestCase):
 
     def test_listdir(self):
         self.assertEqual(sorted([self.path, self.path2]), sorted(self.fs.listdir("/tmp")))
-
-
-class TestImportMockFile(unittest.TestCase):
-
-    def test_mockfile(self):
-        from luigi.mock import MockFile
-        if six.PY3:
-            with self.assertWarnsRegex(DeprecationWarning, r'MockFile has been renamed MockTarget'):
-                self.assertTrue(isinstance(MockFile('foo'), MockTarget))
-        else:
-            self.assertTrue(isinstance(MockFile('foo'), MockTarget))


### PR DESCRIPTION
## Description
`luigi.mock.MockFile` removed

## Motivation and Context
It's deprecated since 2015
