### PR TITLE
add python 3.8, 3.9 support and migration to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,39 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-postgres
 
+    - python: 3.8
+      env: TOXENV=py38-core
+    - python: 3.8
+      env: TOXENV=py38-dropbox
+      if: env(DROPBOX_APP_TOKEN) is present
+    - python: 3.8
+      env: TOXENV=py38-unixsocket
+    - python: 3.8
+      env: TOXENV=py38-postgres
+    - python: 3.8
+      env: TOXENV=py38-apache
+
+    - python: 3.9
+      env: TOXENV=py39-core
+    - python: 3.9
+      env: TOXENV=py39-dropbox
+      if: env(DROPBOX_APP_TOKEN) is present
+    - python: 3.9
+      env: TOXENV=py39-unixsocket
+    - python: 3.9
+      env: TOXENV=py39-postgres
+    - python: 3.9
+      dist: xenial
+      sudo: true
+      env: TOXENV=py39-apache
+
 cache:
   directories:
     - $HOME/.pip-cache
 
 install:
-  - pip install 'tox<3.0'
+  - pip install 'tox<4.0'
+  - pip install --upgrade virtualenv  # for install cryptography, see https://travis-ci.community/t/pip-install-cryptography-fails-on-py36/11233
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_e05f6ccc270e_key -iv $encrypted_e05f6ccc270e_iv -in test/gcloud-credentials.json.enc -out test/gcloud-credentials.json -d

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://img.shields.io/pypi/l/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 
-Luigi is a Python (3.6, 3.7 tested) package that helps you build complex
+Luigi is a Python (3.6, 3.7, 3.8, 3.9 tested) package that helps you build complex
 pipelines of batch jobs. It handles dependency resolution, workflow management,
 visualization, handling failures, command line integration, and much more.
 

