### PR TITLE
Improve message when an exception is raised during default value parsing

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -415,7 +415,11 @@ class Task(metaclass=Register):
         # Then use the defaults for anything not filled in
         for param_name, param_obj in params:
             if param_name not in result:
-                if not param_obj.has_task_value(task_family, param_name):
+                try:
+                    has_task_value = param_obj.has_task_value(task_family, param_name)
+                except Exception as exc:
+                    raise ValueError("%s: Error when parsing the default value of '%s'" % (exc_desc, param_name)) from exc
+                if not has_task_value:
                     raise parameter.MissingParameterException("%s: requires the '%s' parameter to be set" % (exc_desc, param_name))
                 result[param_name] = param_obj.task_value(task_family, param_name)
 

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -821,22 +821,26 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         p = luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar"))
         self.assertEqual(timedelta(weeks=5), _value(p))
 
+    @mock.patch('luigi.parameter.ParameterException')
     @with_config({"foo": {"bar": "P3Y6M4DT12H30M5S"}})
-    def testTimeDelta8601YearMonthNotSupported(self):
+    def testTimeDelta8601YearMonthNotSupported(self, exc):
         def f():
             return _value(luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar")))
-        self.assertRaises(luigi.parameter.ParameterException, f)  # ISO 8601 durations with years or months are not supported
+        self.assertRaises(ValueError, f)  # ISO 8601 durations with years or months are not supported
+        exc.assert_called_once_with("Invalid time delta - could not parse P3Y6M4DT12H30M5S")
 
     @with_config({"foo": {"bar": "PT6M"}})
     def testTimeDelta8601MAfterT(self):
         p = luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar"))
         self.assertEqual(timedelta(minutes=6), _value(p))
 
+    @mock.patch('luigi.parameter.ParameterException')
     @with_config({"foo": {"bar": "P6M"}})
-    def testTimeDelta8601MBeforeT(self):
+    def testTimeDelta8601MBeforeT(self, exc):
         def f():
             return _value(luigi.TimeDeltaParameter(config_path=dict(section="foo", name="bar")))
-        self.assertRaises(luigi.parameter.ParameterException, f)  # ISO 8601 durations with months are not supported
+        self.assertRaises(ValueError, f)  # ISO 8601 durations with months are not supported
+        exc.assert_called_once_with("Invalid time delta - could not parse P6M")
 
     def testHasDefaultNoSection(self):
         self.assertRaises(luigi.parameter.MissingParameterException,

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -18,7 +18,7 @@ import doctest
 import pickle
 import warnings
 
-from helpers import unittest, LuigiTestCase
+from helpers import unittest, LuigiTestCase, with_config
 from datetime import datetime, timedelta
 
 import luigi
@@ -160,6 +160,14 @@ class TaskTest(unittest.TestCase):
             disable_window = 17
         task = ATask()
         self.assertEqual(task.disable_window_seconds, 17)
+
+    @with_config({"ATaskWithBadParam": {"bad_param": "bad_value"}})
+    def test_bad_param(self):
+        class ATaskWithBadParam(luigi.Task):
+            bad_param = luigi.IntParameter()
+
+        with self.assertRaisesRegex(ValueError, r"ATaskWithBadParam\[args=\(\), kwargs={}\]: Error when parsing the default value of 'bad_param'") as exc:
+            ATaskWithBadParam()
 
 
 class ExternalizeTaskTest(LuigiTestCase):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -166,7 +166,7 @@ class TaskTest(unittest.TestCase):
         class ATaskWithBadParam(luigi.Task):
             bad_param = luigi.IntParameter()
 
-        with self.assertRaisesRegex(ValueError, r"ATaskWithBadParam\[args=\(\), kwargs={}\]: Error when parsing the default value of 'bad_param'") as exc:
+        with self.assertRaisesRegex(ValueError, r"ATaskWithBadParam\[args=\(\), kwargs={}\]: Error when parsing the default value of 'bad_param'"):
             ATaskWithBadParam()
 
 


### PR DESCRIPTION
## Description
When an exception is raised during default value parsing, only the exception of the parameter is raised so we can't know which parameter of which task failed.

## Motivation and Context
In big workflows it can be quite painful to find which parameter of which task failed.

## Have you tested this? If so, how?
I have included unit tests.