### PR TITLE
Handling of pickle files in binary mode and correction of bjobs comma…

### DIFF
--- a/luigi/contrib/lsf_runner.py
+++ b/luigi/contrib/lsf_runner.py
@@ -37,7 +37,7 @@ def do_work_on_compute_node(work_dir):
 
     # Open up the pickle file with the work to be done
     os.chdir(work_dir)
-    with open("job-instance.pickle", "r") as pickle_file_handle:
+    with open("job-instance.pickle", "rb") as pickle_file_handle:
         job = pickle.load(pickle_file_handle)
 
     # Do the work contained


### PR DESCRIPTION
…nd options (support for old versions of LSF)

## Description
1. Changes related to bytes-like object handling instead of string type.
2. Changes in order to support older versions of LSF.

The changes described were made in order to run the LSF modules correctly. Without these changes, I experienced several errors using Python 3.6.

## Motivation and Context
I have made some changes to the LSF modules (lsf.py and lsf_runner.py). 

1. Changes due to the following error: TypeError: a bytes-like object is required, not 'str'
I changed the way the pickle files are handled, they should be opened in binary mode, pickle data is explicitly defined as binary: 
"The pickle module implements binary protocols for serializing and de-serializing a Python object structure. “Pickling” is the process whereby a Python object hierarchy is converted into a byte stream, and “unpickling” is the inverse operation, whereby a byte stream (from a binary file or bytes-like object) is converted back into an object hierarchy."
Due to this change, some data had to be changed from string type to a bytes-like object.
In addition, subprocess returns bytes objects for stdout stream, I made some changes in lsf.py module because in some parts of the code this stdout was taken as string type or was parsed incorrectly.
2. Changes due to problems with older versions of LSF
In LSF 9.1.1.1, the -noheader and -o options are added to the bjobs command; therefore, I made some changes to the track_job function (lsf.py) in order to support previous LSF versions.

## Have you tested this? If so, how?
I ran my jobs and the test/contrib/lsf_test.py with this code and it works for me. 