### PR TITLE
Truncate traceback for failure email

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -437,6 +437,9 @@ sender
   User name in from field of error e-mails.
   Default value: luigi-client@<server_name>
 
+traceback_max_length
+  Maximum length for traceback included in error email. Default is 5000.
+
 
 [batch_notifier]
 ----------------

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -84,6 +84,9 @@ class email(luigi.Config):
         default='',
         config_path=dict(section='core', name='error-email'),
         description='Address to send error e-mails to')
+    traceback_max_length = luigi.parameter.IntParameter(
+        default=5000,
+        description='Max length for error traceback')
     sender = luigi.parameter.Parameter(
         default=DEFAULT_CLIENT_EMAIL,
         config_path=dict(section='core', name='email-sender'),
@@ -372,6 +375,11 @@ def format_task_error(headline, task, command, formatted_exception=None):
 
     :return: message body
     """
+
+    if formatted_exception:
+        if len(formatted_exception) > email().traceback_max_length:
+            truncated_exception = formatted_exception[:email().traceback_max_length]
+            formatted_exception = f"{truncated_exception}...Traceback exceeds max length and has been truncated."
 
     if formatted_exception:
         formatted_exception = wrap_traceback(formatted_exception)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1324,6 +1324,17 @@ class WorkerEmailTest(LuigiTestCase):
         self.assertEqual(1, len(emails))
         self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
 
+    @email_patch
+    def test_run_error_long_traceback(self, emails):
+        class A(luigi.Task):
+            def run(self):
+                raise Exception("b0rk"*10500)
+
+        a = A()
+        luigi.build([a], workers=1, local_scheduler=True)
+        self.assertTrue(len(emails[0]) < 10000)
+        self.assertTrue(emails[0].find("Traceback exceeds max length and has been truncated"))
+
     @with_config({'batch_email': {'email_interval': '0'}, 'worker': {'send_failure_email': 'False'}})
     @email_patch
     def test_run_error_email_batch(self, emails):


### PR DESCRIPTION
## Description
Add traceback_max_length config option which truncates the traceback included in task failure email (default 5000). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Suggesting this change because of an error I encountered: "ClientError: An Error occurred (InvalidParameterValue) when calling the SendRawEmail operation: message length is more than 10485760 bytes long". The root cause was a very long sql query which led to a mysql error. The error traceback included the super long query and due to its length, the luigi "task failure" email failed causing the worker to error during "_handle_next_task". The issue was then disguised, the scheduler continued to show the task as "running". The email that failed was ~17m bytes long. This adds a traceback_max_length config option for the failure email which truncates the traceback included in task failure email (default 5000 which is roughly where Rollbar truncated it). 

## Have you tested this? If so, how?
I included a unit test
