### PR TITLE
Improve optional parameters

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -38,7 +38,10 @@ from luigi.parameter import (
     DateIntervalParameter, TimeDeltaParameter,
     IntParameter, FloatParameter, BoolParameter,
     TaskParameter, EnumParameter, DictParameter, ListParameter, TupleParameter,
-    NumericalParameter, ChoiceParameter, OptionalParameter
+    NumericalParameter, ChoiceParameter, OptionalParameter, OptionalStrParameter,
+    OptionalIntParameter, OptionalFloatParameter, OptionalBoolParameter,
+    OptionalDictParameter, OptionalListParameter, OptionalTupleParameter,
+    OptionalChoiceParameter, OptionalNumericalParameter,
 )
 
 from luigi import configuration
@@ -60,7 +63,10 @@ __all__ = [
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
-    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'LuigiStatusCode',
+    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter',
+    'OptionalIntParameter', 'OptionalFloatParameter', 'OptionalBoolParameter',
+    'OptionalDictParameter', 'OptionalListParameter', 'OptionalTupleParameter',
+    'OptionalChoiceParameter', 'OptionalNumericalParameter', 'LuigiStatusCode',
     '__version__',
 ]
 

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -63,7 +63,7 @@ __all__ = [
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
-    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter',
+    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'OptionalStrParameter',
     'OptionalIntParameter', 'OptionalFloatParameter', 'OptionalBoolParameter',
     'OptionalDictParameter', 'OptionalListParameter', 'OptionalTupleParameter',
     'OptionalChoiceParameter', 'OptionalNumericalParameter', 'LuigiStatusCode',

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -335,7 +335,7 @@ class OptionalParameterMixin:
     Mixin to make a parameter class optional and treat empty string as None.
     """
 
-    expected_type = str
+    expected_type = type(None)
 
     def serialize(self, x):
         """

--- a/test/optional_parameter_test.py
+++ b/test/optional_parameter_test.py
@@ -1,0 +1,104 @@
+import luigi
+import mock
+
+from helpers import LuigiTestCase, with_config
+
+
+class OptionalParameterTest(LuigiTestCase):
+
+    def actual_test(current_test, cls, default, expected_value, expected_type, bad_data, **kwargs):
+
+        class TestConfig(luigi.Config):
+            param = cls(default=default, **kwargs)
+            empty_param = cls(default=default, **kwargs)
+
+            def run(self):
+                assert self.param == expected_value
+                assert self.empty_param is None
+
+        # Test parsing empty string (should be None)
+        current_test.assertIsNone(cls(**kwargs).parse(''))
+
+        # Test that warning is raised only with bad type
+        with mock.patch('luigi.parameter.warnings') as warnings:
+            TestConfig()
+            warnings.warn.assert_not_called()
+
+        if cls != luigi.OptionalChoiceParameter:
+            with mock.patch('luigi.parameter.warnings') as warnings:
+                TestConfig(param=None)
+                warnings.warn.assert_not_called()
+
+            with mock.patch('luigi.parameter.warnings') as warnings:
+                TestConfig(param=bad_data)
+                if cls == luigi.OptionalBoolParameter:
+                    warnings.warn.assert_not_called()
+                else:
+                    warnings.warn.assert_called_with(
+                        '{} "param" with value "{}" is not of type "{}" or None.'.format(
+                            cls.__name__,
+                            bad_data,
+                            expected_type
+                        ),
+                        luigi.parameter.OptionalParameterTypeWarning
+                    )
+
+        # Test with value from config
+        current_test.assertTrue(luigi.build([TestConfig()], local_scheduler=True))
+
+    @with_config({"TestConfig": {"param": "expected value", "empty_param": ""}})
+    def test_optional_parameter(self):
+        self.actual_test(luigi.OptionalParameter, None, "expected value", "str", 0)
+        self.actual_test(luigi.OptionalParameter, "default value", "expected value", "str", 0)
+
+    @with_config({"TestConfig": {"param": "10", "empty_param": ""}})
+    def test_optional_int_parameter(self):
+        self.actual_test(luigi.OptionalIntParameter, None, 10, "int", "bad data")
+        self.actual_test(luigi.OptionalIntParameter, 1, 10, "int", "bad data")
+
+    @with_config({"TestConfig": {"param": "true", "empty_param": ""}})
+    def test_optional_bool_parameter(self):
+        self.actual_test(luigi.OptionalBoolParameter, None, True, "bool", "bad data")
+        self.actual_test(luigi.OptionalBoolParameter, False, True, "bool", "bad data")
+
+    @with_config({"TestConfig": {"param": "10.5", "empty_param": ""}})
+    def test_optional_float_parameter(self):
+        self.actual_test(luigi.OptionalFloatParameter, None, 10.5, "float", "bad data")
+        self.actual_test(luigi.OptionalFloatParameter, 1.5, 10.5, "float", "bad data")
+
+    @with_config({"TestConfig": {"param": '{"a": 10}', "empty_param": ""}})
+    def test_optional_dict_parameter(self):
+        self.actual_test(luigi.OptionalDictParameter, None, {"a": 10}, "FrozenOrderedDict", "bad data")
+        self.actual_test(luigi.OptionalDictParameter, {"a": 1}, {"a": 10}, "FrozenOrderedDict", "bad data")
+
+    @with_config({"TestConfig": {"param": "[10.5]", "empty_param": ""}})
+    def test_optional_list_parameter(self):
+        self.actual_test(luigi.OptionalListParameter, None, (10.5, ), "tuple", "bad data")
+        self.actual_test(luigi.OptionalListParameter, (1.5, ), (10.5, ), "tuple", "bad data")
+
+    @with_config({"TestConfig": {"param": "[10.5]", "empty_param": ""}})
+    def test_optional_tuple_parameter(self):
+        self.actual_test(luigi.OptionalTupleParameter, None, (10.5, ), "tuple", "bad data")
+        self.actual_test(luigi.OptionalTupleParameter, (1.5, ), (10.5, ), "tuple", "bad data")
+
+    @with_config({"TestConfig": {"param": "10.5", "empty_param": ""}})
+    def test_optional_numerical_parameter_float(self):
+        self.actual_test(luigi.OptionalNumericalParameter, None, 10.5, "float", "bad data", var_type=float, min_value=0, max_value=100)
+        self.actual_test(luigi.OptionalNumericalParameter, 1.5, 10.5, "float", "bad data", var_type=float, min_value=0, max_value=100)
+
+    @with_config({"TestConfig": {"param": "10", "empty_param": ""}})
+    def test_optional_numerical_parameter_int(self):
+        self.actual_test(luigi.OptionalNumericalParameter, None, 10, "int", "bad data", var_type=int, min_value=0, max_value=100)
+        self.actual_test(luigi.OptionalNumericalParameter, 1, 10, "int", "bad data", var_type=int, min_value=0, max_value=100)
+
+    @with_config({"TestConfig": {"param": "expected value", "empty_param": ""}})
+    def test_optional_choice_parameter(self):
+        choices = ["default value", "expected value"]
+        self.actual_test(luigi.OptionalChoiceParameter, None, "expected value", "str", "bad data", choices=choices)
+        self.actual_test(luigi.OptionalChoiceParameter, "default value", "expected value", "str", "bad data", choices=choices)
+
+    @with_config({"TestConfig": {"param": "1", "empty_param": ""}})
+    def test_optional_choice_parameter_int(self):
+        choices = [0, 1, 2]
+        self.actual_test(luigi.OptionalChoiceParameter, None, 1, "int", "bad data", var_type=int, choices=choices)
+        self.actual_test(luigi.OptionalChoiceParameter, "default value", 1, "int", "bad data", var_type=int, choices=choices)

--- a/test/optional_parameter_test.py
+++ b/test/optional_parameter_test.py
@@ -6,7 +6,7 @@ from helpers import LuigiTestCase, with_config
 
 class OptionalParameterTest(LuigiTestCase):
 
-    def actual_test(current_test, cls, default, expected_value, expected_type, bad_data, **kwargs):
+    def actual_test(self, cls, default, expected_value, expected_type, bad_data, **kwargs):
 
         class TestConfig(luigi.Config):
             param = cls(default=default, **kwargs)
@@ -17,7 +17,7 @@ class OptionalParameterTest(LuigiTestCase):
                 assert self.empty_param is None
 
         # Test parsing empty string (should be None)
-        current_test.assertIsNone(cls(**kwargs).parse(''))
+        self.assertIsNone(cls(**kwargs).parse(''))
 
         # Test that warning is raised only with bad type
         with mock.patch('luigi.parameter.warnings') as warnings:
@@ -44,7 +44,7 @@ class OptionalParameterTest(LuigiTestCase):
                     )
 
         # Test with value from config
