### PR TITLE
remove StreamingBodyAdaptor that didn't allow choosing the chunk size

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -76,21 +76,6 @@ class DeprecatedBotoClientException(Exception):
     pass
 
 
-class _StreamingBodyAdaptor(io.IOBase):
-    """
-    Adapter class wrapping botocore's StreamingBody to make a file like iterable
-    """
-
-    def __init__(self, streaming_body):
-        self.streaming_body = streaming_body
-
-    def read(self, size):
-        return self.streaming_body.read(size)
-
-    def close(self):
-        return self.streaming_body.close()
-
-
 class S3Client(FileSystem):
     """
     boto3-powered S3 client.
@@ -586,7 +571,7 @@ class AtomicS3File(AtomicLocalFile):
 
 class ReadableS3File(object):
     def __init__(self, s3_key):
-        self.s3_key = _StreamingBodyAdaptor(s3_key.get()['Body'])
+        self.s3_key = s3_key.get()['Body']
         self.buffer = []
         self.closed = False
         self.finished = False

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -23,7 +23,6 @@ system operations. The `boto3` library is required to use S3 targets.
 from __future__ import division
 
 import datetime
-import io
 import itertools
 import logging
 import os


### PR DESCRIPTION
### Context

The StreamingBodyAdaptor caused performance issues:
Calling `__iter__()` on a StreamingBodyAdaptor object defaulted to chunks of 1 byte, which was really slowing down reads.
We weren't able to pass the `size` parameter to change the chunk size while iterating on the streaming body.

### Solution

botocore StreamingBody implementation already provides a complete implementation of streaming by chunks, that behaves like a file.
https://github.com/boto/botocore/blob/master/botocore/response.py#L90

It supersedes luigi's StreamingBodyAdaptor
It defaults to chunks of 1024 bytes, and can be adjusted. 
It also offers iter_lines() and iter_chunks() methods.

I guess that maybe it didn't exist at the time the `StreamingBodyAdaptor` was written.

### Testing

We are using this change in production and it works as expected