### PR TITLE
Return bq job id from biquery.run_job()

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -787,6 +787,7 @@ BigqueryRunQueryTask = BigQueryRunQueryTask
 BigqueryCreateViewTask = BigQueryCreateViewTask
 ExternalBigqueryTask = ExternalBigQueryTask
 
+
 class BigQueryExecutionError(Exception):
     def __init__(self, job_id, error_message) -> None:
         super(BigQueryExecutionError, self).__init__('BigQuery job {} failed: {}'.format(job_id, error_message))

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -349,7 +349,7 @@ class BigQueryClient:
             if status['status']['state'] == 'DONE':
                 if status['status'].get('errorResult'):
                     raise Exception('BigQuery job failed: {}'.format(status['status']['errorResult']))
-                return
+                return job_id
 
             logger.info('Waiting for job %s:%s to complete...', project_id, job_id)
             time.sleep(5)

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -336,6 +336,9 @@ class BigQueryClient:
 
            :param dataset:
            :type dataset: BQDataset
+           :return: the job id of the job.
+           :rtype: str
+           :raises luigi.contrib.BigQueryExecutionError: if the job fails.
         """
 
         if dataset and not self.dataset_exists(dataset):
@@ -790,6 +793,12 @@ ExternalBigqueryTask = ExternalBigQueryTask
 
 class BigQueryExecutionError(Exception):
     def __init__(self, job_id, error_message) -> None:
+        """
+        :param job_id: BigQuery Job ID
+        :type job_id: str
+        :param error_message: status['status']['errorResult'] for the failed job
+        :type error_message: str
+        """
         super(BigQueryExecutionError, self).__init__('BigQuery job {} failed: {}'.format(job_id, error_message))
         self.error_message = error_message
         self.job_id = job_id

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -348,7 +348,7 @@ class BigQueryClient:
             status = self.client.jobs().get(projectId=project_id, jobId=job_id).execute(num_retries=10)
             if status['status']['state'] == 'DONE':
                 if status['status'].get('errorResult'):
-                    raise Exception('BigQuery job failed: {}'.format(status['status']['errorResult']))
+                    raise BigQueryExecutionError(job_id, status['status']['errorResult'])
                 return job_id
 
             logger.info('Waiting for job %s:%s to complete...', project_id, job_id)
@@ -786,3 +786,9 @@ BigqueryLoadTask = BigQueryLoadTask
 BigqueryRunQueryTask = BigQueryRunQueryTask
 BigqueryCreateViewTask = BigQueryCreateViewTask
 ExternalBigqueryTask = ExternalBigQueryTask
+
+class BigQueryExecutionError(Exception):
+    def __init__(self, job_id, error_message) -> None:
+        super(BigQueryExecutionError, self).__init__('BigQuery job {} failed: {}'.format(job_id, error_message))
+        self.error_message = error_message
+        self.job_id = job_id

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -799,6 +799,6 @@ class BigQueryExecutionError(Exception):
         :param error_message: status['status']['errorResult'] for the failed job
         :type error_message: str
         """
-        super(BigQueryExecutionError, self).__init__('BigQuery job {} failed: {}'.format(job_id, error_message))
+        super().__init__('BigQuery job {} failed: {}'.format(job_id, error_message))
         self.error_message = error_message
         self.job_id = job_id

--- a/test/contrib/bigquery_gcloud_test.py
+++ b/test/contrib/bigquery_gcloud_test.py
@@ -38,6 +38,7 @@ import avro.schema
 from avro.datafile import DataFileWriter
 from avro.io import DatumWriter
 from luigi.contrib.gcs import GCSTarget
+from luigi.contrib.bigquery import BigQueryExecutionError
 
 from nose.plugins.attrib import attr
 from helpers import unittest
@@ -321,6 +322,19 @@ class BigQueryGcloudTest(unittest.TestCase):
         task.run()
 
         self.assertTrue(self.bq_client.table_exists(self.table))
+
+    def test_run_successful_job(self):
+        body = {'configuration': {'query': {'query': 'select count(*) from unnest([1,2,3])'}}}
+
+        job_id = self.bq_client.run_job(PROJECT_ID, body)
+
+        self.assertIsNotNone(job_id)
+        self.assertNotEqual('', job_id)
+
+    def test_run_failing_job(self):
+        body = {'configuration': {'query': {'query': 'this is not a valid query'}}}
+
+        self.assertRaises(BigQueryExecutionError, lambda: self.bq_client.run_job(PROJECT_ID, body))
 
 
 @attr('gcloud')


### PR DESCRIPTION
This ensures that the `job_id` is accessible to client code after running a BQ job; this is useful for getting logs or other metadata from the job, and/or logging the job id itself to other places than just what's done by this class.