### PR TITLE
Removed wrong type of FileSystemTarget.__init__ path arg from doc

### DIFF
--- a/luigi/target.py
+++ b/luigi/target.py
@@ -213,7 +213,7 @@ class FileSystemTarget(Target):
         """
         Initializes a FileSystemTarget instance.
 
-        :param str path: the path associated with this FileSystemTarget.
+        :param path: the path associated with this FileSystemTarget.
         """
         # cast to str to allow path to be objects like pathlib.PosixPath and py._path.local.LocalPath
         self.path = str(path)


### PR DESCRIPTION
There is a nice feature in `FileSystemTarget.__init__` that calls `str` on the path parameter to allow passing `Path` objects (and similar ones). But the type of the argument is wrongly documented as str, causing my pycharm to show an annoying warning. I think we should just remove the type from the documentation.