### PR TITLE
upgrade azure-storage and pass token_credential argument (#3005)

### DIFF
--- a/luigi/contrib/azureblob.py
+++ b/luigi/contrib/azureblob.py
@@ -63,6 +63,7 @@ class AzureBlobClient(FileSystem):
             * `token_credential` - A token credential used to authenticate HTTPS requests. The token value should be updated before its expiration.
         """
         self.options = {"account_name": account_name, "account_key": account_key, "sas_token": sas_token}
+        kwargs["protocol"] = kwargs.get("protocol") or "https"  # Default protocol to https if it's not set
         self.kwargs = kwargs
 
     @property
@@ -74,7 +75,8 @@ class AzureBlobClient(FileSystem):
                                                  connection_string=self.kwargs.get("connection_string"),
                                                  endpoint_suffix=self.kwargs.get("endpoint_suffix"),
                                                  custom_domain=self.kwargs.get("custom_domain"),
-                                                 is_emulated=self.kwargs.get("is_emulated") or False)
+                                                 is_emulated=self.kwargs.get("is_emulated") or False,
+                                                 token_credential=self.kwargs.get("token_credential"))
 
     def upload(self, tmp_path, container, blob, **kwargs):
         logging.debug("Uploading file '{tmp_path}' to container '{container}' and blob '{blob}'".format(

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,8 @@ deps =
     pymongo==3.4.0
     toml<2.0.0
     responses<1.0.0
-    azure-storage<=0.36
+    azure-storage-common==2.1.0
+    azure-storage-blob==2.1.0
     datadog==0.22.0
     prometheus-client==0.5.0
     dropbox: dropbox>=9.3.0<10.0
@@ -124,7 +125,8 @@ deps =
     Sphinx>=1.4.4,<1.5
     sphinx_rtd_theme
     enum34>1.1.0
-    azure-storage<=0.36
+    azure-storage-common==2.1.0
+    azure-storage-blob==2.1.0
     prometheus-client==0.5.0
 commands =
 # build API docs


### PR DESCRIPTION
### Motivation and context

azure-storage==0.36 didn't support `token_credential` argument in `BlockBlobService` init.
Upgrade to the new package `azure-storage-blob` and use the last version that still supports `BlockBlobService` (it's deprecated, but that can be upgraded another time)

### Description

Fixes #3005 by passing `token_credential` argument.

I also had to explicitely default the protocol to "https", otherwise the initialization fails when we provide a token_credential argument.

I successfully ran azureblob unit tests