### PR TITLE
Make task.disable_window be default source of window int

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -218,12 +218,12 @@ class Task(metaclass=Register):
         Override this positive integer to have different ``disable_window`` at task level.
         Check :ref:`scheduler-config`
         """
-        return self.disable_window_seconds
+        return None
 
     @property
     def disable_window_seconds(self):
         warnings.warn("Use of `disable_window_seconds` has been deprecated, use `disable_window` instead", DeprecationWarning)
-        return None
+        return self.disable_window
 
     @property
     def owner_email(self):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -152,6 +152,15 @@ class TaskTest(unittest.TestCase):
         with self.assertWarnsRegex(UserWarning, 'Parameter "timedelta_param" with value ".*" is not of type timedelta.'):
             DummyTask(**params)
 
+    def test_disable_window_seconds(self):
+        """
+        Deprecated disable_window_seconds param uses disable_window value
+        """
+        class ATask(luigi.Task):
+            disable_window = 17
+        task = ATask()
+        self.assertEqual(task.disable_window_seconds, 17)
+
 
 class ExternalizeTaskTest(LuigiTestCase):
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

When accessing `task.disable_window` property, use the property directly. Do not call the deprecated `task.disable_window_seconds`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3029 

Current implementation gives a deprecation warning even when accessing the correct `task.disable_window` property, which is confusing. Fixing this means that the deprecation warning becomes more meaningful - it will only appear when `task.disable_window_seconds` is incorrectly accessed.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Have ran this change locally for me in my employers' Luigi test suite and removed 21 warnings when running a small test on a single task. However, that test suite does not use `disable_window`.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
