### PR TITLE
Add Parquet support to Luigi's big query SourceFormat

### DIFF
--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -52,6 +52,7 @@ class SourceFormat:
     CSV = 'CSV'
     DATASTORE_BACKUP = 'DATASTORE_BACKUP'
     NEWLINE_DELIMITED_JSON = 'NEWLINE_DELIMITED_JSON'
+    PARQUET = 'PARQUET'
 
 
 class FieldDelimiter:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for Parquet format for BigQueryLoadTask.

## Description
BigQuery API supports parquet files out of the box, however Luigi does not expose this type as an option.
This is the same value as `google.cloud.bigquery` class `SourceFormat.PARQUET`.

I ran my jobs with this code and it works for me.

Theoretically, `ORC` format could be added in the same manner, but I haven't tested it yey. 
more info can be found [here](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.SourceFormat.html) 