### PR TITLE
Extend luigi.contrib.ecs module to support feeding additional kwargs to ecs run_task

### DIFF
--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -50,6 +50,7 @@ Written and maintained by Jake Feala (@jfeala) for Outlier Bio (@outlierbio)
 
 """
 
+import copy
 import time
 import logging
 import luigi
@@ -150,8 +151,10 @@ class ECSTask(luigi.Task):
 
         Override to return list of dicts with keys 'name' and 'command',
         describing the container names and commands to pass to the container.
-        Directly corresponds to the `overrides` parameter of runTask API. For
-        example::
+        These values will be specified in the `containerOverrides` property of
+        the `overrides` parameter passed to the runTask API.
+
+        Example::
 
             [
                 {
@@ -163,6 +166,73 @@ class ECSTask(luigi.Task):
         """
         pass
 
+    @property
+    def combined_overrides(self):
+        """
+        Return single dict combining any provided `overrides` parameters.
+
+        This is used to allow custom `overrides` parameters to be specified in
+        `self.run_task_kwargs` while ensuring that the values specified in
+        `self.command` are honored in `containerOverrides`.
+        """
+        overrides = copy.deepcopy(self.run_task_kwargs.get('overrides', {}))
+        if self.command:
+            if 'containerOverrides' in overrides:
+                new_commands = []
+                for command in self.command:
+                    for container_override in overrides['containerOverrides']:
+                        if container_override['name'] == command['name']:
+                            # containerOverrides collision found; ensure the
+                            # `self.command` value takes priority
+                            container_override['command'] = command['command']
+                            break
+                    else:
+                        new_commands.append(command)
+                overrides['containerOverrides'].extend(new_commands)
+            else:
+                overrides['containerOverrides'] = self.command
+        return overrides
+
+    @property
+    def run_task_kwargs(self):
+        """
+        Additional keyword arguments to be provided to ECS runTask API.
+
+        Override this property in a subclass to provide additional parameters
+        such as `network_configuration`, `launchType`, etc.
+
+        If the returned `dict` includes an `overrides` value with a nested
+        `containerOverrides` array defining one or more container `command`
+        values, prior to calling `run_task` they will be combined with and
+        superseded by any colliding values specified separately in the
+        `command` property.
+
+        Example::
+
+            {
+                'launchType': 'FARGATE',
+                'platformVersion': '1.4.0',
+                'networkConfiguration': {
+                    'awsvpcConfiguration': {
+                        'subnets': [
+                            'subnet-01234567890abcdef',
+                            'subnet-abcdef01234567890'
+                        ],
+                        'securityGroups': [
+                            'sg-abcdef01234567890',
+                        ],
+                        'assignPublicIp': 'ENABLED'
+                    }
+                },
+                'overrides': {
+                    'ephemeralStorage': {
+                        'sizeInGiB': 30
+                    }
+                }
+            }
+        """
+        return {}
+
     def run(self):
         if (not self.task_def and not self.task_def_arn) or \
                 (self.task_def and self.task_def_arn):
@@ -173,15 +243,16 @@ class ECSTask(luigi.Task):
             response = client.register_task_definition(**self.task_def)
             self.task_def_arn = response['taskDefinition']['taskDefinitionArn']
 
+        run_task_kwargs = self.run_task_kwargs
+        run_task_kwargs.update({
+            'taskDefinition': self.task_def_arn,
+            'cluster': self.cluster,
+            'overrides': self.combined_overrides,
+        })
+
         # Submit the task to AWS ECS and get assigned task ID
         # (list containing 1 string)
