### PR TITLE
Flush stream_for_searching_tracking_url

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -192,6 +192,7 @@ class ExternalProgramTask(luigi.Task):
                             self.build_tracking_url(match.group(1))
                         )
                 else:
+                    file_to_write.flush()
                     sleep(time_to_sleep)
 
         track_proc = Process(target=_track_url_by_pattern)


### PR DESCRIPTION
A fix for issue [2999](https://github.com/spotify/luigi/issues/2999)

## Description
Flush the stream

## Motivation and Context
 [Issue 2999 - ExternalProgramTask: stream_for_searching_tracking_url is not flushed, causing program output to be lost.](https://github.com/spotify/luigi/issues/2999)

## Have you tested this? If so, how?
"I ran my jobs with this code and it works for me."
