### PR TITLE
add to LocalTarget read and write from text, json, pickle

### DIFF
--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -26,6 +26,8 @@ import tempfile
 import io
 import warnings
 import errno
+import pickle
+import json
 
 from luigi.format import FileWrapper, get_default_format
 from luigi.target import FileAlreadyExists, MissingParentDirectory, NotADirectory, FileSystem, FileSystemTarget, AtomicLocalFile
@@ -179,6 +181,30 @@ class LocalTarget(FileSystemTarget):
 
     def copy(self, new_path, raise_if_exists=False):
         self.fs.copy(self.path, new_path, raise_if_exists)
+
+    def read_text(self):
+        with open(self.path, "r") as f:
+            return f.read()
+
+    def read_json(self, **json_read_kw):
+        with open(self.path, "r") as f:
+            return json.load(f, **json_read_kw)
+
+    def read_pickle(self, **pickle_read_kw):
+        with open(self.path, "rb") as f:
+            return pickle.load(f, **pickle_read_kw)
+
+    def write_text(self, obj, mode="w"):
+        with open(self.path, mode) as f:
+            f.write(obj)
+
+    def write_json(self, obj, **json_dump_kw):
+        with open(self.path, "w") as f:
+            json.dump(obj, f, **json_dump_kw)
+
+    def write_pickle(self, obj, **pickle_dump_kw):
+        with open(self.path, "wb") as f:
+            pickle.dump(obj, f, **pickle_dump_kw)
 
     @property
     def fn(self):

--- a/test/local_target_test.py
+++ b/test/local_target_test.py
@@ -270,6 +270,33 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
             self.assertRaises(Exception, t.open, mode)
         print()
 
+    def test_read_text(self):
+        t = LocalTarget("tmp.txt", is_tmp=True)
+        t.write_text("test read text")
+        assert t.exists()
+        assert t.read_text() == "test read text"
+
+    def test_read_json(self):
+        t = LocalTarget("tmp.json", is_tmp=True)
+        t.write_json("test read json")
+        assert t.exists()
+        assert t.read_json() == "test read json"
+
+    def test_read_pickle(self):
+        t = LocalTarget("tmp.pickle", is_tmp=True)
+        t.write_pickle("test read pickle")
+        assert t.exists()
+        assert t.read_pickle() == "test read pickle"
+
+    def test_write_text(self):
+        self.test_read_text()
+
+    def test_write_json(self):
+        self.test_read_json()
+
+    def test_write_pickle(self):
+        self.test_read_pickle()
+
 
 class LocalTargetCreateDirectoriesTest(LocalTargetTest):
     path = '/tmp/%s/xyz/test.txt' % random.randint(0, 999999999)

--- a/test/local_target_test.py
+++ b/test/local_target_test.py
@@ -278,15 +278,19 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
     def test_read_json(self):
         t = LocalTarget("tmp.json", is_tmp=True)
-        t.write_json("test read json")
+        d = {"foo": "bar"}
+        t.write_json(d)
         assert t.exists()
-        assert t.read_json() == "test read json"
+        d_ = t.read_json()
+        assert "foo" in d_ and d_["foo"] == "bar"
 
     def test_read_pickle(self):
         t = LocalTarget("tmp.pickle", is_tmp=True)
-        t.write_pickle("test read pickle")
+        d = {"foo": "bar"}
+        t.write_pickle(d)
         assert t.exists()
-        assert t.read_pickle() == "test read pickle"
+        d_ = t.read_pickle()
+        assert "foo" in d_ and d_["foo"] == "bar"
 
     def test_write_text(self):
         self.test_read_text()


### PR DESCRIPTION
This PR aims to enrich LocalTarget with read and write functions for text, json and pickle files.


## Description
Add following functions to LocalTarget:

1. read_text
2. read_json
3. read_pickle
4. write_text
5. write_json
6. write_pickle

## Motivation and Context
It will remove a lot of boilerplate code:
```
class TaskA(luigi.Task):

    def output(self):
        return luigi.LocalTarget("foo.json")

    def run(self):
        output = dict(foo="bar")
        self.output().write_json(output)

class Task(luigi.Task):

    def requires(self):
        return TaskA()

    def output(self):
        return luigi.LocalTarget("foo.pickle")

   def run(self):
        input = self.input().read_json()
       # Fancy computations
        self.output().write_pickle(input)
```

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.
