### PR TITLE
update documentation to prefer pykube-ng

### DIFF
--- a/examples/kubernetes.py
+++ b/examples/kubernetes.py
@@ -19,7 +19,7 @@ Example Kubernetes Job Task.
 
 Requires:
 
-- pykube: ``pip install pykube``
+- pykube: ``pip install pykube-ng``
 - A local minikube custer up and running: http://kubernetes.io/docs/getting-started-guides/minikube/
 
 **WARNING**: For Python versions < 3.5 the kubeconfig file must point to a Kubernetes API

--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -28,7 +28,7 @@ For more information about Kubernetes Jobs: http://kubernetes.io/docs/user-guide
 
 Requires:
 
-- pykube: ``pip install pykube``
+- pykube: ``pip install pykube-ng``
 
 Written and maintained by Marco Capuccini (@mcapuccini).
 """

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -21,7 +21,7 @@ Tests for the Kubernetes Job wrapper.
 
 Requires:
 
-- pykube: ``pip install pykube``
+- pykube: ``pip install pykube-ng``
 - A local minikube custer up and running: http://kubernetes.io/docs/getting-started-guides/minikube/
 
 **WARNING**: For Python versions < 3.5 the kubeconfig file must point to a Kubernetes API


### PR DESCRIPTION
## Description
Updates documentation to inform a user of the Kubernetes module to use pykube-ng as pykube is no longer maintained. 

## Have you tested this? If so, how?
I have captured a manual test done here #2922 

I could add automated tests for this but i think it would be rewriting the existing one. I have also had some issues locally running the current tests for this module (https://github.com/spotify/luigi/pull/2815). 