### PR TITLE
fix lsf module for python 3

### DIFF
--- a/luigi/contrib/lsf_runner.py
+++ b/luigi/contrib/lsf_runner.py
@@ -39,7 +39,7 @@ def do_work_on_compute_node(work_dir):
 
     # Open up the pickle file with the work to be done
     os.chdir(work_dir)
-    with open("job-instance.pickle", "r") as pickle_file_handle:
+    with open("job-instance.pickle", "rb") as pickle_file_handle:
         job = pickle.load(pickle_file_handle)
 
     # Do the work contained


### PR DESCRIPTION
## Description
- use 'rb' mode for writing and reading pickle files. this is already implemented in sge module.
- add 'python' in the command sequence. otherwise receive "permission denied" error.

## Motivation and Context
- to update lsf module. see issue #2873 

## Have you tested this? If so, how?
- I ran my jobs with this code and it works for me.
- The job can be submitted on LSF queue and status are properly tracked.