-        if self.command:
-            overrides = {'containerOverrides': self.command}
-        else:
-            overrides = {}
-        response = client.run_task(taskDefinition=self.task_def_arn,
-                                   overrides=overrides,
-                                   cluster=self.cluster)
+        response = client.run_task(**run_task_kwargs)
 
         if response['failures']:
             raise Exception(", ".join(["fail to run task {0} reason: {1}".format(failure['arn'], failure['reason'])

--- a/luigi/contrib/ecs.py
+++ b/luigi/contrib/ecs.py
@@ -182,7 +182,6 @@ class ECSTask(luigi.Task):
         else:
             container_overrides.append(command)
 
-
     @property
     def combined_overrides(self):
         """

--- a/test/contrib/ecs_test.py
+++ b/test/contrib/ecs_test.py
@@ -53,6 +53,13 @@ TEST_TASK_DEF = {
             'name': 'hello-world',
             'image': 'ubuntu',
             'command': ['/bin/echo', 'hello world']
+        },
+        {
+            'memory': 1,
+            'essential': True,
+            'name': 'hello-world-2',
+            'image': 'ubuntu',
+            'command': ['/bin/echo', 'hello world #2!']
         }
     ]
 }
@@ -72,6 +79,47 @@ class ECSTaskOverrideCommand(ECSTaskNoOutput):
     @property
     def command(self):
         return [{'name': 'hello-world', 'command': ['/bin/sleep', '10']}]
+
+
+class ECSTaskCustomRunTaskKwargs(ECSTaskNoOutput):
+
+    @property
+    def run_task_kwargs(self):
+        return {'overrides': {'ephemeralStorage': {'sizeInGiB': 30}}}
+
+
+class ECSTaskCustomRunTaskKwargsWithCommand(ECSTaskNoOutput):
+
+    @property
+    def command(self):
+        return [
+            {'name': 'hello-world', 'command': ['/bin/sleep', '10']},
+            {'name': 'hello-world-2', 'command': ['/bin/sleep', '10']},
+        ]
+
+    @property
+    def run_task_kwargs(self):
+        return {
+            'launchType': 'FARGATE',
+            'platformVersion': '1.4.0',
+            'networkConfiguration': {
+                'awsvpcConfiguration': {
+                    'subnets': [
+                        'subnet-01234567890abcdef',
+                        'subnet-abcdef01234567890'
+                    ],
+                    'securityGroups': [
+                        'sg-abcdef01234567890',
+                    ],
+                    'assignPublicIp': 'ENABLED'
+                }
+            },
+            'overrides': {
+                'ephemeralStorage': {
+                    'sizeInGiB': 30
+                }
+            }
+        }
 
 
 @pytest.mark.aws
@@ -96,4 +144,24 @@ class TestECSTask(unittest.TestCase):
     @mock_ecs
     def test_override_command(self):
         t = ECSTaskOverrideCommand(task_def_arn=self.arn)
+        luigi.build([t], local_scheduler=True)
+
+    @mock_ecs
+    def test_custom_run_task_kwargs(self):
+        t = ECSTaskCustomRunTaskKwargs(task_def_arn=self.arn)
+        self.assertEqual(t.combined_overrides, {
+            'ephemeralStorage': {'sizeInGiB': 30}
+        })
+        luigi.build([t], local_scheduler=True)
+
+    @mock_ecs
+    def test_custom_run_task_kwargs_with_command(self):
+        t = ECSTaskCustomRunTaskKwargsWithCommand(task_def_arn=self.arn)
+        self.assertEqual(t.combined_overrides, {
+            'containerOverrides': [
+                {'name': 'hello-world', 'command': ['/bin/sleep', '10']},
+                {'name': 'hello-world-2', 'command': ['/bin/sleep', '10']},
+            ],
+            'ephemeralStorage': {'sizeInGiB': 30}
+        })
         luigi.build([t], local_scheduler=True)


### PR DESCRIPTION
## Description
This updates the `luigi.contrib.ecs` module by providing a new overridable `run_task_kwargs` property that can be used to feed additional keyword arguments to the `boto3` ECS `run_task` call.

## Motivation and Context
The existing module only allows users to provide dynamic container commands via `containerOverrides`, so is very limited to running simple ECS tasks. With these changes, it's now possible to change the launch type on the fly (e.g. EC2 -> FARGATE), give a task additional ephemeral storage, specify custom network configuration, etc.

These changes play nicely with the old version of the module and don't break the previous API.

## Have you tested this? If so, how?
Yes, I updated `test/contrib/ecs_test.py` and all tests pass.
