### PR TITLE
add postgres service and build matrix

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -9,6 +9,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-16.04
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         include:
@@ -43,6 +59,16 @@ jobs:
           - python-version: 3.9
             tox-env: py39-apache
 
+          - python-version: 3.6
+            tox-env: py36-postgres
+          - python-version: 3.7
+            tox-env: py37-postgres
+          - python-version: 3.8
+            tox-env: py38-postgres
+          - python-version: 3.9
+            tox-env: py39-postgres
+
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -65,6 +91,10 @@ jobs:
           mysql -e 'create database IF NOT EXISTS luigi_test;' -uroot -proot || true
           mysql -e 'create user 'travis'@'localhost';' -uroot -proot || true
           mysql -e 'grant all privileges ON *.* TO 'travis'@'localhost';' -uroot -proot || true
+      - name: Create PSQL database
+        if: ${{ contains(matrix.tox-env, 'postgres') }} 
+        run: |
+          PGPASSWORD=postgres psql -h localhost -p 5432 -c 'create database spotify;' -U postgres
       - name: Build
         run: |
           OVERRIDE_SKIP_CI_TESTS=${{ matrix.OVERRIDE_SKIP_CI_TESTS }} tox -e ${{ matrix.tox-env }}

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip 'tox<3.0'
-      - name: Setup DB
+      - name: Setup MySQL DB
         run: |
           sudo /etc/init.d/mysql start
           mysql -e 'create database IF NOT EXISTS luigi_test;' -uroot -proot || true


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
In order to run the postgres tests, we need to create a postgres service and a database.

Added a postgres service that gets created on *every* build unfortunately.
Then on the specific postgres builds I added a step to create the database.

```


test/contrib/postgres_test.py::DailyCopyToTableTest::test_bulk_complete PASSED [ 16%]
test/contrib/postgres_test.py::PostgresQueryTest::test_bulk_complete PASSED [ 33%]
test/contrib/postgres_test.py::PostgresQueryTest::test_override_port PASSED [ 50%]
test/contrib/postgres_test.py::PostgresQueryTest::test_port_encoded_in_host PASSED [ 66%]
test/contrib/postgres_test.py::TestCopyToTableWithMetaColumns::test_copy_with_metadata_columns_disabled PASSED [ 83%]
test/contrib/postgres_test.py::TestCopyToTableWithMetaColumns::test_copy_with_metadata_columns_enabled PASSED **[100%]

```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Moving away from Travis CI https://github.com/spotify/luigi/issues/3016

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
