### PR TITLE
Scope SQLA session so object lifespans rendering for task history

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -245,28 +245,32 @@ def from_utc(utcTime, fmt=None):
 
 class RecentRunHandler(BaseTaskHistoryHandler):
     def get(self):
-        tasks = self._scheduler.task_history.find_latest_runs()
-        self.render("recent.html", tasks=tasks)
+        with self._scheduler.task_history._session(None) as session:
+            tasks = self._scheduler.task_history.find_latest_runs(session)
+            self.render("recent.html", tasks=tasks)
 
 
 class ByNameHandler(BaseTaskHistoryHandler):
     def get(self, name):
-        tasks = self._scheduler.task_history.find_all_by_name(name)
-        self.render("recent.html", tasks=tasks)
+        with self._scheduler.task_history._session(None) as session:
+            tasks = self._scheduler.task_history.find_all_by_name(name, session)
+            self.render("recent.html", tasks=tasks)
 
 
 class ByIdHandler(BaseTaskHistoryHandler):
     def get(self, id):
-        task = self._scheduler.task_history.find_task_by_id(id)
-        self.render("show.html", task=task)
+        with self._scheduler.task_history._session(None) as session:
+            task = self._scheduler.task_history.find_task_by_id(id, session)
+            self.render("show.html", task=task)
 
 
 class ByParamsHandler(BaseTaskHistoryHandler):
     def get(self, name):
         payload = self.get_argument('data', default="{}")
         arguments = json.loads(payload)
-        tasks = self._scheduler.task_history.find_all_by_parameters(name, session=None, **arguments)
-        self.render("recent.html", tasks=tasks)
+        with self._scheduler.task_history._session(None) as session:
+            tasks = self._scheduler.task_history.find_all_by_parameters(name, session=session, **arguments)
+            self.render("recent.html", tasks=tasks)
 
 
 class RootPathHandler(BaseTaskHistoryHandler):


### PR DESCRIPTION
## Description

For SQLAlchemy >1.4 it seems setting `expire_on_commit` to `False` is less forgiving that older versions. This causes the following exception to be thrown when visiting the "/history" tab.

```python
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <TaskRecord at 0x7f943e167190> is not bound to a Session; lazy load operation of attribute 'parameters' cannot proceed (Background on this error at: http://sqlalche.me/e/14/bhk3)
```

## Motivation and Context
This resolves issue https://github.com/spotify/luigi/issues/3006.

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me when using SQLAlchemy 1.4.1.


