### PR TITLE
add codecov step

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -45,8 +45,15 @@ jobs:
           mysql -e 'create user 'travis'@'localhost';' -uroot -proot || true
           mysql -e 'grant all privileges ON *.* TO 'travis'@'localhost';' -uroot -proot || true
       - name: Build
+        env:
+          TOXENV: ${{ matrix.tox-env }}
+        run: tox
+      - name: Codecov
+        env: 
+          COVERAGE_PROCESS_START: .coveragerc
         run: |
-          tox -e ${{ matrix.tox-env }}
+          pip install codecov
+          codecov -e ${{ matrix.tox-env }}
 
   postgres:
     runs-on: ubuntu-20.04
@@ -98,8 +105,15 @@ jobs:
         run: |
           PGPASSWORD=postgres psql -h localhost -p 5432 -c 'create database spotify;' -U postgres
       - name: Build
+        env:
+          TOXENV: ${{ matrix.tox-env }}
+        run: tox
+      - name: Codecov
+        env: 
+          COVERAGE_PROCESS_START: .coveragerc
         run: |
-          tox -e ${{ matrix.tox-env }}
+          pip install codecov
+          codecov -e ${{ matrix.tox-env }}
 
   base:
     runs-on: ubuntu-20.04
@@ -172,7 +186,16 @@ jobs:
           key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.txt', format('requirements{0}.txt', matrix.spark-version-suffix))) }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip 'tox<3.0'
+          python -m pip install --upgrade pip 'tox<4.0'
       - name: Build
+        env:
+          TOXENV: ${{ matrix.tox-env }}
+          OVERRIDE_SKIP_CI_TESTS: ${{ matrix.OVERRIDE_SKIP_CI_TESTS }}
+        run: tox
+      - name: Codecov
+        if: ${{ matrix.tox-env != 'flake8' && matrix.tox-env != 'docs' }}
+        env: 
+          COVERAGE_PROCESS_START: .coveragerc
         run: |
-          OVERRIDE_SKIP_CI_TESTS=${{ matrix.OVERRIDE_SKIP_CI_TESTS }} tox -e ${{ matrix.tox-env }}
+          pip install codecov
+          codecov -e ${{ matrix.tox-env }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,8 +28,9 @@ coverage:
     - "luigi/contrib/mrrunner.py"
     - "luigi/contrib/kubernetes.py"
 
-
+  require_ci_to_pass: yes
   notify:
+    after_n_builds: 24
     wait_for_ci: yes
 # For luigi we do not want any comments
 comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,5 +28,8 @@ coverage:
     - "luigi/contrib/mrrunner.py"
     - "luigi/contrib/kubernetes.py"
 
+
+  notify:
+    wait_for_ci: yes
 # For luigi we do not want any comments
 comment: false

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,6 @@ commands =
     azureblob: python test/runtests.py -m azureblob {posargs:}
     core: python test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" {posargs:}
     ##
-    codecov -e TOXENV
     azureblob: {toxinidir}/scripts/ci/stop_azurite.sh
 
 [testenv:visualiser]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Moved codecov from tox to github action step.
There has been some flakiness and not sure if it's expected to work like that.
It seems that when the different environments register the coverage, it might prematurely throw an error on the step and we need to re-run it

Added the notify flag in order for codecov to wait for all the CI builds to finish before reporting the status.
```
  notify:
    wait_for_ci: yes
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
