### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -882,8 +882,8 @@ class WorkerKeepAliveTests(LuigiTestCase):
             time.sleep(0.1)
 
             try:
-                self.assertEqual(first_should_live, t1.isAlive())
-                self.assertEqual(second_should_live, t2.isAlive())
+                self.assertEqual(first_should_live, t1.is_alive())
+                self.assertEqual(second_should_live, t2.is_alive())
 
             finally:
                 # mark the task done so the worker threads will die


### PR DESCRIPTION
## Description

Use is_alive in favour of isAlive for Python 3.9 compatibility. is_alive is Python 2 compatible change.

## Motivation and Context

Fixes #2939 