### PR TITLE
replace naive retry with tenacity

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -154,7 +154,7 @@ class RemoteScheduler:
         return Retrying(wait=wait_fixed(self._rpc_retry_wait),
                         stop=stop_after_attempt(self._rpc_retry_attempts),
                         reraise=True,
-                        before=retry_logging)
+                        after=retry_logging)
 
     def _fetch(self, url_suffix, body):
         full_url = _urljoin(self._url, url_suffix)

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -146,17 +146,14 @@ class RemoteScheduler:
 
     def _get_retry_decorator(self):
         def retry_logging(retry_state):
-            logger.warning("Failed connecting to remote scheduler %r", self._url, exc_info=True)
-            logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number, self._rpc_retry_attempts))
+            if self._rpc_log_retries:
+                logger.warning("Failed connecting to remote scheduler %r", self._url, exc_info=True)
+                logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number, self._rpc_retry_attempts))
 
-        if self._rpc_log_retries:
-            return retry(wait=wait_fixed(self._rpc_retry_wait),
-                         stop=stop_after_attempt(self._rpc_retry_attempts),
-                         reraise=True,
-                         after=retry_logging)
         return retry(wait=wait_fixed(self._rpc_retry_wait),
                      stop=stop_after_attempt(self._rpc_retry_attempts),
-                     reraise=True)
+                     reraise=True,
+                     after=retry_logging)
 
     def _fetch(self, url_suffix, body):
         full_url = _urljoin(self._url, url_suffix)

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -148,7 +148,7 @@ class RemoteScheduler:
         def retry_logging(retry_state):
             if self._rpc_log_retries:
                 logger.warning("Failed connecting to remote scheduler %r", self._url, exc_info=True)
-                logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number+1, self._rpc_retry_attempts))
+                logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number + 1, self._rpc_retry_attempts))
                 logger.info("Wait for %d seconds" % self._rpc_retry_wait)
 
         return Retrying(wait=wait_fixed(self._rpc_retry_wait),

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -148,13 +148,13 @@ class RemoteScheduler:
         def retry_logging(retry_state):
             if self._rpc_log_retries:
                 logger.warning("Failed connecting to remote scheduler %r", self._url, exc_info=True)
-                logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number, self._rpc_retry_attempts))
+                logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number+1, self._rpc_retry_attempts))
                 logger.info("Wait for %d seconds" % self._rpc_retry_wait)
 
         return Retrying(wait=wait_fixed(self._rpc_retry_wait),
                         stop=stop_after_attempt(self._rpc_retry_attempts),
                         reraise=True,
-                        after=retry_logging)
+                        before=retry_logging)
 
     def _fetch(self, url_suffix, body):
         full_url = _urljoin(self._url, url_suffix)

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -29,9 +29,7 @@ from urllib.parse import urljoin, urlencode, urlparse
 from urllib.request import urlopen, Request
 from urllib.error import URLError
 
-from tenacity import retry
-from tenacity import wait_fixed
-from tenacity import stop_after_attempt
+from tenacity import retry, wait_fixed, stop_after_attempt
 from luigi import configuration
 from luigi.scheduler import RPC_METHODS
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -149,6 +149,7 @@ class RemoteScheduler:
             if self._rpc_log_retries:
                 logger.warning("Failed connecting to remote scheduler %r", self._url, exc_info=True)
                 logger.info("Retrying attempt %r of %r (max)" % (retry_state.attempt_number, self._rpc_retry_attempts))
