### PR TITLE
Pin jinja2 version; >3.1 breaks sphinx build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -132,6 +132,7 @@ basepython=python3
 deps =
     sqlalchemy
     boto3
+    jinja2==3.0.3
     Sphinx>=1.4.4,<1.5
     sphinx_rtd_theme
     azure-storage<=0.36


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Pin jinja2 version to avoid error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/readthedocs/readthedocs.org/issues/9037

`doc` build failure prevents merge of PRs

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Local doc test and build is passing. Checking remote Github Actions now through PR

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
