### PR TITLE
Import config parser into TOML parser

### DIFF
--- a/luigi/configuration/toml_parser.py
+++ b/luigi/configuration/toml_parser.py
@@ -24,8 +24,9 @@ except ImportError:
 from .base_parser import BaseParser
 from ..freezing import recursively_freeze
 
+from configparser import ConfigParser
 
-class LuigiTomlParser(BaseParser):
+class LuigiTomlParser(BaseParser, ConfigParser):
     NO_DEFAULT = object()
     enabled = bool(toml)
     data = dict()


### PR DESCRIPTION
## Description
When using S3Client() with TOML parser you get this error:

```
defaults = dict(configuration.get_config().defaults())
AttributeError: 'LuigiTomlParser' object has no attribute 'defaults'
```

Importing ConfigParser into toml_parser solves the issue. 