### PR TITLE
Use updated uri for gcs batch reqs

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -60,6 +60,9 @@ EVENTUAL_CONSISTENCY_SLEEP_INTERVAL = 0.1
 # Maximum number of sleeps for eventual consistency.
 EVENTUAL_CONSISTENCY_MAX_SLEEPS = 300
 
+# Uri for batch requests
+GCS_BATCH_URI = 'https://storage.googleapis.com/batch/storage/v1'
+
 
 def _wait_for_consistency(checker):
     """Eventual consistency: wait until GCS reports something is true.
@@ -231,7 +234,7 @@ class GCSClient(luigi.target.FileSystem):
                 raise InvalidDeleteException(
                     'Path {} is a directory. Must use recursive delete'.format(path))
 
-            req = http.BatchHttpRequest()
+            req = http.BatchHttpRequest(batch_uri=GCS_BATCH_URI)
             for it in self._list_iter(bucket, self._add_path_delimiter(obj)):
                 req.add(self.client.objects().delete(bucket=bucket, object=it['name']))
             req.execute()

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     cdh,hdp: hdfs>=2.0.4,<3.0.0
     postgres: psycopg2<3.0
     mysql-connector-python>=8.0.12
-    gcloud: google-api-python-client>=1.4.0,<2.0
+    gcloud: google-api-python-client>=1.6.6,<2.0
     avro-python3
     gcloud: google-auth==1.4.1
     gcloud: google-auth-httplib2==0.0.3


### PR DESCRIPTION
## Description
The default batch_uri used by BatchHttpRequest is deprecated: https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html

This update uses the gcs specific batch uri in gcs_client and bumps google-api-python-client's lower bound to make sure we use a compatible version.  Currently batch removals using the client are calling the deprecated uri (https://github.com/googleapis/google-api-python-client/blob/master/googleapiclient/http.py#L1175).

## Have you tested this? If so, how?
I have run the gcs_client test which covers batch removal and I also tested end-to-end with an actual luigi job we use this in.