### PR TITLE
Fix docs explaining write modes for Luigi Targets. Closes #2783

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -127,6 +127,31 @@ An example:
                                 )
                             )
 
+It's useful to note that if you're writing to a binary file, Luigi automatically
+strips the ``'b'`` flag due to how atomic writes/reads work. In order to write a binary
+file, such as a pickle file, you should instead use ``format=Nop`` when calling
+LocalTarget. Following the above example:
+
+.. code:: python
+
+    class GenerateWords(luigi.Task):
+
+        def output(self):
+            return luigi.LocalTarget('words.pckl', format=Nop)
+
+        def run(self):
+            import pickle
+
+            # write a dummy list of words to output file
+            words = [
+                    'apple',
+                    'banana',
+                    'grapefruit'
+                    ]
+
+            with self.output().open('w') as f:
+                pickle.dump(words, f)
+
 .. _Task.input:
 
 Task.input

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -235,7 +235,8 @@ class FileSystemTarget(Target):
 
         :param str mode: the mode `r` opens the FileSystemTarget in read-only mode, whereas `w` will
                          open the FileSystemTarget in write mode. Subclasses can implement
-                         additional options.
+                         additional options. Using `b` is not supported; initialize with
+                         `format=Nop` instead.
         """
         pass
 


### PR DESCRIPTION
## Description
I added some documentation under `Task.run()` and under the API docs for `target.FileSystemTarget` explaining not to use the binary `b` flag, but instead use `format=Nop`. This closes #2783 , at least for now. In the future, we might want to instead throw a warning explaining not to use `b`.

## Motivation and Context
Closes #2783 .

## Have you tested this? If so, how?
Built + opened documentation locally and it seems to have worked.