### PR TITLE
Patch BigQueryClient to retry on network error

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -48,11 +48,11 @@ def is_error_5xx(err):
 
 
 bq_retry = retry(retry=(retry_if_exception(is_error_5xx) | retry_if_exception_type(RETRYABLE_ERRORS)),
-                  wait=wait_exponential(multiplier=1, min=1, max=10),
-                  stop=stop_after_attempt(3),
-                  reraise=True,
-                  after=lambda x: x.args[0].__initialise_client()
-                  )
+                 wait=wait_exponential(multiplier=1, min=1, max=10),
+                 stop=stop_after_attempt(3),
+                 reraise=True,
+                 after=lambda x: x.args[0].__initialise_client()
+                 )
 
 
 class CreateDisposition:


### PR DESCRIPTION
## Description

This patch retries by re-creating the client object if it fails (up to a retry limit), so that the client will not be timed out when calling `complete()` on the BigQueryTarget after a long job.

## Motivation and Context

At the moment sometimes long jobs can cause the BigQueryClient to timeout since the connection is created at initialisation of the target.


## Have you tested this? If so, how?

Yes, passing this patched client worked for jobs that would have timeout issues previously.
