### PR TITLE
Improve control over dynamic requirements

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -209,7 +209,7 @@ the Task.run_ method will resume from scratch each time a new task is yielded.
 In other words, you should make sure your Task.run_ method is idempotent.
 (This is good practice for all Tasks in Luigi, but especially so for tasks with dynamic dependencies).
 As this might entail redundant calls to tasks' :func:`~luigi.task.Task.complete` methods,
-you should consider setting the "cache_task_completion" option int the :ref:`worker-config`.
+you should consider setting the "cache_task_completion" option in the :ref:`worker-config`.
 To further control how dynamic task requirements are handled internally by worker nodes,
 there is also the option to wrap dependent tasks by :class:`~luigi.task.DynamicRequirements`.
 

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -208,9 +208,9 @@ It does come with some constraints:
 the Task.run_ method will resume from scratch each time a new task is yielded.
 In other words, you should make sure your Task.run_ method is idempotent.
 (This is good practice for all Tasks in Luigi, but especially so for tasks with dynamic dependencies).
-As this might entail redundant calls to tasks' Task.complete_ method, you should consider
-using the "cache_task_completion" :ref:`worker-config`.
-To further control how dynamic task requirements handled internally by worker nodes,
+As this might entail redundant calls to tasks' Task.complete_ methods, you should consider
+setting the "cache_task_completion" option int the :ref:`worker-config`.
+To further control how dynamic task requirements are handled internally by worker nodes,
 there is also the option to wrap dependent tasks by :class:`~luigi.task.DynamicRequirements`.
 
 For an example of a workflow using dynamic dependencies, see

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -198,8 +198,8 @@ You can also yield a list of tasks.
         def run(self):
             other_target = yield OtherTask()
 
-        # dynamic dependencies resolve into targets
-        f = other_target.open('r')
+            # dynamic dependencies resolve into targets
+            f = other_target.open('r')
 
 
 This mechanism is an alternative to Task.requires_ in case

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -208,8 +208,8 @@ It does come with some constraints:
 the Task.run_ method will resume from scratch each time a new task is yielded.
 In other words, you should make sure your Task.run_ method is idempotent.
 (This is good practice for all Tasks in Luigi, but especially so for tasks with dynamic dependencies).
-As this might entail redundant calls to tasks' Task.complete_ methods, you should consider
-setting the "cache_task_completion" option int the :ref:`worker-config`.
+As this might entail redundant calls to tasks' :func:`~luigi.task.Task.complete` methods,
+you should consider setting the "cache_task_completion" option int the :ref:`worker-config`.
 To further control how dynamic task requirements are handled internally by worker nodes,
 there is also the option to wrap dependent tasks by :class:`~luigi.task.DynamicRequirements`.
 

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -198,8 +198,8 @@ You can also yield a list of tasks.
         def run(self):
             other_target = yield OtherTask()
 
-	    # dynamic dependencies resolve into targets
-	    f = other_target.open('r')
+        # dynamic dependencies resolve into targets
+        f = other_target.open('r')
 
 
 This mechanism is an alternative to Task.requires_ in case
@@ -208,6 +208,10 @@ It does come with some constraints:
 the Task.run_ method will resume from scratch each time a new task is yielded.
 In other words, you should make sure your Task.run_ method is idempotent.
 (This is good practice for all Tasks in Luigi, but especially so for tasks with dynamic dependencies).
+As this might entail redundant calls to tasks' Task.complete_ method, you should consider
+using the "cache_task_completion" :ref:`worker-config`.
+To further control how dynamic task requirements handled internally by worker nodes,
+there is also the option to wrap dependent tasks by :class:`~luigi.task.DynamicRequirements`.
 
 For an example of a workflow using dynamic dependencies, see
 `examples/dynamic_requirements.py <https://github.com/spotify/luigi/blob/master/examples/dynamic_requirements.py>`_.

--- a/examples/dynamic_requirements.py
+++ b/examples/dynamic_requirements.py
@@ -93,11 +93,11 @@ class Dynamic(luigi.Task):
             f.write('Tada!')
 
         # and in case data is rather long, consider wrapping the requirements
-        # in DynamicRequirements and optionally definining a custom complete method
+        # in DynamicRequirements and optionally define a custom complete method
         def custom_complete(complete_fn):
-            # example: Data stores all outputs in the same directory, so avoid doing len(data) fs
-            # calls and rather check the first, and do a basename comparison for the rest
-            # (complete_fn defaults to "lambda task: task.complete" but can also include caching)
+            # example: Data() stores all outputs in the same directory, so avoid doing len(data) fs
+            # calls but rather check the only the first, and compare basenames for the rest
+            # (complete_fn defaults to "lambda task: task.complete()" but can also include caching)
             if not complete_fn(data_dependent_deps[0]):
                 return False
             paths = [task.output().path for task in data_dependent_deps]

