### PR TITLE
Drop Python 3.3 and 3.4 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,11 @@ if sys.platform == 'nt':
 else:
     install_requires.append('python-daemon')
 
-# Tornado >=5 requires updated ssl module so we only allow it for recent enough
-# versions of python (3.4+).
-if sys.version_info[:2] >= (3, 4):
-    install_requires.append('tornado>=4.0,<6')
+# Start from tornado 6, the minimum supported Python version is 3.5.2.
+if sys.version_info[:3] >= (3, 5, 2):
+    install_requires.append('tornado>=5.0,<7')
 else:
-    install_requires.append('tornado>=4.0,<5')
+    install_requires.append('tornado>=5.0,<6')
 
 # Note: To support older versions of setuptools, we're explicitly not
 #   using conditional syntax (i.e. 'enum34>1.1.0;python_version<"3.4"').
@@ -111,8 +110,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{33,34,35,36,37}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{35,36,37}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Drop Python 3.3 and 3.4 support. Also allows more recent tornado version (>=6,<7).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Python 3.3 and 3.4 have reached end of life quite a while ago. This PR also addresses #2949.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I installed Luigi under Python 2.7 and 3.6 and that worked as expected.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