--- a/test/contrib/_webhdfs_test.py
+++ b/test/contrib/_webhdfs_test.py
@@ -20,10 +20,10 @@ from helpers import unittest
 
 from luigi.contrib import webhdfs
 
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('apache')
+@pytest.mark.apache
 class TestWebHdfsTarget(unittest.TestCase):
 
     '''

--- a/test/contrib/azureblob_test.py
+++ b/test/contrib/azureblob_test.py
@@ -22,7 +22,7 @@ import os
 import unittest
 import json
 
-from nose.plugins.attrib import attr
+import pytest
 
 import luigi
 from luigi.contrib.azureblob import AzureBlobClient, AzureBlobTarget
@@ -34,7 +34,7 @@ is_emulated = False if account_name else True
 client = AzureBlobClient(account_name, account_key, sas_token, is_emulated=is_emulated)
 
 
-@attr('azureblob')
+@pytest.mark.azureblob
 class AzureBlobClientTest(unittest.TestCase):
     def setUp(self):
         self.client = client
@@ -157,7 +157,7 @@ class FinalTask(luigi.Task):
         return luigi.LocalTarget("samefile")
 
 
-@attr('azureblob')
+@pytest.mark.azureblob
 class AzureBlobTargetTest(unittest.TestCase):
     def setUp(self):
         self.client = client

--- a/test/contrib/batch_test.py
+++ b/test/contrib/batch_test.py
@@ -20,7 +20,7 @@ from helpers import unittest
 import luigi.contrib.batch as batch
 from helpers import skipOnTravis
 
-from nose.plugins.attrib import attr
+import pytest
 
 try:
     import boto3
@@ -100,7 +100,7 @@ class MockBotoLogsClient:
         }
 
 
-@attr('aws')
+@pytest.mark.aws
 @skipOnTravis("boto3 now importable. These tests need mocked")
 class BatchClientTest(unittest.TestCase):
 
@@ -163,7 +163,7 @@ class BatchClientTest(unittest.TestCase):
             self.assertTrue('log line 1' in context.exception)
 
 
-@attr('aws')
+@pytest.mark.aws
 @skipOnTravis("boto3 now importable. These tests need mocked")
 class BatchTaskTest(unittest.TestCase):
 

--- a/test/contrib/bigquery_gcloud_test.py
+++ b/test/contrib/bigquery_gcloud_test.py
@@ -40,7 +40,7 @@ from avro.io import DatumWriter
 from luigi.contrib.gcs import GCSTarget
 from luigi.contrib.bigquery import BigQueryExecutionError
 
-from nose.plugins.attrib import attr
+import pytest
 from helpers import unittest
 
 # In order to run this test, you should set your GCS/BigQuery project/bucket.
@@ -63,7 +63,7 @@ def bucket_url(suffix):
     return 'gs://{}/{}/{}'.format(BUCKET_NAME, TEST_FOLDER, suffix)
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class TestLoadTask(bigquery.BigQueryLoadTask):
     source = luigi.Parameter()
     table = luigi.Parameter()
@@ -84,7 +84,7 @@ class TestLoadTask(bigquery.BigQueryLoadTask):
         return bigquery.BigQueryTarget(PROJECT_ID, self.dataset, self.table, location=self.location)
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class TestRunQueryTask(bigquery.BigQueryRunQueryTask):
     query = ''' SELECT 'hello' as field1, 2 as field2 '''
     table = luigi.Parameter()
@@ -94,7 +94,7 @@ class TestRunQueryTask(bigquery.BigQueryRunQueryTask):
         return bigquery.BigQueryTarget(PROJECT_ID, self.dataset, self.table)
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class TestExtractTask(bigquery.BigQueryExtractTask):
     source = luigi.Parameter()
     table = luigi.Parameter()
@@ -119,7 +119,7 @@ class TestExtractTask(bigquery.BigQueryExtractTask):
             table=self.table)
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class BigQueryGcloudTest(unittest.TestCase):
     def setUp(self):
         self.bq_client = bigquery.BigQueryClient(CREDENTIALS)
@@ -337,7 +337,7 @@ class BigQueryGcloudTest(unittest.TestCase):
         self.assertRaises(BigQueryExecutionError, lambda: self.bq_client.run_job(PROJECT_ID, body))
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class BigQueryLoadAvroTest(unittest.TestCase):
     def _produce_test_input(self):
         schema = avro.schema.parse("""

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -26,7 +26,7 @@ from luigi.contrib.gcs import GCSTarget
 
 from helpers import unittest
 from mock import MagicMock
-from nose.plugins.attrib import attr
+import pytest
 
 PROJECT_ID = 'projectid'
 DATASET_ID = 'dataset'
@@ -123,7 +123,7 @@ class TestExtractTask(bigquery.BigQueryExtractTask):
         return TestExternalBigQueryTask()
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class BigQueryTest(unittest.TestCase):
 
     def test_bulk_complete(self):

--- a/test/contrib/cascading_test.py
+++ b/test/contrib/cascading_test.py
@@ -17,13 +17,13 @@
 
 from helpers import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 import luigi.target
 from luigi.contrib.target import CascadingClient
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class CascadingClientTest(unittest.TestCase):
 
     def setUp(self):

--- a/test/contrib/dataproc_test.py
+++ b/test/contrib/dataproc_test.py
@@ -19,7 +19,7 @@ except ImportError:
 import luigi
 import os
 import time
-from nose.plugins.attrib import attr
+import pytest
 
 # In order to run this test, you should set these to your GCS project.
 # Unfortunately there's no mock
@@ -38,7 +38,7 @@ class _DataprocBaseTestCase(unittest.TestCase):
         pass
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class DataprocTaskTest(_DataprocBaseTestCase):
 
     def test_1_create_cluster(self):

--- a/test/contrib/docker_runner_test.py
+++ b/test/contrib/docker_runner_test.py
@@ -35,7 +35,7 @@ import luigi
 import logging
 from luigi.contrib.docker_runner import DockerTask
 
-from nose.plugins.attrib import attr
+import pytest
 
 logger = logging.getLogger('luigi-interface')
 
@@ -127,7 +127,7 @@ class MultipleDockerTaskRedefProperties(luigi.WrapperTask):
                 for opt in ['one', 'two', 'three']]
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestDockerTask(unittest.TestCase):
 
     # def tearDown(self):

--- a/test/contrib/dropbox_test.py
+++ b/test/contrib/dropbox_test.py
@@ -5,7 +5,7 @@ import unittest
 import uuid
 from datetime import datetime
 
-from nose.plugins.attrib import attr
+import pytest
 
 import luigi
 from luigi.format import NopFormat
@@ -56,7 +56,7 @@ DROPBOX_TEST_FILE_TO_UPLOAD_LARGE = DROPBOX_TEST_PATH + '/file.blob'
 DROPBOX_TEST_NON_EXISTING_FILE = DROPBOX_TEST_SIMPLE_DIR + 'ajdlkajfal'
 
 
-@attr('dropbox')
+@pytest.mark.dropbox
 class TestClientDropbox(unittest.TestCase):
     def setUp(self):
         self.luigiconn = DropboxClient(DROPBOX_APP_TOKEN)
@@ -241,7 +241,7 @@ class TestClientDropbox(unittest.TestCase):
         self.assertTrue(self.luigiconn.exists(DROPBOX_TEST_FILE_TO_COPY_DEST))
 
 
-@attr('dropbox')
+@pytest.mark.dropbox
 class TestDropboxTarget(unittest.TestCase):
     def setUp(self):
         self.luigiconn = DropboxClient(DROPBOX_APP_TOKEN)

--- a/test/contrib/ecs_test.py
+++ b/test/contrib/ecs_test.py
@@ -36,7 +36,7 @@ import unittest
 import luigi
 from luigi.contrib.ecs import ECSTask, _get_task_statuses
 from moto import mock_ecs
-from nose.plugins.attrib import attr
+import pytest
 
 try:
     import boto3
@@ -74,7 +74,7 @@ class ECSTaskOverrideCommand(ECSTaskNoOutput):
         return [{'name': 'hello-world', 'command': ['/bin/sleep', '10']}]
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestECSTask(unittest.TestCase):
 
     @mock_ecs

--- a/test/contrib/esindex_test.py
+++ b/test/contrib/esindex_test.py
@@ -41,7 +41,7 @@ import luigi
 from elasticsearch.connection import Urllib3HttpConnection
 from luigi.contrib.esindex import CopyToIndex, ElasticsearchTarget
 
-from nose.plugins.attrib import attr
+import pytest
 
 HOST = os.getenv('ESINDEX_TEST_HOST', 'localhost')
 PORT = os.getenv('ESINDEX_TEST_PORT', 9200)
@@ -65,7 +65,7 @@ except Exception:
     raise unittest.SkipTest('Unable to connect to ElasticSearch')
 
 
-@attr('aws')
+@pytest.mark.aws
 class ElasticsearchTargetTest(unittest.TestCase):
 
     """ Test touch and exists. """
@@ -160,7 +160,7 @@ def _cleanup():
         es.indices.delete(INDEX)
 
 
-@attr('aws')
+@pytest.mark.aws
 class CopyToIndexTest(unittest.TestCase):
 
     """ Test indexing tasks. """
@@ -230,7 +230,7 @@ class CopyToIndexTest(unittest.TestCase):
                                             doc_type=task3.doc_type, id=234))
 
 
-@attr('aws')
+@pytest.mark.aws
 class MarkerIndexTest(unittest.TestCase):
 
     @classmethod
@@ -308,7 +308,7 @@ class IndexingTask4(CopyToTestIndex):
                  'name': 'another', 'date': 'today'}]
 
 
-@attr('aws')
+@pytest.mark.aws
 class IndexHistSizeTest(unittest.TestCase):
 
     @classmethod

--- a/test/contrib/external_program_test.py
+++ b/test/contrib/external_program_test.py
@@ -30,7 +30,7 @@ from luigi.contrib.external_program import ExternalProgramRunError
 from mock import patch, call
 from subprocess import Popen
 import mock
-from nose.plugins.attrib import attr
+import pytest
 
 
 def poll_generator():
@@ -75,7 +75,7 @@ class TestEchoTask(ExternalProgramTask):
         return ['echo', self.MESSAGE]
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class ExternalProgramTaskTest(unittest.TestCase):
     @patch('luigi.contrib.external_program.subprocess.Popen')
     def test_run(self, proc):
@@ -296,7 +296,7 @@ class TestExternalPythonProgramTask(ExternalPythonProgramTask):
         return luigi.LocalTarget('output')
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class ExternalPythonProgramTaskTest(unittest.TestCase):
     @patch.dict('os.environ', {'OTHERVAR': 'otherval'}, clear=True)
     @patch('luigi.contrib.external_program.subprocess.Popen')

--- a/test/contrib/gcs_test.py
+++ b/test/contrib/gcs_test.py
@@ -34,7 +34,7 @@ from unittest import mock
 
 from luigi.contrib import gcs
 from target_test import FileSystemTargetTestMixin
-from nose.plugins.attrib import attr
+import pytest
 
 # In order to run this test, you should set these to your GCS project/bucket.
 # Unfortunately there's no mock
@@ -75,7 +75,7 @@ class _GCSBaseTestCase(unittest.TestCase):
         self.client.remove(bucket_url(''), recursive=True)
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class GCSClientTest(_GCSBaseTestCase):
 
     def test_not_exists(self):
@@ -176,7 +176,7 @@ class GCSClientTest(_GCSBaseTestCase):
             fp.close()
 
 
-@attr('gcloud')
+@pytest.mark.gcloud
 class GCSTargetTest(_GCSBaseTestCase, FileSystemTargetTestMixin):
 
     def create_target(self, format=None):

--- a/test/contrib/hadoop_jar_test.py
+++ b/test/contrib/hadoop_jar_test.py
@@ -21,7 +21,7 @@ import shlex
 from helpers import unittest
 from luigi.contrib.hadoop_jar import HadoopJarJobError, HadoopJarJobTask, fix_paths
 from mock import patch, Mock
-from nose.plugins.attrib import attr
+import pytest
 
 
 class TestHadoopJarJob(HadoopJarJobTask):
@@ -49,7 +49,7 @@ class TestRemoteHadoopJarTwoParamJob(TestRemoteHadoopJarJob):
     param2 = luigi.Parameter()
 
 
-@attr('apache')
+@pytest.mark.apache
 class FixPathsTest(unittest.TestCase):
     def test_fix_paths_non_hdfs_target_path(self):
         mock_job = Mock()

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -29,7 +29,7 @@ import luigi.notifications
 import mock
 from luigi.mock import MockTarget
 from io import StringIO
-from nose.plugins.attrib import attr
+import pytest
 
 luigi.notifications.DEBUG = True
 
@@ -241,7 +241,7 @@ class CommonTests:
         test_case.assertFalse(success)
 
 
-@attr('apache')
+@pytest.mark.apache
 class MapreduceLocalTest(unittest.TestCase):
     use_hdfs = False
 
@@ -286,7 +286,7 @@ class MapreduceLocalTest(unittest.TestCase):
         MockTarget.fs.clear()
 
 
-@attr('apache')
+@pytest.mark.apache
 class CreatePackagesArchive(unittest.TestCase):
 
     def setUp(self):
@@ -381,7 +381,7 @@ class KeyboardInterruptedMockProcess(MockProcess):
             raise KeyboardInterrupt
 
 
-@attr('apache')
+@pytest.mark.apache
 class JobRunnerTest(unittest.TestCase):
     def setUp(self):
         self.tracking_urls = []

--- a/test/contrib/hdfs/webhdfs_client_test.py
+++ b/test/contrib/hdfs/webhdfs_client_test.py
@@ -16,15 +16,18 @@
 #
 import unittest
 
-from hdfs import InsecureClient
-from hdfs.ext.kerberos import KerberosClient
-from nose.plugins.attrib import attr
+import pytest
+try:
+    from hdfs import InsecureClient
+    from hdfs.ext.kerberos import KerberosClient
+except ImportError:
+    raise unittest.SkipTest('Unable to load hdfs module')
 
 from helpers import with_config
 from luigi.contrib.hdfs import WebHdfsClient
 
 
-@attr('apache')
+@pytest.mark.apache
 class TestWebHdfsClient(unittest.TestCase):
 
     @with_config({'webhdfs': {'client_type': 'insecure'}})

--- a/test/contrib/hdfs/webhdfs_client_test.py
+++ b/test/contrib/hdfs/webhdfs_client_test.py
@@ -17,14 +17,12 @@
 import unittest
 
 import pytest
-try:
-    from hdfs import InsecureClient
-    from hdfs.ext.kerberos import KerberosClient
-except ImportError:
-    raise unittest.SkipTest('Unable to load hdfs module')
 
 from helpers import with_config
 from luigi.contrib.hdfs import WebHdfsClient
+
+InsecureClient = pytest.importorskip('hdfs.InsecureClient')
+KerberosClient = pytest.importorskip('hdfs.ext.kerberos.KerberosClient')
 
 
 @pytest.mark.apache

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -25,10 +25,10 @@ import luigi.contrib.hive
 import mock
 from luigi import LocalTarget
 
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('apache')
+@pytest.mark.apache
 class HiveTest(unittest.TestCase):
     count = 0
 
@@ -76,7 +76,7 @@ class HiveTest(unittest.TestCase):
         self.assertTrue(os.path.exists(dirname))
 
 
-@attr('apache')
+@pytest.mark.apache
 class HiveCommandClientTest(unittest.TestCase):
     """Note that some of these tests are really for the CDH releases of Hive, to which I do not currently have access.
     Hopefully there are no significant differences in the expected output"""
@@ -409,7 +409,7 @@ class MyHiveTask(luigi.contrib.hive.HiveQueryTask):
         return 'banana banana %s' % self.param
 
 
-@attr('apache')
+@pytest.mark.apache
 class TestHiveTask(unittest.TestCase):
     task_class = MyHiveTask
 
@@ -452,7 +452,7 @@ class TestHiveTaskArgs(TestHiveTask):
             self.assertEqual(arglist[idx - 1], '--hiveconf')
 
 
-@attr('apache')
+@pytest.mark.apache
 class TestHiveTarget(unittest.TestCase):
 
     def test_hive_table_target(self):

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -36,7 +36,7 @@ import logging
 import mock
 from luigi.contrib.kubernetes import KubernetesJobTask
 
-from nose.plugins.attrib import attr
+import pytest
 
 logger = logging.getLogger('luigi-interface')
 
@@ -76,7 +76,7 @@ class FailJob(KubernetesJobTask):
         return {"dummy_label": "dummy_value"}
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestK8STask(unittest.TestCase):
 
     def test_success_job(self):

--- a/test/contrib/lsf_test.py
+++ b/test/contrib/lsf_test.py
@@ -34,7 +34,7 @@ from mock import patch
 import luigi
 from luigi.contrib.lsf import LSFJobTask
 
-from nose.plugins.attrib import attr
+import pytest
 
 DEFAULT_HOME = ''
 
@@ -70,7 +70,7 @@ class TestJobTask(LSFJobTask):
         return luigi.LocalTarget(os.path.join(DEFAULT_HOME, 'test_lsf_file_' + str(self.i)))
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSGEJob(unittest.TestCase):
 
     '''Test from SGE master node'''

--- a/test/contrib/mongo_test.py
+++ b/test/contrib/mongo_test.py
@@ -20,7 +20,7 @@ from helpers import unittest
 
 from luigi.contrib.mongodb import MongoCellTarget, MongoRangeTarget
 
-from nose.plugins.attrib import attr
+import pytest
 
 HOST = 'localhost'
 PORT = 27017
@@ -37,7 +37,7 @@ except Exception:
     raise unittest.SkipTest('Unable to connect to local mongoDB instance')
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class MongoCellTargetTest(unittest.TestCase):
 
     """ MongoCellTarget unittest on local test database """
@@ -150,7 +150,7 @@ class MongoCellTargetTest(unittest.TestCase):
             self.tearDown()
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class MongoRangerTargetTest(unittest.TestCase):
 
     """ MongoRangelTarget unittest on local test database """

--- a/test/contrib/mysqldb_test.py
+++ b/test/contrib/mysqldb_test.py
@@ -7,7 +7,7 @@ import luigi.contrib.mysqldb
 import datetime
 from helpers import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 def datetime_to_epoch(dt):
@@ -48,7 +48,7 @@ class DummyMysqlImporter(luigi.contrib.mysqldb.CopyToTable):
 
 
 # Testing that an existing update will not be run in RangeDaily
-@attr('mysql')
+@pytest.mark.mysql
 class DailyCopyToTableTest(unittest.TestCase):
 
     @mock.patch('mysql.connector.connect')
@@ -72,7 +72,7 @@ class DailyCopyToTableTest(unittest.TestCase):
         self.assertFalse(task.complete())
 
 
-@attr('mysql')
+@pytest.mark.mysql
 class TestCopyToTableWithMetaColumns(unittest.TestCase):
     @mock.patch("luigi.contrib.mysqldb.CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
     @mock.patch("luigi.contrib.mysqldb.CopyToTable._add_metadata_columns")

--- a/test/contrib/opener_test.py
+++ b/test/contrib/opener_test.py
@@ -7,10 +7,10 @@ from luigi.contrib.opener import OpenerTarget, NoOpenerError
 from luigi.mock import MockTarget
 from luigi.local_target import LocalTarget
 
-from nose.plugins.attrib import attr
+import pytest
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestOpenerTarget(unittest.TestCase):
 
     def setUp(self):

--- a/test/contrib/pig_test.py
+++ b/test/contrib/pig_test.py
@@ -23,7 +23,7 @@ from helpers import unittest
 from luigi.contrib.pig import PigJobError, PigJobTask
 from mock import patch
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 class SimpleTestJob(PigJobTask):
@@ -54,7 +54,7 @@ class ComplexTestJob(PigJobTask):
         return ['-x', 'local']
 
 
-@attr('apache')
+@pytest.mark.apache
 class SimplePigTest(unittest.TestCase):
     def setUp(self):
         pass
@@ -92,7 +92,7 @@ class SimplePigTest(unittest.TestCase):
             subprocess.Popen = p
 
 
-@attr('apache')
+@pytest.mark.apache
 class ComplexPigTest(unittest.TestCase):
     def setUp(self):
         pass

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -18,7 +18,7 @@ import luigi.contrib.postgres
 from luigi.tools.range import RangeDaily
 from helpers import unittest
 import mock
-from nose.plugins.attrib import attr
+import pytest
 
 
 def datetime_to_epoch(dt):
@@ -58,7 +58,7 @@ class DummyPostgresImporter(luigi.contrib.postgres.CopyToTable):
     )
 
 
-@attr('postgres')
+@pytest.mark.postgres
 class DailyCopyToTableTest(unittest.TestCase):
     maxDiff = None
 
@@ -106,7 +106,7 @@ class DummyPostgresQueryWithPortEncodedInHost(DummyPostgresQuery):
     host = 'dummy_host:1234'
 
 
-@attr('postgres')
+@pytest.mark.postgres
 class PostgresQueryTest(unittest.TestCase):
     maxDiff = None
 
@@ -139,7 +139,7 @@ class PostgresQueryTest(unittest.TestCase):
         self.assertEquals(output.port, '1234')
 
 
-@attr('postgres')
+@pytest.mark.postgres
 class TestCopyToTableWithMetaColumns(unittest.TestCase):
     @mock.patch("luigi.contrib.postgres.CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
     @mock.patch("luigi.contrib.postgres.CopyToTable._add_metadata_columns")

--- a/test/contrib/postgres_with_server_test.py
+++ b/test/contrib/postgres_with_server_test.py
@@ -17,7 +17,7 @@
 import os
 
 from helpers import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 import luigi
 import luigi.notifications
@@ -108,7 +108,7 @@ class Metric2(MetricBase):
         yield 'metric2', 3
 
 
-@attr('postgres')
+@pytest.mark.postgres
 class TestPostgresImportTask(unittest.TestCase):
 
     def test_default_escape(self):

--- a/test/contrib/prometheus_metric_test.py
+++ b/test/contrib/prometheus_metric_test.py
@@ -1,5 +1,5 @@
 from helpers import unittest
-from nose.plugins.attrib import attr
+import pytest
 from prometheus_client import CONTENT_TYPE_LATEST
 
 from luigi.contrib.prometheus_metric import PrometheusMetricsCollector
@@ -17,7 +17,7 @@ TASK_ID = 'TaskID'
 TASK_FAMILY = 'TaskFamily'
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class PrometheusMetricTest(unittest.TestCase):
     def setUp(self):
         self.collector = PrometheusMetricsCollector()

--- a/test/contrib/rdbms_test.py
+++ b/test/contrib/rdbms_test.py
@@ -24,7 +24,7 @@ import mock
 
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 # Fake AWS and S3 credentials taken from `../redshift_test.py`.
@@ -67,7 +67,7 @@ class DummyS3CopyToTableKey(DummyS3CopyToTableBase):
     aws_secret_access_key = AWS_SECRET_KEY
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3CopyToTableWithMetaColumns(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.metadata_columns", new_callable=mock.PropertyMock, return_value=[('created_tz', 'TIMESTAMP')])

--- a/test/contrib/redis_test.py
+++ b/test/contrib/redis_test.py
@@ -19,7 +19,7 @@
 from time import sleep
 from helpers import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 try:
     import redis
@@ -37,7 +37,7 @@ MARKER_PREFIX = 'luigi_test'
 EXPIRE = 5
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class RedisTargetTest(unittest.TestCase):
 
     """ Test touch, exists and target expiration"""

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -26,7 +26,7 @@ from helpers import unittest, with_config
 from luigi.contrib import redshift
 from luigi.contrib.s3 import S3Client
 
-from nose.plugins.attrib import attr
+import pytest
 
 if (3, 4, 0) <= sys.version_info[:3] < (3, 4, 3):
     # spulec/moto#308
@@ -142,14 +142,14 @@ class DummyS3CopyToTempTable(DummyS3CopyToTableKey):
     queries = ["insert into dummy_table select * from stage_dummy_table;"]
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestInternalCredentials(unittest.TestCase, DummyS3CopyToTableKey):
     def test_from_property(self):
         self.assertEqual(self.aws_access_key_id, AWS_ACCESS_KEY)
         self.assertEqual(self.aws_secret_access_key, AWS_SECRET_KEY)
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestExternalCredentials(unittest.TestCase, DummyS3CopyToTableBase):
     @mock.patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "env_key",
                                   "AWS_SECRET_ACCESS_KEY": "env_secret"})
@@ -164,7 +164,7 @@ class TestExternalCredentials(unittest.TestCase, DummyS3CopyToTableBase):
         self.assertEqual(self.aws_secret_access_key, "config_secret")
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3CopyToTableWithMetaColumns(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.enable_metadata_columns", new_callable=mock.PropertyMock, return_value=True)
     @mock.patch("luigi.contrib.redshift.S3CopyToTable._add_metadata_columns")
@@ -227,7 +227,7 @@ class TestS3CopyToTableWithMetaColumns(unittest.TestCase):
         self.assertFalse(mock_update_columns.called)
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3CopyToTable(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_copy_missing_creds(self, mock_redshift_target):
@@ -567,7 +567,7 @@ class TestS3CopyToTable(unittest.TestCase):
         )
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3CopyToSchemaTable(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.S3CopyToTable.copy")
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
@@ -616,7 +616,7 @@ class DummyRedshiftUnloadTask(luigi.contrib.redshift.RedshiftUnloadTask):
         return "SELECT 'a' as col_a, current_date as col_b"
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestRedshiftUnloadTask(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_redshift_unload_command(self, mock_redshift_target):
@@ -654,7 +654,7 @@ class DummyRedshiftAutocommitQuery(luigi.contrib.redshift.RedshiftQuery):
         return "SELECT 'a' as col_a, current_date as col_b"
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestRedshiftAutocommitQuery(unittest.TestCase):
     @mock.patch("luigi.contrib.redshift.RedshiftTarget")
     def test_redshift_autocommit_query(self, mock_redshift_target):
@@ -672,7 +672,7 @@ class TestRedshiftAutocommitQuery(unittest.TestCase):
         self.assertTrue(mock_connect.autocommit)
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestRedshiftManifestTask(unittest.TestCase):
     def test_run(self):
         with mock_s3():

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -31,7 +31,7 @@ from luigi.target import MissingParentDirectory
 from moto import mock_s3, mock_sts
 from target_test import FileSystemTargetTestMixin
 
-from nose.plugins.attrib import attr
+import pytest
 
 if (3, 4, 0) <= sys.version_info[:3] < (3, 4, 3):
     # spulec/moto#308
@@ -50,7 +50,7 @@ def create_bucket():
     return conn
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
 
     def setUp(self):
@@ -148,7 +148,7 @@ class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
         self.assertEqual('s3://mybucket/test_file', path)
 
 
-@attr('aws')
+@pytest.mark.aws
 class TestS3Client(unittest.TestCase):
     def setUp(self):
         f = tempfile.NamedTemporaryFile(mode='wb', delete=False)

--- a/test/contrib/salesforce_test.py
+++ b/test/contrib/salesforce_test.py
@@ -27,7 +27,7 @@ import mock
 from luigi.mock import MockTarget
 import re
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 def mocked_requests_get(*args, **kwargs):
@@ -62,7 +62,7 @@ def mocked_open(*args, **kwargs):
         return old__open(*args)
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSalesforceAPI(unittest.TestCase):
     # We patch 'requests.get' with our own method. The mock object is passed in to our test case method.
     @mock.patch('requests.get', side_effect=mocked_requests_get)
@@ -92,7 +92,7 @@ class TestQuerySalesforce(QuerySalesforce):
         return "SELECT * FROM %s" % self.object_name
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSalesforceQuery(unittest.TestCase):
 
     @mock.patch('builtins.open', side_effect=mocked_open)

--- a/test/contrib/scalding_test.py
+++ b/test/contrib/scalding_test.py
@@ -25,7 +25,7 @@ import shutil
 import tempfile
 import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 class MyScaldingTask(scalding.ScaldingJobTask):
@@ -35,7 +35,7 @@ class MyScaldingTask(scalding.ScaldingJobTask):
         return self.scala_source
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class ScaldingTest(unittest.TestCase):
     def setUp(self):
         self.scalding_home = os.path.join(tempfile.gettempdir(), 'scalding-%09d' % random.randint(0, 999999999))

--- a/test/contrib/sge_test.py
+++ b/test/contrib/sge_test.py
@@ -26,7 +26,7 @@ from mock import patch
 import luigi
 from luigi.contrib.sge import SGEJobTask, _parse_qstat_state
 
-from nose.plugins.attrib import attr
+import pytest
 
 DEFAULT_HOME = '/home'
 
@@ -49,7 +49,7 @@ def on_sge_master():
         return False
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSGEWrappers(unittest.TestCase):
 
     def test_track_job(self):
@@ -76,7 +76,7 @@ class TestJobTask(SGEJobTask):
         return luigi.LocalTarget(os.path.join(DEFAULT_HOME, 'testfile_' + str(self.i)))
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSGEJob(unittest.TestCase):
 
     """Test from SGE master node"""

--- a/test/contrib/spark_test.py
+++ b/test/contrib/spark_test.py
@@ -31,7 +31,7 @@ from multiprocessing import Value
 from subprocess import Popen
 from io import BytesIO
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 def poll_generator():
@@ -113,7 +113,7 @@ class MessyNamePySparkTask(TestPySparkTask):
     name = 'AppName(a,b,c,1:2,3/4)'
 
 
-@attr('apache')
+@pytest.mark.apache
 class SparkSubmitTaskTest(unittest.TestCase):
     ss = 'ss-stub'
 
@@ -253,7 +253,7 @@ class SparkSubmitTaskTest(unittest.TestCase):
                 self.assertEqual(test_val.value, 1)
 
 
-@attr('apache')
+@pytest.mark.apache
 class PySparkTaskTest(unittest.TestCase):
     ss = 'ss-stub'
 

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -28,7 +28,7 @@ import luigi
 import sqlalchemy
 from luigi.contrib import sqla
 from luigi.mock import MockTarget
-from nose.plugins.attrib import attr
+import pytest
 from helpers import skipOnTravis
 
 
@@ -46,7 +46,7 @@ class BaseTask(luigi.Task):
         out.close()
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSQLA(unittest.TestCase):
     NUM_WORKERS = 1
 
@@ -387,7 +387,7 @@ class TestSQLA(unittest.TestCase):
         self._check_entries(task2.output().engine)
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestSQLA2(TestSQLA):
     """ 2 workers version
     """

--- a/test/contrib/streaming_test.py
+++ b/test/contrib/streaming_test.py
@@ -9,7 +9,7 @@ from luigi.contrib import mrrunner
 from luigi.contrib.hadoop import HadoopJobRunner, JobTask
 from luigi.contrib.hdfs import HdfsTarget
 
-from nose.plugins.attrib import attr
+import pytest
 
 
 class MockStreamingJob(JobTask):
@@ -36,7 +36,7 @@ class MockStreamingJobWithExtraArguments(JobTask):
         return rv
 
 
-@attr('apache')
+@pytest.mark.apache
 class StreamingRunTest(unittest.TestCase):
 
     @mock.patch('luigi.contrib.hadoop.shutil')

--- a/test/contrib/test_ssh.py
+++ b/test/contrib/test_ssh.py
@@ -28,7 +28,7 @@ import target_test
 from luigi.contrib.ssh import RemoteContext, RemoteFileSystem, RemoteTarget, RemoteCalledProcessError
 from luigi.target import MissingParentDirectory, FileAlreadyExists
 
-from nose.plugins.attrib import attr
+import pytest
 
 working_ssh_host = os.environ.get('SSH_TEST_HOST', 'localhost')
 # set this to a working ssh host string (e.g. "localhost") to activate integration tests
@@ -61,7 +61,7 @@ except Exception:
     raise unittest.SkipTest('Not able to connect to ssh server')
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestRemoteContext(unittest.TestCase):
 
     def setUp(self):
@@ -109,7 +109,7 @@ class TestRemoteContext(unittest.TestCase):
             print("Closing tunnel")
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestRemoteTarget(unittest.TestCase):
 
     """ These tests assume RemoteContext working
@@ -161,7 +161,7 @@ class TestRemoteTarget(unittest.TestCase):
         self.assertEqual(file_content, "hello")
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestRemoteFilesystem(unittest.TestCase):
     def setUp(self):
         self.fs = RemoteFileSystem(working_ssh_host)
@@ -195,7 +195,7 @@ class TestRemoteFilesystem(unittest.TestCase):
         self.assertEqual([self.target.path], list(self.fs.listdir(self.directory)))
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestGetAttrRecursion(unittest.TestCase):
     def test_recursion_on_delete(self):
         target = RemoteTarget("/etc/this/does/not/exist", working_ssh_host)
@@ -204,7 +204,7 @@ class TestGetAttrRecursion(unittest.TestCase):
                 fh.write("test")
 
 
-@attr('contrib')
+@pytest.mark.contrib
 class TestRemoteTargetAtomicity(unittest.TestCase, target_test.FileSystemTargetTestMixin):
     path = '/tmp/luigi_remote_atomic_test.txt'
     ctx = RemoteContext(working_ssh_host)

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -27,6 +27,7 @@ import luigi.worker
 
 
 class DummyTask(luigi.Task):
+    task_namespace = 'customized_run'
     n = luigi.Parameter()
 
     def __init__(self, *args, **kwargs):
@@ -126,5 +127,5 @@ class CustomizedWorkerTest(unittest.TestCase):
 
     def test_cmdline_custom_worker(self):
         self.assertFalse(self.worker_scheduler_factory.worker.complete())
-        luigi.run(['DummyTask', '--n', '4'], worker_scheduler_factory=self.worker_scheduler_factory)
+        luigi.run(['customized_run.DummyTask', '--n', '4'], worker_scheduler_factory=self.worker_scheduler_factory)
         self.assertTrue(self.worker_scheduler_factory.worker.complete())

--- a/test/customized_run_test.py
+++ b/test/customized_run_test.py
@@ -27,7 +27,7 @@ import luigi.worker
 
 
 class DummyTask(luigi.Task):
-    task_namespace = 'customized_run'
+    task_namespace = 'customized_run'  # to prevent task name coflict between tests
     n = luigi.Parameter()
 
     def __init__(self, *args, **kwargs):

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -29,6 +29,7 @@ luigi.notifications.DEBUG = True
 
 
 class A(luigi.Task):
+    task_namespace = 'decorator'  # to prevent task name conflict between tests
     param1 = luigi.Parameter("class A-specific default")
 
 

--- a/test/event_callbacks_test.py
+++ b/test/event_callbacks_test.py
@@ -218,6 +218,7 @@ class B(HappyTestFriend):
 
 
 class A(HappyTestFriend):
+    task_namespace = 'event_callbacks'  # to prevent task name coflict between tests
 
     def requires(self):
         return [B(1), B(2)]

--- a/test/instance_test.py
+++ b/test/instance_test.py
@@ -42,6 +42,7 @@ class InstanceTest(unittest.TestCase):
         test = self
 
         class A(luigi.Task):
+            task_namespace = 'instance'  # to prevent task name conflict between tests
 
             def __init__(self):
                 self.has_run = False
@@ -63,6 +64,7 @@ class InstanceTest(unittest.TestCase):
 
     def test_external_instance_cache(self):
         class A(luigi.Task):
+            task_namespace = 'instance'  # to prevent task name conflict between tests
             pass
 
         class OtherA(luigi.ExternalTask):

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 #
 
+import sys
 import warnings
 
-import nose
+import pytest
 
 if __name__ == '__main__':
     with warnings.catch_warnings():
@@ -27,4 +28,4 @@ if __name__ == '__main__':
             message='(.*)outputs has no custom(.*)',
             category=UserWarning
         )
-        nose.main()
+        sys.exit(pytest.main(sys.argv[1:]))

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -19,7 +19,7 @@ import itertools
 import mock
 import time
 from helpers import unittest
-from nose.plugins.attrib import attr
+import pytest
 import luigi.notifications
 from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, \
     UNKNOWN, RUNNING, BATCH_RUNNING, UPSTREAM_RUNNING, Scheduler
@@ -28,7 +28,7 @@ luigi.notifications.DEBUG = True
 WORKER = 'myworker'
 
 
-@attr('scheduler')
+@pytest.mark.scheduler
 class SchedulerApiTest(unittest.TestCase):
 
     def setUp(self):

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -33,7 +33,7 @@ from urllib.parse import (
 
 import tornado.ioloop
 from tornado.testing import AsyncHTTPTestCase
-from nose.plugins.attrib import attr
+import pytest
 
 try:
     from unittest import mock
@@ -352,7 +352,7 @@ class _ServerTest(unittest.TestCase):
         self.assertEqual(work['task_id'], 'A')
 
 
-@attr('unixsocket')
+@pytest.mark.unixsocket
 class UNIXServerTest(_ServerTest):
     class ServerClient:
         def __init__(self):
@@ -390,6 +390,10 @@ class INETServerClient:
 
 
 class _INETServerTest(_ServerTest):
+    # HACK: nose ignores class whose name starts with underscore
+    # see: https://github.com/nose-devs/nose/blob/6f9dada1a5593b2365859bab92c7d1e468b64b7b/nose/selector.py#L72
+    # This hack affects derived classes of this class e.g. INETProcessServerTest, INETLuigidServerTest, INETLuigidDaemonServerTest.
+    __test__ = False
 
     def test_with_cmdline(self):
         """
@@ -400,6 +404,8 @@ class _INETServerTest(_ServerTest):
 
 
 class INETProcessServerTest(_INETServerTest):
+    __test__ = True
+
     class ServerClient(INETServerClient):
         def run_server(self):
             luigi.server.run(api_port=self.port, address='127.0.0.1')
@@ -426,6 +432,8 @@ class INETURLLibServerTest(INETProcessServerTest):
 
 
 class INETLuigidServerTest(_INETServerTest):
+    __test__ = True
+
     class ServerClient(INETServerClient):
         def run_server(self):
             # I first tried to things like "subprocess.call(['luigid', ...]),
@@ -437,6 +445,7 @@ class INETLuigidServerTest(_INETServerTest):
 
 
 class INETLuigidDaemonServerTest(_INETServerTest):
+    __test__ = True
 
     class ServerClient(INETServerClient):
         def __init__(self):

--- a/test/task_serialize_test.py
+++ b/test/task_serialize_test.py
@@ -28,9 +28,10 @@ We use the hypothesis package to do property-based tests.
 import string
 import luigi
 import json
+from datetime import datetime
 
 import hypothesis as hyp
-from hypothesis.extra.datetime import datetimes as hyp_datetimes
+from hypothesis.strategies import datetimes as hyp_datetimes
 
 _no_value = luigi.parameter._no_value
 
@@ -62,7 +63,7 @@ int_parameters_def = _mk_param_strategy(luigi.IntParameter, hyp.strategies.integ
 float_parameters_def = _mk_param_strategy(luigi.FloatParameter,
                                           hyp.strategies.floats(min_value=-1e100, max_value=+1e100), True)
 bool_parameters_def = _mk_param_strategy(luigi.BoolParameter, hyp.strategies.booleans(), True)
-date_parameters_def = _mk_param_strategy(luigi.DateParameter, hyp_datetimes(min_year=1900, timezones=[]), True)
+date_parameters_def = _mk_param_strategy(luigi.DateParameter, hyp_datetimes(min_value=datetime(1900, 1, 1)), True)
 
 any_default_parameters = hyp.strategies.one_of(
     parameters_def, int_parameters_def, float_parameters_def, bool_parameters_def, date_parameters_def

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import doctest
 import pickle
 import warnings

--- a/test/wrap_test.py
+++ b/test/wrap_test.py
@@ -27,6 +27,7 @@ luigi.notifications.DEBUG = True
 
 
 class A(luigi.Task):
+    task_namespace = 'wrap'  # to prevent task name conflict between tests
 
     def output(self):
         return MockTarget('/tmp/a.txt')

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,41 @@
 [tox]
-envlist = py{35,36,37}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{35,36,37,38,39}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
+
+[pytest]
+addopts = --cov=luigi -vv --strict-markers --ignore-glob="**/_*" --fulltrace
+testpaths = test
+markers =
+    contrib: tests related to luigi/contrib
+    apache: tests related to apache
+    aws: tests related to AWS
+    postgres: tests related to postgresql
+    mysql: tests related to mysql
+    scheduler: tests related to scheduler
+    cdh: tests related to cdh
+    hdp: tests related to hdp
+    gcloud: tests related to GCP
+    unixsocket: tests related to unixsocket
+    dropbox: tests related to dropbox
+    azureblob: tests related to azure
 
 [testenv]
 usedevelop = True
 install_command = pip install {opts} {packages}
 deps =
+    pytest<7.0
+    pytest-cov>=2.0,<3.0
     mock<2.0
-    moto==1.3.6
+    moto>=1.3.10
     HTTPretty==0.8.10
-    nose<2.0
     docker>=2.1.0
-    unittest2<2.0
-    boto<3.0
-    boto3>=1.4.4
+    boto>=2.42,<3.0
+    boto3>=1.11.0
     pyhive[presto]==0.6.1
-    s3transfer==0.1.13
-    sqlalchemy<2.0
-    elasticsearch<2.0.0
+    s3transfer>=0.3,<4.0
+    sqlalchemy<1.4
+    elasticsearch>=1.0.0,<2.0.0
     psutil<4.0
-    enum34>1.1.0
     cdh,hdp: hdfs>=2.0.4,<3.0.0
     postgres: psycopg2<3.0
     mysql-connector-python>=8.0.12
@@ -28,12 +44,12 @@ deps =
     gcloud: google-auth==1.4.1
     gcloud: google-auth-httplib2==0.0.3
     google-compute-engine
-    coverage>=4.1,<4.2
+    coverage>=5.0,<6
     codecov>=1.4.0
     requests>=2.20.0,<3.0
     unixsocket: requests-unixsocket<1.0
     pygments
-    hypothesis[datetime]<4.0.0
+    hypothesis>=6.7.0,<7.0.0
     selenium==3.0.2
     pymongo==3.4.0
     toml<2.0.0
@@ -50,21 +66,9 @@ setenv =
     cdh: HADOOP_HOME={toxinidir}/.tox/hadoop-cdh
     hdp: HADOOP_DISTRO=hdp
     hdp: HADOOP_HOME={toxinidir}/.tox/hadoop-hdp
-    contrib: NOSE_ATTR=contrib
-    apache: NOSE_ATTR=apache
-    aws: NOSE_ATTR=aws
-    postgres: NOSE_ATTR=postgres
-    scheduler: NOSE_ATTR=scheduler
-    cdh,hdp: NOSE_ATTR=minicluster
-    gcloud: NOSE_ATTR=gcloud
-    unixsocket: NOSE_ATTR=unixsocket
-    dropbox: NOSE_ATTR=dropbox
-    azureblob: NOSE_ATTR=azureblob
-    core: NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox
     LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
     COVERAGE_PROCESS_START={toxinidir}/.coveragerc
     FULL_COVERAGE=true
-    core: NOSE_WITH_DOCTEST=1
     AWS_DEFAULT_REGION=us-east-1
     AWS_ACCESS_KEY_ID=accesskey
     AWS_SECRET_ACCESS_KEY=secretkey
@@ -72,9 +76,19 @@ commands =
     cdh,hdp: {toxinidir}/scripts/ci/setup_hadoop_env.sh
     azureblob: {toxinidir}/scripts/ci/install_start_azurite.sh {toxinidir}/scripts/ci
     python --version
-    coverage run test/runtests.py -v --ignore-files='(^\.|^_|^setup\.py$)' \
-    {posargs:}
-    coverage combine
+    ## main commands
+    contrib: python test/runtests.py -m contrib {posargs:}
+    apache: python test/runtests.py -m apache {posargs:}
+    aws: python test/runtests.py -m aws {posargs:}
+    postgres: python test/runtests.py -m postgres {posargs:}
+    scheduler: python test/runtests.py -m scheduler {posargs:}
+    cdh,hdp: python test/runtests.py -m minicluster {posargs:}
+    gcloud: python test/runtests.py -m gcloud {posargs:}
+    unixsocket: python test/runtests.py -m unixsocket {posargs:}
+    dropbox: python test/runtests.py -m dropbox {posargs:}
+    azureblob: python test/runtests.py -m azureblob {posargs:}
+    core: python test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" {posargs:}
+    ##
     codecov -e TOXENV
     azureblob: {toxinidir}/scripts/ci/stop_azurite.sh
 
@@ -82,18 +96,15 @@ commands =
 usedevelop = True
 deps =
     mock<2.0
-    nose<2.0
-    unittest2<2.0
     selenium==3.0.2
 passenv = {[testenv]passenv}
 setenv =
     LC_ALL = en_US.utf-8
-    NOSE_EVAL_ATTR=not minicluster and not gcloud and not postgres and not unixsocket
     LUIGI_CONFIG_PATH={toxinidir}/test/testconfig/luigi.cfg
     TEST_VISUALISER=1
 commands =
     python --version
-    nosetests -v --tests=test/visualiser
+    pytest -m "not minicluster and not gcloud and not postgres and not unixsocket" test/visualiser
 
 # Flake8 Configuration, inspired from https://gitlab.com/pycqa/flake8/blob/master/tox.ini
 # By putting it here, local flake8 runs will also pick it up.
@@ -123,7 +134,6 @@ deps =
     boto3
     Sphinx>=1.4.4,<1.5
     sphinx_rtd_theme
-    enum34>1.1.0
     azure-storage<=0.36
     prometheus-client==0.5.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ setenv =
     TEST_VISUALISER=1
 commands =
     python --version
-    pytest -m "not minicluster and not gcloud and not postgres and not unixsocket" test/visualiser
+    pytest test/visualiser
 
 # Flake8 Configuration, inspired from https://gitlab.com/pycqa/flake8/blob/master/tox.ini
 # By putting it here, local flake8 runs will also pick it up.


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

fix  #3046, related to #2886, #2939

This PR migrates from nose to pytest and adds python 3.8 and 3.9 support.

Details are as follows
- migrate from `nose` to `pytest`
  - place `test/conftest.py` to change test root
  - replace `@attr` decorator into `pytest.mark` to group tests
  - fix a few imports e.g. [here](https://github.com/spotify/luigi/pull/3048/files#diff-e590b5303093e390593b16c301f3ad6e3728f6afb8029d0f2fcb16964274ed53R19)
  - attach namespace on some test tasks to isolate each test e.g. [here](https://github.com/spotify/luigi/pull/3048/files#diff-053b30ca6a42cf2e4792b6b8ee44adf480820b1ad01ecce3942ec7dc816ff0d1R45)
- add py38 and py39 CI on `tox` and `travis`
  - update [test dependencies](https://github.com/spotify/luigi/pull/3048/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R46) 
  - update virtualenv to resolve [cryptography installation problem](https://travis-ci.community/t/pip-install-cryptography-fails-on-py36/11233) 
    - [diff](https://github.com/spotify/luigi/pull/3048/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R107)
  - replace hypothesis.extra.datetime into hypothesis.strategies because of it's deprecation 
    - [diff](https://github.com/spotify/luigi/pull/3048/files#diff-d602eb271306017d537b4e752eecddfd78d03bd496dc7fca0c00e63ed75ca7d0R34)

## Motivation and Context

### pytest migration
[`nose`](https://github.com/nose-devs/nose)  is not in active development and several deprecation warnings are occurred.

### add python 3.8, 3.9 tests
easy to follow latest python versions

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->

I ran tests locally and on travis, too