--- a/examples/dynamic_requirements.py
+++ b/examples/dynamic_requirements.py
@@ -96,7 +96,7 @@ class Dynamic(luigi.Task):
         # in DynamicRequirements and optionally define a custom complete method
         def custom_complete(complete_fn):
             # example: Data() stores all outputs in the same directory, so avoid doing len(data) fs
-            # calls but rather check the only the first, and compare basenames for the rest
+            # calls but rather check only the first, and compare basenames for the rest
             # (complete_fn defaults to "lambda task: task.complete()" but can also include caching)
             if not complete_fn(data_dependent_deps[0]):
                 return False

--- a/examples/dynamic_requirements.py
+++ b/examples/dynamic_requirements.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import os
 import random as rnd
 import time
 
@@ -90,6 +91,20 @@ class Dynamic(luigi.Task):
 
         with self.output().open('w') as f:
             f.write('Tada!')
+
+        # and in case data is rather long, consider wrapping the requirements
+        # in DynamicRequirements and optionally definining a custom complete method
+        def custom_complete(complete_fn):
+            # example: Data stores all outputs in the same directory, so avoid doing len(data) fs
+            # calls and rather check the first, and do a basename comparison for the rest
+            # (complete_fn defaults to "lambda task: task.complete" but can also include caching)
+            if not complete_fn(data_dependent_deps[0]):
+                return False
+            paths = [task.output().path for task in data_dependent_deps]
+            basenames = os.listdir(os.path.dirname(paths[0]))  # a single fs call
+            return all(os.path.basename(path) in basenames for path in paths)
+
+        yield luigi.DynamicRequirements(data_dependent_deps, custom_complete)
 
 
 if __name__ == '__main__':

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -21,7 +21,9 @@ Package containing core luigi functionality.
 from luigi.__meta__ import __version__
 
 from luigi import task
-from luigi.task import Task, Config, ExternalTask, WrapperTask, namespace, auto_namespace
+from luigi.task import (
+    Task, Config, ExternalTask, WrapperTask, namespace, auto_namespace, DynamicRequirements,
+)
 
 from luigi import target
 from luigi.target import Target
