### PR TITLE
use metaclass directly

### DIFF
--- a/luigi/contrib/presto.py
+++ b/luigi/contrib/presto.py
@@ -7,7 +7,6 @@ from enum import Enum
 from time import sleep
 
 import luigi
-from luigi.six import add_metaclass
 from luigi.contrib import rdbms
 from luigi.task_register import Register
 
@@ -191,8 +190,7 @@ class PrestoTarget(luigi.Target):
             raise
 
 
-@add_metaclass(WithPrestoClient)
-class PrestoTask(rdbms.Query):
+class PrestoTask(rdbms.Query, metaclass=WithPrestoClient):
     """
     Task for executing presto queries
     During its executions tracking url and percentage progress are set


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This removes the reference to `luigi.six` in master commit, brought in by #2885

@drowoseque PTAL

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`luigi.six` is no longer in py2-deprecation branch.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
