### PR TITLE
tox cleanup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{33,34,35,36,37}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, pypy-scheduler, docs, flake8
+envlist = py{33,34,35,36,37}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [testenv]
@@ -23,7 +23,7 @@ deps =
     postgres: psycopg2<3.0
     mysql-connector-python>=8.0.12
     gcloud: google-api-python-client>=1.4.0,<2.0
-    py33,py34,py35,py36,py37: avro-python3
+    avro-python3
     gcloud: google-auth==1.4.1
     gcloud: google-auth-httplib2==0.0.3
     google-compute-engine
@@ -101,21 +101,20 @@ max-line-length = 160
 builtins = unicode
 
 [testenv:flake8]
+basepython=python3
 deps =
     flake8>=3.2.0
 commands =
     flake8 --exclude=doc,.tox
     flake8 --max-line-length=100 --ignore=E265 doc
 
-[testenv:autopep8]
-deps = autopep8
-commands = autopep8 --ignore E309,E501 -a -i -r luigi test examples bin
-
 [testenv:isort]
+basepython=python3
 deps = isort
 commands = isort -w 120 -rc luigi test examples bin
 
 [testenv:docs]
+basepython=python3
 # Build documentation using sphinx.
 # Call this using `tox -e docs`.
 deps =


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
* Removed `pypy-scheduler` that doesn't seem to do anything
* No conditional dep for `avro-python3`
* Force `flake8`, `isort` and `docs` to use `python3`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
