### PR TITLE
Fix Azkaban link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Conceptually, Luigi is similar to `GNU
 Make <http://www.gnu.org/software/make/>`_ where you have certain tasks
 and these tasks in turn may have dependencies on other tasks. There are
 also some similarities to `Oozie <http://oozie.apache.org/>`_
-and `Azkaban <http://data.linkedin.com/opensource/azkaban>`_. One major
+and `Azkaban <https://azkaban.github.io/>`_. One major
 difference is that Luigi is not just built specifically for Hadoop, and
 it's easy to extend it with other kinds of tasks.
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Replace the link to Azkaban project with the correct link.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current link seems irrelevant:

- Before: http://data.linkedin.com/opensource/azkaban that is redirected to https://engineering.linkedin.com/teams/data
- This PR: https://azkaban.github.io


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
