### PR TITLE
Add ability to run Kubernetes CronJobs from Luigi UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ var/
 *.manifest
 *.spec
 
+# Pyenv
+.python-version
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -607,6 +607,9 @@ kubeconfig_path
 max_retrials
   Maximum number of retrials in case of job failure.
 
+namespace
+	The name of the Kubernetes namespace
+
 .. _service-account: http://kubernetes.io/docs/user-guide/kubeconfig-file
 .. _kubeconfig: http://kubernetes.io/docs/user-guide/service-accounts
 .. _minikube: http://kubernetes.io/docs/getting-started-guides/minikube

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -22,6 +22,8 @@ See :doc:`/central_scheduler` for more info.
 """
 
 import collections
+import datetime
+
 try:
     from collections.abc import MutableSet
 except ImportError:
@@ -29,6 +31,11 @@ except ImportError:
 import json
 
 from luigi.batch_notifier import BatchNotifier
+
+try:
+    from kubernetes import client, config
+except ImportError:
+    print("No Kubernetes environment")
 
 try:
     import cPickle as pickle
@@ -1486,6 +1493,55 @@ class Scheduler(object):
             return self._state.get_task(task_id).pretty_id
         else:
             return task_id
+
+    @rpc_method()
+    def jobs(self):
+        try:
+            if configuration.get_config().get("kubernetes", "auth_method") == "kubeconfig":
+                config.load_kube_config()
+            else:
+                config.load_incluster_config()
+
+            batch_api_v1 = client.BatchV1beta1Api()
+
+            namespace = configuration.get_config().get("kubernetes", "namespace", "default")
+
+            result = []
+            for cron_job in batch_api_v1.list_namespaced_cron_job(namespace).items:
+                last_run = cron_job.status.last_schedule_time
+                result.append({
+                    "name": cron_job.metadata.name,
+                    "last_scheduled_run_at": last_run.strftime("%Y-%m-%d %H:%M:%S") if last_run else "Never ran"
+                })
+
+            return result
+        except (TypeError, NameError):
+            logger.error("Missing Kubernetes configurations")
+
+    @rpc_method()
+    def trigger_job(self, job_name):
+        try:
+            if configuration.get_config().get("kubernetes", "auth_method") == "kubeconfig":
+                config.load_kube_config()
+            else:
+                config.load_incluster_config()
+
+            batch_api_v1 = client.BatchV1beta1Api()
+
+            namespace = configuration.get_config().get("kubernetes", "namespace", "default")
+
+            job = batch_api_v1.read_namespaced_cron_job(job_name, namespace)
+            job_template = job.spec.job_template
+
+            unique_identified = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            job_template.metadata.name = "{}-manual-{}".format(job_name, unique_identified)
+            client.BatchV1Api().create_namespaced_job(body=job_template, namespace=namespace)
+
+            return "Successfully triggered the {}!".format(job_name)
+
+        except (TypeError, NameError):
+            logger.error("Missing Kubernetes configurations")
+            return "Failed triggering {}!".format(job_name)
 
     @rpc_method()
     def worker_list(self, include_running=True, **kwargs):

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -401,6 +401,7 @@
                                 <li><a class="js-nav-link" href="#tab=graph" data-tab="dependencyGraph">Dependency Graph</a></li>
                                 <li><a class="js-nav-link" href="#tab=workers" data-tab="workerList">Workers</a></li>
                                 <li><a class="js-nav-link" href="#tab=resource" data-tab="resourceList">Resources</a></li>
+                                <li class="jobs-menu-item hidden"><a class="js-nav-link" href="#tab=jobs" data-tab="jobList">Jobs</a></li>
                             </ul>
                             <form class="navbar-form navbar-right" id="pause-form">
                             </form>
@@ -564,6 +565,17 @@
             <section id="workerList" class="container-fluid tab-pane active">
             </section>
             <section id="resourceList" class="tab-pane">
+            </section>
+            <section id="jobList" class="tab-pane hidden">
+                <table id="jobTable" class="table table-striped">
+                    <thead>
+                        <th>Name</th>
+                        <th>Last Scheduled Run</th>
+                        <th>Actions</th>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
             </section>
         </div> <!-- /.tab-content -->
         </div> <!-- /.content -->

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -213,5 +213,11 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.getJobList = function(callback) {
+        jsonRPC(this.urlRoot + "/jobs", {}, function(response) {
+            callback(response.response);
+        });
+    };
+
     return LuigiAPI;
 })();

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1183,7 +1183,7 @@ function visualiserApp(luigi) {
         luigi.getJobList(function(jobs) {
             if(jobs.length > 0) {
                 $(".jobs-menu-item").removeClass("hidden");
-				$("#jobsList").removeClass("hidden");
+				$("#jobList").removeClass("hidden");
 
 				$.each(jobs, function(index, job) {
 

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -516,6 +516,8 @@ function visualiserApp(luigi) {
         } else if (fragmentQuery.tab == "resources") {
             expandResources(fragmentQuery.resources);
             switchTab("resourceList");
+        } else if (fragmentQuery.tab == "jobs") {
+            switchTab("jobList");
         } else if (fragmentQuery.tab == "graph") {
             var taskId = fragmentQuery.taskId;
             var hideDone = fragmentQuery.hideDone === '1' ? true : false;
@@ -1178,6 +1180,43 @@ function visualiserApp(luigi) {
             });
         });
 
+        luigi.getJobList(function(jobs) {
+            if(jobs.length > 0) {
+                $(".jobs-menu-item").removeClass("hidden");
+				$("#jobsList").removeClass("hidden");
+
+				$.each(jobs, function(index, job) {
+
+					var newTableRow = "<tr>" +
+							"<td>" + job["name"] + "</td>" +
+							"<td>" + job["last_scheduled_run_at"] + "</td>" +
+							"<td><a class='job' data-url='/api/trigger_job' data-name='" + job["name"] + "'>Trigger</a></td>"
+						"</tr>";
+					$("#jobList tbody").append(newTableRow);
+				});
+
+				$("#jobTable").DataTable({
+					stateSave: true,
+					language: {
+						search: "Filter table:"
+					},
+				});
+
+				$(".job").click(function(e) {
+					$.ajax({
+						url: $(this).data("url"),
+						type: "GET",
+						data: {data: JSON.stringify({ job_name: $(this).data("name") })},
+						dataType: "json"
+					}).done(function(data) {
+						alert(data["response"]);
+					});
+					return false;
+				});
+			}
+        });
+
+
         dt = $('#taskTable').DataTable({
             stateSave: true,
             stateSaveCallback: function(settings, data) {
@@ -1551,6 +1590,8 @@ function visualiserApp(luigi) {
             } else if (tabId == 'resourceList') {
                 state.resources = JSON.stringify(expandedResources());
                 state.tab = 'resources';
+            } else if (tabId == 'jobList') {
+                state.tab = 'jobs';
             }
 
             location.hash = '#' + URI.buildQuery(state);

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ meta = {}
 with open("luigi/__meta__.py", "r") as f:
     exec(f.read(), meta)
 
+if os.environ.get('KUBERNETES_CLUSTER', None) == 'True':
+    install_requires.append('kubernetes==10.0.1')
+
 setup(
     name='luigi',
     version=meta['__version__'],


### PR DESCRIPTION
## Description
To extend the usability of Luigi UI, added the ability to read the CronJobs
from Kubernetes cluster in a specific namespace and the ability to run the
CronJobs manually from Luigi UI.

## Motivation and Context
The Luigi UI is limited and does not have the ability to list and run jobs as in other scheduling tools. As a starting point, added interaction with Kubernetes API that can list the CronJobs in a Kubernetes cluster (which most probably will be scheduled jobs that uses Luigi) and add the ability to run those jobs manually. This reduces the overhead of authorization of the Kubernetes cluster, hopping to the CronJobs page and triggering the job manually.


## Have you tested this? If so, how?
The changes are tested with:

1. Existing valid Kubernetes configurations
2. Invalid Kubernetes configrations
3. `kubeconfig` authorization method
4. `service-account` authorization` method

