### PR TITLE
Add Tracktics to company list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Hopper <https://www.hopper.com/>`_
 * `VOYAGE GROUP/Zucks <https://zucks.co.jp/en/>`_
 * `Textpert <https://www.textpert.ai/>`_
+* `Tracktics <https://www.tracktics.com/>`_
 * `Whizar <https://www.whizar.com/>`_
 * `xtream <https://www.xtreamers.io/>`__
 * `Skyscanner <https://www.skyscanner.net/>`_


### PR DESCRIPTION
## Description
This adds [Tracktics](https://www.tracktics.com/) to the list of companies using Luigi in README.rst