### PR TITLE
When initially entering data without object id

### DIFF
--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -92,6 +92,14 @@ class MongoCellTarget(MongoTarget):
         """
         Write value to the target
         """
+        self.get_collection().insert_one(
+            value
+        )
+
+    def update(self, value):
+        """
+        Update value to the target
+        """
         self.get_collection().update_one(
             {'_id': self._document_id},
             {'$set': {self._path: value}},


### PR DESCRIPTION
Add the method you use to enter data initially without object id.
When using the write method, you can put the document_id and path parameter values in an empty string value. like ''

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
