### PR TITLE
OptionalParameter in ExternalPythonProgramTask

### DIFF
--- a/luigi/contrib/external_program.py
+++ b/luigi/contrib/external_program.py
@@ -260,13 +260,13 @@ class ExternalPythonProgramTask(ExternalProgramTask):
     :py:class:`luigi.parameter.Parameter` s for setting a virtualenv and for
     extending the ``PYTHONPATH``.
     """
-    virtualenv = luigi.Parameter(
+    virtualenv = luigi.OptionalParameter(
         default=None,
         positional=False,
         description='path to the virtualenv directory to use. It should point to '
                     'the directory containing the ``bin/activate`` file used for '
                     'enabling the virtualenv.')
-    extra_pythonpath = luigi.Parameter(
+    extra_pythonpath = luigi.OptionalParameter(
         default=None,
         positional=False,
         description='extend the search path for modules by prepending this '


### PR DESCRIPTION
As of now, `ExternalPythonProgramTask` parameters are simple `Parameter`.
But the default for both of them is `None` and they are used only if they are not None.
If the value for any of them is not provided, a warning is raised, for example:
`UserWarning: Parameter "extra_pythonpath" with value "None" is not of type string.`

Therefore I think that the appropriate type is OptionalParameter instead.

PS: First pull request for me, I hope I'm doing it right. Otherwise please help me understand what's wrong. Thanks