### PR TITLE
group tasks by task class in SVG visualizer

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -19,6 +19,9 @@ Graph = (function() {
     /* Amount of horizontal space given for each node */
     var nodeWidth = 200;
 
+    /* Random horizontal offset for each row */
+    var jitterWidth = 100;
+
     /* Calculate minimum SVG height required for legend */
     var legendMaxY = (function () {
         return Object.keys(statusColors).length * legendLineHeight + ( legendLineHeight / 2 )
@@ -156,7 +159,6 @@ Graph = (function() {
 
         return rowSizes;
     }
-
     /* Format nodes according to their depth and horizontal sort order.
        Algorithm: evenly distribute nodes along each depth level, offsetting each
        by the text line height to prevent overlapping text. This is done within
@@ -164,18 +166,25 @@ Graph = (function() {
        is at least nodeWidth to ensure readability. The height of each level is
        determined by number of nodes divided by number of columns, rounded up. */
     function layoutNodes(nodes, rowSizes) {
-        var numCols = Math.max(2, Math.floor(graphWidth / nodeWidth));
+        var numCols = Math.max(2, Math.floor((graphWidth - jitterWidth) / nodeWidth));
         function rowStartPosition(depth) {
             if (depth === 0) return 20;
             var rowHeight = Math.ceil(rowSizes[depth-1] / numCols);
             return rowStartPosition(depth-1)+Math.max(rowHeight * nodeHeight + 100);
+        }
+        var jitter = []
+        for (var i in rowSizes) {
+            jitter[i] = Math.ceil(Math.random() * jitterWidth)
         }
         $.each(nodes, function(i, node) {
             var numRows = Math.ceil(rowSizes[node.depth] / numCols);
             var levelCols = Math.ceil(rowSizes[node.depth] / numRows);
             var row = node.xOrder % numRows;
             var col = node.xOrder / numRows;
-            node.x = ((col + 1) / (levelCols + 1)) * (graphWidth - 200);
+            node.x =
+                ((col + 1) / (levelCols + 1))
+                * (graphWidth - jitterWidth - nodeWidth)
+                + jitter[node.depth];
             node.y = rowStartPosition(node.depth) + row * nodeHeight;
         });
     }

--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -153,9 +153,6 @@ Graph = (function() {
             }
         }
         placeNodes(nodes[0], 0);
-        console.log("nodes with rows")
-        console.log(nodes)
-        console.log(rowSizes)
 
         return rowSizes;
     }

--- a/luigi/static/visualiser/js/test/graph_test.js
+++ b/luigi/static/visualiser/js/test/graph_test.js
@@ -62,6 +62,40 @@ test("computeDepth", function() {
     equal(E.depth, -1);
 });
 
+test("computeRowsSelfDeps", function () {
+    var A1 = {name: "A", taskId: "A1", deps: ["A2"], depth: -1}
+    var A2 = {name: "A", taskId: "A2", deps: [], depth: -1}
+    var nodes = [A1, A2]
+    var nodeIndex = {"A1": 0, "A2": 1}
+    var rowSizes = Graph.testableMethods.computeRows(nodes, nodeIndex)
+    equal(A1.depth, 0)
+    equal(A2.depth, 1)
+    equal(rowSizes, [1, 1])
+});
+
+test("computeRowsGrouped", function() {
+    var A0 = {name: "A", taskId: "A0", deps: ["D0", "B0"], depth: -1}
+    var B0 = {name: "B", taskId: "B0", deps: ["C1", "C2"], depth: -1}
+    var C1 = {name: "C", taskId: "C1", deps: ["D1", "E1"], depth: -1}
+    var C2 = {name: "C", taskId: "C2", deps: ["D2", "E2"], depth: -1}
+    var D0 = {name: "D", taskId: "D0", deps: [], depth: -1}
+    var D1 = {name: "D", taskId: "D1", deps: [], depth: -1}
+    var D2 = {name: "D", taskId: "D2", deps: [], depth: -1}
+    var E1 = {name: "E", taskId: "E1", deps: [], depth: -1}
+    var E2 = {name: "E", taskId: "E2", deps: [], depth: -1}
+    var rowSizes = Graph.testableMethods.computeRows(nodes, nodeIndex)
+    equal(A0.depth, 0)
+    equal(B0.depth, 1)
+    equal(C1.depth, 2)
+    equal(C2.depth, 2)
+    equal(D0.depth, 3)
+    equal(D1.depth, 3)
+    equal(D2.depth, 3)
+    equal(E1.depth, 4)
+    equal(E2.depth, 4)
+    equal(rowSizes, [1, 1, 2, 3, 2])
+});
+
 test("createGraph", function() {
     var tasks = [
         {taskId: "A", deps: ["B","C"], status: "PENDING"},


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

I adjusted the SVG task visualizer so that it groups tasks by task class. I.e. it doesn't but tasks of different classes at the same depth level anymore.

There is one exception: if at least one task requires a task of the same task class, it falls back to the old way of visualizing the tree.

In addition, to avoid overlapping edges, a different (random) horizontal offset is added to each depth level.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main goal is to make the task graph quicker to interpret by grouping tasks of the same task class.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I have included two new unit tests but haven't run them yet. Counting on Travis here.

I also ran my jobs with this code and got the following image:

original:

![task_visualizer_old](https://user-images.githubusercontent.com/28426758/142181736-e25297f8-6f3d-456a-ad08-31e8ea5dcb36.png)

with my changes applied:

![task_visualizer_new](https://user-images.githubusercontent.com/28426758/142181748-a0f48302-6898-4356-8c78-bfea93648377.png)
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->


## Request

Feel free to test the new visualizer with your workflows and let me know how you like it.

All you'd have to do is replace `/site-packages/luigi/static/visualiser/js/graph.js`, wait a few seconds and reload `localhost:8082`.