### PR TITLE
AzureBlobTarget: use file basename for the temp download_file_location

### DIFF
--- a/luigi/contrib/azureblob.py
+++ b/luigi/contrib/azureblob.py
@@ -179,7 +179,8 @@ class ReadableAzureBlobFile:
         self.closed = False
         self.download_when_reading = download_when_reading
         self.azure_blob_options = kwargs
-        self.download_file_location = os.path.join(tempfile.mkdtemp(prefix=str(datetime.datetime.utcnow())), blob)
+        self.download_file_location = os.path.join(tempfile.mkdtemp(prefix=str(datetime.datetime.utcnow())),
+                                                   os.path.basename(blob))
         self.fid = None
 
     def read(self, n=None):

--- a/test/contrib/azureblob_test.py
+++ b/test/contrib/azureblob_test.py
@@ -117,7 +117,7 @@ class AzureBlobClientTest(unittest.TestCase):
 
 class MovieScriptTask(luigi.Task):
     def output(self):
-        return AzureBlobTarget("luigi-test", "movie-cheesy.txt", client, download_when_reading=False)
+        return AzureBlobTarget("luigi-test", "path/to/movie-cheesy.txt", client, download_when_reading=False)
 
     def run(self):
         client.connection.create_container("luigi-test")
@@ -170,3 +170,12 @@ class AzureBlobTargetTest(unittest.TestCase):
 
     def test_AzureBlobTarget(self):
         luigi.build([FinalTask()], local_scheduler=True, log_level='NOTSET')
+
+    def test_AzureBlobTarget_download_when_reading(self):
+        task = MovieScriptTask()
+        task.run()
+        target = task.output()
+        # Test reading a target blob with a context manager and download_when_reading=True
+        target.download_when_reading = True
+        with target.open("r") as f:
+            assert "James Bond" in f.read()


### PR DESCRIPTION
### Motivation and context

When the target blob is inside a path (for instance "path/to/target") and we use `download_when_reading=True`,
the directories don't exist and reading the target fails with:

```
  File "src/luigi/luigi/contrib/azureblob.py", line 194, in __enter__
    self.client.download_as_file(self.container, self.blob, self.download_file_location)
  File "src/luigi/luigi/contrib/azureblob.py", line 101, in download_as_file
    return self.connection.get_blob_to_path(container, blob, location)
  File "src/luigi/venv/lib/python3.6/site-packages/azure/storage/blob/baseblobservice.py", line 1765, in get_blob_to_path
    with open(file_path, open_mode) as stream:
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/7q/l5knvjqx3pg569hwsdrzjw480000gn/T/2020-10-12 14:20:01.950869689rh5q2/path/to/movie-cheesy.txt'
```

### Description 

Use `os.path.basename(blob)` to keep only the blob name as file name instead of the full path (it's written in a temporary directory anyway)

I changed a test task target to `"path/to/movie-cheesy.txt"`instead of `"movie-cheesy.txt"`
I added a test that reproduces the issue.
