### PR TITLE
Update central_scheduler.rst

### DIFF
--- a/doc/central_scheduler.rst
+++ b/doc/central_scheduler.rst
@@ -31,8 +31,8 @@ To run the server as a daemon run:
 
 Note that this requires ``python-daemon``.
 By default, the server starts on AF_INET and AF_INET6 port ``8082``
-(which can be changed with the ``--port`` flag) and listens on all IPs.
-(To use an AF_UNIX socket use the ``--unix-socket`` flag)
+(which can be changed with the ``--port`` flag) and listens on all IPs. To listen on a single IP, pass the ``--address`` flag and the IP to use.
+To use an AF_UNIX socket use the ``--unix-socket`` flag.
 
 For a full list of configuration options and defaults,
 see the :ref:`scheduler configuration section <scheduler-config>`.

--- a/doc/central_scheduler.rst
+++ b/doc/central_scheduler.rst
@@ -31,7 +31,7 @@ To run the server as a daemon run:
 
 Note that this requires ``python-daemon``.
 By default, the server starts on AF_INET and AF_INET6 port ``8082``
-(which can be changed with the ``--port`` flag) and listens on all IPs. To listen on a single IP, pass the ``--address`` flag and the IP to use.
+(which can be changed with the ``--port`` flag) and listens on all IPs. To change the default behavior of listening on all IPs, pass the ``--address`` flag and the IP address to listen on.
 To use an AF_UNIX socket use the ``--unix-socket`` flag.
 
 For a full list of configuration options and defaults,


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
We operate in a datacenter that was complaining about luigi running without authentication (called out in https://github.com/spotify/luigi/issues/2212) and listening for traffic on external interfaces (IP address). To get around this I passed `--address 127.0.0.1` to the luigi call in the systemd service file to allow the webserver to listen only on localhost. I noticed this flag wasn't documented so I figured I'd add it to this file so that others see it mentioned alongside the port flag. Someone else at my company noticed this issue cited above and didn't realize that the `--address` flag existed. 

## Motivation and Context
Basically, this is just to bring into the docs what I found by just running `luigi --help`. 

## Have you tested this? If so, how?
docs only update

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
