### PR TITLE
Handle rare race condition in worker process terminate

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -270,10 +270,11 @@ class TaskProcess(multiprocessing.Process):
     def terminate(self):
         """Terminate this process and its subprocesses."""
         # default terminate() doesn't cleanup child processes, it orphans them.
-        try:
-            return self._recursive_terminate()
-        except ImportError:
-            return super(TaskProcess, self).terminate()
+        if super(TaskProcess, self).is_alive():
+            try:
+                return self._recursive_terminate()
+            except ImportError:
+                return super(TaskProcess, self).terminate()
 
     @contextlib.contextmanager
     def _forward_attributes(self):

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -147,19 +147,17 @@ class TaskProcessTest(LuigiTestCase):
         task_process = TaskProcess(task, worker_id, queue, mock.Mock())
         task_process.start()
 
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
         mock_kill = MagicMock(side_effect=NoSuchProcess(task_process.pid, "TEST No such process"))
 
         with patch("os.kill", mock_kill):
 
-            parent = Process(task_process.pid)
-            while not parent.children():
-                # wait for child process to startup
-                sleep(0.01)
-
             [child] = parent.children()
-            task_process.terminate()
-
-            # no errors!
+            task_process.terminate() # no errors!
 
         # ensure cleanup
         task_process.terminate()
@@ -179,19 +177,17 @@ class TaskProcessTest(LuigiTestCase):
         task_process = TaskProcess(task, worker_id, queue, mock.Mock())
         task_process.start()
 
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
         mock_kill = MagicMock(side_effect=OSError(1, "TEST Operation not permitted"))
 
         with patch("os.kill", mock_kill):
 
-            parent = Process(task_process.pid)
-            while not parent.children():
-                # wait for child process to startup
-                sleep(0.01)
-
             [child] = parent.children()
-            task_process.terminate()
-
-            # no errors!
+            task_process.terminate() # no errors
 
         # ensure cleanup
         task_process.terminate()
@@ -211,14 +207,14 @@ class TaskProcessTest(LuigiTestCase):
         task_process = TaskProcess(task, worker_id, queue, mock.Mock())
         task_process.start()
 
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
         mock_kill = MagicMock(side_effect=OSError(24, "TEST Too many open files"))
 
         with patch("os.kill", mock_kill):
-
-            parent = Process(task_process.pid)
-            while not parent.children():
-                # wait for child process to startup
-                sleep(0.01)
 
             with self.assertRaises(OSError):
                 [child] = parent.children()

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -157,7 +157,7 @@ class TaskProcessTest(LuigiTestCase):
         with patch("os.kill", mock_kill):
 
             [child] = parent.children()
-            task_process.terminate() # no errors!
+            task_process.terminate()  # no errors!
 
         # ensure cleanup
         task_process.terminate()
@@ -187,7 +187,7 @@ class TaskProcessTest(LuigiTestCase):
         with patch("os.kill", mock_kill):
 
             [child] = parent.children()
-            task_process.terminate() # no errors
+            task_process.terminate()  # no errors
 
         # ensure cleanup
         task_process.terminate()

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -20,7 +20,8 @@ import sys
 
 from helpers import LuigiTestCase, StringContaining
 import mock
-from psutil import Process
+from mock import patch
+from psutil import Process, NoSuchProcess
 from time import sleep
 
 import luigi
@@ -128,6 +129,113 @@ class TaskProcessTest(LuigiTestCase):
             sleep(0.01)
 
         [child] = parent.children()
+        task_process.terminate()
+        child.wait(timeout=1.0)  # wait for terminate to complete
+
+        self.assertFalse(parent.is_running())
+        self.assertFalse(child.is_running())
+
+    @patch('os.kill')
+    def test_no_such_process_is_ignored(self, os_kill_fn):
+        """
+        Process is already gone, no one else has claimed this PID yet should be OK
+        """
+        class HangingSubprocessTask(luigi.Task):
+            def run(self):
+                python = sys.executable
+                check_call([python, '-c', 'while True: pass'])
+
+        task = HangingSubprocessTask()
+        queue = mock.Mock()
+        worker_id = 1
+
+        task_process = TaskProcess(task, worker_id, queue, mock.Mock())
+        task_process.start()
+
+        os_kill_fn.side_effect = NoSuchProcess(task_process.pid, "TEST No such process")
+
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
+        [child] = parent.children()
+        task_process.terminate()
+
+        # no errors!
+
+        os_kill_fn.side_effect = None # cleanup
+        task_process.terminate()
+        child.wait(timeout=1.0)  # wait for terminate to complete
+
+        self.assertFalse(parent.is_running())
+        self.assertFalse(child.is_running())
+
+    @patch('os.kill')
+    def test_operation_not_permitted_is_ignored(self, os_kill_fn):
+        """
+        Process is already gone, and someone else has claimed this PID should be OK
+        """
+        class HangingSubprocessTask(luigi.Task):
+            def run(self):
+                python = sys.executable
+                check_call([python, '-c', 'while True: pass'])
+
+        task = HangingSubprocessTask()
+        queue = mock.Mock()
+        worker_id = 1
+
+        task_process = TaskProcess(task, worker_id, queue, mock.Mock())
+        task_process.start()
+
+        os_kill_fn.side_effect = OSError(1, "TEST Operation not permitted")
+
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
+        [child] = parent.children()
+        task_process.terminate()
+
+        # no errors!
+
+        os_kill_fn.side_effect = None # cleanup
+        task_process.terminate()
+        child.wait(timeout=1.0)  # wait for terminate to complete
+
+        self.assertFalse(parent.is_running())
+        self.assertFalse(child.is_running())
+
+    @patch('os.kill')
+    def test_other_exceptions_do_raise(self, os_kill_fn):
+        """
+        Any other type of OSError should raise an exception like normal
+        """
+        class HangingSubprocessTask(luigi.Task):
+            def run(self):
+                python = sys.executable
+                check_call([python, '-c', 'while True: pass'])
+
+        task = HangingSubprocessTask()
+        queue = mock.Mock()
+        worker_id = 1
+
+        task_process = TaskProcess(task, worker_id, queue, mock.Mock())
+        task_process.start()
+
+        os_kill_fn.side_effect = OSError(24, "TEST Too many open files")
+
+        parent = Process(task_process.pid)
+        while not parent.children():
+            # wait for child process to startup
+            sleep(0.01)
+
+        with self.assertRaises(OSError):
+            [child] = parent.children()
+            task_process.terminate()
+
+        os_kill_fn.side_effect = None # cleanup
         task_process.terminate()
         child.wait(timeout=1.0)  # wait for terminate to complete
 


### PR DESCRIPTION
## Description
There's already a handler in the code for when the PID we're trying to kill no longer exists, but no handler for what happens one step further than that -- the worker process was already gone, but then another process on the same instance came in and took the same PID. This PR adds a catch for this situation so the whole worker doesn't die with `OSError 1: Operation not permitted`.

## Motivation and Context
We saw the above error in some of our production clusters, dug in a bit and found out that the `luigi-worker` process was attempting to kill PIDs it didn't even own.

## Have you tested this? If so, how?
Because of its random-chance nature, bug was hard to reproduce, but (a) we verified manually (in a Python shell) that this catches the right error in the right circumstances, and (b) we haven't seen it again since implementing this fix.
