### PR TITLE
Fix Python 3 incompatible code in LSF contrib module

### DIFF
--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -83,7 +83,7 @@ def track_job(job_id):
     """
     cmd = "bjobs -noheader -o stat {}".format(job_id)
     track_job_proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, shell=True, text=True)
+        cmd, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
     status = track_job_proc.communicate()[0].strip('\n')
     return status
 
@@ -246,7 +246,7 @@ class LSFJobTask(luigi.Task):
         # Submit the job
         run_job_proc = subprocess.Popen(
             [str(a) for a in args],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=self.tmp_dir, text=True)
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=self.tmp_dir, universal_newlines=True)
         output = run_job_proc.communicate()[0]
 
         # ASSUMPTION

--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -207,14 +207,7 @@ class LSFJobTask(luigi.Task):
         Dump instance to file.
         """
         self.job_file = os.path.join(out_dir, 'job-instance.pickle')
-        if self.__module__ == '__main__':
-            dump_inst = pickle.dumps(self)
-            module_name = os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
-            dump_inst = dump_inst.replace('(c__main__', "(c" + module_name)
-            open(self.job_file, "w").write(dump_inst)
-
-        else:
-            pickle.dump(self, open(self.job_file, "w"))
+        pickle.dump(self, open(self.job_file, "wb"))
 
     def _run_job(self):
         """

--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -83,7 +83,7 @@ def track_job(job_id):
     """
     cmd = "bjobs -noheader -o stat {}".format(job_id)
     track_job_proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, shell=True)
+        cmd, stdout=subprocess.PIPE, shell=True, text=True)
     status = track_job_proc.communicate()[0].strip('\n')
     return status
 
@@ -253,7 +253,7 @@ class LSFJobTask(luigi.Task):
         # Submit the job
         run_job_proc = subprocess.Popen(
             [str(a) for a in args],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=self.tmp_dir)
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=self.tmp_dir, text=True)
         output = run_job_proc.communicate()[0]
 
         # ASSUMPTION


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The LSF contrib module does not seem to work on Python 3 (tested on 3.8) due to what looks like a Python 2.7-focussed implementation.

The current implementation treats outputs of `subprocess.Popen` and outputs of `pickle.dumps` as strings, which throws errors when doing string modifications later in the same file. Both of these output in bytes by default though, since at least Python 3.5 (`pickle.dumps` returned a string in Python 2.x). Adding `universal_newlines=True` makes Popen output strings again.

I also removed code that seemed to do some pickle-string (again, Python 2.7 behavior) manipulation for which I couldn't find documentation and which does not work in 3.x

This should also fix this (stale, closed) issue: https://github.com/spotify/luigi/issues/2873

## Have you tested this? If so, how?
I ran a few LSF test jobs with this change on Python 3.8 and it works.
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
