### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/luigi/freezing.py
+++ b/luigi/freezing.py
@@ -4,7 +4,11 @@ Please, do not use it outside of Luigi codebase itself.
 """
 
 
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import operator
 import functools
 

--- a/luigi/tools/deps.py
+++ b/luigi/tools/deps.py
@@ -47,7 +47,10 @@ from luigi.task import flatten
 from luigi import parameter
 import sys
 from luigi.cmdline_parser import CmdlineParser
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 def get_task_requires(task):
@@ -118,7 +121,7 @@ def main():
 
         if isinstance(task_output, dict):
             output_descriptions = [get_task_output_description(output) for label, output in task_output.items()]
-        elif isinstance(task_output, collections.Iterable):
+        elif isinstance(task_output, Iterable):
             output_descriptions = [get_task_output_description(output) for output in task_output]
         else:
             output_descriptions = [get_task_output_description(task_output)]


### PR DESCRIPTION
## Description

Import ABC from collections.abc for Python 3.9 compatibility since Python 3.9 raises an ImportError.

## Motivation and Context

Improves Python 3.9 compatibility.