-        current_test.assertTrue(luigi.build([TestConfig()], local_scheduler=True))
+        self.assertTrue(luigi.build([TestConfig()], local_scheduler=True))
 
     @with_config({"TestConfig": {"param": "expected value", "empty_param": ""}})
     def test_optional_parameter(self):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -357,13 +357,21 @@ class ParameterTest(LuigiTestCase):
         TestConfig(param="str")
         warnings.warn.assert_not_called()
 
-    @mock.patch('luigi.parameter.warnings')
-    def test_no_warn_on_none_in_optional(self, warnings):
+    def test_no_warn_on_none_in_optional(self):
         class TestConfig(luigi.Config):
             param = luigi.OptionalParameter(default=None)
 
-        TestConfig()
-        warnings.warn.assert_not_called()
+        with mock.patch('luigi.parameter.warnings') as warnings:
+            TestConfig()
+            warnings.warn.assert_not_called()
+
+        with mock.patch('luigi.parameter.warnings') as warnings:
+            TestConfig(param=None)
+            warnings.warn.assert_not_called()
+
+        with mock.patch('luigi.parameter.warnings') as warnings:
+            TestConfig(param="")
+            warnings.warn.assert_not_called()
 
     @mock.patch('luigi.parameter.warnings')
     def test_no_warn_on_string_in_optional(self, warnings):
