### PR TITLE
Add worker config to cache task completion results.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -356,6 +356,15 @@ check_complete_on_run
   missing.
   Defaults to false.
 
+cache_task_completion
+  By default, luigi task processes might check the completion status multiple
+  times per task which is a safe way to avoid potential inconsistencies. For
+  tasks with many dynamic dependencies, yielded in multiple stages, this might
+  become expensive, e.g. in case the per-task completion check entails remote
+  resources. When set to true, completion checks are cached so that tasks
+  declared as complete once are not checked again.
+  Defaults to false.
+
 
 [elasticsearch]
 ---------------

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -197,7 +197,12 @@ class TaskProcess(multiprocessing.Process):
                 with self._forward_attributes():
                     new_deps = self._run_get_new_deps()
                 if not new_deps:
-                    if not self.check_complete_on_run or self.check_complete(self.task):
+                    if not self.check_complete_on_run:
+                        # update the cache
+                        if self.task_completion_cache is not None:
+                            self.task_completion_cache[self.task.task_id] = True
+                        status = DONE
+                    elif self.check_complete(self.task):
                         status = DONE
                     else:
                         raise TaskException("Task finished running, but complete() is still returning false.")

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -460,8 +460,7 @@ class WorkerTest(LuigiTestCase):
                 self.has_run = True
 
         # test the enabled feature
-        with Worker(scheduler=self.sch, worker_id='2') as w:
-            w._config.cache_task_completion = True
+        with Worker(scheduler=self.sch, worker_id='2', cache_task_completion=True) as w:
             b0 = B(i=0)
             a0 = A(i=0)
             a1 = A(i=1)
@@ -480,8 +479,7 @@ class WorkerTest(LuigiTestCase):
             self.assertEqual(a2.complete_count, 3)
 
         # test the disabled feature
-        with Worker(scheduler=self.sch, worker_id='2') as w:
-            w._config.cache_task_completion = False
+        with Worker(scheduler=self.sch, worker_id='2', cache_task_completion=False) as w:
             b10 = B(i=10)
             a10 = A(i=10)
             a11 = A(i=11)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -474,9 +474,9 @@ class WorkerTest(LuigiTestCase):
             w.run()
             # the complete methods of a's yielded first in b's run method were called equally often
             self.assertEqual(b0.complete_count, 1)
-            self.assertEqual(a0.complete_count, 3)
-            self.assertEqual(a1.complete_count, 3)
-            self.assertEqual(a2.complete_count, 3)
+            self.assertEqual(a0.complete_count, 2)
+            self.assertEqual(a1.complete_count, 2)
+            self.assertEqual(a2.complete_count, 2)
 
         # test the disabled feature
         with Worker(scheduler=self.sch, worker_id='2', cache_task_completion=False) as w:

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -434,6 +434,71 @@ class WorkerTest(LuigiTestCase):
             self.assertEqual(a2.complete_count, 2)
             self.assertEqual(b2.complete_count, 2)
 
+    def test_cache_task_completion_config(self):
+        class A(Task):
+
+            i = luigi.IntParameter()
+
+            def __init__(self, *args, **kwargs):
+                super(A, self).__init__(*args, **kwargs)
+                self.complete_count = 0
+                self.has_run = False
+
+            def complete(self):
+                self.complete_count += 1
+                return self.has_run
+
+            def run(self):
+                self.has_run = True
+
+        class B(A):
+
+            def run(self):
+                yield A(i=self.i + 0)
+                yield A(i=self.i + 1)
+                yield A(i=self.i + 2)
+                self.has_run = True
+
+        # test the enabled feature
+        with Worker(scheduler=self.sch, worker_id='2') as w:
+            w._config.cache_task_completion = True
+            b0 = B(i=0)
+            a0 = A(i=0)
+            a1 = A(i=1)
+            a2 = A(i=2)
+            self.assertTrue(w.add(b0))
+            # a's are required dynamically, so their counts must be 0
+            self.assertEqual(b0.complete_count, 1)
+            self.assertEqual(a0.complete_count, 0)
+            self.assertEqual(a1.complete_count, 0)
+            self.assertEqual(a2.complete_count, 0)
+            w.run()
+            # the complete methods of a's yielded first in b's run method were called equally often
+            self.assertEqual(b0.complete_count, 1)
+            self.assertEqual(a0.complete_count, 3)
+            self.assertEqual(a1.complete_count, 3)
+            self.assertEqual(a2.complete_count, 3)
+
+        # test the disabled feature
+        with Worker(scheduler=self.sch, worker_id='2') as w:
+            w._config.cache_task_completion = False
+            b10 = B(i=10)
+            a10 = A(i=10)
+            a11 = A(i=11)
+            a12 = A(i=12)
+            self.assertTrue(w.add(b10))
+            # a's are required dynamically, so their counts must be 0
+            self.assertEqual(b10.complete_count, 1)
+            self.assertEqual(a10.complete_count, 0)
+            self.assertEqual(a11.complete_count, 0)
+            self.assertEqual(a12.complete_count, 0)
+            w.run()
+            # the complete methods of a's yielded first in b's run method were called more often
+            self.assertEqual(b10.complete_count, 1)
+            self.assertEqual(a10.complete_count, 5)
+            self.assertEqual(a11.complete_count, 4)
+            self.assertEqual(a12.complete_count, 3)
+
     def test_gets_missed_work(self):
         class A(Task):
             done = False


### PR DESCRIPTION
## Description

This PR adds a new worker config `cache_task_completion` which, when enabled (default is `False` of course), leads to tasks' successful `complete()` results being cached by the worker. In short, this can save resources in case tasks have a large number of dynamic dependencies that are yielded in several stages (see below), and the tasks' `complete()` calls are somewhat expensive (e.g. when file targets are remote).

## Motivation and Context

We sometimes have k's of tasks being yielded through dynamic dependencies, and we only use files on remote locations. Therefore we want to limit the number of API calls and would really benefit from this option. Also, in our case we are sure that once a task is complete, it never toggles to being incomplete again, so that this kind of caching is 100% safe (and I'm sure that the opposite is rather rare). Example:

```python
class MyTask(luigi.Task):
    ...
    def run(self):
        # first round
        deps_1 = [DepA1(), DepB1(), ..., DepZ1()]
        outputs_1 = yield deps_1

        # second round
        # (with some artificial relation to outputs_1 to justify that two yields are required ...)
        deps_1 = [dep(param=x) for dep, x in zip([DepA2, DepB2, ..., DepZ2], outputs_1)]
        yield deps_2
```

When running, `deps_1` are yielded twice, and the completion checks are triggered multiple times:

1. when `yield`ed the first time and reaching [this point](https://github.com/spotify/luigi/blob/a295041d9c344135ef7f8d41e26f6fdbe6e55c58/luigi/worker.py#L149),
2. [before being added to the tree](https://github.com/spotify/luigi/blob/a295041d9c344135ef7f8d41e26f6fdbe6e55c58/luigi/worker.py#L748)
3. after each dep ran, in the [post-run check](https://github.com/spotify/luigi/blob/a295041d9c344135ef7f8d41e26f6fdbe6e55c58/luigi/worker.py#L195),
4. when `yield`ed the second time at the same position as 1.5. 

And for every additional round of yielding, there will be another check (same as 4.). With the new config enabled, the checks would only run for 1. and 2..

## Have you tested this? If so, how?

I added a test to `worker_test.py` that checks the number of `complete()` calls of tasks being yielded as dynamic dependencies, with and without the new config. The documentation is updated as well.
