### PR TITLE
Optionally detect parameter collisions - fix #2566

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -356,6 +356,16 @@ check_complete_on_run
   missing.
   Defaults to false.
 
+prevent_parameter_collision
+  In complex pipelines especially when tasks are inherited, it can happen that
+  different tasks define parameters with the same name. Luigi would normally use
+  the same value for both parameter instances, which might not be desired.
+  When set to ``true``, luigi will check for parameter collisions and refuse to
+  run if a parameter is defined multiple times. Optionally, an allow-list of
+  parameters called ``collisions_to_ignore`` can be passed to ``inherits/requires``,
+  to ignore when checking for duplicate parameters.
+  Defaults to false.
+
 
 [elasticsearch]
 ---------------

--- a/test/parameter_collision_test.py
+++ b/test/parameter_collision_test.py
@@ -1,0 +1,49 @@
+import unittest
+
+import luigi
+from luigi.util import requires
+
+from helpers import with_config
+
+
+class A(luigi.Task):
+    num = luigi.IntParameter()
+
+
+class B(luigi.Task):
+    num = luigi.IntParameter()
+
+
+class ParameterCollisionDetectionTest(unittest.TestCase):
+    @with_config({"worker": {"prevent_parameter_collision": "true"}})
+    def test_parameter_collision_with_inherited_task(self):
+        with self.assertRaises(ValueError):
+
+            @requires(A)
+            class T(luigi.Task):
+                num = luigi.IntParameter()
+
+    @with_config({"worker": {"prevent_parameter_collision": "true"}})
+    def test_parameter_collision_in_inheriting_tasks(self):
+        with self.assertRaises(ValueError):
+
+            @requires(A, B)
+            class T(luigi.Task):
+                pass
+
+    def test_no_parameter_collision_when_disabled_in_config(self):
+        @requires(A, B)
+        class T(luigi.Task):
+            pass
+
+    @with_config({"worker": {"prevent_parameter_collision": "true"}})
+    def test_parameter_collision_with_inherited_task_ignored_by_allowlist(self):
+        @requires(A, collisions_to_ignore=["num"])
+        class T(luigi.Task):
+            num = luigi.IntParameter()
+
+    @with_config({"worker": {"prevent_parameter_collision": "true"}})
+    def test_parameter_collision_in_inheriting_tasks_ignored_by_allowlist(self):
+        @requires(A, B, collisions_to_ignore=["num"])
+        class T(luigi.Task):
+            pass


### PR DESCRIPTION
Hi all, based on issue #2566 and PR #2565 by @KenyaDonDraper, this PR adds this functionality plus a setting that enables this check (defaulting to `false`). This way, this functionality can be added without possibly affecting existing workflows.
I also added documentation and tests.