### PR TITLE
kubernetes: labels are applied to pod

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -363,7 +363,8 @@ class KubernetesJobTask(luigi.Task):
                 "backoffLimit": self.backoff_limit,
                 "template": {
                     "metadata": {
-                        "name": self.uu_name
+                        "name": self.uu_name,
+                        "labels": {}
                     },
                     "spec": self.spec_schema
                 }
@@ -376,6 +377,8 @@ class KubernetesJobTask(luigi.Task):
                 self.active_deadline_seconds
         # Update user labels
         job_json['metadata']['labels'].update(self.labels)
+        job_json['spec']['template']['metadata']['labels'].update(self.labels)
+
         # Add default restartPolicy if not specified
         if "restartPolicy" not in self.spec_schema:
             job_json["spec"]["template"]["spec"]["restartPolicy"] = "Never"

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -71,6 +71,10 @@ class FailJob(KubernetesJobTask):
         }]
     }
 
+    @property
+    def labels(self):
+        return {"dummy_label": "dummy_value"}
+
 
 @attr('contrib')
 class TestK8STask(unittest.TestCase):
@@ -90,6 +94,7 @@ class TestK8STask(unittest.TestCase):
         job = Job(kube_api, jobs.response["items"][0])
         self.assertTrue("failed" in job.obj["status"])
         self.assertTrue(job.obj["status"]["failed"] > fail.max_retrials)
+        self.assertTrue(job.obj['spec']['template']['metadata']['labels'] == fail.labels())
 
     @mock.patch.object(KubernetesJobTask, "_KubernetesJobTask__get_job_status")
     @mock.patch.object(KubernetesJobTask, "signal_complete")


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently Labels are applied only at Kubernetes Job level. This means that the pods scheduled by a job have no labels.
Changes introduced in this PR makes pods get the same labels as those passed under `@labels` property

## Motivation and Context
On cloud kubernetes sometimes it is is useful to give labels to pods, this is for example to let a pod assume a particular role 

## Have you tested this? If so, how?
- added a dummy unit test
- schedule tasks in our kubernetes, verified pods got expected labels

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
