### PR TITLE
Fix package descriptions for pypi.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,15 @@ def get_static_files(path):
 
 luigi_package_data = sum(map(get_static_files, ["luigi/static", "luigi/templates"]), [])
 
-readme_note = """\
+readme_note = """
 .. note::
 
    For the latest source, discussion, etc, please visit the
-   `GitHub repository <https://github.com/spotify/luigi>`_\n\n
+   `GitHub repository <https://github.com/spotify/luigi>`_
 """
 
 with open('README.rst') as fobj:
-    long_description = readme_note + fobj.read()
+    long_description = "\n\n" + readme_note + "\n\n" + fobj.read()
 
 install_requires = ['python-dateutil>=2.7.5,<3']
 
@@ -75,7 +75,7 @@ with open("luigi/__meta__.py", "r") as f:
 setup(
     name='luigi',
     version=meta['__version__'],
-    description=meta['__doc__'],
+    description=meta['__doc__'].strip(),
     long_description=long_description,
     author=meta['__author__'],
     url=meta['__contact__'],


### PR DESCRIPTION
## Description

Luigi's `long_description` seems to be broken on [PyPI](https://pypi.org/project/luigi/2.8.11/) as of version [2.8.11](https://github.com/spotify/luigi/releases/tag/2.8.11).

As @honnix [pointed out](https://github.com/spotify/luigi/pull/2760#issuecomment-637391038), this could have been caused by a PR of me (and maybe the way that PyPI shows the short package description now in the grey top bar).

## Changes and tests

As it turned out, the `readme_note` defined in setup.py must start with at least one line break, while the short description should not contain any of them. I added these two small changes and tested with a [temporary PyPI package](https://pypi.org/project/personal-luigi-test/2.8.17/) that looks fine (going to delete it again after the merge). I used

```bash
python setup.py sdist && twine upload "dist/$(python setup.py --fullname).tar.gz"
```

for the release.
