### PR TITLE
Allowed wider popovers in dependency graph.

### DIFF
--- a/luigi/static/visualiser/css/luigi.css
+++ b/luigi/static/visualiser/css/luigi.css
@@ -234,3 +234,7 @@ span.status-icon {
   background-color: rgb(0, 166, 90) !important;
   color: white !important;
 }
+
+.popover{
+    max-width: 100% !important; 
+}


### PR DESCRIPTION
## Description

Edited CSS to make popovers with long arguments look better.

Changing in luigi.css and not bootstrap to allow for bootstrap upgrades without reverting this change, thus marking it as important.

## Motivation and Context

This is a visual change only. It does no affect any real functionality, but does make Luigi look nicer.

## Have you tested this? If so, how?

Testes and looks fine in Chrome, Firefox and Edge.

## Before

![luigi_before](https://user-images.githubusercontent.com/352885/74911248-83e4fa00-53bc-11ea-8150-117de1b0fff3.png)

## After

![luigi_after](https://user-images.githubusercontent.com/352885/74911136-4aac8a00-53bc-11ea-81e9-7a4860112519.png)



