### PR TITLE
[luigi.contrib.gcs] Add GCSFileWrapper

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -475,7 +475,7 @@ class GCSTarget(luigi.target.FileSystemTarget):
     def open(self, mode='r'):
         if mode == 'r':
             return self.format.pipe_reader(
-                FileWrapper(io.BufferedReader(self.fs.download(self.path))))
+                GCSFileWrapper(io.BufferedReader(self.fs.download(self.path))))
         elif mode == 'w':
             return self.format.pipe_writer(AtomicGCSFile(self.path, self.fs))
         else:
@@ -529,3 +529,7 @@ class GCSFlagTarget(GCSTarget):
     def exists(self):
         flag_target = self.path + self.flag
         return self.fs.exists(flag_target)
+
+
+class GCSFileWrapper(FileWrapper):
+    pass


### PR DESCRIPTION
## Description
Added GCSFileWrapper and changed to use GCSFileWrapper instead of FileWrapper

## Motivation and Context
I cannot distinguish File-Instance of GCS and other by `type()` because of using FileWrapper.

## Have you tested this? If so, how?
I ran my job and I have confirmed that GCSFileWrapper and FileWrapper can be distinguished.
