### PR TITLE
Add documentation for the check_complete_on_run config setting

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -364,7 +364,14 @@ check_unfulfilled_deps
 force_multiprocessing
   By default, luigi uses multiprocessing when *more than one* worker process is
   requested. When set to true, multiprocessing is used independent of the
-  the number of workers.
+  number of workers.
+  Defaults to false.
+
+check_complete_on_run
+  By default, luigi tasks are marked as 'done' when they finish running without
+  raising an error. When set to true, tasks will also verify that their outputs
+  exist when they finish running, and will fail immediately if the outputs are
+  missing.
   Defaults to false.
 
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds documentation for the check_complete_on_run configuration setting that I introduced several months ago.

## Motivation and Context
There have been a handful of issues opened that were solved by using this setting, which is difficult to discover. I've been meaning to do this for months.

## Have you tested this? If so, how?
I have re-read the documentation in this pull request and, as a native English speaker, confirmed it is grammatically and semantically sound.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
