### PR TITLE
Kubernetes contrib : waiting for cluster scale up

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -228,7 +228,7 @@ class KubernetesJobTask(luigi.Task):
            'Unschedulable' not in condition['reason'] or\
            'message' not in condition:
             return False
-        
+
         match = re.match(r'(\d)\/(\d) nodes are available.*', condition['message'])
         if match:
             current_nodes = int(match.group(1))

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -110,7 +110,7 @@ class TestK8STask(unittest.TestCase):
         kubernetes_job._KubernetesJobTask__track_job()
         # Make sure successful job signals
         self.assertTrue(mock_signal.called)
-        
+
     def test_cluster_is_scaling(self):
         kubernetes_job = KubernetesJobTask()
         condition = {

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -110,3 +110,30 @@ class TestK8STask(unittest.TestCase):
         kubernetes_job._KubernetesJobTask__track_job()
         # Make sure successful job signals
         self.assertTrue(mock_signal.called)
+
+    def test_cluster_is_scaling(self):
+        kubernetes_job = KubernetesJobTask()
+        condition = {
+            "reason": "Unschedulable",
+            "message": "0/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory."
+        }
+        assert kubernetes_job.__is_scaling_in_progress(condition)
+
+        condition = {
+            "reason": "ContainersNotReady",
+            "message": "0/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory."
+        }
+        assert kubernetes_job.__is_scaling_in_progress(condition) is False
+
+        condition = {
+            "reason": "Unschedulable",
+            "message": "1/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory."
+        }
+        assert kubernetes_job.__is_scaling_in_progress(condition) is True
+
+        condition = {
+            "reason": "Unschedulable",
+            "message": "other message"
+        }
+        assert kubernetes_job.__is_scaling_in_progress(condition) is False
+

--- a/test/contrib/kubernetes_test.py
+++ b/test/contrib/kubernetes_test.py
@@ -110,7 +110,7 @@ class TestK8STask(unittest.TestCase):
         kubernetes_job._KubernetesJobTask__track_job()
         # Make sure successful job signals
         self.assertTrue(mock_signal.called)
-
+        
     def test_cluster_is_scaling(self):
         kubernetes_job = KubernetesJobTask()
         condition = {
@@ -137,3 +137,30 @@ class TestK8STask(unittest.TestCase):
         }
         assert kubernetes_job.__is_scaling_in_progress(condition) is False
 
+        condition = {
+            "message": "other message"
+        }
+        assert kubernetes_job.__is_scaling_in_progress(condition) is False
+
+    @mock.patch.object(KubernetesJobTask, "_KubernetesJobTask__get_job_status")
+    @mock.patch.object(KubernetesJobTask, "KubernetesJobTask__get_pods")
+    def test_output_when_scaling(self, mock_get_pods, mock_job_status):
+        # mock that the job succeeded
+        cond1 = {
+            "reason": "Unschedulable",
+            "message": "1/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory."
+        }
+        mock_job_status.return_value = "succeeded"
+        mock_get_pods.return_value = [
+            {
+                'conditions': [
+                    cond1
+                ]
+             }
+        ]
+        # create a kubernetes job
+        kubernetes_job = KubernetesJobTask()
+        # set logger and uu_name due to logging in __track_job()
+        kubernetes_job._KubernetesJobTask__logger = logger
+        kubernetes_job.uu_name = "test"
+        self.assertTrue(kubernetes_job._KubernetesJobTask____verify_job_has_started())


### PR DESCRIPTION


## Description
Makes sure Luigi waits for kubernetes to scale up when waiting for a job run.


## Motivation and Context
Sometimes scheduling a new job results in the cluster needing to scale up. 
In these scenarios current luigi throws an exception which exits the pipeline. In the meantime the cluster runs the job after scaling up.
Changes introduced in this PR makes it so that Luigi waits for Scale up to take place when waiting for a job to run. 


## Have you tested this? If so, how?
- unit tests included in this PR
- scheduling a task for my pipepelines
