### PR TITLE
add 'encoding' argument

### DIFF
--- a/luigi/configuration/base_parser.py
+++ b/luigi/configuration/base_parser.py
@@ -32,9 +32,9 @@ class BaseParser:
         return cls._instance
 
     @classmethod
-    def add_config_path(cls, path):
+    def add_config_path(cls, path, encoding=None):
         cls._config_paths.append(path)
-        cls.reload()
+        cls.reload(encoding)
 
     @classmethod
     def reload(cls):

--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -143,7 +143,7 @@ class LuigiConfigParser(BaseParser, ConfigParser):
         _DEFAULT_INTERPOLATION = CombinedInterpolation([BasicInterpolation(), EnvironmentInterpolation()])
 
     @classmethod
-    def reload(cls):
+    def reload(cls, encoding=None):
         # Warn about deprecated old-style config paths.
         deprecated_paths = [p for p in cls._config_paths if os.path.basename(p) == 'client.cfg' and os.path.exists(p)]
         if deprecated_paths:
@@ -151,7 +151,7 @@ class LuigiConfigParser(BaseParser, ConfigParser):
                           "Found: {paths!r}".format(paths=deprecated_paths),
                           DeprecationWarning)
 
-        return cls.instance().read(cls._config_paths)
+        return cls.instance().read(cls._config_paths, encoding=encoding)
 
     def _get_with_default(self, method, section, option, default, expected_type=None, **kwargs):
         """


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->
Add 'encoding' argument to base_parser.py and cfg_parser.py

## Description
<!--- Describe your changes -->
Add 'encoding' argument to specify config file encoding.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently LuigiConfigParser.add_config_path() fails when config file(e.g. luigi.toml) contains japanese.
Since luigi config file may contains japanese, I think LuigiConfigParser.add_config_path() should accepts 'encoding' argument.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I ran my jobs with this code and it works for me.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
