### PR TITLE
Fix the kubernetes test

### DIFF
--- a/luigi/contrib/kubernetes.py
+++ b/luigi/contrib/kubernetes.py
@@ -33,6 +33,7 @@ Requires:
 Written and maintained by Marco Capuccini (@mcapuccini).
 """
 import logging
+import os
 import time
 import uuid
 from datetime import datetime
@@ -54,7 +55,7 @@ class kubernetes(luigi.Config):
         default="kubeconfig",
         description="Authorization method to access the cluster")
     kubeconfig_path = luigi.Parameter(
-        default="~/.kube/config",
+        default=os.getenv("KUBECONFIG", "~/.kube/config"),
         description="Path to kubeconfig file for cluster authentication")
     max_retrials = luigi.IntParameter(
         default=0,


### PR DESCRIPTION
I was trying to run the kubernetes test, but it didn't pass.

With these changes, it was able to pass using minikube.

----

- When a job fails, it asserts rather than exits

- There are other labels besides the custom ones

- Need to mock out the verify_job_has_started()

- Showing the pods requires access to the cluster
