### PR TITLE
Add support for __init_subclass in Task metaclass.

### DIFF
--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -54,7 +54,7 @@ class Register(abc.ABCMeta):
     ambiguous task name (two :py:class:`Task` have the same name). This denotes
     an error."""
 
-    def __new__(metacls, classname, bases, classdict):
+    def __new__(metacls, classname, bases, classdict, **kwargs):
         """
         Custom class creation for namespacing.
 
@@ -63,7 +63,7 @@ class Register(abc.ABCMeta):
         When the set or inherited namespace evaluates to ``None``, set the task namespace to
         whatever the currently declared namespace is.
         """
-        cls = super(Register, metacls).__new__(metacls, classname, bases, classdict)
+        cls = super(Register, metacls).__new__(metacls, classname, bases, classdict, **kwargs)
         cls._namespace_at_class_time = metacls._get_namespace(cls.__module__)
         metacls._reg.append(cls)
         return cls

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -409,3 +409,15 @@ class AutoNamespaceTest(LuigiTestCase):
             pass
         luigi.namespace(scope='incorrect_namespace')
         self.assertEqual(MyTask.get_task_namespace(), '')
+
+
+class InitSubclassTest(LuigiTestCase):
+    def test_task_works_with_init_subclass(self):
+        class ReceivesClassKwargs(luigi.Task):
+            def __init_subclass__(cls, x, **kwargs):
+                super(ReceivesClassKwargs, cls).__init_subclass__()
+                cls.x = x
+
+        class Receiver(ReceivesClassKwargs, x=1):
+            pass
+        self.assertEquals(Receiver.x, 1)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Since python 3.6 and PEP 487 metaclasses must pass kwargs to super. Otherwise the __init_subclass__ hook fails.

<!--- Describe your changes -->

## Motivation and Context

For a detailed discussion regarding the same issue in abc see:
https://bugs.python.org/issue29581
And the patch for the issue above:
https://github.com/python/cpython/commit/6fb12b5c43945f61f3da82e33eafb4ddae2296ee

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Have you tested this? If so, how?
Unit test added
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
