### PR TITLE
Fix error with LuigiTomlParser usage in S3Client

### DIFF
--- a/luigi/configuration/toml_parser.py
+++ b/luigi/configuration/toml_parser.py
@@ -61,6 +61,23 @@ class LuigiTomlParser(BaseParser):
 
         return self.data
 
+    def defaults(self):
+        """
+        Unlike ConfigParser, [DEFAULT] section is not particularly meaningful in toml.
+        This is to match LuigiConfigParser.
+        """
+        return {}
+
+    def items(self, section=None):
+        """
+        Return a list of (name, value) tuples for each option in a section.
+        This is to match LuigiConfigParser.
+        """
+        if section is None:
+            return self.data.items()
+        else:
+            return [(option, value) for option, value in self.data[section].items()]
+
     def get(self, section, option, default=NO_DEFAULT, **kwargs):
         try:
             return self.data[section][option]

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -480,9 +480,12 @@ class S3Client(FileSystem):
 
     @staticmethod
     def _get_s3_config(key=None):
-        defaults = dict(configuration.get_config().defaults())
+        # LuigiConfigParser has defaults since [DEFAULT] is a special section
+        # LuigiTomlParser does not have it because [DEFAULT] is not a special section
+        luigi_config = configuration.get_config()
+        defaults = dict(luigi_config.defaults()) if hasattr(luigi_config, "defaults") else {}
         try:
-            config = dict(configuration.get_config().items('s3'))
+            config = dict(luigi_config['s3'])
         except (NoSectionError, KeyError):
             return {}
         # So what ports etc can be read without us having to specify all dtypes


### PR DESCRIPTION
## Description
My attempt to address issue of toml usage error in S3Client from https://github.com/spotify/luigi/pull/2996

<!--- Describe your changes -->
I'm providing two solutions to choose from, one to fill lacking functions into LuigiTomlParser and another to change the usage into more generic one. While I prefer the second one, when the reviewers prefer one over another, I'll add tests for it.

LuigiConfigParser is built on top of Python's ConfigParser, which is MutableMapping at the end.
LuigiTomlParser is using toml (the module), and it does not provide a comparable class but rather provide load/dump via decoder/encoder.
They work a bit differently. A touch to BaseParser may be needed on a long term because there may be other issues due to differences in their functionalities (not being addressed in this PR).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves error on S3Client when attempting to use toml. It would give this before:
```
defaults = dict(configuration.get_config().defaults())
AttributeError: 'LuigiTomlParser' object has no attribute 'defaults'
```

## Have you tested this? If so, how?
I ran my jobs with this code and it works for me.

I'm happy to add tests when one solution is preferred over another by the reviewers.
