### PR TITLE
changed order of ConfigParser import attempts to try configparser first

### DIFF
--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -36,11 +36,11 @@ import warnings
 # In python3 ConfigParser was renamed
 # https://stackoverflow.com/a/41202010
 try:
-    from ConfigParser import ConfigParser, NoOptionError, NoSectionError, InterpolationError
-    Interpolation = object
-except ImportError:
     from configparser import ConfigParser, NoOptionError, NoSectionError, InterpolationError
     from configparser import Interpolation, BasicInterpolation
+except ImportError:
+    from ConfigParser import ConfigParser, NoOptionError, NoSectionError, InterpolationError
+    Interpolation = object
 
 from .base_parser import BaseParser
 

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -37,9 +37,9 @@ except ImportError:
     from urllib.parse import urlsplit
 
 try:
-    from ConfigParser import NoSectionError
-except ImportError:
     from configparser import NoSectionError
+except ImportError:
+    from ConfigParser import NoSectionError
 
 from luigi import six
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -30,9 +30,9 @@ import operator
 from ast import literal_eval
 
 try:
-    from ConfigParser import NoOptionError, NoSectionError
-except ImportError:
     from configparser import NoOptionError, NoSectionError
+except ImportError:
+    from ConfigParser import NoOptionError, NoSectionError
 
 from luigi import date_interval
 from luigi import task_register

--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -28,9 +28,9 @@ from luigi.configuration import get_config, LuigiConfigParser
 # In python3 ConfigParser was renamed
 # https://stackoverflow.com/a/41202010
 try:
-    from ConfigParser import NoSectionError
-except ImportError:
     from configparser import NoSectionError
+except ImportError:
+    from ConfigParser import NoSectionError
 
 
 class BaseLogging(object):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

In all modules where ConfigParser/configparser is imported, reverse the order of the try-except so that importing configparser is tried first.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is intended to address #2917 by ensuring that luigi first tries to import configparser before attempting to import ConfigParser, allowing Python 2 clients that have the configparser backport installed to experience the same parsing behavior as Python 3 clients.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Smoke-tested in Python 2 (with configparser installed) and Python 3. I successfully ran luigi with a config file containing "%%" in both Python 2 and Python 3. I don't have a formal test for my specific use case yet (I think it reduces to proving that configparser is imported when available in Python 2), but I'm happy to add a test for this if needed.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
