### PR TITLE
Close requests.Socket in RemoteScheduler before exiting (#3173)

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -173,6 +173,8 @@ def _schedule_and_run(tasks, worker_scheduler_factory=None, override_defaults=No
         success &= worker.run()
     luigi_run_result = LuigiRunResult(worker, success)
     logger.info(luigi_run_result.summary_text)
+    if hasattr(sch, 'close'):
+        sch.close()
     return luigi_run_result
 
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -27,7 +27,6 @@ import luigi.server
 from server_test import ServerTestBase
 import socket
 from multiprocessing import Process, Queue
-import requests
 
 
 class RemoteSchedulerTest(unittest.TestCase):
@@ -147,8 +146,8 @@ class RPCTest(scheduler_api_test.SchedulerApiTest, ServerTestBase):
 
 class RequestsFetcherTest(ServerTestBase):
     def test_fork_changes_session(self):
-        session = requests.Session()
-        fetcher = luigi.rpc.RequestsFetcher(session)
+        fetcher = luigi.rpc.RequestsFetcher()
+        session = fetcher.session
 
         q = Queue()
 


### PR DESCRIPTION
## Description
If using `luigi.build` and `sys.exit`, `ResourceWarning` on unclosed socket is raised. As it can be easily fixed, I've added `requests.Session.close` call before exiting. 

## Motivation and Context
Fixes #3173

## Have you tested this? If so, how?
I've tested it using code below under py38. Adding solid unit/integration test requires running remote scheduler and I will need guidance if one is needed. 
```
import sys
from time import sleep

import luigi


class Task(luigi.Task):
    p = luigi.IntParameter()

    def run(self):
        with self.output().open('w') as f:
            sleep(1)
            f.write(str(self.p))

    def output(self):
        return luigi.LocalTarget(f'file_{self.p}.txt')


if __name__ == '__main__':
    sys.exit(0 if luigi.build([Task(p=2)], local_scheduler=False) else 1)
```
