### PR TITLE
Show task progress in visualizer workers tab.

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -214,6 +214,7 @@
                         <th>Name</th>
                         <th>Priority</th>
                         <th>Resources</th>
+                        <th>Progress</th>
                         <th>Time</th>
                         <th>Actions</th>
                       </thead>
@@ -223,8 +224,17 @@
                         <td>{{displayName}}</td>
                         <td>{{priority}}</td>
                         <td>{{resources}}</td>
+                        <td>
+                          {{#progressPercentage}}
+                          <div class="progress">
+                            <div class="progress-bar taskProgressBar" role="progressbar" data-task-id="{{taskId}}" style="width: {{progressPercentage}}%" aria-valuenow="{{progressPercentage}}" aria-valuemin="0" aria-valuemax="100">{{progressPercentage}}%</div>
+                          </div>
+                          {{/progressPercentage}}
+                          {{^progressPercentage}}-{{/progressPercentage}}
+                        </td>
                         <td>{{displayTime}}</td>
-                        <td><a href="#tab=graph&taskId={{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
+                        <td>
+                          <a href="#tab=graph&taskId={{encodedTaskId}}" class="btn btn-info btn-xs" title="View graph" data-toggle="tooltip" data-action="drawGraph"><i class="fa fa-sitemap"/></a>
                           {{#trackingUrl}}<a target="_blank" href="{{trackingUrl}}" class="btn btn-primary btn-xs" title="Track Progress" data-toggle="tooltip"><i class="fa fa-eye"></i></a>{{/trackingUrl}}
                           {{#statusMessage}}<button class="btn btn-primary btn-xs statusMessage" title="Status message" data-toggle="tooltip" data-task-id="{{taskId}}" data-display-name="{{displayName}}"><i class="fa fa-comment"></i></button>{{/statusMessage}}
                           {{^statusMessage}}

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -344,15 +344,16 @@ function visualiserApp(luigi) {
                         }
                     });
                     luigi.getTaskProgressPercentage(data.taskId, function(data) {
-                        if (data.progressPercentage === null)
-                            $("#statusMessageModal .progress").hide();
-                        else {
-                            $("#statusMessageModal .progress").show();
-                            $("#statusMessageModal .progress-bar")
-                                .attr('aria-valuenow', data.progressPercentage)
-                                .text(data.progressPercentage + '%')
-                                .css({'width': data.progressPercentage + '%'});
-                        }
+                        // show or hide the progress bar container in the message model
+                        $("#statusMessageModal .progress").toggle(data.progressPercentage !== null);
+
+                        // adjust the status of both progress bars (message model and worker list)
+                        var value = data.progressPercentage || 0;
+                        var progressBars = $('#statusMessageModal .progress-bar, ' +
+                            '.worker-table tbody .taskProgressBar[data-task-id="' + data.taskId + '"]');
+                        progressBars.attr('aria-valuenow', value)
+                            .text(value + '%')
+                            .css({'width': value + '%'});
                     });
                 }
             },

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -344,10 +344,10 @@ function visualiserApp(luigi) {
                         }
                     });
                     luigi.getTaskProgressPercentage(data.taskId, function(data) {
-                        // show or hide the progress bar container in the message model
+                        // show or hide the progress bar container in the message modal
                         $("#statusMessageModal .progress").toggle(data.progressPercentage !== null);
 
-                        // adjust the status of both progress bars (message model and worker list)
+                        // adjust the status of both progress bars (message modal and worker list)
                         var value = data.progressPercentage || 0;
                         var progressBars = $('#statusMessageModal .progress-bar, ' +
                             '.worker-table tbody .taskProgressBar[data-task-id="' + data.taskId + '"]');


### PR DESCRIPTION
## Description

This PR adds the task progress percentage as a bootstrap progress bar in a new column to the table of running tasks in the "Workers" tab:

![progress](https://dl.dropboxusercontent.com/s/ara53ns0t899gvh/worker_list_progress.png)

The value is even updated when the message modal of the specific task is open (which already had the ability to update task messages and progress via polling).

I didn't include the new column in the actual "Task List" tab, because it is probably only important for currently running tasks.


## Motivation and Context

When dealing with a couple long-running tasks, it is a nice feature to see the progress per task already in the worker tab.


## Have you tested this? If so, how?

The behavior is rather static, and I couldn't find existing tests that check similar features. However, I verified that the automatic updating via the `refreshInterval` of the opened modal is working properly and handles also `null` values.
