### PR TITLE
add AssistDigital as company

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,7 @@ Some more companies are using Luigi but haven't had a chance yet to write about 
 * `Jodel <https://www.jodel.com/>`_
 * `Mekar <https://mekar.id/en/>`_
 * `M3 <https://corporate.m3.com/en/>`_
+* `Assist Digital <https://www.assistdigital.com/>`_
 
 We're more than happy to have your company added here. Just send a PR on GitHub.
 


### PR DESCRIPTION

## Description
This add AssistDigital to the list of companies using Luigi in README.rst 