### PR TITLE
Relativize unnecessary absolute URL

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -271,7 +271,7 @@ class ByParamsHandler(BaseTaskHistoryHandler):
 
 class RootPathHandler(BaseTaskHistoryHandler):
     def get(self):
-        self.redirect("/static/visualiser/index.html")
+        self.redirect("static/visualiser/index.html")
 
     def head(self):
         """HEAD endpoint for health checking the scheduler"""


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the leading slash in the redirect to `/static/visualiser/index.html` defined in `luigi.server.RootPathHandler.get`.
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes Luigi more proxy-friendly, namely so that it can be proxied to have a nonempty base path. (In my case, I use this patch to successfully run Luigi behind [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy)).

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Yes, I have been running a patched version of Luigi for a while now, and I've never had a problem.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
