### PR TITLE
Fix some spelling typos

### DIFF
--- a/doc/running_luigi.rst
+++ b/doc/running_luigi.rst
@@ -4,7 +4,7 @@ Running Luigi
 Running from the Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The prefered way to run Luigi tasks is through the ``luigi`` command line tool
+The preferred way to run Luigi tasks is through the ``luigi`` command line tool
 that will be installed with the pip package.
 
 .. code-block:: python

--- a/luigi/cmdline_parser.py
+++ b/luigi/cmdline_parser.py
@@ -75,7 +75,7 @@ class CmdlineParser(object):
             # Check that what we believe to be the task is correctly spelled
             Register.get_task_cls(root_task)
         known_args = parser.parse_args(args=cmdline_args)
-        self.known_args = known_args  # Also publically expose parsed arguments
+        self.known_args = known_args  # Also publicly expose parsed arguments
 
     @staticmethod
     def _build_parser(root_task=None, help_all=False):

--- a/luigi/contrib/esindex.py
+++ b/luigi/contrib/esindex.py
@@ -169,7 +169,7 @@ class ElasticsearchTarget(luigi.Target):
         """
         Mark this update as complete.
 
-        The document id would be sufficent but,
+        The document id would be sufficient but,
         for documentation,
         we index the parameters `update_id`, `target_index`, `target_doc_type` and `date` as well.
         """

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -523,7 +523,7 @@ class HadoopJobRunner(JobRunner):
 
         arglist += self.streaming_args
 
-        # Add additonal non-generic  per-job streaming args
+        # Add additional non-generic  per-job streaming args
         extra_streaming_args = job.extra_streaming_arguments()
         for (arg, value) in extra_streaming_args:
             if not arg.startswith('-'):  # safety first

--- a/luigi/contrib/pai.py
+++ b/luigi/contrib/pai.py
@@ -253,7 +253,7 @@ class PaiTask(luigi.Task):
     def __init__(self, *args, **kwargs):
         """
         :param pai_url: The rest server url of PAI clusters, default is 'http://127.0.0.1:9186'.
-        :param token: The toke used to auth the rest server of PAI.
+        :param token: The token used to auth the rest server of PAI.
         """
         super(PaiTask, self).__init__(*args, **kwargs)
         self.__init_token()

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -737,7 +737,7 @@ class RedshiftUnloadTask(postgres.PostgresQuery, _CredentialsMixin):
 
     Usage:
     Subclass and override the required `host`, `database`, `user`, `password`, `table`, and `query` attributes.
-    Optionally, override the `autocommit` atribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
+    Optionally, override the `autocommit` attribute to run the query in autocommit mode - this is necessary to run VACUUM for example.
     Override the `run` method if your use case requires some action with the query result.
     Task instances require a dynamic `update_id`, e.g. via parameter(s), otherwise the query will only execute once
     To customize the query signature as recorded in the database marker table, override the `update_id` property.

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -126,7 +126,7 @@ class S3Client(FileSystem):
         aws_access_key_id = options.get('aws_access_key_id')
         aws_secret_access_key = options.get('aws_secret_access_key')
 
-        # Removing key args would break backwards compability
+        # Removing key args would break backwards compatibility
         role_arn = options.get('aws_role_arn')
         role_session_name = options.get('aws_role_session_name')
 

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -46,7 +46,7 @@ Example configuration section in luigi.cfg::
     scalding-home: /usr/share/scalding
 
     # provided dependencies, e.g. jars required for compiling but not executing
-    # scalding jobs. Currently requred jars:
+    # scalding jobs. Currently required jars:
     # org.apache.hadoop/hadoop-core/0.20.2
     # org.slf4j/slf4j-log4j12/1.6.6
     # log4j/log4j/1.2.15

--- a/luigi/contrib/simulate.py
+++ b/luigi/contrib/simulate.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('luigi-interface')
 
 class RunAnywayTarget(luigi.Target):
     """
-    A target used to make a task run everytime it is called.
+    A target used to make a task run every time it is called.
 
     Usage:
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -445,7 +445,7 @@ class Worker(object):
 
 class SimpleTaskState(object):
     """
-    Keep track of the current state and handle persistance.
+    Keep track of the current state and handle persistence.
 
     The point of this class is to enable other ways to keep state, eg. by using a database
     These will be implemented by creating an abstract base class that this and other classes

--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -3,10 +3,10 @@
 
 # Finds all tasks and task outputs on the dependency paths from the given downstream task T
 # up to the given source/upstream task S (optional). If the upstream task is not given,
-# all upstream tasks on all dependancy paths of T will be returned.
+# all upstream tasks on all dependency paths of T will be returned.
 
 # Terms:
-# if  the execution of Task T depends on the output of task S on a dependancy graph,
+# if  the execution of Task T depends on the output of task S on a dependency graph,
 #  T is called a downstream/sink task, S is called an upstream/source task.
 
 # This is useful and practical way to find all upstream tasks of task T.

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -993,7 +993,7 @@ class WorkerDisabledTest(LuigiTestCase):
     def _test_stop_getting_new_work_build(self, sch, worker):
         """
         I got motivated to create this test case when I saw that the
-        execution_summary crashed after my first attemted solution.
+        execution_summary crashed after my first attempted solution.
         """
         class KillWorkerTask(luigi.Task):
             did_actually_run = False


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.