### PR TITLE
Fixing problem with ListParameter and Dynamic Dependencies

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1054,7 +1054,10 @@ class ListParameter(Parameter):
         :param str x: the value to parse.
         :return: the parsed value.
         """
-        return list(json.loads(x, object_pairs_hook=FrozenOrderedDict))
+        i = json.loads(x, object_pairs_hook=FrozenOrderedDict)
+        if i is None:
+            return None
+        return list(i)
 
     def serialize(self, x):
         """

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -476,6 +476,17 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.ListParameter()
         self.assertEqual(hash(Foo(args=[1, "hello"]).args), hash(p.normalize(p.parse('[1,"hello"]'))))
 
+    def test_list_param_with_default_none_in_dynamic_req_task(self):
+        class TaskWithDefaultNoneParameter(RunOnceTask):
+            args = luigi.parameter.ListParameter(default=None)
+
+        class DynamicTaskCallsDefaultNoneParameter(RunOnceTask):
+            def run(self):
+                yield [TaskWithDefaultNoneParameter()]
+                self.comp = True
+
+        self.assertTrue(self.run_locally(['DynamicTaskCallsDefaultNoneParameter']))
+
     def test_list_dict(self):
         class Foo(luigi.Task):
             args = luigi.parameter.ListParameter()


### PR DESCRIPTION
## Description

The fix is to allow ListParameter parsing to return None or a list.

## Motivation and Context
Here we are addressing issue #2969 

It is necessary to allow the same behavior as a regular task's parameter handling on a task with dynamic requirements.

## Have you tested this? If so, how?

Yes, I executed the same example reported in the issue and it fixes the problem.

Edit: also added tests on test/parameter_test.py