+                logger.info("Wait for %d seconds" % self._rpc_retry_wait)
 
         return Retrying(wait=wait_fixed(self._rpc_retry_wait),
                         stop=stop_after_attempt(self._rpc_retry_attempts),

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -160,7 +160,7 @@ class RemoteScheduler:
         scheduler_retry = self._get_retry_decorator()
 
         try:
-            response = scheduler_retry.call(RemoteScheduler._call(self._fetcher, full_url, body, self._connect_timeout))
+            response = scheduler_retry.call(self._fetcher.fetch(full_url, body, self._connect_timeout))
         except self._fetcher.raises as e:
             raise RPCError(
                 "Errors (%d attempts) when connecting to remote scheduler %r" %
@@ -168,10 +168,6 @@ class RemoteScheduler:
                 e
             )
         return response
-
-    @staticmethod
-    def _call(fetcher, full_url, body, timeout):
-        return fetcher.fetch(full_url, body, timeout)
 
     def _request(self, url, data, attempts=3, allow_null=True):
         body = {'data': json.dumps(data)}

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -25,7 +25,6 @@ from luigi.scheduler import Scheduler
 import scheduler_api_test
 import luigi.server
 from server_test import ServerTestBase
-import time
 import socket
 from multiprocessing import Process, Queue
 import requests
@@ -41,15 +40,8 @@ class RemoteSchedulerTest(unittest.TestCase):
                     fetcher.fetch.assert_called_once_with('http://zorg.com/api/123', '{}', 42)
 
     def get_work(self, fetcher_side_effect):
-        class ShorterWaitRemoteScheduler(luigi.rpc.RemoteScheduler):
-            """
-            A RemoteScheduler which waits shorter than usual before retrying (to speed up tests).
-            """
-
-            def _wait(self):
-                time.sleep(1)
-
-        scheduler = ShorterWaitRemoteScheduler('http://zorg.com', 42)
+        scheduler = luigi.rpc.RemoteScheduler('http://zorg.com', 42)
+        scheduler._rpc_retry_wait = 1  # shorten wait time to speed up tests
 
         with mock.patch.object(scheduler, '_fetcher') as fetcher:
             fetcher.raises = socket.timeout, socket.gaierror
@@ -82,9 +74,9 @@ class RemoteSchedulerTest(unittest.TestCase):
         self.get_work(fetch_results)
         self.assertEqual([
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
-            mock.call.info('Retrying attempt 2 of 3 (max)'),
+            mock.call.info('Retrying attempt 1 of 3 (max)'),
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
-            mock.call.info('Retrying attempt 3 of 3 (max)'),
+            mock.call.info('Retrying attempt 2 of 3 (max)'),
         ], mock_logger.mock_calls)
 
     @with_config({'core': {'rpc-log-retries': 'false'}})

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -75,8 +75,10 @@ class RemoteSchedulerTest(unittest.TestCase):
         self.assertEqual([
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
             mock.call.info('Retrying attempt 1 of 3 (max)'),
+            mock.call.info('Wait for 1 seconds'),
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
             mock.call.info('Retrying attempt 2 of 3 (max)'),
+            mock.call.info('Wait for 1 seconds'),
         ], mock_logger.mock_calls)
 
     @with_config({'core': {'rpc-log-retries': 'false'}})

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -74,10 +74,10 @@ class RemoteSchedulerTest(unittest.TestCase):
         self.get_work(fetch_results)
         self.assertEqual([
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
-            mock.call.info('Retrying attempt 1 of 3 (max)'),
+            mock.call.info('Retrying attempt 2 of 3 (max)'),
             mock.call.info('Wait for 1 seconds'),
             mock.call.warning('Failed connecting to remote scheduler %r', 'http://zorg.com', exc_info=True),
-            mock.call.info('Retrying attempt 2 of 3 (max)'),
+            mock.call.info('Retrying attempt 3 of 3 (max)'),
             mock.call.info('Wait for 1 seconds'),
         ], mock_logger.mock_calls)
 

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1152,13 +1152,6 @@ class WorkerEmailTest(LuigiTestCase):
     def test_connection_error(self, emails):
         sch = RemoteScheduler('http://tld.invalid:1337', connect_timeout=1)
 
-        self.waits = 0
-
-        def dummy_wait():
-            self.waits += 1
-
-        sch._wait = dummy_wait
-
         class A(DummyTask):
             pass
 
@@ -1167,8 +1160,8 @@ class WorkerEmailTest(LuigiTestCase):
         with Worker(scheduler=sch) as worker:
             try:
                 worker.add(a)
-            except RPCError:
-                self.assertEqual(self.waits, 2)  # should attempt to add it 3 times
+            except RPCError as e:
+                self.assertTrue(e.args[0].find("Errors (3 attempts)") != -1)
                 self.assertNotEqual(emails, [])
                 self.assertTrue(emails[0].find("Luigi: Framework error while scheduling %s" % (a,)) != -1)
             else:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1162,7 +1162,7 @@ class WorkerEmailTest(LuigiTestCase):
             try:
                 worker.add(a)
             except RPCError as e:
-                self.assertTrue(e.args[0].find("Errors (3 attempts)") != -1)
+                self.assertTrue(str(e).find("Errors (3 attempts)") != -1)
                 self.assertNotEqual(emails, [])
                 self.assertTrue(emails[0].find("Luigi: Framework error while scheduling %s" % (a,)) != -1)
             else:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1151,6 +1151,7 @@ class WorkerEmailTest(LuigiTestCase):
     @email_patch
     def test_connection_error(self, emails):
         sch = RemoteScheduler('http://tld.invalid:1337', connect_timeout=1)
+        sch._rpc_retry_wait = 1  # shorten wait time to speed up tests
 
         class A(DummyTask):
             pass


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Related to https://github.com/spotify/luigi/issues/3025

I implemented retry procedure using tenacity library.
https://github.com/jd/tenacity

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to https://github.com/spotify/luigi/pull/3022 , there are some naive implementations of retries in luigi.
To simplify such codes, I introduce tenacity library and implement retries using function decorator.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I fixed and ran tests locally
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
