### PR TITLE
Fix deps tree indent

### DIFF
--- a/luigi/tools/deps_tree.py
+++ b/luigi/tools/deps_tree.py
@@ -9,18 +9,18 @@ Use this to visualize the execution plan in the terminal.
     $ luigi-deps-tree --module foo_complex examples.Foo
     ...
     └─--[Foo-{} (PENDING)]
-       |--[Bar-{'num': '0'} (PENDING)]
-       |  |--[Bar-{'num': '4'} (PENDING)]
-       |  └─--[Bar-{'num': '5'} (PENDING)]
-       |--[Bar-{'num': '1'} (PENDING)]
-       └─--[Bar-{'num': '2'} (PENDING)]
-          └─--[Bar-{'num': '6'} (PENDING)]
-             |--[Bar-{'num': '7'} (PENDING)]
-             |  |--[Bar-{'num': '9'} (PENDING)]
-             |  └─--[Bar-{'num': '10'} (PENDING)]
-             |     └─--[Bar-{'num': '11'} (PENDING)]
-             └─--[Bar-{'num': '8'} (PENDING)]
-                └─--[Bar-{'num': '12'} (PENDING)]
+        |---[Bar-{'num': '0'} (PENDING)]
+        |   |---[Bar-{'num': '4'} (PENDING)]
+        |   └─--[Bar-{'num': '5'} (PENDING)]
+        |---[Bar-{'num': '1'} (PENDING)]
+        └─--[Bar-{'num': '2'} (PENDING)]
+            └─--[Bar-{'num': '6'} (PENDING)]
+                |---[Bar-{'num': '7'} (PENDING)]
+                |   |---[Bar-{'num': '9'} (PENDING)]
+                |   └─--[Bar-{'num': '10'} (PENDING)]
+                |       └─--[Bar-{'num': '11'} (PENDING)]
+                └─--[Bar-{'num': '8'} (PENDING)]
+                    └─--[Bar-{'num': '12'} (PENDING)]
 """
 
 from luigi.task import flatten
@@ -52,10 +52,10 @@ def print_tree(task, indent='', last=True):
     result = '\n' + indent
     if(last):
         result += '└─--'
-        indent += '   '
+        indent += '    '
     else:
-        result += '|--'
-        indent += '|  '
+        result += '|---'
+        indent += '|   '
     result += '[{0}-{1} ({2})]'.format(name, params, is_complete)
     children = flatten(task.requires())
     for index, child in enumerate(children):


### PR DESCRIPTION
Back in 2018, @PeteW wrote a nice CLI that prints the dependency tree of a task without having to run that. This PR provides a slight modification to the indentation he used to print the tree. In essence, this PR makes all tree characters 4-spaced.

Here is where we discussed the change:
https://github.com/spotify/luigi/issues/2920#issuecomment-728365990