### PR TITLE
Destructor of LocalTarget sometimes fails with AttributeError: 'LocalTarget' object has no attribute 'is_tmp'

### DIFF
--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -186,5 +186,5 @@ class LocalTarget(FileSystemTarget):
         return self.path
 
     def __del__(self):
-        if self.is_tmp and self.exists():
+        if hasattr(self, "is_tmp") and self.is_tmp and self.exists():
             self.remove()

--- a/test/local_target_test.py
+++ b/test/local_target_test.py
@@ -354,3 +354,13 @@ class FileSystemTest(unittest.TestCase):
         LocalTarget(src).open('w').close()
         self.fs.move(src, dest)
         self.assertTrue(os.path.exists(dest))
+
+
+class DestructorTest(unittest.TestCase):
+
+    def test_destructor(self):
+        # LocalTarget might not be fully initialised if an exception is thrown in the constructor of LocalTarget or a
+        # subclass. The destructor can't expect attributes to be initialised.
+        t = LocalTarget(is_tmp=True)
+        del t.is_tmp
+        t.__del__()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes the destructor of LocalTarget more robust in case of partially initialised objects. 

## Motivation and Context
LocalTarget might not be fully initialised if an exception is thrown in the constructor of LocalTarget or a subclass.
Python will call the destructor anyway which will fail since is_tmp is not initialized.
Initialising is_tmp earlier in the constructor solves the problem in case of exceptions in LocalTarget but not for subclasses.
Possibly related to https://github.com/spotify/luigi/issues/3020

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
Unit test added.
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