@@ -379,7 +387,7 @@ class ParameterTest(LuigiTestCase):
             param = luigi.OptionalParameter()
 
         TestConfig(param=1)
-        warnings.warn.assert_called_once_with('OptionalParameter "param" with value "1" is not of type string or None.')
+        warnings.warn.assert_called_once_with('OptionalParameter "param" with value "1" is not of type "str" or None.', luigi.parameter.OptionalParameterTypeWarning)
 
     def test_optional_parameter_parse_none(self):
         self.assertIsNone(luigi.OptionalParameter().parse(''))

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -387,7 +387,10 @@ class ParameterTest(LuigiTestCase):
             param = luigi.OptionalParameter()
 
         TestConfig(param=1)
-        warnings.warn.assert_called_once_with('OptionalParameter "param" with value "1" is not of type "str" or None.', luigi.parameter.OptionalParameterTypeWarning)
+        warnings.warn.assert_called_once_with(
+            'OptionalParameter "param" with value "1" is not of type "str" or None.',
+            luigi.parameter.OptionalParameterTypeWarning
+        )
 
     def test_optional_parameter_parse_none(self):
         self.assertIsNone(luigi.OptionalParameter().parse(''))


### PR DESCRIPTION
## Description
Update OptionalParameter and add several other parameter classes for other types.

## Motivation and Context
Parameters raise warnings when their default value is None. As far as I know, it is only possible to use OptionalParameter for string type so I added optional classes for other types.

## Have you tested this? If so, how?
I have included unit tests.