### PR TITLE
Read parameter values from parent classes in configuration files

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -198,15 +198,15 @@ class Parameter(object):
 
         return self.parse(value)
 
-    def _get_value(self, task_name, param_name):
-        for value, warn in self._value_iterator(task_name, param_name):
+    def _get_value(self, task_name, param_name, allow_default=True):
+        for value, warn in self._value_iterator(task_name, param_name, allow_default):
             if value != _no_value:
                 if warn:
                     warnings.warn(warn, DeprecationWarning)
                 return value
         return _no_value
 
-    def _value_iterator(self, task_name, param_name):
+    def _value_iterator(self, task_name, param_name, allow_default=True):
         """
         Yield the parameter values, with optional deprecation warning as second tuple value.
 
@@ -222,10 +222,13 @@ class Parameter(object):
             yield (self._get_value_from_config(self._config_path['section'], self._config_path['name']),
                    'The use of the configuration [{}] {} is deprecated. Please use [{}] {}'.format(
                        self._config_path['section'], self._config_path['name'], task_name, param_name))
-        yield (self._default, None)
+        if allow_default:
+            yield (self._default, None)
+        else:
+            yield (_no_value, None)
 
-    def has_task_value(self, task_name, param_name):
-        return self._get_value(task_name, param_name) != _no_value
+    def has_task_value(self, task_name, param_name, allow_default=True):
+        return self._get_value(task_name, param_name, allow_default) != _no_value
 
     def task_value(self, task_name, param_name):
         value = self._get_value(task_name, param_name)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -416,7 +416,7 @@ class Task(object):
         # Then use the defaults for anything not filled in
         for param_name, param_obj in params:
             if param_name not in result:
-                if param_obj.has_task_value(task_family, param_name):
+                if param_obj.has_task_value(task_family, param_name, allow_default=False):
                     result[param_name] = param_obj.task_value(task_family, param_name)
 
         # Then use the defaults of parents for anything still not filled in
@@ -424,13 +424,16 @@ class Task(object):
         for parent in parents:
             for param_name, param_obj in params:
                 if param_name not in result:
-                    if param_obj.has_task_value(parent, param_name):
+                    if param_obj.has_task_value(parent, param_name, allow_default=False):
                         result[param_name] = param_obj.task_value(parent, param_name)
 
         # Only then check for missing values
         for param_name, param_obj in params:
             if param_name not in result:
-                raise parameter.MissingParameterException("%s: requires the '%s' parameter to be set" % (exc_desc, param_name))
+                if param_obj.has_task_value(task_family, param_name, allow_default=True):
+                    result[param_name] = param_obj.task_value(task_family, param_name)
+                else:
+                    raise parameter.MissingParameterException("%s: requires the '%s' parameter to be set" % (exc_desc, param_name))
 
         def list_to_tuple(x):
             """ Make tuples out of lists and sets to allow hashing """


### PR DESCRIPTION
## Description
Fix #2864 

Currently, during instantiation of a task, values of parameters are only checked in the following order:

- Positional arguments
- Keywords arguments
- defaults of task

How I changed this:

- Positional arguments
- Keywords arguments
- defaults of task
- **defaults of parents task**

## Have you tested this? If so, how?
"I ran my jobs with this code and it works for me.
