### PR TITLE
[luigi.contrib.hive] HiveTableTarget inherits HivePartitionTarget

### DIFF
--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -471,10 +471,20 @@ class HiveQueryRunner(luigi.contrib.hadoop.JobRunner):
 
 class HivePartitionTarget(luigi.Target):
     """
-    exists returns true if the table's partition exists.
+    Target representing Hive table or Hive partition
     """
 
     def __init__(self, table, partition, database='default', fail_missing_table=True, client=None):
+        """
+        @param table: Table name
+        @type table: str
+        @param partition: partition specificaton in form of
+        dict of {"partition_column_1": "partition_value_1", "partition_column_2": "partition_value_2", ... }
+        If `partition` is `None` or `{}` then target is Hive nonpartitioned table
+        @param database: Database name
+        @param fail_missing_table: flag to ignore errors raised due to table nonexistence
+        @param client: `HiveCommandClient` instance. Default if `client is None`
+        """
         self.database = database
         self.table = table
         self.partition = partition
@@ -482,6 +492,9 @@ class HivePartitionTarget(luigi.Target):
         self.fail_missing_table = fail_missing_table
 
     def exists(self):
+        """
+        returns `True` if the partition/table exists
+        """
         try:
             logger.debug(
                 "Checking Hive table '{d}.{t}' for partition {p}".format(
@@ -513,13 +526,10 @@ class HivePartitionTarget(luigi.Target):
             raise Exception("Couldn't find location for table: {0}".format(str(self)))
         return location
 
-    def open(self, mode):
-        return NotImplementedError("open() is not supported for {}".format(self.__class__.__name__))
-
 
 class HiveTableTarget(HivePartitionTarget):
     """
-    exists returns true if the table exists.
+    Target representing non-partitioned table
     """
 
     def __init__(self, table, database='default', client=None):
@@ -527,7 +537,7 @@ class HiveTableTarget(HivePartitionTarget):
             table=table,
             partition=None,
             database=database,
-            fail_missing_table=True,
+            fail_missing_table=False,
             client=client,
         )
 

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -460,7 +460,7 @@ class TestHiveTarget(unittest.TestCase):
         client = mock.Mock()
         target = luigi.contrib.hive.HiveTableTarget(database='db', table='foo', client=client)
         target.exists()
-        client.table_exists.assert_called_with('foo', 'db')
+        client.table_exists.assert_called_with('foo', 'db', None)
 
     def test_hive_partition_target(self):
         client = mock.Mock()
@@ -480,9 +480,10 @@ class ExternalHiveTaskTest(unittest.TestCase):
         output = _Task().output()
 
         # assert
-        assert isinstance(output, luigi.contrib.hive.HiveTableTarget)
+        assert isinstance(output, luigi.contrib.hive.HivePartitionTarget)
         assert output.database == 'schema1'
         assert output.table == 'table1'
+        assert output.partition == {}
 
     def test_partition_exists(self):
         # arrange


### PR DESCRIPTION
## Description
`luigi.contrib.hive.HiveTableTarget` inherits `HivePartitionTarget`

## Motivation and Context
* `HiveTableTarget` is a particular case of `HivePartitionTarget` with no partition
* methods in `HiveTableTarget` are copy-pasted from `HivePartitionTarget`

## Have you tested this? If so, how?
Unit-tests are updated