### PR TITLE
"except ImportError" removed

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -23,10 +23,7 @@ import mimetypes
 import os
 import tempfile
 import time
-try:
-    from urlparse import urlsplit
-except ImportError:
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 from luigi.contrib import gcp
 import luigi.target

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -34,10 +34,7 @@ import random
 import re
 import shutil
 import signal
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import subprocess
 import sys
 import tempfile

--- a/luigi/contrib/hdfs/config.py
+++ b/luigi/contrib/hdfs/config.py
@@ -28,10 +28,7 @@ import warnings
 import os
 import getpass
 
-try:
-    from urlparse import urlparse, urlunparse
-except ImportError:
-    from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 
 class hdfs(luigi.Config):

--- a/luigi/contrib/mrrunner.py
+++ b/luigi/contrib/mrrunner.py
@@ -29,10 +29,7 @@ mapper, combiner, or reducer on the Hadoop nodes.
 
 from __future__ import print_function
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 import logging
 import os
 import sys

--- a/luigi/contrib/pai.py
+++ b/luigi/contrib/pai.py
@@ -34,10 +34,7 @@ import logging
 import luigi
 import abc
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
+from urllib.parse import urljoin
 
 import json
 

--- a/luigi/contrib/pyspark_runner.py
+++ b/luigi/contrib/pyspark_runner.py
@@ -28,10 +28,7 @@ other arguments are the ones returned by PySparkTask.app_options()
 
 from __future__ import print_function
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 import logging
 import sys
 import os

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -31,15 +31,9 @@ import os.path
 import warnings
 from multiprocessing.pool import ThreadPool
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
-try:
-    from ConfigParser import NoSectionError
-except ImportError:
-    from configparser import NoSectionError
+from configparser import NoSectionError
 
 from luigi import six
 

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -36,7 +36,6 @@ except ImportError:
     logger.warning("This module requires the python package 'requests'.")
 
 
-
 def get_soql_fields(soql):
     """
     Gets queried columns names.

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -34,10 +34,7 @@ try:
 except ImportError:
     logger.warning("This module requires the python package 'requests'.")
 
-try:
-    from urlparse import urlsplit
-except ImportError:
-    from urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 
 def get_soql_fields(soql):

--- a/luigi/contrib/salesforce.py
+++ b/luigi/contrib/salesforce.py
@@ -23,6 +23,7 @@ from collections import OrderedDict
 import re
 import csv
 import tempfile
+from urllib.parse import urlsplit
 
 import luigi
 from luigi import Task
@@ -34,7 +35,6 @@ try:
 except ImportError:
     logger.warning("This module requires the python package 'requests'.")
 
-from urllib.parse import urlsplit
 
 
 def get_soql_fields(soql):

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -95,10 +95,7 @@ import time
 import sys
 import logging
 import random
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 import luigi
 from luigi.contrib.hadoop import create_packages_archive

--- a/luigi/contrib/sge_runner.py
+++ b/luigi/contrib/sge_runner.py
@@ -34,10 +34,7 @@ return from SGETask.run()
 
 import os
 import sys
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 import logging
 import tarfile
 

--- a/luigi/contrib/spark.py
+++ b/luigi/contrib/spark.py
@@ -26,10 +26,7 @@ import importlib
 import tarfile
 import inspect
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from luigi import six
 from luigi.contrib.external_program import ExternalProgramTask

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -29,10 +29,7 @@ from json import JSONEncoder
 import operator
 from ast import literal_eval
 
-try:
-    from ConfigParser import NoOptionError, NoSectionError
-except ImportError:
-    from configparser import NoOptionError, NoSectionError
+from configparser import NoOptionError, NoSectionError
 
 from luigi import date_interval
 from luigi import task_register

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -22,18 +22,12 @@ See :doc:`/central_scheduler` for more info.
 """
 
 import collections
-try:
-    from collections.abc import MutableSet
-except ImportError:
-    from collections import MutableSet
+from collections.abc import MutableSet
 import json
 
 from luigi.batch_notifier import BatchNotifier
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 import functools
 import hashlib
 import itertools

--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -25,12 +25,7 @@ import os.path
 
 from luigi.configuration import get_config, LuigiConfigParser
 
-# In python3 ConfigParser was renamed
-# https://stackoverflow.com/a/41202010
-try:
-    from ConfigParser import NoSectionError
-except ImportError:
-    from configparser import NoSectionError
+from configparser import NoSectionError
 
 
 class BaseLogging(object):

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -20,10 +20,6 @@ It is a central concept of Luigi and represents the state of the workflow.
 See :doc:`/tasks` for an overview.
 """
 
-try:
-    from itertools import imap as map
-except ImportError:
-    pass
 from contextlib import contextmanager
 import logging
 import traceback

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -40,10 +40,7 @@ import subprocess
 import sys
 import contextlib
 
-try:
-    import Queue
-except ImportError:
-    import queue as Queue
+import queue as Queue
 import random
 import socket
 import threading
@@ -64,10 +61,7 @@ from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
 from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 logger = logging.getLogger('luigi-interface')
 

--- a/test/_test_ftp.py
+++ b/test/_test_ftp.py
@@ -28,13 +28,9 @@ import os
 import shutil
 import sys
 from helpers import unittest
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import BytesIO
 
-    def StringIO(s):
-        return BytesIO(s.encode('utf8'))
+from io import StringIO
+
 
 from luigi.contrib.ftp import RemoteFileSystem, RemoteTarget
 


### PR DESCRIPTION
## Description
statements like
```
try:
    import lib_from_py3
except ImportError:
   import lib_from_py2
```
eliminated

## Motivation and Context
#2830 