### PR TITLE
Add a UTC date to the marker document and venv/ to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/luigi/contrib/esindex.py
+++ b/luigi/contrib/esindex.py
@@ -169,7 +169,9 @@ class ElasticsearchTarget(luigi.Target):
 
         The document id would be sufficient but,
         for documentation,
-        we index the parameters `update_id`, `target_index`, `target_doc_type` and `date` as well.
+        we index the parameters `update_id`, `target_index`, `target_doc_type` and `date` as well.  `date_utc` added
+        so we can be sure to get the actual date and time based upon UTC and not the client date and time based on the
+        client machine.
         """
         self.create_marker_index()
         self.es.index(index=self.marker_index, doc_type=self.marker_doc_type,
@@ -177,7 +179,8 @@ class ElasticsearchTarget(luigi.Target):
                           'update_id': self.update_id,
                           'target_index': self.index,
                           'target_doc_type': self.doc_type,
-                          'date': datetime.datetime.now()})
+                          'date': datetime.datetime.now(),
+                          'date_utc': datetime.datetime.utcnow()})
         self.es.indices.flush(index=self.marker_index)
         self.ensure_hist_size()
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an additional field to the marker entry for the ElasticSearch target so we also have the UTC based date.

I also use PyCharm which sets up the local virtual as `venv/` so I wanted to be sure that was ignored as part of .gitignore

## Motivation and Context
We use UTC dates to control incremental processes and knowing when this marker was last updated based upon a UTC
date is needed for us.

## Have you tested this? If so, how?
I have run "tox -e py39-core test/contrib/esindex_test.py" locally on this change.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
