### PR TITLE
Fixing TOML logging configuration

### DIFF
--- a/luigi/freezing.py
+++ b/luigi/freezing.py
@@ -56,3 +56,14 @@ def recursively_freeze(value):
     elif isinstance(value, list) or isinstance(value, tuple):
         return tuple(recursively_freeze(v) for v in value)
     return value
+
+
+def recursively_thaw(value):
+    """
+    Recursively walks the given ``FrozenOrderedDict``, converting all ``FrozenOrderedDict`` objects into ``dict``.
+    """
+    if isinstance(value, FrozenOrderedDict):
+        value = dict(value)
+    if isinstance(value, dict):
+        return dict(((k, recursively_thaw(v)) for k, v in value.items()))
+    return value

--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -24,6 +24,7 @@ import logging.config
 import os.path
 
 from luigi.configuration import get_config, LuigiConfigParser
+from luigi.freezing import recursively_thaw
 
 from configparser import NoSectionError
 
@@ -40,6 +41,11 @@ class BaseLogging:
             logging_config = cls.config['logging']
         except (TypeError, KeyError, NoSectionError):
             return False
+
+        # The logging module modifies the logging_config dictionary
+        # in place, so we need to make sure it is not frozen before passing in
+        logging_config = recursively_thaw(logging_config)
+
         logging.config.dictConfig(logging_config)
         return True
 


### PR DESCRIPTION
## Description
Using the `logging` section of a TOML configuration file is currently not working, because the `logging` module attempts to modify the given configuration dictionary in-place, and all parsed TOML configuration sections are converted to the immutable `FrozenOrderedDict` after being read.

This change "thaws" the `FrozenOrderedDict` before passing it into the `logging` module.

## Motivation and Context
I was trying to use a TOML configuration file for logging, as shown in https://github.com/spotify/luigi/blob/master/examples/config.toml
however, trying to use it resulted in the following error

```
Traceback (most recent call last):                                                                                                                                                                                                                            
  File "/Users/kushnerl/miniconda3/lib/python3.7/logging/config.py", line 543, in configure                                                                                                                                                                   
    formatters[name])                                                                                                                                                                                                                                         
TypeError: 'FrozenOrderedDict' object does not support item assignment                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
The above exception was the direct cause of the following exception:                                                                                                                                                                                          
                                                                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                                                                            
 ...                                                                                                                                                                                                               File "/Users/kushnerl/miniconda3/lib/python3.7/site-packages/luigi/interface.py", line 237, in build                         
    luigi_run_result = _schedule_and_run(tasks, worker_scheduler_factory, override_defaults=env_params)                        
  File "/Users/kushnerl/miniconda3/lib/python3.7/site-packages/luigi/interface.py", line 145, in _schedule_and_run             
    InterfaceLogging.setup(env_params)                                                                                                                                                                                                                        
  File "/Users/kushnerl/miniconda3/lib/python3.7/site-packages/luigi/setup_logging.py", line 78, in setup                                                                                                                                                     
    configured = cls._section(opts)                                                                                                                                                                                                                           
  File "/Users/kushnerl/miniconda3/lib/python3.7/site-packages/luigi/setup_logging.py", line 43, in _section                                                                                                                                                  
    logging.config.dictConfig(logging_config)                                                                                                                                                                                                                 
  File "/Users/kushnerl/miniconda3/lib/python3.7/logging/config.py", line 800, in dictConfig                                                                                                                                                                  
    dictConfigClass(config).configure()                                                                                                                                                                                                                       
  File "/Users/kushnerl/miniconda3/lib/python3.7/logging/config.py", line 546, in configure                                    
    'formatter %r' % name) from e                                                                                              
ValueError: Unable to configure formatter 'default' 
```

