### PR TITLE
add python 3.8, 3.9 on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: System :: Monitoring',
     ],
 )


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->
related to https://github.com/spotify/luigi/pull/3048

I added python 3.8, 3.9 on setup.py.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

I missed to add python versions on setup.py in https://github.com/spotify/luigi/pull/3048 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To show python versions at PyPI. 

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

tested on CI

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
