### PR TITLE
Add namespace to kubectl hints

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -248,7 +248,7 @@ class KubernetesJobTask(luigi.Task):
     def __print_kubectl_hints(self):
         self.__logger.info("To stream Pod logs, use:")
         for pod in self.__get_pods():
-            self.__logger.info("`kubectl logs -f pod/%s`" % pod.name)
+            self.__logger.info("`kubectl logs -f pod/%s -n %s`" % (pod.name, pod.namespace))
 
     def __verify_job_has_started(self):
         """Asserts that the job has successfully started"""


### PR DESCRIPTION
## Description

Add `-n NAMESPACE` argument to kubectl hints. 

## Motivation and Context

When checking logs of Luigi `KubernetesJobTask`s it provides a convenient command to quickly check the logs of the kubernetes job launched by the task, like this:

```
kubectl logs -f pod/my-job-name-158238383
```

However, I run my jobs on different namespaces, so it would be better to include `-n NAMESPACE` argument in the hint as well, to not add it manually.

## Have you tested this? If so, how?

I did not run my pipeline with it yet, but I made sure that `namespace` is a valid attribute of a `pykube.Pod`.
