### PR TITLE
Add ExternalProgramTask param debug_environment

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -65,6 +65,12 @@ class ExternalProgramTask(luigi.Task):
     """
 
     capture_output = luigi.BoolParameter(default=True, significant=False, positional=False)
+    debug_environment = luigi.BoolParameter(
+        default=True,
+        significant=False,
+        positional=False,
+        description="If True, all environment variables will be debugged if the execution raises an error. While "
+                    "this is helpful for debugging errors, it can reveal private information in production scenarios.")
 
     stream_for_searching_tracking_url = luigi.parameter.ChoiceParameter(
         var_type=str, choices=['none', 'stdout', 'stderr'], default='none',
@@ -162,7 +168,10 @@ class ExternalProgramTask(luigi.Task):
             if not success:
                 raise ExternalProgramRunError(
                     'Program failed with return code={}:'.format(proc.returncode),
-                    args, env=env, stdout=stdout, stderr=stderr)
+                    args,
+                    env=env if self.debug_environment else None,
+                    stdout=stdout,
+                    stderr=stderr)
         finally:
             if self.capture_output:
                 tmp_stderr.close()


### PR DESCRIPTION
## Description
This PR adds a parameter named `debug_environment` to the class `ExternalProgramTask`. If it is set to `False`, environment variables won't be printed to stderr when an error occurs.

## Motivation and Context
There are several scenarios in which you would not like to see all your environment variables being printed onto the stderr stream. For example, it is possible that they include private access tokens. It should be possible to run your pipeline on Travis CI using Shippable or something similar without revealing this information to the public. 

## Have you tested this? If so, how?
I have included unit tests, but I still need to check whether Travis will accept them. :D