### PR TITLE
Add failed_execution_summary_log_level config setting

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -374,6 +374,12 @@ check_complete_on_run
   missing.
   Defaults to false.
 
+failed_execution_summary_log_level
+  Controls the log level at which the execution summaries for failed tasks are
+  reported. Useful for trimming down the size of test suite or system log output,
+  but still including failure information for debugging purposes.
+  Defaults to INFO.
+
 
 [elasticsearch]
 ---------------

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -172,7 +172,14 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
         logger.info('Done scheduling tasks')
         success &= worker.run()
     luigi_run_result = LuigiRunResult(worker, success)
-    logger.info(luigi_run_result.summary_text)
+
+    if success:
+        logger.info(luigi_run_result.summary_text)
+    else:
+        # convert our configured log level for failed execution summaries to a numeric log level
+        failed_summary_log_level = logging._checkLevel(worker._config.failed_execution_summary_log_level)
+        logger.log(failed_summary_log_level, luigi_run_result.summary_text)
+
     return luigi_run_result
 
 

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -57,7 +57,7 @@ from luigi.target import Target
 from luigi.task import Task, flatten, getpaths, Config
 from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
-from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter
+from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter, ChoiceParameter
 
 import json
 
@@ -451,6 +451,10 @@ class worker(Config):
                                           description='If true, only mark tasks as done after running if they are complete. '
                                           'Regardless of this setting, the worker will always check if external '
                                           'tasks are complete before marking them as done.')
+    failed_execution_summary_log_level = ChoiceParameter(
+        default='INFO',
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        description="Log level to use when reporting a failed execution summary. Passing execution summaries are logged as INFO.")
     force_multiprocessing = BoolParameter(default=False,
                                           description='If true, use multiprocessing also when '
                                           'running with 1 worker')

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -110,13 +110,13 @@ class InterfaceTest(LuigiTestCase):
     @with_config({'worker': {'failed_execution_summary_log_level': 'ERROR'}})
     def test_interface_run_failure_logs_to_configured_level(self):
         self.worker.add = Mock(side_effect=[True, True])
-        self.worker.run = Mock(side_effect=RuntimeError)
+        self.worker.run = Mock(return_value=False)
         with self.assertLogs(logging.getLogger('luigi-interface'), logging.ERROR):
             self._run_interface()
 
     def test_interface_run_failure_defaults_to_logging_at_info(self):
         self.worker.add = Mock(side_effect=[True, True])
-        self.worker.run = Mock(side_effect=RuntimeError)
+        self.worker.run = Mock(return_value=False)
         with self.assertLogs(logging.getLogger('luigi-interface'), logging.INFO):
             self._run_interface()
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adds a new config setting to allow failed execution summaries to be logged at a different log level than successful execution summaries. The default value of the setting maintains Luigi's current behavior: it logs all execution summaries as INFO.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test suite output of our application that uses Luigi is extremely verbose, and a big contributor is the logs for tasks that were successfully executed, which we generally don't care about. This change allows us to configure our test suite (and, perhaps, our production logs) to only include execution summaries for executions that failed.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I have included unit tests.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
