### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -362,7 +362,7 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         print(stdout)
         print(stderr)
 
-        self.assertNotEquals(returncode, 1)
+        self.assertNotEqual(returncode, 1)
         self.assertFalse(b'required_test_param' in stderr)
 
 

--- a/test/contrib/external_daily_snapshot_test.py
+++ b/test/contrib/external_daily_snapshot_test.py
@@ -32,18 +32,18 @@ class ExternalDailySnapshotTest(unittest.TestCase):
     def test_latest(self):
         MockTarget('data-xyz-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='xyz')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))
 
     def test_latest_not_exists(self):
         MockTarget('data-abc-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 11), param='abc', lookback=5)
-        self.assertEquals(d.date, datetime.date(2012, 1, 7))
+        self.assertEqual(d.date, datetime.date(2012, 1, 7))
 
     def test_deterministic(self):
         MockTarget('data-pqr-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', a='zebra', aa='Congo')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))
 
         MockTarget('data-pqr-zebra-Congo-2012-01-05').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', aa='Congo', a='zebra')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))  # Should still be the same
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))  # Should still be the same

--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -168,7 +168,7 @@ class HdfsTargetTestMixin(FileSystemTargetTestMixin):
         self.assertFalse(files.glob_exists(3))
         self.assertFalse(files.glob_exists(1))
 
-    def assertRegexpMatches(self, text, expected_regexp, msg=None):
+    def assertRegex(self, text, expected_regexp, msg=None):
         """Python 2.7 backport."""
         if isinstance(expected_regexp, str):
             expected_regexp = re.compile(expected_regexp)
@@ -201,22 +201,22 @@ class HdfsTargetTestMixin(FileSystemTargetTestMixin):
         res9 = hdfs.tmppath(path9, include_unix_username=False)
 
         # Then: I should get correct results relative to Luigi temporary directory
-        self.assertRegexpMatches(res1, "^/tmp/dir1/dir2/file-luigitemp-\\d+")
+        self.assertRegex(res1, "^/tmp/dir1/dir2/file-luigitemp-\\d+")
         # it would be better to see hdfs:///path instead of hdfs:/path, but single slash also works well
-        self.assertRegexpMatches(res2, "^hdfs:/tmp/dir1/dir2/file-luigitemp-\\d+")
-        self.assertRegexpMatches(res3, "^hdfs://somehost/tmp/dir1/dir2/file-luigitemp-\\d+")
-        self.assertRegexpMatches(res4, "^file:///tmp/dir1/dir2/file-luigitemp-\\d+")
-        self.assertRegexpMatches(res5, "^/tmp/dir/file-luigitemp-\\d+")
+        self.assertRegex(res2, "^hdfs:/tmp/dir1/dir2/file-luigitemp-\\d+")
+        self.assertRegex(res3, "^hdfs://somehost/tmp/dir1/dir2/file-luigitemp-\\d+")
+        self.assertRegex(res4, "^file:///tmp/dir1/dir2/file-luigitemp-\\d+")
+        self.assertRegex(res5, "^/tmp/dir/file-luigitemp-\\d+")
         # known issue with duplicated "tmp" if schema is present
-        self.assertRegexpMatches(res6, "^file:///tmp/tmp/dir/file-luigitemp-\\d+")
+        self.assertRegex(res6, "^file:///tmp/tmp/dir/file-luigitemp-\\d+")
         # known issue with duplicated "tmp" if schema is present
-        self.assertRegexpMatches(res7, "^hdfs://somehost/tmp/tmp/dir/file-luigitemp-\\d+")
-        self.assertRegexpMatches(res8, "^/tmp/luigitemp-\\d+")
-        self.assertRegexpMatches(res9, "/tmp/tmpdir/file")
+        self.assertRegex(res7, "^hdfs://somehost/tmp/tmp/dir/file-luigitemp-\\d+")
+        self.assertRegex(res8, "^/tmp/luigitemp-\\d+")
+        self.assertRegex(res9, "/tmp/tmpdir/file")
 
     def test_tmppath_username(self):
-        self.assertRegexpMatches(hdfs.tmppath('/path/to/stuff', include_unix_username=True),
-                                 "^/tmp/[a-z0-9_]+/path/to/stuff-luigitemp-\\d+")
+        self.assertRegex(hdfs.tmppath('/path/to/stuff', include_unix_username=True),
+                         "^/tmp/[a-z0-9_]+/path/to/stuff-luigitemp-\\d+")
 
     def test_pickle(self):
         t = hdfs.HdfsTarget("/tmp/dir")

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -132,11 +132,11 @@ class PostgresQueryTest(unittest.TestCase):
 
     def test_override_port(self):
         output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
-        self.assertEquals(output.port, 1234)
+        self.assertEqual(output.port, 1234)
 
     def test_port_encoded_in_host(self):
         output = DummyPostgresQueryWithPortEncodedInHost(date=datetime.datetime(1991, 3, 24)).output()
-        self.assertEquals(output.port, '1234')
+        self.assertEqual(output.port, '1234')
 
 
 @pytest.mark.postgres

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -342,7 +342,7 @@ class TestS3Client(unittest.TestCase):
         s3_client.get('s3://mybucket/putMe', tmp_file_path)
         with open(tmp_file_path, 'r') as f:
             content = f.read()
-        self.assertEquals(content, self.tempFileContents.decode("utf-8"))
+        self.assertEqual(content, self.tempFileContents.decode("utf-8"))
         tmp_file.close()
 
     def test_get_as_bytes(self):
@@ -352,7 +352,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_bytes('s3://mybucket/putMe')
 
-        self.assertEquals(contents, self.tempFileContents)
+        self.assertEqual(contents, self.tempFileContents)
 
     def test_get_as_string(self):
         create_bucket()
@@ -361,7 +361,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe2')
 
-        self.assertEquals(contents, self.tempFileContents.decode('utf-8'))
+        self.assertEqual(contents, self.tempFileContents.decode('utf-8'))
 
     def test_get_as_string_latin1(self):
         create_bucket()
@@ -370,7 +370,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe3', encoding='ISO-8859-1')
 
-        self.assertEquals(contents, self.tempFileContents.decode('ISO-8859-1'))
+        self.assertEqual(contents, self.tempFileContents.decode('ISO-8859-1'))
 
     def test_get_key(self):
         create_bucket()

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -204,9 +204,9 @@ class CoreConfigTest(LuigiTestCase):
 
     @with_config({})
     def test_parallel_scheduling_processes_default(self):
-        self.assertEquals(0, core().parallel_scheduling_processes)
+        self.assertEqual(0, core().parallel_scheduling_processes)
 
     @with_config({'core': {'parallel-scheduling-processes': '1234'}})
     def test_parallel_scheduling_processes(self):
         from luigi.interface import core
-        self.assertEquals(1234, core().parallel_scheduling_processes)
+        self.assertEqual(1234, core().parallel_scheduling_processes)


### PR DESCRIPTION
## Description

The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .

## Motivation and Context

This adds Python 3.11 support. The changes are as below : 

```
assertEquals ->assertEqual
assertRegexpMatches -> assertRegex
assertNotEquals -> assertNotEqual
```

