### PR TITLE
build apache tests

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -21,7 +21,6 @@ jobs:
           - python-version: 3.9
             tox-env: py39-core
 
-
           - python-version: 3.6
             tox-env: py36-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
@@ -34,6 +33,15 @@ jobs:
           - python-version: 3.9
             tox-env: py39-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
+
+          - python-version: 3.6
+            tox-env: py36-apache
+          - python-version: 3.7
+            tox-env: py37-apache
+          - python-version: 3.8
+            tox-env: py38-apache
+          - python-version: 3.9
+            tox-env: py39-apache
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Simply adding the apache test build in github actions.


```

test/contrib/hadoop_jar_test.py::FixPathsTest::test_fix_paths_non_hdfs_target_path PASSED [  1%]
test/contrib/hadoop_jar_test.py::FixPathsTest::test_fix_paths_non_hdfs_target_str PASSED [  2%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_cmd_line PASSED    [  4%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_failing_job PASSED [  5%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_instantiate_job PASSED [  7%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_map_only PASSED    [  8%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_run PASSED         [ 10%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_run_2 PASSED       [ 11%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_unicode_job PASSED [ 13%]
test/contrib/hadoop_test.py::MapreduceLocalTest::test_use_json_as_data_interchange_format_job PASSED [ 14%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_module PASSED [ 16%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package PASSED [ 17%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package_submodule PASSED [ 19%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package_submodule_with_absolute_import PASSED [ 20%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package_submodule_without_imports PASSED [ 22%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package_subpackage PASSED [ 23%]
test/contrib/hadoop_test.py::CreatePackagesArchive::test_create_packages_archive_package_subpackage_submodule PASSED [ 25%]
test/contrib/hadoop_test.py::JobRunnerTest::test_kill_application_on_interrupt PASSED [ 26%]
test/contrib/hadoop_test.py::JobRunnerTest::test_kill_job_on_interrupt PASSED [ 28%]
test/contrib/hadoop_test.py::JobRunnerTest::test_kill_last_application_on_interrupt PASSED [ 29%]
test/contrib/hadoop_test.py::JobRunnerTest::test_kill_last_mapreduce_on_interrupt PASSED [ 31%]
test/contrib/hadoop_test.py::JobRunnerTest::test_multiple_tracking_urls PASSED [ 32%]
test/contrib/hadoop_test.py::JobRunnerTest::test_tracking_url_captured_on_fail PASSED [ 34%]
test/contrib/hadoop_test.py::JobRunnerTest::test_tracking_url_old_version PASSED [ 35%]
test/contrib/hadoop_test.py::JobRunnerTest::test_tracking_url_yarn PASSED [ 37%]
test/contrib/hive_test.py::HiveTest::test_create_parent_dirs PASSED      [ 38%]
test/contrib/hive_test.py::HiveTest::test_run_hive_command PASSED        [ 40%]
test/contrib/hive_test.py::HiveTest::test_run_hive_script_exists PASSED  [ 41%]
test/contrib/hive_test.py::HiveTest::test_run_hive_script_not_exists PASSED [ 43%]
test/contrib/hive_test.py::HiveCommandClientTest::test_apacheclient_table_exists PASSED [ 44%]
test/contrib/hive_test.py::HiveCommandClientTest::test_apacheclient_table_schema PASSED [ 46%]
test/contrib/hive_test.py::HiveCommandClientTest::test_client_def PASSED [ 47%]
test/contrib/hive_test.py::HiveCommandClientTest::test_default_table_location PASSED [ 49%]
test/contrib/hive_test.py::HiveCommandClientTest::test_metastore_partition_spec_has_the_same_order PASSED [ 50%]
test/contrib/hive_test.py::HiveCommandClientTest::test_metastoreclient_partition_existence_regardless_of_order PASSED [ 52%]
test/contrib/hive_test.py::HiveCommandClientTest::test_partition_spec PASSED [ 53%]
test/contrib/hive_test.py::HiveCommandClientTest::test_run_hive_command PASSED [ 55%]
test/contrib/hive_test.py::HiveCommandClientTest::test_table_exists PASSED [ 56%]
test/contrib/hive_test.py::HiveCommandClientTest::test_table_schema PASSED [ 58%]
test/contrib/hive_test.py::TestHiveTask::test_run PASSED                 [ 59%]
test/contrib/hive_test.py::TestHiveTaskArgs::test_arglist PASSED         [ 61%]
test/contrib/hive_test.py::TestHiveTaskArgs::test_run PASSED             [ 62%]
test/contrib/hive_test.py::TestHiveTarget::test_hive_partition_target PASSED [ 64%]
test/contrib/hive_test.py::TestHiveTarget::test_hive_table_target PASSED [ 65%]
test/contrib/pig_test.py::SimplePigTest::test_run__fail PASSED           [ 67%]
test/contrib/pig_test.py::SimplePigTest::test_run__success PASSED        [ 68%]
test/contrib/pig_test.py::ComplexPigTest::test_run__fail PASSED          [ 70%]
test/contrib/pig_test.py::ComplexPigTest::test_run__success PASSED       [ 71%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_app_interruption PASSED [ 73%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_app_must_be_set PASSED [ 74%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_defaults PASSED    [ 76%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_dont_log_stderr_on_success PASSED [ 77%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_environment_is_set_correctly PASSED [ 79%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_handle_failed_job PASSED [ 80%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_run PASSED         [ 82%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_tracking_url_is_found_in_stderr_client_mode PASSED [ 83%]
test/contrib/spark_test.py::SparkSubmitTaskTest::test_tracking_url_is_found_in_stderr_cluster_mode PASSED [ 85%]
test/contrib/spark_test.py::PySparkTaskTest::test_name_cleanup PASSED    [ 86%]
test/contrib/spark_test.py::PySparkTaskTest::test_pyspark_runner PASSED  [ 88%]
test/contrib/spark_test.py::PySparkTaskTest::test_pyspark_session_runner_use_spark_session_true PASSED [ 89%]
test/contrib/spark_test.py::PySparkTaskTest::test_pyspark_session_runner_use_spark_session_true_spark1 PASSED [ 91%]
test/contrib/spark_test.py::PySparkTaskTest::test_run PASSED             [ 92%]
test/contrib/spark_test.py::PySparkTaskTest::test_run_with_cluster PASSED [ 94%]
test/contrib/spark_test.py::PySparkTaskTest::test_run_with_pickle_dump PASSED [ 95%]
test/contrib/streaming_test.py::StreamingRunTest::test_package_binary_run PASSED [ 97%]
test/contrib/streaming_test.py::StreamingRunTest::test_run_with_extra_arguments PASSED [ 98%]
test/contrib/streaming_test.py::StreamingRunTest::test_standard_run PASSED [100%]
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving away from Travis CI https://github.com/spotify/luigi/issues/3016

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
