### PR TITLE
Garbage collect task result queue when worker context exits

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -606,6 +606,7 @@ class Worker:
         for task in self._running_tasks.values():
             if task.is_alive():
                 task.terminate()
+        self._task_result_queue.close()
         return False  # Don't suppress exception
 
     def _generate_worker_info(self):

--- a/test/worker_external_task_test.py
+++ b/test/worker_external_task_test.py
@@ -185,9 +185,9 @@ class WorkerExternalTaskTest(unittest.TestCase):
         # split up scheduling task and running to simulate runtime scenario
         with self._make_worker() as w:
             w.add(test_task)
-        # touch output so test_task should be considered complete at runtime
-        open(test_task.output_path, 'a').close()
-        success = w.run()
+            # touch output so test_task should be considered complete at runtime
+            open(test_task.output_path, 'a').close()
+            success = w.run()
 
         self.assertTrue(success)
         # upstream dependency output didn't exist at runtime


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Adds a call to explicitly close() the task result queue when a worker exits, rather than waiting for the worker to be garbage collected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are certain contexts (e.g. during test runs on certain architectures) where a worker may not be garbage collected until significantly after it exits. In test suites affected by this, running many Luigi tasks via the local scheduler can cause the test suite to break due to exceeding the system's open files threshold (as each task result queue uses a separate file-based semaphore). This fails all tests after the threshold is reached. Explicitly closing the task result queue when a worker exits ensures that the queue is not held open unnecessarily. Due to the behavior of close(), this should not close the queue for other producers/consumers, only the worker in question.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
After making this change and re-running my test suite, the 'too many open files' issue is no longer present.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