@@ -56,6 +58,7 @@ from luigi.event import Event
 
 __all__ = [
     'task', 'Task', 'Config', 'ExternalTask', 'WrapperTask', 'namespace', 'auto_namespace',
+    'DynamicRequirements',
     'target', 'Target', 'LocalTarget', 'rpc', 'RemoteScheduler',
     'RPCError', 'parameter', 'Parameter', 'DateParameter', 'MonthParameter',
     'YearParameter', 'DateHourParameter', 'DateMinuteParameter', 'DateSecondParameter',

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -810,7 +810,7 @@ class DynamicRequirements(object):
     """
 
     def __init__(self, requirements, custom_complete=None):
-        super(DynamicRequirements, self).__init__()
+        super().__init__()
 
         # store attributes
         self.requirements = requirements

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -787,7 +787,7 @@ class DynamicRequirements(object):
                     if not complete_fn(large_chunk_of_tasks[0]):
                         return False
                     paths = [task.output().path for task in large_chunk_of_tasks]
-                    basenames = os.path.listdir(os.path.dirname(paths[0]))  # a single fs call
+                    basenames = os.listdir(os.path.dirname(paths[0]))  # a single fs call
                     return all(os.path.basename(path) in basenames for path in paths)
 
                 yield DynamicRequirements(large_chunk_of_tasks, custom_complete)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -770,8 +770,8 @@ class DynamicRequirements(object):
     Wraps dynamic requirements yielded in tasks's run methods to control how completeness checks of
     (e.g.) large chunks of tasks are performed. Besides the wrapped *requirements*, instances of
     this class can be passed an optional function *custom_complete* that might implement an
-    optimized check for completeness. If set, the function will be called with a single argument
-    *complete_fn* which should be used to perform the per-task check. Example:
+    optimized check for completeness. If set, the function will be called with a single argument,
+    *complete_fn*, which should be used to perform the per-task check. Example:
 
     .. code-block:: python
 
@@ -783,7 +783,7 @@ class DynamicRequirements(object):
 
                 def custom_complete(complete_fn):
                     # example: assume OtherTask always write into the same directory, so just check
-                    #          if the first task is complete, and then do a base name comparison
+                    #          if the first task is complete, and compare basenames for the rest
                     if not complete_fn(large_chunk_of_tasks[0]):
                         return False
                     paths = [task.output().path for task in large_chunk_of_tasks]
@@ -816,8 +816,9 @@ class DynamicRequirements(object):
         self.requirements = requirements
         self.custom_complete = custom_complete
 
-        # cached flat requirements
+        # cached flat requirements and paths
         self._flat_requirements = None
+        self._paths = None
 
     @property
     def flat_requirements(self):
@@ -827,7 +828,9 @@ class DynamicRequirements(object):
 
     @property
     def paths(self):
-        return getpaths(self.requirements)
+        if self._paths is None:
+            self._paths = getpaths(self.requirements)
+        return self._paths
 
     def complete(self, complete_fn=None):
         # default completeness check

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -823,6 +823,7 @@ class DynamicRequirements(object):
     def flat_requirements(self):
         if self._flat_requirements is None:
             self._flat_requirements = flatten(self.requirements)
+        return self._flat_requirements
 
     @property
     def paths(self):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -152,16 +152,16 @@ class TaskProcess(multiprocessing.Process):
 
             # if requires is not a DynamicRequirements, create one to use its default behavior
             if not isinstance(requires, DynamicRequirements):
-                reqs = DynamicRequirements(requires)
+                requires = DynamicRequirements(requires)
 
-            if not reqs.complete(self.check_complete):
+            if not requires.complete(self.check_complete):
                 # when therequirements are not complete yet, return them which adds them to the tree
                 new_deps = [(t.task_module, t.task_family, t.to_str_params())
-                            for t in reqs.flat_requirements]
+                            for t in requires.flat_requirements]
                 return new_deps
 
             # get the next generator result
-            next_send = reqs.paths
+            next_send = requires.paths
 
     def run(self):
         logger.info('[pid %s] Worker %s running   %s', os.getpid(), self.worker_id, self.task)

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -55,7 +55,7 @@ from luigi.task_register import load_task
 from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler, RetryPolicy
 from luigi.scheduler import WORKER_STATE_ACTIVE, WORKER_STATE_DISABLED
 from luigi.target import Target
-from luigi.task import Task, flatten, getpaths, Config
+from luigi.task import Task, flatten, getpaths, Config, DynamicRequirements
 from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
 from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter
@@ -150,13 +150,18 @@ class TaskProcess(multiprocessing.Process):
             except StopIteration:
                 return None
 
-            new_req = flatten(requires)
-            if all(self.check_complete(t) for t in new_req):
-                next_send = getpaths(requires)
-            else:
+            # if requires is not a DynamicRequirements, create one to use its default behavior
+            if not isinstance(requires, DynamicRequirements):
+                reqs = DynamicRequirements(requires)
+
+            if not reqs.complete(self.check_complete):
+                # when therequirements are not complete yet, return them which adds them to the tree
                 new_deps = [(t.task_module, t.task_family, t.to_str_params())
-                            for t in new_req]
+                            for t in reqs.flat_requirements]
                 return new_deps
+
+            # get the next generator result
+            next_send = reqs.paths
 
     def run(self):
         logger.info('[pid %s] Worker %s running   %s', os.getpid(), self.worker_id, self.task)

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -55,7 +55,7 @@ from luigi.task_register import load_task
 from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler, RetryPolicy
 from luigi.scheduler import WORKER_STATE_ACTIVE, WORKER_STATE_DISABLED
 from luigi.target import Target
-from luigi.task import Task, flatten, getpaths, Config, DynamicRequirements
+from luigi.task import Task, Config, DynamicRequirements
 from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
 from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -155,7 +155,7 @@ class TaskProcess(multiprocessing.Process):
                 requires = DynamicRequirements(requires)
 
             if not requires.complete(self.check_complete):
-                # when therequirements are not complete yet, return them which adds them to the tree
+                # not all requirements are complete, return them which adds them to the tree
                 new_deps = [(t.task_module, t.task_family, t.to_str_params())
                             for t in requires.flat_requirements]
                 return new_deps


### PR DESCRIPTION
This PR is meant as a continuation of #3178 and further improves the control over dynamic task requirements handled by the worker.

## Description

I added a shallow class `DynamicRequirements` which is intended to wrap a batch of tasks being yielded as dyn. reqs. and optionally to define a custom, probably optimized completeness check for that batch. The new class is understood by the `TaskProcess` as a valid yield value of run() methods, which required changes to only a few lines.

## Motivation and Context

As already mentioned in #3178, we are sometimes dealing with k's of tasks yielded as dynamic requirements in some wrapper task. These tasks store their outputs in a remote location and we can make the assumption that they are located in the same directory (presumably not unusual). For this matter we don't want to "stat" all output files separately, but just do a "listdir" on the common base directory, followed by a local comparison of basenames, saving us k's of interactions with remote resources.  Although we make use of the caching implemented in the referenced PR, we would like to further reduce remote API calls but the workers (or rather TaskProcess) internally flatten all requirements and perform separate completeness checks:

https://github.com/spotify/luigi/blob/master/luigi/worker.py#L154

*Which* requirements exist and which don't is not of interest at this point, so *batched* completeness checks as the one suggested above would be fully compatible with the current logic :)

## Have you tested this? If so, how?

Yep, I added a new test case, update the docs, and amended the `dynamic_requirements.py` example.