### PR TITLE
Silent UnconsumedParameterWarning for core.autoload_range

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -49,6 +49,7 @@ class core(task.Config):
     This is arguably a bit of a hack.
     '''
     use_cmdline_section = False
+    _ignore_unconsumed = {'autoload_range'}
 
     local_scheduler = parameter.BoolParameter(
         default=False,

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -439,6 +439,8 @@ class Task(metaclass=Register):
         if task_family in conf.sections():
             for key, value in conf[task_family].items():
                 composite_key = f"{task_family}_{key}"
+                if key in getattr(cls, '_ignore_unconsumed', []):
+                    continue
                 if key not in result and composite_key not in cls._unconsumed_params:
                     warnings.warn(
                         "The configuration contains the parameter "

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -188,6 +188,8 @@ class TaskTest(unittest.TestCase):
             a = luigi.Parameter(default="a")
 
         class TaskB(luigi.Task):
+            _ignore_unconsumed = ['b']
+
             a = luigi.Parameter(default="a")
 
         with warnings.catch_warnings(record=True) as w:
@@ -203,11 +205,10 @@ class TaskTest(unittest.TestCase):
             TaskA()
             TaskB()
 
-            assert len(w) == 4
+            assert len(w) == 3
             expected = [
                 ("b", "TaskA"),
                 ("c", "TaskA"),
-                ("b", "TaskB"),
                 ("c", "TaskB"),
             ]
             for i, (expected_value, task_name) in zip(w, expected):


### PR DESCRIPTION
## Description
`autoload_range` set in `luigi.cfg` emits `UnconsumedParameterWarning` as value is used only in `luigi.__init__`. I've added internal field `_ignore_unconsumed` to ignore this parameter in `core` class. 

## Motivation and Context
My motivation in to silent all warnings emitted by luigi in my developed code as it's add some noise in tests. 

## Have you tested this? If so, how?
I've run simple graph with this change to ensure that's warning is no longer emitted. 
