### PR TITLE
Use PEP593 to support typing of parameters

### DIFF
--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+from typing import Annotated
 
 from helpers import with_config, LuigiTestCase, parsing, in_parse, RunOnceTask
 from datetime import timedelta
@@ -1329,3 +1330,15 @@ class TestPathParameter:
                 luigi.build([path_parameter["cls"]()], local_scheduler=True)
         else:
             assert luigi.build([path_parameter["cls"]()], local_scheduler=True)
+
+
+class TestPEP593Parameters:
+    def test_parsing(self) -> None:
+        class Task(luigi.Task):
+            param: Annotated[int, luigi.IntParameter()]
+            default_param: Annotated[int, luigi.BoolParameter()] = False
+
+        params = dict(Task.get_params())
+        assert isinstance(params["param"], luigi.IntParameter)
+        assert isinstance(params["default_param"], luigi.BoolParameter)
+        assert params["default_param"]._default is False

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -16,7 +16,12 @@
 #
 
 import datetime
-from typing import Annotated
+import sys
+import unittest
+if sys.version_info < (3, 9):
+    Annotated = None
+else:
+    from typing import Annotated
 
 from helpers import with_config, LuigiTestCase, parsing, in_parse, RunOnceTask
 from datetime import timedelta
@@ -1341,6 +1346,7 @@ class TestPathParameter:
             assert luigi.build([path_parameter["cls"]()], local_scheduler=True)
 
 
+@unittest.skipIf(sys.version_info < (3, 9), 'only for Python>=3.9')
 class TestPEP593Parameters(LuigiTestCase):
     def test_parsing(self) -> None:
         params = dict(PEP593Task.get_params())

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -153,15 +153,6 @@ class NoopTask(luigi.Task):
     pass
 
 
-class PEP593Task(luigi.Task):
-    param: Annotated[int, luigi.IntParameter()]
-    default_param: Annotated[bool, luigi.BoolParameter()] = False
-
-    def run(self):
-        PEP593Task._param_val = self.param
-        PEP593Task._default_param_val = self.default_param
-
-
 class MyEnum(enum.Enum):
     A = 1
     C = 3
@@ -1344,6 +1335,18 @@ class TestPathParameter:
                 luigi.build([path_parameter["cls"]()], local_scheduler=True)
         else:
             assert luigi.build([path_parameter["cls"]()], local_scheduler=True)
+
+
+if Annotated is None:
+    PEP593Task = luigi.Task
+else:
+    class PEP593Task(luigi.Task):
+        param: Annotated[int, luigi.IntParameter()]
+        default_param: Annotated[bool, luigi.BoolParameter()] = False
+
+        def run(self):
+            PEP593Task._param_val = self.param
+            PEP593Task._default_param_val = self.default_param
 
 
 @unittest.skipIf(sys.version_info < (3, 9), 'only for Python>=3.9')


### PR DESCRIPTION
This uses PEP593 Annotations to support typing of parameters in a way that will make mypy & co treat the instance variables correctly.