### PR TITLE
Make worker_timeout=0 override the default timeout

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -123,7 +123,7 @@ class TaskProcess(multiprocessing.Process):
         self.worker_id = worker_id
         self.result_queue = result_queue
         self.status_reporter = status_reporter
-        self.worker_timeout = task.worker_timeout or worker_timeout
+        self.worker_timeout = task.worker_timeout if task.worker_timeout is not None else worker_timeout
         self.timeout_time = time.time() + self.worker_timeout if self.worker_timeout else None
         self.use_multiprocessing = use_multiprocessing or self.timeout_time is not None
         self.check_unfulfilled_deps = check_unfulfilled_deps

--- a/test/worker_task_test.py
+++ b/test/worker_task_test.py
@@ -133,3 +133,21 @@ class TaskProcessTest(LuigiTestCase):
 
         self.assertFalse(parent.is_running())
         self.assertFalse(child.is_running())
+
+    def test_disable_worker_timeout(self):
+        """
+        When a task sets worker_timeout explicitly to 0, it should disable the timeout, even if it
+        is configured globally.
+        """
+        class Task(luigi.Task):
+            worker_timeout = 0
+
+        task_process = TaskProcess(
+            task=Task(),
+            worker_id=1,
+            result_queue=mock.Mock(),
+            status_reporter=mock.Mock(),
+            worker_timeout=10,
+
+        )
+        self.assertEqual(task_process.worker_timeout, 0)


### PR DESCRIPTION
This a resubmission of #2891, which was closed by stale-bot. The outstanding change request was to turn a comment into a test. This is implemented now.

Sometimes it is useful to exclude certain tasks from the default worker
timeout (set in the Luigi config). This was possible before commit
af6cf07 by setting `worker_timeout = 0` for a task. Since this commit
there is no distinction between `0` and `None` anymore and this approach
doesn't work anymore. The present commit introduces this distinction
again.


## Have you tested this? If so, how?

I ran my jobs with this code and it works for me. Also added a test case.
