### PR TITLE
Fix string and byte error in contrib/hadoop.py

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -971,7 +971,7 @@ class JobTask(BaseHadoopJobTask):
             if self.__module__ == '__main__':
                 d = pickle.dumps(self)
                 module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-                d = d.replace(b'(c__main__', "(c" + module_name)
+                d = d.replace(b'c__main__', b'c' + module_name.encode('ascii'))
                 open(file_name, "wb").write(d)
 
             else:


### PR DESCRIPTION

## Description
The  code  d = d.replace(b'(c__main__', "(c" + module_name)   is a mixed usage of str and byte and cannot run in python3. 

It is not related to the business logic, just a language issue. 

## Have you tested this? If so, how?
Yes, 
