### PR TITLE
support _FrozenOrderedDict in flatten

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -39,7 +39,7 @@ from luigi import six
 
 from luigi import parameter
 from luigi.task_register import Register
-from luigi.parameter import ParameterVisibility
+from luigi.parameter import ParameterVisibility, _FrozenOrderedDict
 
 Parameter = parameter.Parameter
 logger = logging.getLogger('luigi-interface')
@@ -872,7 +872,7 @@ def flatten(struct):
     if struct is None:
         return []
     flat = []
-    if isinstance(struct, dict):
+    if isinstance(struct, dict) or isinstance(struct, _FrozenOrderedDict):
         for _, result in six.iteritems(struct):
             flat += flatten(result)
         return flat

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -27,6 +27,8 @@ import luigi
 import luigi.task
 import luigi.util
 import collections
+
+from luigi.parameter import _FrozenOrderedDict
 from luigi.task_register import load_task
 
 
@@ -112,6 +114,7 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(flatten('foo'), ['foo'])
         self.assertEqual(flatten(42), [42])
         self.assertEqual(flatten((len(i) for i in ["foo", "troll"])), [3, 5])
+        self.assertEqual(flatten(_FrozenOrderedDict({'a': 'foo', 'b': 'bar'})), ['foo', 'bar'])
         self.assertRaises(TypeError, flatten, (len(i) for i in ["foo", "troll", None]))
 
     def test_externalized_task_picklable(self):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
- `luigi.task.flatten` supports instances of `_FrozenOrderedDict`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-  I would like to flatten  `DictParameter` values.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I have included unit tests.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
