### PR TITLE
no mo enum 34

### DIFF
--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -88,6 +88,26 @@ are not the same instance:
     >>> hash(c) == hash(d)
     True
 
++Parameter visibility
+^^^^^^^^^^^^^^^^^^^^
+
+Using :class:`~luigi.parameter.ParameterVisibility` you can configure parameter visibility. By default, all
+parameters are public, but you can also set them hidden or private.
+
+.. code:: python
+
+    >>> import luigi
+    >>> from luigi.parameter import ParameterVisibility
+    
+    >>> luigi.Parameter(visibility=ParameterVisibility.PRIVATE)
+
+``ParameterVisibility.PUBLIC`` (default) - visible everywhere
+
+``ParameterVisibility.HIDDEN`` - ignored in WEB-view, but saved into database if save db_history is true
+
+``ParameterVisibility.PRIVATE`` - visible only inside task.
+
+
 Parameter types
 ^^^^^^^^^^^^^^^
 

--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -43,6 +43,7 @@ from luigi import configuration
 
 from luigi import interface
 from luigi.interface import run, build
+from luigi.execution_summary import LuigiStatusCode
 
 from luigi import event
 from luigi.event import Event
@@ -59,5 +60,5 @@ __all__ = [
     'FloatParameter', 'BoolParameter', 'TaskParameter',
     'ListParameter', 'TupleParameter', 'EnumParameter', 'DictParameter',
     'configuration', 'interface', 'local_target', 'run', 'build', 'event', 'Event',
-    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter'
+    'NumericalParameter', 'ChoiceParameter', 'OptionalParameter', 'LuigiStatusCode'
 ]

--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -33,6 +33,7 @@ import logging
 import os
 import warnings
 
+from configparser import Interpolation
 try:
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 except ImportError:
@@ -40,6 +41,10 @@ except ImportError:
 
 
 class LuigiConfigParser(ConfigParser):
+
+    # for python2/3 compatibility
+    _DEFAULT_INTERPOLATION = Interpolation()
+
     NO_DEFAULT = object()
     _instance = None
     _config_paths = [

--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -33,11 +33,11 @@ import logging
 import os
 import warnings
 
+from configparser import Interpolation
 try:
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
-    Interpolation = object
 except ImportError:
-    from configparser import ConfigParser, NoOptionError, NoSectionError, Interpolation
+    from configparser import ConfigParser, NoOptionError, NoSectionError
 
 
 class LuigiConfigParser(ConfigParser):

--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -33,11 +33,12 @@ import logging
 import os
 import warnings
 
-from configparser import Interpolation
 try:
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
+    Interpolation = object
 except ImportError:
     from configparser import ConfigParser, NoOptionError, NoSectionError
+    from configparser import Interpolation
 
 
 class LuigiConfigParser(ConfigParser):

--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -33,11 +33,11 @@ import logging
 import os
 import warnings
 
-from configparser import Interpolation
 try:
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
+    Interpolation = object
 except ImportError:
-    from configparser import ConfigParser, NoOptionError, NoSectionError
+    from configparser import ConfigParser, NoOptionError, NoSectionError, Interpolation
 
 
 class LuigiConfigParser(ConfigParser):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -476,19 +476,19 @@ def _status_to_code_num(status_code):
     POSIX assigns special meanings to 1 and 2 so start from 3
     """
     if status_code == LuigiStatusCode.SUCCESS:
-        return 3
+        return 0
     elif status_code == LuigiStatusCode.SUCCESS_WITH_RETRY:
-        return 4
+        return 3
     elif status_code == LuigiStatusCode.FAILED:
-        return 5
+        return 4
     elif status_code == LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED:
-        return 6
+        return 5
     elif status_code == LuigiStatusCode.SCHEDULING_FAILED:
-        return 7
+        return 6
     elif status_code == LuigiStatusCode.NOT_RUN:
-        return 8
+        return 7
     elif status_code == LuigiStatusCode.MISSING_EXT:
-        return 9
+        return 8
 
 
 def _summary_wrap(str_output):

--- a/luigi/execution_summary.py
+++ b/luigi/execution_summary.py
@@ -24,12 +24,70 @@ at the end of luigi invocations.
 import textwrap
 import collections
 import functools
+import enum
 
 import luigi
 
 
 class execution_summary(luigi.Config):
     summary_length = luigi.IntParameter(default=5)
+
+
+class LuigiStatusCode(enum.Enum):
+    """
+    All possible status codes for the attribute ``status`` in :class:`~luigi.execution_summary.LuigiRunResult` when
+    the argument ``detailed_summary=True`` in *luigi.run() / luigi.build*.
+    Here are the codes and what they mean:
+
+    =============================  ==========================================================
+    Status Code Name               Meaning
+    =============================  ==========================================================
+    SUCCESS                        There were no failed tasks or missing dependencies
+    SUCCESS_WITH_RETRY             There were failed tasks but they all succeeded in a retry
+    FAILED                         There were failed tasks
+    FAILED_AND_SCHEDULING_FAILED   There were failed tasks and tasks whose scheduling failed
+    SCHEDULING_FAILED              There were tasks whose scheduling failed
+    NOT_RUN                        There were tasks that were not granted run permission by the scheduler
+    MISSING_EXT                    There were missing external dependencies
+    =============================  ==========================================================
+
+    """
+    SUCCESS = (":)", "there were no failed tasks or missing dependencies")
+    SUCCESS_WITH_RETRY = (":)", "there were failed tasks but they all succeeded in a retry")
+    FAILED = (":(", "there were failed tasks")
+    FAILED_AND_SCHEDULING_FAILED = (":(", "there were failed tasks and tasks whose scheduling failed")
+    SCHEDULING_FAILED = (":(", "there were tasks whose scheduling failed")
+    NOT_RUN = (":|", "there were tasks that were not granted run permission by the scheduler")
+    MISSING_EXT = (":|", "there were missing external dependencies")
+
+
+class LuigiRunResult(object):
+    """
+    The result of a call to build/run when passing the detailed_summary=True argument.
+
+    Attributes:
+        - one_line_summary (str): One line summary of the progress.
+        - summary_text (str): Detailed summary of the progress.
+        - status (LuigiStatusCode): Luigi Status Code. See :class:`~luigi.execution_summary.LuigiStatusCode` for what these codes mean.
+        - status_code_num (int): Numeric representation for status (LuigiStatusCode)
+        - worker (luigi.worker.worker): Worker object. See :class:`~luigi.worker.worker`.
+        - scheduling_succeeded (bool): Boolean which is *True* if all the tasks were scheduled without errors.
+
+    """
+    def __init__(self, worker, worker_add_run_status=True):
+        self.worker = worker
+        summary_dict = _summary_dict(worker)
+        self.summary_text = _summary_wrap(_summary_format(summary_dict, worker))
+        self.status = _tasks_status(summary_dict)
+        self.status_code_num = _status_to_code_num(self.status)
+        self.one_line_summary = _create_one_line_summary(self.status)
+        self.scheduling_succeeded = worker_add_run_status
+
+    def __str__(self):
+        return "LuigiRunResult with status {0}".format(self.status)
+
+    def __repr__(self):
+        return "LuigiRunResult(status={0!r},worker={1!r},scheduling_succeeded={2!r})".format(self.status, self.worker, self.scheduling_succeeded)
 
 
 def _partition_tasks(worker):
@@ -377,33 +435,60 @@ def _summary_format(set_tasks, worker):
         if len(ext_workers) == 0:
             str_output += '\n'
         str_output += 'Did not run any tasks'
-    smiley = ""
-    reason = ""
-    if set_tasks["ever_failed"]:
-        if not set_tasks["failed"]:
-            smiley = ":)"
-            reason = "there were failed tasks but they all succeeded in a retry"
-        else:
-            smiley = ":("
-            reason = "there were failed tasks"
-            if set_tasks["scheduling_error"]:
-                reason += " and tasks whose scheduling failed"
-    elif set_tasks["scheduling_error"]:
-        smiley = ":("
-        reason = "there were tasks whose scheduling failed"
-    elif set_tasks["not_run"]:
-        smiley = ":|"
-        reason = "there were tasks that were not granted run permission by the scheduler"
-    elif set_tasks["still_pending_ext"]:
-        smiley = ":|"
-        reason = "there were missing external dependencies"
-    else:
-        smiley = ":)"
-        reason = "there were no failed tasks or missing external dependencies"
-    str_output += "\nThis progress looks {0} because {1}".format(smiley, reason)
+    one_line_summary = _create_one_line_summary(_tasks_status(set_tasks))
+    str_output += "\n{0}".format(one_line_summary)
     if num_all_tasks == 0:
         str_output = 'Did not schedule any tasks'
     return str_output
+
+
+def _create_one_line_summary(status_code):
+    """
+    Given a status_code of type LuigiStatusCode which has a tuple value, returns a one line summary
+    """
+    return "This progress looks {0} because {1}".format(*status_code.value)
+
+
+def _tasks_status(set_tasks):
+    """
+    Given a grouped set of tasks, returns a LuigiStatusCode
+    """
+    if set_tasks["ever_failed"]:
+        if not set_tasks["failed"]:
+            return LuigiStatusCode.SUCCESS_WITH_RETRY
+        else:
+            if set_tasks["scheduling_error"]:
+                return LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED
+            return LuigiStatusCode.FAILED
+    elif set_tasks["scheduling_error"]:
+        return LuigiStatusCode.SCHEDULING_FAILED
+    elif set_tasks["not_run"]:
+        return LuigiStatusCode.NOT_RUN
+    elif set_tasks["still_pending_ext"]:
+        return LuigiStatusCode.MISSING_EXT
+    else:
+        return LuigiStatusCode.SUCCESS
+
+
+def _status_to_code_num(status_code):
+    """
+    Given a status_code of type LuigiStatusCode, returns a numeric value representing it
+    POSIX assigns special meanings to 1 and 2 so start from 3
+    """
+    if status_code == LuigiStatusCode.SUCCESS:
+        return 3
+    elif status_code == LuigiStatusCode.SUCCESS_WITH_RETRY:
+        return 4
+    elif status_code == LuigiStatusCode.FAILED:
+        return 5
+    elif status_code == LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED:
+        return 6
+    elif status_code == LuigiStatusCode.SCHEDULING_FAILED:
+        return 7
+    elif status_code == LuigiStatusCode.NOT_RUN:
+        return 8
+    elif status_code == LuigiStatusCode.MISSING_EXT:
+        return 9
 
 
 def _summary_wrap(str_output):

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -220,7 +220,8 @@ class PidLockAlreadyTakenExit(SystemExit):
 def run(*args, **kwargs):
     luigi_run_result = _run(*args, **kwargs)
     if kwargs.get('detailed_summary'):
-        return luigi_run_result
+        # return status code instead of entire class to keep interface similar (used to return bool)
+        return luigi_run_result.status_code_num
     else:
         return luigi_run_result.scheduling_succeeded
 
@@ -279,6 +280,7 @@ def build(tasks, worker_scheduler_factory=None, detailed_summary=False, **env_pa
     luigi_run_result = _schedule_and_run(tasks, worker_scheduler_factory,
         override_defaults=env_params)
     if detailed_summary:
-        return luigi_run_result
+        # return status code instead of entire class to keep interface similar (used to return bool)
+        return luigi_run_result.status_code_num
     else:
         return luigi_run_result.scheduling_succeeded

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -88,6 +88,10 @@ class email(luigi.Config):
         default=DEFAULT_CLIENT_EMAIL,
         config_path=dict(section='core', name='email-sender'),
         description='Address to send e-mails from')
+    region = luigi.parameter.Parameter(
+        default='',
+        config_path=dict(section='email', name='region'),
+        description='AWS region for SES if you want to override the default AWS region for boto3')
 
 
 class smtp(luigi.Config):
@@ -219,7 +223,8 @@ def send_email_ses(sender, subject, message, recipients, image_png):
     """
     from boto3 import client as boto3_client
 
-    client = boto3_client('ses')
+    region = email().region or None
+    client = boto3_client('ses', region_name=region)
 
     msg_root = generate_email(sender, subject, message, recipients, image_png)
     response = client.send_raw_email(Source=sender,

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -38,6 +38,7 @@ import logging
 import os
 import re
 import time
+import uuid
 
 from luigi import six
 
@@ -147,6 +148,10 @@ class scheduler(Config):
     record_task_history = parameter.BoolParameter(default=False)
 
     prune_on_get_work = parameter.BoolParameter(default=False)
+
+    pause_enabled = parameter.BoolParameter(default=True)
+
+    send_messages = parameter.BoolParameter(default=True)
 
     def _get_retry_policy(self):
         return RetryPolicy(self.retry_count, self.disable_hard_timeout, self.disable_window)
@@ -276,8 +281,8 @@ class OrderedSet(collections.MutableSet):
 
 class Task(object):
     def __init__(self, task_id, status, deps, resources=None, priority=0, family='', module=None,
-                 params=None, param_visibilities=None, tracking_url=None, status_message=None,
-                 progress_percentage=None, retry_policy='notoptional'):
+                 params=None, accepts_messages=False, param_visibilities=None, tracking_url=None,
+                 status_message=None, progress_percentage=None, retry_policy='notoptional'):
         self.id = task_id
         self.stakeholders = set()  # workers ids that are somehow related to this task (i.e. don't prune while any of these workers are still active)
         self.workers = OrderedSet()  # workers ids that can perform task - task is 'BROKEN' if none of these workers are active
@@ -302,11 +307,13 @@ class Task(object):
         self.public_params = {}
         self.hidden_params = {}
         self.set_params(params)
+        self.accepts_messages = accepts_messages
         self.retry_policy = retry_policy
         self.failures = Failures(self.retry_policy.disable_window)
         self.tracking_url = tracking_url
         self.status_message = status_message
         self.progress_percentage = progress_percentage
+        self.scheduler_message_responses = {}
         self.scheduler_disable_time = None
         self.runnable = False
         self.batchable = False
@@ -782,9 +789,9 @@ class Scheduler(object):
     @rpc_method()
     def add_task(self, task_id=None, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
-                 priority=0, family='', module=None, params=None, param_visibilities=None,
-                 assistant=False, tracking_url=None, worker=None, batchable=None,
-                 batch_id=None, retry_policy_dict=None, owners=None, **kwargs):
+                 priority=0, family='', module=None, params=None, accepts_messages=False,
+                 param_visibilities=None, assistant=False, tracking_url=None, worker=None,
+                 batchable=None, batch_id=None, retry_policy_dict=None, owners=None, **kwargs):
         """
         * add task identified by task_id if it doesn't exist
         * if deps is not None, update dependency list
@@ -806,7 +813,8 @@ class Scheduler(object):
         if worker.enabled:
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
-                priority=priority, family=family, module=module, params=params, param_visibilities=param_visibilities
+                priority=priority, family=family, module=module, params=params,
+                accepts_messages=accepts_messages, param_visibilities=param_visibilities
             )
         else:
             _default_task = None
@@ -945,16 +953,47 @@ class Scheduler(object):
         self._state.get_worker(worker).add_rpc_message('set_worker_processes', n=n)
 
     @rpc_method()
+    def send_scheduler_message(self, worker, task, content):
+        if not self._config.send_messages:
+            return {"message_id": None}
+
+        message_id = str(uuid.uuid4())
+        self._state.get_worker(worker).add_rpc_message('dispatch_scheduler_message', task_id=task,
+                                                       message_id=message_id, content=content)
+
+        return {"message_id": message_id}
+
+    @rpc_method()
+    def add_scheduler_message_response(self, task_id, message_id, response):
+        if self._state.has_task(task_id):
+            task = self._state.get_task(task_id)
+            task.scheduler_message_responses[message_id] = response
+
+    @rpc_method()
+    def get_scheduler_message_response(self, task_id, message_id):
+        response = None
+        if self._state.has_task(task_id):
+            task = self._state.get_task(task_id)
+            response = task.scheduler_message_responses.pop(message_id, None)
+        return {"response": response}
+
+    @rpc_method()
+    def is_pause_enabled(self):
+        return {'enabled': self._config.pause_enabled}
+
+    @rpc_method()
     def is_paused(self):
         return {'paused': self._paused}
 
     @rpc_method()
     def pause(self):
-        self._paused = True
+        if self._config.pause_enabled:
+            self._paused = True
 
     @rpc_method()
     def unpause(self):
-        self._paused = False
+        if self._config.pause_enabled:
+            self._paused = False
 
     @rpc_method()
     def update_resources(self, **resources):
@@ -1047,9 +1086,19 @@ class Scheduler(object):
         for task in worker.get_tasks(self._state, PENDING, FAILED):
             if self._upstream_status(task.id, upstream_status_table) == UPSTREAM_DISABLED:
                 continue
-            num_pending += 1
-            num_unique_pending += int(len(task.workers) == 1)
-            num_pending_last_scheduled += int(task.workers.peek(last=True) == worker_id)
+            has_failed_dependency = False
+            for dep in task.deps:
+                dep_task = self._state.get_task(dep, default=None)
+                if dep_task.status == UNKNOWN:
+                    # consider this task as not pending since these dependencies have broken
+                    # requires. this means that they won't ever be retried and can't succeed at all
+                    has_failed_dependency = True
+                    break
+
+            if not has_failed_dependency:
+                num_pending += 1
+                num_unique_pending += int(len(task.workers) == 1)
+                num_pending_last_scheduled += int(task.workers.peek(last=True) == worker_id)
 
         return {
             'n_pending_tasks': num_pending,
@@ -1265,6 +1314,8 @@ class Scheduler(object):
             ret['re_enable_able'] = task.scheduler_disable_time is not None
         if include_deps:
             ret['deps'] = list(task.deps if deps is None else deps)
+        if self._config.send_messages and task.status == RUNNING:
+            ret['accepts_messages'] = task.accepts_messages
         return ret
 
     @rpc_method()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -38,7 +38,6 @@ import logging
 import os
 import re
 import time
-import uuid
 
 from luigi import six
 
@@ -148,10 +147,6 @@ class scheduler(Config):
     record_task_history = parameter.BoolParameter(default=False)
 
     prune_on_get_work = parameter.BoolParameter(default=False)
-
-    pause_enabled = parameter.BoolParameter(default=True)
-
-    send_messages = parameter.BoolParameter(default=True)
 
     def _get_retry_policy(self):
         return RetryPolicy(self.retry_count, self.disable_hard_timeout, self.disable_window)
@@ -281,8 +276,8 @@ class OrderedSet(collections.MutableSet):
 
 class Task(object):
     def __init__(self, task_id, status, deps, resources=None, priority=0, family='', module=None,
-                 params=None, accepts_messages=False, param_visibilities=None, tracking_url=None,
-                 status_message=None, progress_percentage=None, retry_policy='notoptional'):
+                 params=None, param_visibilities=None, tracking_url=None, status_message=None,
+                 progress_percentage=None, retry_policy='notoptional'):
         self.id = task_id
         self.stakeholders = set()  # workers ids that are somehow related to this task (i.e. don't prune while any of these workers are still active)
         self.workers = OrderedSet()  # workers ids that can perform task - task is 'BROKEN' if none of these workers are active
@@ -307,13 +302,11 @@ class Task(object):
         self.public_params = {}
         self.hidden_params = {}
         self.set_params(params)
-        self.accepts_messages = accepts_messages
         self.retry_policy = retry_policy
         self.failures = Failures(self.retry_policy.disable_window)
         self.tracking_url = tracking_url
         self.status_message = status_message
         self.progress_percentage = progress_percentage
-        self.scheduler_message_responses = {}
         self.scheduler_disable_time = None
         self.runnable = False
         self.batchable = False
@@ -789,9 +782,9 @@ class Scheduler(object):
     @rpc_method()
     def add_task(self, task_id=None, status=PENDING, runnable=True,
                  deps=None, new_deps=None, expl=None, resources=None,
-                 priority=0, family='', module=None, params=None, accepts_messages=False,
-                 param_visibilities=None, assistant=False, tracking_url=None, worker=None,
-                 batchable=None, batch_id=None, retry_policy_dict=None, owners=None, **kwargs):
+                 priority=0, family='', module=None, params=None, param_visibilities=None,
+                 assistant=False, tracking_url=None, worker=None, batchable=None,
+                 batch_id=None, retry_policy_dict=None, owners=None, **kwargs):
         """
         * add task identified by task_id if it doesn't exist
         * if deps is not None, update dependency list
@@ -813,8 +806,7 @@ class Scheduler(object):
         if worker.enabled:
             _default_task = self._make_task(
                 task_id=task_id, status=PENDING, deps=deps, resources=resources,
-                priority=priority, family=family, module=module, params=params,
-                accepts_messages=accepts_messages, param_visibilities=param_visibilities
+                priority=priority, family=family, module=module, params=params, param_visibilities=param_visibilities
             )
         else:
             _default_task = None
@@ -829,7 +821,7 @@ class Scheduler(object):
             task.family = family
         if not getattr(task, 'module', None):
             task.module = module
-        if not getattr(task, 'param_visibilities', None):
+        if not task.param_visibilities:
             task.param_visibilities = _get_default(param_visibilities, {})
         if not task.params:
             task.set_params(params)
@@ -953,47 +945,16 @@ class Scheduler(object):
         self._state.get_worker(worker).add_rpc_message('set_worker_processes', n=n)
 
     @rpc_method()
-    def send_scheduler_message(self, worker, task, content):
-        if not self._config.send_messages:
-            return {"message_id": None}
-
-        message_id = str(uuid.uuid4())
-        self._state.get_worker(worker).add_rpc_message('dispatch_scheduler_message', task_id=task,
-                                                       message_id=message_id, content=content)
-
-        return {"message_id": message_id}
-
-    @rpc_method()
-    def add_scheduler_message_response(self, task_id, message_id, response):
-        if self._state.has_task(task_id):
-            task = self._state.get_task(task_id)
-            task.scheduler_message_responses[message_id] = response
-
-    @rpc_method()
-    def get_scheduler_message_response(self, task_id, message_id):
-        response = None
-        if self._state.has_task(task_id):
-            task = self._state.get_task(task_id)
-            response = task.scheduler_message_responses.pop(message_id, None)
-        return {"response": response}
-
-    @rpc_method()
-    def is_pause_enabled(self):
-        return {'enabled': self._config.pause_enabled}
-
-    @rpc_method()
     def is_paused(self):
         return {'paused': self._paused}
 
     @rpc_method()
     def pause(self):
-        if self._config.pause_enabled:
-            self._paused = True
+        self._paused = True
 
     @rpc_method()
     def unpause(self):
-        if self._config.pause_enabled:
-            self._paused = False
+        self._paused = False
 
     @rpc_method()
     def update_resources(self, **resources):
@@ -1314,8 +1275,6 @@ class Scheduler(object):
             ret['re_enable_able'] = task.scheduler_disable_time is not None
         if include_deps:
             ret['deps'] = list(task.deps if deps is None else deps)
-        if self._config.send_messages and task.status == RUNNING:
-            ret['accepts_messages'] = task.accepts_messages
         return ret
 
     @rpc_method()

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -829,7 +829,7 @@ class Scheduler(object):
             task.family = family
         if not getattr(task, 'module', None):
             task.module = module
-        if not task.param_visibilities:
+        if not getattr(task, 'param_visibilities', None):
             task.param_visibilities = _get_default(param_visibilities, {})
         if not task.params:
             task.set_params(params)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -484,8 +484,8 @@ class Task(object):
                         batched_params[param_name] = [param.parse(x) for x in param_str]
                 else:
                     kwargs[param_name] = param.parse(param_str)
-
-        # Append the attribute after initialization so as to reuse the registries instance_cache
+        
+        # Append the attribute after initialization so as to reuse the registry's instance_cache
         ret = cls(**kwargs)
         # TODO evaluate if doing an .update is better?
         setattr(ret, TASK_BATCHED_PARAMS_VAR, batched_params)

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -49,6 +49,7 @@ TASK_ID_TRUNCATE_PARAMS = 16
 TASK_ID_TRUNCATE_HASH = 10
 TASK_ID_INVALID_CHAR_REGEX = re.compile(r'[^A-Za-z0-9_]')
 _SAME_AS_PYTHON_MODULE = '_same_as_python_module'
+TASK_BATCHED_PARAMS_VAR = '_batched_params'
 
 
 def namespace(namespace=None, scope=''):
@@ -365,6 +366,15 @@ class Task(object):
     def batch_param_names(cls):
         return [name for name, p in cls.get_params() if p._is_batchable()]
 
+    @property
+    def batched_params(self):
+        """
+        Get the batched over values for the parameters with a defined batching_method
+
+        :returns a dict of (name, value) where name is the original param_name and the value is the batched over list
+        """
+        return getattr(self, TASK_BATCHED_PARAMS_VAR)
+
     @classmethod
     def get_param_names(cls, include_significant=False):
         return [name for name, p in cls.get_params() if include_significant or p.significant]
@@ -432,6 +442,18 @@ class Task(object):
         # Register kwargs as an attribute on the class. Might be useful
         self.param_kwargs = dict(param_values)
 
+        # Register default batched_params consisting of just single item lists for batchable params
+        #   if they are found in param_kwargs, this will be overwritten in actual batched calls by
+        #   from_str_params
+        batched_params = {}
+        for name in self.batch_param_names():
+                if name in self.param_kwargs:
+                    batched_params[name] = [self.param_kwargs[name]]
+                else:
+                    batched_params[name] = []
+
+        setattr(self, TASK_BATCHED_PARAMS_VAR, batched_params)
+
         self._warn_on_wrong_param_types()
         self.task_id = task_id_str(self.get_task_family(), self.to_str_params(only_significant=True))
         self.__hash = hash(self.task_id)
@@ -464,15 +486,25 @@ class Task(object):
         :param params_str: dict of param name -> value as string.
         """
         kwargs = {}
+        batched_params = {}
         for param_name, param in cls.get_params():
             if param_name in params_str:
                 param_str = params_str[param_name]
                 if isinstance(param_str, list):
                     kwargs[param_name] = param._parse_list(param_str)
+                    if param._is_batchable():
+                        batched_params[param_name] = [param.parse(x) for x in param_str]
                 else:
                     kwargs[param_name] = param.parse(param_str)
+                    if param._is_batchable():
+                        batched_params[param_name] = [param.parse(param_str)]
 
-        return cls(**kwargs)
+        # Append the attribute after initialization so as to reuse the registry's instance_cache
+        ret = cls(**kwargs)
+
+        # TODO(EJS) evaluate if doing an .update is better?
+        setattr(ret, TASK_BATCHED_PARAMS_VAR, batched_params)
+        return ret
 
     def to_str_params(self, only_significant=False):
         """

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -39,6 +39,7 @@ from luigi import six
 
 from luigi import parameter
 from luigi.task_register import Register
+from luigi.parameter import ParameterVisibility
 
 Parameter = parameter.Parameter
 logger = logging.getLogger('luigi-interface')
@@ -455,7 +456,7 @@ class Task(object):
         setattr(self, TASK_BATCHED_PARAMS_VAR, batched_params)
 
         self._warn_on_wrong_param_types()
-        self.task_id = task_id_str(self.get_task_family(), self.to_str_params(only_significant=True))
+        self.task_id = task_id_str(self.get_task_family(), self.to_str_params(only_significant=True, only_public=True))
         self.__hash = hash(self.task_id)
 
         self.set_tracking_url = None
@@ -506,17 +507,28 @@ class Task(object):
         setattr(ret, TASK_BATCHED_PARAMS_VAR, batched_params)
         return ret
 
-    def to_str_params(self, only_significant=False):
+    def to_str_params(self, only_significant=False, only_public=False):
         """
         Convert all parameters to a str->str hash.
         """
         params_str = {}
         params = dict(self.get_params())
         for param_name, param_value in six.iteritems(self.param_kwargs):
-            if (not only_significant) or params[param_name].significant:
+            if (((not only_significant) or params[param_name].significant)
+                    and ((not only_public) or params[param_name].visibility == ParameterVisibility.PUBLIC)
+                    and params[param_name].visibility != ParameterVisibility.PRIVATE):
                 params_str[param_name] = params[param_name].serialize(param_value)
 
         return params_str
+
+    def _get_param_visibilities(self):
+        param_visibilities = {}
+        params = dict(self.get_params())
+        for param_name, param_value in six.iteritems(self.param_kwargs):
+            if params[param_name].visibility != ParameterVisibility.PRIVATE:
+                param_visibilities[param_name] = params[param_name].visibility.serialize()
+
+        return param_visibilities
 
     def clone(self, cls=None, **kwargs):
         """

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -659,8 +659,7 @@ class RangeDaily(RangeDailyBase):
 
     def missing_datetimes(self, finite_datetimes):
         try:
-            cls_with_params = functools.partial(self.of, **self.of_params)
-            complete_parameters = self.of.bulk_complete.__func__(cls_with_params, map(self.datetime_to_parameter, finite_datetimes))
+            complete_parameters = self.of.bulk_complete.__func__(self._instantiate_task_cls, map(self.datetime_to_parameter, finite_datetimes))
             return set(finite_datetimes) - set(map(self.parameter_to_datetime, complete_parameters))
         except NotImplementedError:
             return infer_bulk_complete_from_fs(
@@ -688,8 +687,7 @@ class RangeHourly(RangeHourlyBase):
     def missing_datetimes(self, finite_datetimes):
         try:
             # TODO: Why is there a list() here but not for the RangeDaily??
-            cls_with_params = functools.partial(self.of, **self.of_params)
-            complete_parameters = self.of.bulk_complete.__func__(cls_with_params, list(map(self.datetime_to_parameter, finite_datetimes)))
+            complete_parameters = self.of.bulk_complete.__func__(self._instantiate_task_cls, list(map(self.datetime_to_parameter, finite_datetimes)))
             return set(finite_datetimes) - set(map(self.parameter_to_datetime, complete_parameters))
         except NotImplementedError:
             return infer_bulk_complete_from_fs(
@@ -716,8 +714,7 @@ class RangeByMinutes(RangeByMinutesBase):
 
     def missing_datetimes(self, finite_datetimes):
         try:
-            cls_with_params = functools.partial(self.of, **self.of_params)
-            complete_parameters = self.of.bulk_complete.__func__(cls_with_params, map(self.datetime_to_parameter, finite_datetimes))
+            complete_parameters = self.of.bulk_complete.__func__(self._instantiate_task_cls, map(self.datetime_to_parameter, finite_datetimes))
             return set(finite_datetimes) - set(map(self.parameter_to_datetime, complete_parameters))
         except NotImplementedError:
             return infer_bulk_complete_from_fs(

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -898,6 +898,11 @@ class Worker(object):
             batch_tasks = filter(None, [
                 self._scheduled_tasks.get(batch_id) for batch_id in r['batch_task_ids']])
             self._batch_running_tasks[task_id] = batch_tasks
+            self._scheduled_tasks[task_id] = \
+                load_task(module=r.get('task_module'),
+                          task_name=r['task_family'],
+                          params_str=r['task_params'])
+
 
         return GetWorkResponse(
             task_id=task_id,

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -507,6 +507,9 @@ class Worker(object):
             for batch_task in self._batch_running_tasks.pop(task_id):
                 self._add_task_history.append((batch_task, status, True))
 
+        if task and kwargs.get('params'):
+            kwargs['param_visibilities'] = task._get_param_visibilities()
+
         self._scheduler.add_task(*args, **kwargs)
 
         logger.info('Informed scheduler that task   %s   has status   %s', task_id, status)
@@ -902,7 +905,6 @@ class Worker(object):
                 load_task(module=r.get('task_module'),
                           task_name=r['task_family'],
                           params_str=r['task_params'])
-
 
         return GetWorkResponse(
             task_id=task_id,

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -659,42 +659,44 @@ class Worker(object):
         if self._first_task is None and hasattr(task, 'task_id'):
             self._first_task = task.task_id
         self.add_succeeded = True
-        if multiprocess:
-            queue = multiprocessing.Manager().Queue()
-            pool = multiprocessing.Pool(processes=processes if processes > 0 else None)
-        else:
-            queue = DequeQueue()
-            pool = SingleProcessPool()
-        self._validate_task(task)
-        pool.apply_async(check_complete, [task, queue])
 
-        # we track queue size ourselves because len(queue) won't work for multiprocessing
-        queue_size = 1
-        try:
-            seen = {task.task_id}
-            while queue_size:
-                current = queue.get()
-                queue_size -= 1
-                item, is_complete = current
-                for next in self._add(item, is_complete):
-                    if next.task_id not in seen:
-                        self._validate_task(next)
-                        seen.add(next.task_id)
-                        pool.apply_async(check_complete, [next, queue])
-                        queue_size += 1
-        except (KeyboardInterrupt, TaskException):
-            raise
-        except Exception as ex:
-            self.add_succeeded = False
-            formatted_traceback = traceback.format_exc()
-            self._log_unexpected_error(task)
-            task.trigger_event(Event.BROKEN_TASK, task, ex)
-            self._email_unexpected_error(task, formatted_traceback)
-            raise
-        finally:
-            pool.close()
-            pool.join()
-        return self.add_succeeded
+        with fork_lock:
+            if multiprocess:
+                queue = multiprocessing.Manager().Queue()
+                pool = multiprocessing.Pool(processes=processes if processes > 0 else None)
+            else:
+                queue = DequeQueue()
+                pool = SingleProcessPool()
+            self._validate_task(task)
+            pool.apply_async(check_complete, [task, queue])
+
+            # we track queue size ourselves because len(queue) won't work for multiprocessing
+            queue_size = 1
+            try:
+                seen = {task.task_id}
+                while queue_size:
+                    current = queue.get()
+                    queue_size -= 1
+                    item, is_complete = current
+                    for next in self._add(item, is_complete):
+                        if next.task_id not in seen:
+                            self._validate_task(next)
+                            seen.add(next.task_id)
+                            pool.apply_async(check_complete, [next, queue])
+                            queue_size += 1
+            except (KeyboardInterrupt, TaskException):
+                raise
+            except Exception as ex:
+                self.add_succeeded = False
+                formatted_traceback = traceback.format_exc()
+                self._log_unexpected_error(task)
+                task.trigger_event(Event.BROKEN_TASK, task, ex)
+                self._email_unexpected_error(task, formatted_traceback)
+                raise
+            finally:
+                pool.close()
+                pool.join()
+            return self.add_succeeded
 
     def _add_task_batcher(self, task):
         family = task.task_family

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -898,6 +898,11 @@ class Worker(object):
             batch_tasks = filter(None, [
                 self._scheduled_tasks.get(batch_id) for batch_id in r['batch_task_ids']])
             self._batch_running_tasks[task_id] = batch_tasks
+            self._scheduled_tasks[task_id] = \
+                    load_task(module=r.get('task_module'),
+                              task_name=r['task_family'],
+                              params_str=r['task_params'])
+
 
         return GetWorkResponse(
             task_id=task_id,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 if sys.version_info < (3, 4):
-    install_requires.append('enum34>1.1.0')
+    install_requires.append('enum34>1.2.0')
 
 setup(
     name='luigi',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.0.3',
+    version='2.7.5+affirm.1.1.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ with open('README.rst') as fobj:
 install_requires = [
     'tornado>=4.0,<5',
     'python-daemon<3.0',
+    'enum34>1.1.0 ; python_version < "3.4"'
 ]
 
 if os.environ.get('READTHEDOCS', None) == 'True':
@@ -49,12 +50,9 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.remove('python-daemon<3.0')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
-if sys.version_info < (3, 4):
-    install_requires.append('enum34>1.1.0')
-
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.4.2',
+    version='2.7.5+affirm.1.4.3',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.1.3.0',
+    version='2.7.5.affirm.1.4.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5',
+    version='2.7.5+affirm.1.0.3',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.1.2.0',
+    version='2.7.5.affirm.alextestscheduler',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.1.4.1',
+    version='2.7.5+affirm.1.4.2',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.1.0.0',
+    version='2.7.5.affirm.1.1.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
 
 if sys.version_info < (3, 4):
-    install_requires.append('enum34>1.2.0')
+    install_requires.append('enum34>1.1.0')
 
 setup(
     name='luigi',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.1.0',
+    version='2.7.5.affirm.1.0.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.alextestscheduler',
+    version='2.7.5.affirm.1.3.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.1.0',
+    version='2.7.5.affirm.1.0.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='luigi',
-    version='2.7.5.affirm.1.4.0',
+    version='2.7.5.affirm.1.4.1',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # the License.
 
 import os
+import sys
 
 from setuptools import setup
 
@@ -47,6 +48,9 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     # readthedocs don't like python-daemon, see #1342
     install_requires.remove('python-daemon<3.0')
     install_requires.append('sphinx>=1.4.4')  # Value mirrored in doc/conf.py
+
+if sys.version_info < (3, 4):
+    install_requires.append('enum34>1.1.0')
 
 setup(
     name='luigi',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5',
+    version='2.7.5+affirm.1.1.0',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/test/db_task_history_test.py
+++ b/test/db_task_history_test.py
@@ -24,6 +24,7 @@ import luigi
 from luigi.db_task_history import DbTaskHistory
 from luigi.task_status import DONE, PENDING, RUNNING
 import luigi.scheduler
+from luigi.parameter import ParameterVisibility
 
 
 class DummyTask(luigi.Task):
@@ -32,7 +33,8 @@ class DummyTask(luigi.Task):
 
 class ParamTask(luigi.Task):
     param1 = luigi.Parameter()
-    param2 = luigi.IntParameter()
+    param2 = luigi.IntParameter(visibility=ParameterVisibility.HIDDEN)
+    param3 = luigi.Parameter(default="empty", visibility=ParameterVisibility.PRIVATE)
 
 
 class DbTaskHistoryTest(unittest.TestCase):

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -23,6 +23,7 @@ import luigi.notifications
 from luigi.interface import _WorkerSchedulerFactory
 from luigi.worker import Worker
 from luigi.interface import core
+from luigi.execution_summary import LuigiStatusCode
 
 from mock import Mock, patch, MagicMock
 from helpers import LuigiTestCase, with_config
@@ -46,11 +47,38 @@ class InterfaceTest(LuigiTestCase):
         self.task_a = NoOpTask("a")
         self.task_b = NoOpTask("b")
 
+    def _create_summary_dict_with(self, updates={}):
+        summary_dict = {
+            'completed': set(),
+            'already_done': set(),
+            'ever_failed': set(),
+            'failed': set(),
+            'scheduling_error': set(),
+            'still_pending_ext': set(),
+            'still_pending_not_ext': set(),
+            'run_by_other_worker': set(),
+            'upstream_failure': set(),
+            'upstream_missing_dependency': set(),
+            'upstream_run_by_other_worker': set(),
+            'upstream_scheduling_error': set(),
+            'not_run': set()
+        }
+        summary_dict.update(updates)
+        return summary_dict
+
+    def _summary_dict_module_path():
+        return 'luigi.execution_summary._summary_dict'
+
     def test_interface_run_positive_path(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=True)
 
         self.assertTrue(self._run_interface())
+
+    def test_interface_run_positive_path_with_detailed_summary_enabled(self):
+        self.worker.add = Mock(side_effect=[True, True])
+        self.worker.run = Mock(return_value=True)
+        self.assertTrue(self._run_interface(detailed_summary=True).scheduling_succeeded)
 
     def test_interface_run_with_add_failure(self):
         self.worker.add = Mock(side_effect=[True, False])
@@ -58,11 +86,92 @@ class InterfaceTest(LuigiTestCase):
 
         self.assertFalse(self._run_interface())
 
+    def test_interface_run_with_add_failure_with_detailed_summary_enabled(self):
+        self.worker.add = Mock(side_effect=[True, False])
+        self.worker.run = Mock(return_value=True)
+        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
+
     def test_interface_run_with_run_failure(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=False)
 
         self.assertFalse(self._run_interface())
+
+    def test_interface_run_with_run_failure_with_detailed_summary_enabled(self):
+        self.worker.add = Mock(side_effect=[True, True])
+        self.worker.run = Mock(return_value=False)
+        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_success(self, fake_summary_dict):
+        # Nothing in failed tasks so, should succeed
+        fake_summary_dict.return_value = self._create_summary_dict_with()
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS)
+        self.assertEqual(luigi_run_result.status_code_num, 3)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_success_with_retry(self, fake_summary_dict):
+        # Nothing in failed tasks (only an entry in ever_failed) so, should succeed with retry
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'ever_failed': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
+        self.assertEqual(luigi_run_result.status_code_num, 4)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_failed_when_there_is_one_failed_task(self, fake_summary_dict):
+        # Should fail because a task failed
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'ever_failed': [self.task_a],
+            'failed': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED)
+        self.assertEqual(luigi_run_result.status_code_num, 5)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_failed_with_scheduling_failure(self, fake_summary_dict):
+        # Failed task and also a scheduling error
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'ever_failed': [self.task_a],
+            'failed': [self.task_a],
+            'scheduling_error': [self.task_b]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
+        self.assertEqual(luigi_run_result.status_code_num, 6)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_scheduling_failed_with_one_scheduling_error(self, fake_summary_dict):
+        # Scheduling error for at least one task
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'scheduling_error': [self.task_b]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SCHEDULING_FAILED)
+        self.assertEqual(luigi_run_result.status_code_num, 7)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_not_run_with_one_task_not_run(self, fake_summary_dict):
+        # At least one of the tasks was not run
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'not_run': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.NOT_RUN)
+        self.assertEqual(luigi_run_result.status_code_num, 8)
+
+    @patch(_summary_dict_module_path())
+    def test_that_status_is_missing_ext_with_one_task_with_missing_external_dependency(self, fake_summary_dict):
+        # Missing external dependency for at least one task
+        fake_summary_dict.return_value = self._create_summary_dict_with({
+            'still_pending_ext': [self.task_a]
+        })
+        luigi_run_result = self._run_interface(detailed_summary=True)
+        self.assertEqual(luigi_run_result.status, LuigiStatusCode.MISSING_EXT)
+        self.assertEqual(luigi_run_result.status_code_num, 9)
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()
@@ -94,8 +203,10 @@ class InterfaceTest(LuigiTestCase):
         with patch.object(sys, 'argv', ['my_module.py', '--no-lock', '--my-param', 'my_value', '--local-scheduler']):
             luigi.run(main_task_cls=MyOtherTestTask)
 
-    def _run_interface(self):
-        return luigi.interface.build([self.task_a, self.task_b], worker_scheduler_factory=self.worker_scheduler_factory)
+    def _run_interface(self, **env_params):
+        return luigi.interface.build([self.task_a, self.task_b],
+            worker_scheduler_factory=self.worker_scheduler_factory,
+            **env_params)
 
 
 class CoreConfigTest(LuigiTestCase):

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -108,7 +108,7 @@ class InterfaceTest(LuigiTestCase):
         fake_summary_dict.return_value = self._create_summary_dict_with()
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS)
-        self.assertEqual(luigi_run_result.status_code_num, 3)
+        self.assertEqual(luigi_run_result.status_code_num, 0)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_success_with_retry(self, fake_summary_dict):
@@ -118,7 +118,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
-        self.assertEqual(luigi_run_result.status_code_num, 4)
+        self.assertEqual(luigi_run_result.status_code_num, 3)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_failed_when_there_is_one_failed_task(self, fake_summary_dict):
@@ -129,7 +129,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 5)
+        self.assertEqual(luigi_run_result.status_code_num, 4)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_failed_with_scheduling_failure(self, fake_summary_dict):
@@ -141,7 +141,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 6)
+        self.assertEqual(luigi_run_result.status_code_num, 5)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_scheduling_failed_with_one_scheduling_error(self, fake_summary_dict):
@@ -151,7 +151,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.SCHEDULING_FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 7)
+        self.assertEqual(luigi_run_result.status_code_num, 6)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_not_run_with_one_task_not_run(self, fake_summary_dict):
@@ -161,7 +161,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.NOT_RUN)
-        self.assertEqual(luigi_run_result.status_code_num, 8)
+        self.assertEqual(luigi_run_result.status_code_num, 7)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_missing_ext_with_one_task_with_missing_external_dependency(self, fake_summary_dict):
@@ -171,7 +171,7 @@ class InterfaceTest(LuigiTestCase):
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
         self.assertEqual(luigi_run_result.status, LuigiStatusCode.MISSING_EXT)
-        self.assertEqual(luigi_run_result.status_code_num, 9)
+        self.assertEqual(luigi_run_result.status_code_num, 8)
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -78,7 +78,7 @@ class InterfaceTest(LuigiTestCase):
     def test_interface_run_positive_path_with_detailed_summary_enabled(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=True)
-        self.assertTrue(self._run_interface(detailed_summary=True).scheduling_succeeded)
+        self.assertEqual(self._run_interface(detailed_summary=True), 0)
 
     def test_interface_run_with_add_failure(self):
         self.worker.add = Mock(side_effect=[True, False])
@@ -86,29 +86,18 @@ class InterfaceTest(LuigiTestCase):
 
         self.assertFalse(self._run_interface())
 
-    def test_interface_run_with_add_failure_with_detailed_summary_enabled(self):
-        self.worker.add = Mock(side_effect=[True, False])
-        self.worker.run = Mock(return_value=True)
-        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
-
     def test_interface_run_with_run_failure(self):
         self.worker.add = Mock(side_effect=[True, True])
         self.worker.run = Mock(return_value=False)
 
         self.assertFalse(self._run_interface())
 
-    def test_interface_run_with_run_failure_with_detailed_summary_enabled(self):
-        self.worker.add = Mock(side_effect=[True, True])
-        self.worker.run = Mock(return_value=False)
-        self.assertFalse(self._run_interface(detailed_summary=True).scheduling_succeeded)
-
     @patch(_summary_dict_module_path())
     def test_that_status_is_success(self, fake_summary_dict):
         # Nothing in failed tasks so, should succeed
         fake_summary_dict.return_value = self._create_summary_dict_with()
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS)
-        self.assertEqual(luigi_run_result.status_code_num, 0)
+        self.assertEqual(luigi_run_result, 0)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_success_with_retry(self, fake_summary_dict):
@@ -117,8 +106,7 @@ class InterfaceTest(LuigiTestCase):
             'ever_failed': [self.task_a]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SUCCESS_WITH_RETRY)
-        self.assertEqual(luigi_run_result.status_code_num, 3)
+        self.assertEqual(luigi_run_result, 3)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_failed_when_there_is_one_failed_task(self, fake_summary_dict):
@@ -128,8 +116,7 @@ class InterfaceTest(LuigiTestCase):
             'failed': [self.task_a]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 4)
+        self.assertEqual(luigi_run_result, 4)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_failed_with_scheduling_failure(self, fake_summary_dict):
@@ -140,8 +127,7 @@ class InterfaceTest(LuigiTestCase):
             'scheduling_error': [self.task_b]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.FAILED_AND_SCHEDULING_FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 5)
+        self.assertEqual(luigi_run_result, 5)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_scheduling_failed_with_one_scheduling_error(self, fake_summary_dict):
@@ -150,8 +136,7 @@ class InterfaceTest(LuigiTestCase):
             'scheduling_error': [self.task_b]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.SCHEDULING_FAILED)
-        self.assertEqual(luigi_run_result.status_code_num, 6)
+        self.assertEqual(luigi_run_result, 6)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_not_run_with_one_task_not_run(self, fake_summary_dict):
@@ -160,8 +145,7 @@ class InterfaceTest(LuigiTestCase):
             'not_run': [self.task_a]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.NOT_RUN)
-        self.assertEqual(luigi_run_result.status_code_num, 7)
+        self.assertEqual(luigi_run_result, 7)
 
     @patch(_summary_dict_module_path())
     def test_that_status_is_missing_ext_with_one_task_with_missing_external_dependency(self, fake_summary_dict):
@@ -170,8 +154,7 @@ class InterfaceTest(LuigiTestCase):
             'still_pending_ext': [self.task_a]
         })
         luigi_run_result = self._run_interface(detailed_summary=True)
-        self.assertEqual(luigi_run_result.status, LuigiStatusCode.MISSING_EXT)
-        self.assertEqual(luigi_run_result.status_code_num, 8)
+        self.assertEqual(luigi_run_result, 8)
 
     def test_stops_worker_on_add_exception(self):
         worker = MagicMock()

--- a/test/notifications_test.py
+++ b/test/notifications_test.py
@@ -359,6 +359,27 @@ class TestSESEmail(unittest.TestCase, NotificationFixture):
                     Destinations=self.recipients,
                     RawMessage={'Data': self.mocked_email_msg})
 
+    @with_config({'email': {'region': 'whatever'}})
+    def test_sends_ses_email_with_reguon(self):
+        """
+        Call notifications.send_email_ses with fixture parameters
+        and check that boto is properly called.
+        """
+
+        with mock.patch('boto3.client') as boto_client:
+            with mock.patch('luigi.notifications.generate_email') as generate_email:
+                generate_email.return_value\
+                    .as_string.return_value = self.mocked_email_msg
+
+                notifications.send_email_ses(*self.notification_args)
+
+                boto_client.assert_called_once_with('ses', region_name='whatever')
+                SES = boto_client.return_value
+                SES.send_raw_email.assert_called_once_with(
+                    Source=self.sender,
+                    Destinations=self.recipients,
+                    RawMessage={'Data': self.mocked_email_msg})
+
 
 class TestSNSNotification(unittest.TestCase, NotificationFixture):
     """

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -22,6 +22,7 @@ from helpers import unittest, LuigiTestCase
 import luigi
 import mock
 from luigi.mock import MockTarget, MockFileSystem
+from luigi.task import MixinNaiveBulkComplete
 from luigi.tools.range import (RangeDaily, RangeDailyBase, RangeEvent,
                                RangeHourly, RangeHourlyBase,
                                RangeByMinutes, RangeByMinutesBase,
@@ -1178,6 +1179,23 @@ class RangeInstantiationTest(LuigiTestCase):
                 return False
 
         range_task = RangeDailyBase(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
+                                    of=MyTask,
+                                    start=datetime.date(2015, 12, 1),
+                                    stop=datetime.date(2015, 12, 2),
+                                    param_name='date_param')
+        expected_task = MyTask('woo', datetime.date(2015, 12, 1))
+        self.assertEqual(expected_task, list(range_task._requires())[0])
+
+
+    def test_param_name_with_mixinnaivebulkcomplete(self):
+        class MyTask(MixinNaiveBulkComplete, luigi.Task):
+            some_non_range_param = luigi.Parameter(default='woo')
+            date_param = luigi.DateParameter()
+
+            def complete(self):
+                return False
+
+        range_task = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
                                     of=MyTask,
                                     start=datetime.date(2015, 12, 1),
                                     stop=datetime.date(2015, 12, 2),

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -22,6 +22,7 @@ from helpers import unittest, LuigiTestCase
 import luigi
 import mock
 from luigi.mock import MockTarget, MockFileSystem
+from luigi.task import MixinNaiveBulkComplete
 from luigi.tools.range import (RangeDaily, RangeDailyBase, RangeEvent,
                                RangeHourly, RangeHourlyBase,
                                RangeByMinutes, RangeByMinutesBase,
@@ -1182,6 +1183,22 @@ class RangeInstantiationTest(LuigiTestCase):
                                     start=datetime.date(2015, 12, 1),
                                     stop=datetime.date(2015, 12, 2),
                                     param_name='date_param')
+        expected_task = MyTask('woo', datetime.date(2015, 12, 1))
+        self.assertEqual(expected_task, list(range_task._requires())[0])
+
+    def test_param_name_with_mixinnaivebulkcomplete(self):
+        class MyTask(MixinNaiveBulkComplete, luigi.Task):
+            some_non_range_param = luigi.Parameter(default='woo')
+            date_param = luigi.DateParameter()
+
+            def complete(self):
+                return False
+
+        range_task = RangeDaily(now=datetime_to_epoch(datetime.datetime(2015, 12, 2)),
+                                of=MyTask,
+                                start=datetime.date(2015, 12, 1),
+                                stop=datetime.date(2015, 12, 2),
+                                param_name='date_param')
         expected_task = MyTask('woo', datetime.date(2015, 12, 1))
         self.assertEqual(expected_task, list(range_task._requires())[0])
 

--- a/test/scheduler_parameter_visibilities_test.py
+++ b/test/scheduler_parameter_visibilities_test.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012-2015 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from helpers import LuigiTestCase, RunOnceTask
+import server_test
+
+import luigi
+import luigi.scheduler
+import luigi.worker
+from luigi.parameter import ParameterVisibility
+import json
+import time
+
+
+class SchedulerParameterVisibilitiesTest(LuigiTestCase):
+    def test_task_with_deps(self):
+        s = luigi.scheduler.Scheduler(send_messages=True)
+        with luigi.worker.Worker(scheduler=s) as w:
+            class DynamicTask(RunOnceTask):
+                dynamic_public = luigi.Parameter(default="dynamic_public")
+                dynamic_hidden = luigi.Parameter(default="dynamic_hidden", visibility=ParameterVisibility.HIDDEN)
+                dynamic_private = luigi.Parameter(default="dynamic_private", visibility=ParameterVisibility.PRIVATE)
+
+            class RequiredTask(RunOnceTask):
+                required_public = luigi.Parameter(default="required_param")
+                required_hidden = luigi.Parameter(default="required_hidden", visibility=ParameterVisibility.HIDDEN)
+                required_private = luigi.Parameter(default="required_private", visibility=ParameterVisibility.PRIVATE)
+
+            class Task(RunOnceTask):
+                a = luigi.Parameter(default="a")
+                b = luigi.Parameter(default="b", visibility=ParameterVisibility.HIDDEN)
+                c = luigi.Parameter(default="c", visibility=ParameterVisibility.PRIVATE)
+                d = luigi.Parameter(default="d", visibility=ParameterVisibility.PUBLIC)
+
+                def requires(self):
+                    return required_task
+
+                def run(self):
+                    yield dynamic_task
+
+            dynamic_task = DynamicTask()
+            required_task = RequiredTask()
+            task = Task()
+
+            w.add(task)
+            w.run()
+
+            time.sleep(1)
+            task_deps = s.dep_graph(task_id=task.task_id)
+            required_task_deps = s.dep_graph(task_id=required_task.task_id)
+            dynamic_task_deps = s.dep_graph(task_id=dynamic_task.task_id)
+
+            self.assertEqual('Task(a=a, d=d)', task_deps[task.task_id]['display_name'])
+            self.assertEqual('RequiredTask(required_public=required_param)',
+                             required_task_deps[required_task.task_id]['display_name'])
+            self.assertEqual('DynamicTask(dynamic_public=dynamic_public)',
+                             dynamic_task_deps[dynamic_task.task_id]['display_name'])
+
+            self.assertEqual({'a': 'a', 'd': 'd'}, task_deps[task.task_id]['params'])
+            self.assertEqual({'required_public': 'required_param'},
+                             required_task_deps[required_task.task_id]['params'])
+            self.assertEqual({'dynamic_public': 'dynamic_public'},
+                             dynamic_task_deps[dynamic_task.task_id]['params'])
+
+    def test_public_and_hidden_params(self):
+        s = luigi.scheduler.Scheduler(send_messages=True)
+        with luigi.worker.Worker(scheduler=s) as w:
+            class Task(RunOnceTask):
+                a = luigi.Parameter(default="a")
+                b = luigi.Parameter(default="b", visibility=ParameterVisibility.HIDDEN)
+                c = luigi.Parameter(default="c", visibility=ParameterVisibility.PRIVATE)
+                d = luigi.Parameter(default="d", visibility=ParameterVisibility.PUBLIC)
+
+            task = Task()
+
+            w.add(task)
+            w.run()
+
+            time.sleep(1)
+            t = s._state.get_task(task.task_id)
+            self.assertEqual({'b': 'b'}, t.hidden_params)
+            self.assertEqual({'a': 'a', 'd': 'd'}, t.public_params)
+            self.assertEqual({'a': 0, 'b': 1, 'd': 0}, t.param_visibilities)
+
+
+class Task(RunOnceTask):
+    a = luigi.Parameter(default="a")
+    b = luigi.Parameter(default="b", visibility=ParameterVisibility.HIDDEN)
+    c = luigi.Parameter(default="c", visibility=ParameterVisibility.PRIVATE)
+    d = luigi.Parameter(default="d", visibility=ParameterVisibility.PUBLIC)
+
+
+class RemoteSchedulerParameterVisibilitiesTest(server_test.ServerTestBase):
+    def test_public_params(self):
+        task = Task()
+        luigi.build(tasks=[task], workers=2, scheduler_port=self.get_http_port())
+
+        time.sleep(1)
+
+        response = self.fetch('/api/graph')
+
+        body = response.body
+        decoded = body.decode('utf8').replace("'", '"')
+        data = json.loads(decoded)
+
+        self.assertEqual({'a': 'a', 'd': 'd'}, data['response'][task.task_id]['params'])

--- a/test/scheduler_parameter_visibilities_test.py
+++ b/test/scheduler_parameter_visibilities_test.py
@@ -28,7 +28,7 @@ import time
 
 class SchedulerParameterVisibilitiesTest(LuigiTestCase):
     def test_task_with_deps(self):
-        s = luigi.scheduler.Scheduler(send_messages=True)
+        s = luigi.scheduler.Scheduler()
         with luigi.worker.Worker(scheduler=s) as w:
             class DynamicTask(RunOnceTask):
                 dynamic_public = luigi.Parameter(default="dynamic_public")
@@ -77,7 +77,7 @@ class SchedulerParameterVisibilitiesTest(LuigiTestCase):
                              dynamic_task_deps[dynamic_task.task_id]['params'])
 
     def test_public_and_hidden_params(self):
-        s = luigi.scheduler.Scheduler(send_messages=True)
+        s = luigi.scheduler.Scheduler()
         with luigi.worker.Worker(scheduler=s) as w:
             class Task(RunOnceTask):
                 a = luigi.Parameter(default="a")

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -19,10 +19,16 @@ from __future__ import print_function
 import pickle
 import tempfile
 import time
+import os
+import shutil
+from multiprocessing import Process
 from helpers import unittest
 
 import luigi.scheduler
+import luigi.server
+import luigi.configuration
 from helpers import with_config
+from luigi.target import FileAlreadyExists
 
 
 class SchedulerIoTest(unittest.TestCase):
@@ -247,3 +253,69 @@ class SchedulerWorkerTest(unittest.TestCase):
 
         non_trivial_worker = scheduler_state.get_worker('NON_TRIVIAL')
         self.assertEqual({'A'}, self.get_pending_ids(non_trivial_worker, scheduler_state))
+
+
+class FailingOnDoubleRunTask(luigi.Task):
+    time_to_check_secs = 1
+    time_to_run_secs = 2
+    output_dir = luigi.Parameter(default="")
+
+    def __init__(self, *args, **kwargs):
+        super(FailingOnDoubleRunTask, self).__init__(*args, **kwargs)
+        self.file_name = os.path.join(self.output_dir, "AnyTask")
+
+    def complete(self):
+        time.sleep(self.time_to_check_secs)  # e.g., establish connection
+        exists = os.path.exists(self.file_name)
+        time.sleep(self.time_to_check_secs)  # e.g., close connection
+        return exists
+
+    def run(self):
+        time.sleep(self.time_to_run_secs)
+        if os.path.exists(self.file_name):
+            raise FileAlreadyExists(self.file_name)
+        open(self.file_name, 'w').close()
+
+
+class StableDoneCooldownSecsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.p = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.p)
+
+    def run_task(self):
+        return luigi.build([FailingOnDoubleRunTask(output_dir=self.p)],
+                           detailed_summary=True,
+                           parallel_scheduling=True,
+                           parallel_scheduling_processes=2)
+
+    @with_config({'worker': {'keep_alive': 'false'}})
+    def get_second_run_result_on_double_run(self):
+        server_process = Process(target=luigi.server.run)
+        process = Process(target=self.run_task)
+        try:
+            # scheduler is started
+            server_process.start()
+            # first run is started
+            process.start()
+            time.sleep(FailingOnDoubleRunTask.time_to_run_secs + FailingOnDoubleRunTask.time_to_check_secs)
+            # second run of the same task is started
+            second_run_result = self.run_task()
+            return second_run_result
+        finally:
+            process.join(1)
+            server_process.terminate()
+            server_process.join(1)
+
+    @with_config({'scheduler': {'stable_done_cooldown_secs': '5'}})
+    def test_sending_same_task_twice_with_cooldown_does_not_lead_to_double_run(self):
+        second_run_result = self.get_second_run_result_on_double_run()
+        self.assertEqual(second_run_result.scheduling_succeeded, True)
+
+    @with_config({'scheduler': {'stable_done_cooldown_secs': '0'}})
+    def test_sending_same_task_twice_without_cooldown_leads_to_double_run(self):
+        second_run_result = self.get_second_run_result_on_double_run()
+        self.assertEqual(second_run_result.scheduling_succeeded, False)
+

--- a/test/unknown_state_handling_test.py
+++ b/test/unknown_state_handling_test.py
@@ -1,0 +1,83 @@
+from helpers import LuigiTestCase
+
+
+import luigi
+import luigi.worker
+import luigi.execution_summary
+
+
+class DummyRequires(luigi.Task):
+    def run(self):
+        print('just a dummy task')
+
+
+class FailInRun(luigi.Task):
+    def run(self):
+        print('failing in run')
+        raise Exception
+
+
+class FailInRequires(luigi.Task):
+    def requires(self):
+        print('failing')
+        raise Exception
+        return [DummyRequires()]
+
+    def run(self):
+        print('running')
+
+
+class FailInDepRequires(luigi.Task):
+    def requires(self):
+        return [FailInRequires()]
+
+    def run(self):
+        print('doing a thing')
+
+
+class FailInDepRun(luigi.Task):
+    def requires(self):
+        return [FailInRun()]
+
+    def run(self):
+        print('doing a thing')
+
+
+class UnknownStateTest(LuigiTestCase):
+    def setUp(self):
+        super(UnknownStateTest, self).setUp()
+        self.scheduler = luigi.scheduler.Scheduler(prune_on_get_work=False)
+        self.worker = luigi.worker.Worker(scheduler=self.scheduler)
+
+    def run_task(self, task):
+        self.worker.add(task)  # schedule
+        self.worker.run()  # run
+
+    def summary_dict(self):
+        return luigi.execution_summary._summary_dict(self.worker)
+
+    def test_fail_in_run(self):
+        self.run_task(FailInRun())
+        summary_dict = self.summary_dict()
+
+        self.assertEqual({FailInRun()}, summary_dict['failed'])
+
+    def test_fail_in_requires(self):
+        self.run_task(FailInRequires())
+        summary_dict = self.summary_dict()
+
+        self.assertEqual({FailInRequires()}, summary_dict['scheduling_error'])
+
+    def test_fail_in_dep_run(self):
+        self.run_task(FailInDepRun())
+        summary_dict = self.summary_dict()
+
+        self.assertEqual({FailInRun()}, summary_dict['failed'])
+        self.assertEqual({FailInDepRun()}, summary_dict['still_pending_not_ext'])
+
+    def test_fail_in_dep_requires(self):
+        self.run_task(FailInDepRequires())
+        summary_dict = self.summary_dict()
+
+        self.assertEqual({FailInRequires()}, summary_dict['scheduling_error'])
+        self.assertEqual({FailInDepRequires()}, summary_dict['still_pending_not_ext'])

--- a/test/unknown_state_handling_test.py
+++ b/test/unknown_state_handling_test.py
@@ -21,7 +21,6 @@ class FailInRequires(luigi.Task):
     def requires(self):
         print('failing')
         raise Exception
-        return [DummyRequires()]
 
     def run(self):
         print('running')
@@ -46,8 +45,14 @@ class FailInDepRun(luigi.Task):
 class UnknownStateTest(LuigiTestCase):
     def setUp(self):
         super(UnknownStateTest, self).setUp()
-        self.scheduler = luigi.scheduler.Scheduler(prune_on_get_work=False)
-        self.worker = luigi.worker.Worker(scheduler=self.scheduler)
+        self.scheduler = luigi.scheduler.Scheduler(
+            prune_on_get_work=False,
+            retry_count=1
+        )
+        self.worker = luigi.worker.Worker(
+            scheduler=self.scheduler, 
+            keep_alive=True
+        )
 
     def run_task(self, task):
         self.worker.add(task)  # schedule

--- a/test/visible_parameters_test.py
+++ b/test/visible_parameters_test.py
@@ -1,0 +1,95 @@
+import luigi
+from luigi.parameter import ParameterVisibility
+from helpers import unittest
+import json
+
+
+class TestTask1(luigi.Task):
+    param_one = luigi.Parameter(default='1', visibility=ParameterVisibility.HIDDEN, significant=True)
+    param_two = luigi.Parameter(default='2', significant=True)
+    param_three = luigi.Parameter(default='3', visibility=ParameterVisibility.PRIVATE, significant=True)
+
+
+class TestTask2(luigi.Task):
+    param_one = luigi.Parameter(default='1', visibility=ParameterVisibility.PRIVATE)
+    param_two = luigi.Parameter(default='2', visibility=ParameterVisibility.PRIVATE)
+    param_three = luigi.Parameter(default='3', visibility=ParameterVisibility.PRIVATE)
+
+
+class TestTask3(luigi.Task):
+    param_one = luigi.Parameter(default='1', visibility=ParameterVisibility.HIDDEN, significant=True)
+    param_two = luigi.Parameter(default='2', visibility=ParameterVisibility.HIDDEN, significant=False)
+    param_three = luigi.Parameter(default='3', visibility=ParameterVisibility.HIDDEN, significant=True)
+
+
+class TestTask4(luigi.Task):
+    param_one = luigi.Parameter(default='1', visibility=ParameterVisibility.PUBLIC, significant=True)
+    param_two = luigi.Parameter(default='2', visibility=ParameterVisibility.PUBLIC, significant=False)
+    param_three = luigi.Parameter(default='3', visibility=ParameterVisibility.PUBLIC, significant=True)
+
+
+class Test(unittest.TestCase):
+    def test_to_str_params(self):
+        task = TestTask1()
+
+        self.assertEqual(task.to_str_params(), {'param_one': '1', 'param_two': '2'})
+
+        task = TestTask2()
+
+        self.assertEqual(task.to_str_params(), {})
+
+        task = TestTask3()
+
+        self.assertEqual(task.to_str_params(), {'param_one': '1', 'param_two': '2', 'param_three': '3'})
+
+    def test_all_public_equals_all_hidden(self):
+        hidden = TestTask3()
+        public = TestTask4()
+
+        self.assertEqual(public.to_str_params(), hidden.to_str_params())
+
+    def test_all_public_equals_all_hidden_using_significant(self):
+        hidden = TestTask3()
+        public = TestTask4()
+
+        self.assertEqual(public.to_str_params(only_significant=True), hidden.to_str_params(only_significant=True))
+
+    def test_private_params_and_significant(self):
+        task = TestTask1()
+
+        self.assertEqual(task.to_str_params(), task.to_str_params(only_significant=True))
+
+    def test_param_visibilities(self):
+        task = TestTask1()
+
+        self.assertEqual(task._get_param_visibilities(), {'param_one': 1, 'param_two': 0})
+
+    def test_incorrect_visibility_value(self):
+        class Task(luigi.Task):
+            a = luigi.Parameter(default='val', visibility=5)
+
+        task = Task()
+
+        self.assertEqual(task._get_param_visibilities(), {'a': 0})
+
+    def test_task_id_exclude_hidden_and_private_params(self):
+        task = TestTask1()
+
+        self.assertEqual({'param_two': '2'}, task.to_str_params(only_public=True))
+
+    def test_json_dumps(self):
+        public = json.dumps(ParameterVisibility.PUBLIC.serialize())
+        hidden = json.dumps(ParameterVisibility.HIDDEN.serialize())
+        private = json.dumps(ParameterVisibility.PRIVATE.serialize())
+
+        self.assertEqual('0', public)
+        self.assertEqual('1', hidden)
+        self.assertEqual('2', private)
+
+        public = json.loads(public)
+        hidden = json.loads(hidden)
+        private = json.loads(private)
+
+        self.assertEqual(0, public)
+        self.assertEqual(1, hidden)
+        self.assertEqual(2, private)

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -724,7 +724,6 @@ class WorkerTest(LuigiTestCase):
             value = luigi.IntParameter(batch_method=max)
             has_run = False
 
-
             def run(self):
                 completed.add(self.value)
                 self.has_run = True
@@ -736,7 +735,6 @@ class WorkerTest(LuigiTestCase):
         for task in tasks:
             self.assertTrue(self.w.add(task))
         self.assertTrue(self.w.run())
-
         
         for task in tasks:
             self.assertTrue(task.complete())
@@ -747,13 +745,12 @@ class WorkerTest(LuigiTestCase):
         #Task number 9 should have batched_params of all tasks values
         self.assertEquals(tasks[-1].batched_params, {'value' : list(range(10))})
     
-    def test_run_batch_jobs_which_overlap(self):
+    def test_run_batch_jobs_which_overlap_subset_batch(self):
         completed = set()
 
         class MaxBatchJob(luigi.Task):
             value = luigi.IntParameter(batch_method=max)
             has_run = False
-
 
             def run(self):
                 completed.add(self.value)
@@ -780,12 +777,52 @@ class WorkerTest(LuigiTestCase):
         for task in tasks_which_overlap:
             #Only 4 and 9 run
             self.assertFalse(task.has_run and task.value not in (4,9))
+            #Only 4 and 9 have batched_params (content tested below)
+            self.assertFalse(task.batched_params and task.value not in (4,9))
         
         #Task number 4 should have batched_params of the first batch
         self.assertEquals(tasks[-1].batched_params, {'value' : list(range(5))})
 
         #Task number 9 should have batched_params of all remaining tasks
         self.assertEquals(tasks_batch_2[-1].batched_params, {'value' : list(range(5, 10))})
+    
+    def test_run_batch_jobs_which_overlap_superset_batch(self):
+        completed = set()
+
+        class MaxBatchJob(luigi.Task):
+            value = luigi.IntParameter(batch_method=max)
+            has_run = False
+
+            def run(self):
+                completed.add(self.value)
+                self.has_run = True
+
+            def complete(self):
+                return any(self.value <= ran for ran in completed)
+
+        tasks = [MaxBatchJob(i) for i in range(5)]
+        tasks_batch_2 = [MaxBatchJob(i) for i in range(5, 10)]
+        tasks_which_overlap = tasks + tasks_batch_2
+        for task in tasks:
+            self.assertTrue(self.w.add(task))
+        # "Duplilcate" tasks added w2
+        for task in tasks_which_overlap:
+            self.assertTrue(self.w2.add(task))
+
+        #Run all tasks one batch
+        self.assertTrue(self.w2.run())
+        
+        #Run tasks on w (should be a no op)
+        self.assertTrue(self.w.run())
+        
+        for task in tasks_which_overlap:
+            #Only 9 ran
+            self.assertFalse(task.has_run and task.value != 9)
+            #Only 4 and 9 have batched_params (content tested below)
+            self.assertFalse(task.batched_params and task.value != 9)
+
+        #Task number 9 should have batched_params of all tasks
+        self.assertEquals(tasks_batch_2[-1].batched_params, {'value' : list(range(10))})
 
     def test_run_batch_job_unbatched(self):
         completed = set()

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -736,12 +736,12 @@ class WorkerTest(LuigiTestCase):
             self.assertTrue(self.w.add(task))
         self.assertTrue(self.w.run())
         
-        for task in tasks:
+        for i, task in enumerate(tasks):
             self.assertTrue(task.complete())
             # only task number 9 should run
             self.assertFalse(task.has_run and task.value < 9)
-            # only task number 9 should have batched_params
-            self.assertFalse(task.batched_params and task.value < 9)
+            # only task number 9 should have more than default batched_params
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value < 9)
         #Task number 9 should have batched_params of all tasks values
         self.assertEquals(tasks[-1].batched_params, {'value' : list(range(10))})
     
@@ -774,11 +774,11 @@ class WorkerTest(LuigiTestCase):
         #Run tasks on w2
         self.assertTrue(self.w2.run())
         
-        for task in tasks_which_overlap:
+        for i, task in enumerate(tasks_which_overlap):
             #Only 4 and 9 run
             self.assertFalse(task.has_run and task.value not in (4,9))
-            #Only 4 and 9 have batched_params (content tested below)
-            self.assertFalse(task.batched_params and task.value not in (4,9))
+            #Only 4 and 9 have more than default batched_params (content tested below)
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value not in (4,9))
         
         #Task number 4 should have batched_params of the first batch
         self.assertEquals(tasks[-1].batched_params, {'value' : list(range(5))})
@@ -815,11 +815,11 @@ class WorkerTest(LuigiTestCase):
         #Run tasks on w (should be a no op)
         self.assertTrue(self.w.run())
         
-        for task in tasks_which_overlap:
+        for i, task in enumerate(tasks_which_overlap):
             #Only 9 ran
             self.assertFalse(task.has_run and task.value != 9)
             #Only 4 and 9 have batched_params (content tested below)
-            self.assertFalse(task.batched_params and task.value != 9)
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value != 9)
 
         #Task number 9 should have batched_params of all tasks
         self.assertEquals(tasks_batch_2[-1].batched_params, {'value' : list(range(10))})

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -736,10 +736,93 @@ class WorkerTest(LuigiTestCase):
             self.assertTrue(self.w.add(task))
         self.assertTrue(self.w.run())
 
-        for task in tasks:
+        for i, task in enumerate(tasks):
             self.assertTrue(task.complete())
             # only task number 9 should run
             self.assertFalse(task.has_run and task.value < 9)
+            # only task number 9 should have more than default batched_params
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value < 9)
+        # Task number 9 should have batched_params of all tasks values
+        self.assertEquals(tasks[-1].batched_params, {'value': list(range(10))})
+
+    def test_run_batch_jobs_which_overlap_subset_batch(self):
+        completed = set()
+
+        class MaxBatchJob(luigi.Task):
+            value = luigi.IntParameter(batch_method=max)
+            has_run = False
+
+            def run(self):
+                completed.add(self.value)
+                self.has_run = True
+
+            def complete(self):
+                return any(self.value <= ran for ran in completed)
+
+        tasks = [MaxBatchJob(i) for i in range(5)]
+        tasks_batch_2 = [MaxBatchJob(i) for i in range(5, 10)]
+        tasks_which_overlap = tasks + tasks_batch_2
+        for task in tasks:
+            self.assertTrue(self.w.add(task))
+        # "Duplilcate" tasks added w2
+        for task in tasks_which_overlap:
+            self.assertTrue(self.w2.add(task))
+
+        # Run tasks on w "scheduled" first
+        self.assertTrue(self.w.run())
+
+        # Run tasks on w2
+        self.assertTrue(self.w2.run())
+
+        for i, task in enumerate(tasks_which_overlap):
+            # Only 4 and 9 run
+            self.assertFalse(task.has_run and task.value not in (4, 9))
+            # Only 4 and 9 have more than default batched_params (content tested below)
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value not in (4, 9))
+
+        # Task number 4 should have batched_params of the first batch
+        self.assertEquals(tasks[-1].batched_params, {'value': list(range(5))})
+
+        # Task number 9 should have batched_params of all remaining tasks
+        self.assertEquals(tasks_batch_2[-1].batched_params, {'value': list(range(5, 10))})
+
+    def test_run_batch_jobs_which_overlap_superset_batch(self):
+        completed = set()
+
+        class MaxBatchJob(luigi.Task):
+            value = luigi.IntParameter(batch_method=max)
+            has_run = False
+
+            def run(self):
+                completed.add(self.value)
+                self.has_run = True
+
+            def complete(self):
+                return any(self.value <= ran for ran in completed)
+
+        tasks = [MaxBatchJob(i) for i in range(5)]
+        tasks_batch_2 = [MaxBatchJob(i) for i in range(5, 10)]
+        tasks_which_overlap = tasks + tasks_batch_2
+        for task in tasks:
+            self.assertTrue(self.w.add(task))
+        # "Duplilcate" tasks added w2
+        for task in tasks_which_overlap:
+            self.assertTrue(self.w2.add(task))
+
+        # Run all tasks one batch
+        self.assertTrue(self.w2.run())
+
+        # Run tasks on w (should be a no op)
+        self.assertTrue(self.w.run())
+
+        for i, task in enumerate(tasks_which_overlap):
+            # Only 9 ran
+            self.assertFalse(task.has_run and task.value != 9)
+            # Only 4 and 9 have batched_params (content tested below)
+            self.assertFalse(task.batched_params != {'value': [i]} and task.value != 9)
+
+        # Task number 9 should have batched_params of all tasks
+        self.assertEquals(tasks_batch_2[-1].batched_params, {'value': list(range(10))})
 
     def test_run_batch_job_unbatched(self):
         completed = set()

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,7 @@ deps =
   sqlalchemy
   Sphinx>=1.4.4,<1.5
   sphinx_rtd_theme
+  enum34>1.1.0
 commands =
     # build API docs
     sphinx-apidoc -o doc/api -T luigi --separate


### PR DESCRIPTION
- Fallback process command name in lock.getpcmd
- Moves task id computation into a separate function in task.py
- Speeds up get_work with a number of small tweaks
- Fix documentation generation
- Add DictParameter
- Use immutable and ordered dict in DictParameter
- Add test cases for DictParameter
- Update dict param docs with tag based exammple
- Add parse-serialize test case
- Add enbrite.ly to companies that use Luigi
- Added support for SFTP.
- Update import in parameter, revert setup.py
- Refactor s3 to s3 copying
- correct example spark_als
- Add s3 directory copy tests
- Scheduler UI: Fix python3 issues in resources view
- Scheduler: Remove backward compatibility code
- scheduler.py: Update comment
- Corrected usage of 'query' as it was defined as a property, but reference and used as if it were a method.
- Add DJ/WSJ to list of companies.
- Updated to use iteration (over recursion) and TempFiles to avoid segmentation faults due to massive recursion and extremely large datasets from salesforce.
- Don't make every response an ordereddict. The order of the dictionary fields don't matter here.What matters is that the list of dicts is in the appropriate order if one specifies an order by within their SOQL. Since lists maintain order, this is good."
- Attempt to give luigi s3 module assume role support
- Luigi tasks for google dataproc
- Fixed _ftp_exists(...) method. Previously called nlst(path) on full path including filename and extention. This only worked if the file existed.
- Updated the way asks get run and added more documentation
- scheduler.py: Refactor Scheduler.prune()
- Scheduler: Refactor and bugfix task pruning
- assistants bugfix: Also prune UNKNOWN tasks
- EnumParameter docs: Encourage singular enums
- EnumParameter docs: Use Enum not IntEnum
- Sets task.run to None instead of NotImplemented in ExternalTasks
- Fix spelling error in central_planner_test.py
- Return code for 'check_complete' exception
- Add an index on task_events.task_id.
- Return code for 'requires()' exception
- Re-raise exceptions to trigger "unhandled_exception"
- Add tests for unwanted return code 0
- Added ListParameter and TupleParameter.
- Added tests for List/Tuple Parameter serialize/parse and config read.
- Added comment explanation of parse() execution for TupleParameter.
- Added test for cli arg parse.
- 2.1.0
- Added module level documentation for a couple use cases of luigi.util
- Bug fixes for Hive CLI and Beeline compatibility
- Clarify wording of "clean slate" in scheduler logging
- Add several extra options to bigquery load configuration
- fix failing tests
- Add explicit whitelist of RPC commands for luigid
- Release version 2.1.1
- Add GUI-visible status messages for tasks
- Make luigid honor logging_conf_file
- Add status message endpoints to RPC handler list.
- parameter.py: Rename .__config to ._config_path
- Bugfix: Scheduler crashes for some configs
- Include sys.argv in error emails (#1637)
- Updated grammer in target.AtomicLocalFile class
- Raise Queue.Empty for get() on empty queue
- scheduler: Remove unused prune_done_tasks option (#1640)
- Changed task_history_override to task_history_impl (#1641)
- Fix bug in LocalFileSystem.move (#1643)
- luigid logging: Log less and change logger name (#1636)
- Make status_message optional in task serialization. (#1645)
- Upgraded dagre-d3 to v0.4.17 to resolve issue #1604
- Add the archive parameters to HadoopJobRunner
- move archives paramter to the end. use instance variable directly.
- Warn user if Parameter serializes something other than a string.
- Set scheduler_url, logging_conf_file, and module to '' by default, rather than None. Made appropriate conditional checking updates.
- Update test which uses logging_conf_file to default its value to an empty string rather than None.
- bugfix: Don't crash when logging isn't specified
- Fix typo
- fix failing tests
- remove test_task_limit, to address in a separate PR
- name statuses more consistently
- use the same wording in email as in the log message
- work around erroring (order sensitive) test
- Add GitHub PR template file (#1655)
- Fix test_dep_graph_missing_deps
- Fix test_connection_error
- Revert "work around erroring (order sensitive) test"
- Set namespace for FailingTask
- Default return code set to 0 for 'scheduling_error'
- Add contrib package for MSSQL (#1650)
- Fix running nose with xunit. (#1659)
- changed "visualizer" to "visualiser" to be consistent with the majority of occurrences (#1667)
- Fix formatting of example configuration snippet
- Added rename/copy/move functions to FileSystem and FileSystemTarget classes where applicable
- provide missing S3CopyJSONToTable INFO logging (#1674)
- Removed redundant function
- Fix typo in a log message.
- Compute the 'new_deps' variable only when it's needed.
- Added rename and copy to FileSystem, removed rename from children
- Allow GCSTargets for Hadoop streaming jobs (#1664)
- tox.ini: Remove # comment, fixing travis breakage
- allow sftp default port 22 to be overridden
- Add Hotels.com as user of Luigi to the README.rst
- Fix worker configuration headings. (#1691)
- Add support for multiple results in salesforce batch jobs (#1686)
- Clarify file permission error message (#1692)
- Uses more thorough pid check for locking
- Convert readthedocs link for their .org -> .io migration for hosted projects
- Fixes Sphinx version for docs to 1.3b1
- Accepts more arguments in overridden _warn_node function in doc conf
- [docs] Bump sphinx version for tox builds (#1701)
- Allows package binaries to be passed to job runner (#1565)
- docs: Fix typo (#1703)
- Redshift: raise an error when no columns are found (#1676)
- Fix docs for @inherits decorator. (#1679)
- Adds AWS session token support for redshift copy statements (#1702)
- Updatat six to version 1.10.0 (#1709)
- Added a link to Custobar Luigi slides to Who uses Luigi list
- Can yield (not return) a list of tasks. (#1713)
- Ensure DictParameter's are normalized to FrozenOrderedDict (#1708)
- Implement pass-through parameters on Range tasks (#1675)
- DateParameter docs: Add example with interpolation (#1716)
- Correct docs for Range.of-params (#1715)
- Adding release step for Debian packages. (#1718)
- Add luigi-deps-tree visualising tool (#1680)
- Add combiner to docstrings in mrrunner
- Update example_top_artists.rst (#1662)
- Consistent Luigi spelling in docs (#1723)
- Remove tracking url callback hack (#1722)
- Add note about underscore in parameter names (#1729)
- Deprecated LocalTarget fn propery
- Remove MockTarget path property
- Rename MockTarget class variable _fn to path
- Fix salesforce default content type (#1724)
- Removes redundant function definitions from rpc and server (#1734)
- Reduce number of get_params calls in common_params.
- Add additional event handlers to tasks (#1698)
- Fix bug with GCSFlagTarget
- Caches get_autoconfig_client on a per-thread basis
- Reset terminal colors in external_program (#1742)
- Update call to iteritems in luigi/tools/deps: deprecated in Python 3 (#1749)
- Add tests for hashing parameters (#1719)
- Version 2.2.0
- Add option for list() and/or listdir() to return the boto.s3.key.Key object
- Add tests for list() and listdir()
- README: Add pypi version badge (#1757)
- Normalize ListParameter to be Immutable (#1759)
- docs: Set minimum versions for sphinx (#1760)
- docs: Install sphinx 1.4.4 in setup.py (#1761)
- Fix "owner_email" log message. (#1762)
- Disable codecov comments on GitHub PRs (#1754)
- Remove the confusing "dummy_test_module" directory (#1756)
- Update copy() to return number and size of files copied
- Fix exist method for ftp server
- Remove sitecustomize file (#1755)
- tests: Fix warning in remote_scheduler_test.py (#1774)
- Update retcodes to handle new cases (#1771)
- tests: Skip a inttermittently failing s3 test (#1777)
- Assistants: Don't affect longevity of tasks (#1772)
- Remove abstract Scheduler class (#1778)
- Rename CentralPlannerScheduler to Scheduler (#1781)
- README: Remove monthly downloads badge
- Excludes .tox from flake8 to prevent checking third-party libraries (#1785)
- flake8: Unbreak travis build
- tox: Specify sphinx dependency better
- Add DateSecondParameter to parameter.py (#1779)
- Marking as minimum upstream severity instead of max (#1789)
- Truncates long streaming job confs (#1773)
- tests: Add a testcase confirming #1789 (#1790)
- Changed removing temporary scripts directory from shutil.rmtree() to a subprocess calling 'rm -rf'.
- Added option to run SGEJobTask locally.
- Added InputFileParameter and OutputFileParameter classes.
- Removed unused import.
- Fixed changes to match luigi standard.
- sge: Add pwd to python's path when running on cluster. (#1797)
- Parameterized poll_time for SGEJobTask. (#1795)
- Implement per task retry policies (#1791)
- SGE: Add --dont-remove-tmp-dir parameter to SGEJobTask (#1798)
- Revert "Added InputFileParameter and OutputFileParameter classes." (#1803)
- Made creating a tarball of luigi optional to reduce I/O overhead of running an SGEJobTask.
- Added parameters to SGEJobTask to have control over the job name.
- Add NumericalParameter (#1799)
- Add ChoiceParameter (#1800)
- locking bugfix: make ps print full commands (#1809)
- Add current directory to python path
- Added passthrough for PySFTP Connection keyword arguments to RemoteTarget constructor (#1815)
- Enables running of multiple tasks in batches (#1784)
- Version 2.3.0
- Update RELEASE-PROCESS.rst
- Limits resource usage bar fill to 100% (#1818)
- Adds BATCH_RUNNING to the visualiser (#1817)
- docs: Add instructions for seeing rendered docs (#1814)
- bugfix: worker dies on smtp connection errors (#1821)
- Uses a sane default for pysftp_conn_kwargs (#1825)
- worker.py: Remove old and not useful comment (#1792)
- Bug fix for spark task can not be pickled (#1819)
- Version 2.3.1
- Allows breaking resource strings on commas in visualizer (#1828)
- Moves error messages in the task list to a popup (#1827)
- Add Blendle to list of companies using Luigi (#1837)
- Add and refactor tests for disabling workers (#1838)
- gcp: Add image_version support to Dataproc (#1833)
- pig: Properly use Python3's buffer interface (#1836)
- tests: Skip a inttermittently failing sqla test (#1840)
- tox: Remove last trace of not_imported.py (#1841)
- dataproc tests: Attempt to fix failing build (#1843)
- Prevents batch tasks from running before their dependencies (#1846)
- Allows clients to specify max_shown_tasks in task_list (#1847)
- Sets upstream status for BATCH_RUNNING jobs to UPSTREAM_RUNNING (#1848)
- Filters tasks in second branch of Worker.get_pending_tasks (#1849)
- Fails batch_running tasks if worker dies early (#1850)
- Update local locking logic (#1842)
- Disables siginterrupt for SIGUSR1 (#1844)
- Adds time_running to batch running tasks (#1851)
- worker_tests.py: Fix minor resource leak (#1853)
- server.py: Remove old comment (#1854)
- Fix sample code in SGE package description
- Cleanup server.py file (#1855)
- Tries using path for non-hdfs targets in hadoop_jar (#1824)
- Refine disabling of workers (#1839)
- Version 2.3.2
- Handles errors when loading batch tasks from multiple ids
- Enables worker timeouts with only one worker
- Uses task_process instead of p as a variable name in _run_task
- Renames TaskProcess.random_seed to TaskProcess.use_multiprocessing
- Inherits WorkerTest from LuigiTestCase
- Refactors task load exception error notifications
- Adds a test that task load failures trackbacks are sent to the scheduler
- Updates LuigiTestCase to clear instance caches before and after runs
- Enables running with 0 workers to support assistants (#1861)
- Add support to RangeByMinutes backfilling tasks (#1863)
- Uses task name instead of task_id as job identifier for MR (#1868)
- Prevents batched tasks from all getting marked RUNNING
- Add CORS headers to api requests (#1870)
- Moves e-mail config into luigi.Config classes (#1871)
- pyspark: Fix bug about overriden job name parameter (#1878)
- [bigquery] use the same capitalization as Google does
- [bigquery] clean up some mess
- Add UDF support for BigQuery (#1881)
- docs: batch_mode => batch_method (#1890)
- Use the proc filesystem to gather process information (#1886)
- tests: Disable server_test.test_404 (#1880)
- Version 2.3.3
- LocalTarget: Allow moves across devices (#1877)
- make elasticsearch example run out of the box (#1902)
- Make clone() carry along non-parameters (#1630)
- docs: Update outdated links and config variables
- email: Cleanup email code and log less
- redshift: Correctly escape query used with UNLOAD (#1907)
- file.py: Rename to local_target.py (#1915)
- targets: Implement temporary_path decorator (#1909)
- Add location parameter to BigQueryTarget
- dataset_exists checks dataset regional location
- Add tests for BigQuery dataset location
- Separate BQ tests from GCS tests
- remove testfixtures
- use Python's None instead of 'undefined' when location is unspecified
- [bigquery] point out Avro support
- [bigquery] add BigQueryLoadAvro that adds schema documentation to the table
- add an integration test for BigQueryLoadAvro
- Test to verify description of schema is added.
- clean up tiny unused bits
- fix load_avro_dir test to load an actual directory; fix bugs
- sanitize exception handling, logging and documentation
- add tests for nullable and undocumented fields
- Sets wait_jitter in worker_test.py (#1927)
- Make temporary_path() decorator create directories (#1919)
- Cleanup code and adhere to E305 (#1922)
- Add docs for DataParameter for default=today() (#1928)
- Removes None default params in email config class (#1923)
- Add PyData Berlin 2015 presentation from TrustYou (#1930)
- travis: Don't run failing bigquery tests (#1931)
- Adds a flag to turn off failure e-mails in the worker
- BatchNotifier class to handle sending batch e-mails
- Add batch notification e-mails to the scheduler
- Ensures a consistent pretty_id in scheduler.Task
- Improves documentation of batch_notifier config
- Handles unicode in batch notifier
- Fixes style issues in batch notifier
- Addresses Arash's review
- Revert "Marking as minimum upstream severity instead of max (#1789)"
- Counts FAILED tasks as PENDING in count_pending
- Refactors get_running_tasks and get_pending_tasks
- Version 2.4.0
- BigQuery jobs success verified using status.errorResult
- Add retries for 500 errors in BigQuery
- make RunAnywayTarget compatible with python 2.7
- Make task_namespace inherit from parent Task (#1953)
- Make luigi.task.externalize return shallow copies  (#1952)
- Remove the long-deprecated BooleanParameter (#1959)
- emails: Increase logging if email is misconfigured (#1960)
- [bigquery] add support for non-legacy SQL (#1896)
- externalize: Add a testcase similar to docs (#1963)
- Update SF to cast header value to str (#1912)
- Tests: Move namespace_tests into task_test.py
- namespaces: Fix changed behavior since #1953
- Fix serialization for TimeDeltaParameter (#1968)
- ChainFormat error message fix (#1971)
- Add missing commas to the contrib.sla module code examples. (#1972)
- tests: Remove `__name__ == '__main__'` guards (#1973)
- flake8: Put configuration into standardized place (#1974)
- server_test.py: Fix crash in test_save_state (#1977)
- externalize: Dont register the copied tasks (#1975)
- retcodes: Understand succesful retries (#1951)
- target_test.py: Use clean paths to avoid failures (#1978)
- redshift: Fix formatting of documentation (#1981)
- Version 2.5.0
- Set default log level via config (#1987)
- docs: Update link to ConfigParser (#1990)
- Keep datatable state in the browser history. (#1986)
- minor, file.py: Fix deprecation date
- Remove deprecated backward-compatibility modules (#1995)
- Add redshift copy support for role-based credential string (#1962)
- README - who uses luigi (#2004)
- use compress_response by default (#2007)
- Fixed link to HDFS API docs in README (#2006)
- Update s3 docstrings (#2003)
- Track dependency graph fields values change.
- Task list fields values moved from query params to hash.
- Graph tab fields tracking tests added.
- Cosmetics.
- Task graph display fixed.
- Introduce rpc-attempt retry count and wait time in configuration (#1994)
- add TaskStatusReporter class to fix Windows pickle issue (#1992)
- Move non-core like modules to luigi.contrib
- Make mrrunner module private to luigi
- Control worker processes via UI (scheduler → worker communication) (#1993)
- Allow namespaces to be set to python module (#2000)
- Show number of unread worker messages in UI (#2013)
- Fix required credential string name for key-based redshift copy credentials (#2016)
- Set authors to "The Luigi Authors" (#2009)
- Update TaskParmeter to use updated library code (#2023)
- Version 2.6.0
- Refactored setup of google api clients (#2018)
- Add the extra_arguments to easily pass additional arguments to streaming jobs (#1929)
- Introduce Python3 compatibility in example (#2032)
- Fix bad URI path (#2033)
- Support for Kubernetes Jobs (#1906)
- salesforce: use 'wb' when opening output file (#2034)
- Create ISSUE_TEMPLATE.md (#2030)
- Update PULL_REQUEST_TEMPLATE.md (#2037)
- parametrization -> parameterization (#2046)
- Specify default port to comply with change in init for psycopg 2.7 (#2049)
- Bugfix for retry policy (#2012)
- Address JS error in visualizer when displaying the dependency graph (#2042)
- Fix links to task graphs in visualizer. (#2025)
- Test against Python 3.6 (#2053)
- Add method rename_dont_move to LocalFileSystem (#2057)
- Make temporary_path work with paths not containing a directory (#2058)
- Remove anything related to Debian
- Version 2.6.1
- Fix worker tool box in visualizer (#2063)
- travis: Run less builds
- Fix CSS and JS imports
- Extend from default layout
- Do not raise HDFSCliError inside snakebite client.
- Remove unused class variable.
- Refactor: Simplify client initialisation.
- Add MongoDB Target Support (#2062)
- add Red Hat to list of Luigi users (#2067)
- Update format of luigi users and their public content (#2072)
- Split up the list of users in two lists (#2076)
- Add Squarespace to list of Luigi users (#2081)
- Avoid reading global variables in worker. (#2077)
- Avoid warnings in unit tests. (#2078)
- Document that Parameter now must be a str, to avoid warnings added by issue #1607. (#2082)
- Add Newsela to list of companies using Luigi (#2065)
- Fix duplicate explicit target name warnings (#2088)
- Changed postgres import on TopArtists example (#2090)
- Enable "forgiving failures" from webapp (#2091)
- included Grovo name in README.rst (#2102)
- Fix minor spelling mistakes in log and doc strings (#2101)
- add oao to list of companies using luigi without slides (#1976)
- Add 'IF NOT EXISTS' to prevent duplicate table exception (#2064)
- Defer S3 Client instantiation until needed (#2079)
- sqla: only reflect relevant tables (#2104)
- Add Weebly to list of Luigi users (#2056)
- Parameter: Refactor out wrong type check
- Docs: Mention to avoid simultaneous updates to single file (#2040)
- add listdir method to ftp remote file system (#2114)
- Recursively normalize DictParameter (#2115)
- Don’t use cached autoconfig client in config tests (#2120)
- Check whether renames worked in atomic hdfs pipes (#2119)
- dataproc: more consistently get authentication arguments
- Fix "Show Upstream Dependencies" in visualiser (#2092)
- Update tasks when filter on server is toggled
- Remove search query from url bar on empty query
- Set hideDone on in graph links (#2125)
- Set hideDone in worker root task links (#2126)
- Remove length from state when it equals default (#2128)
- Preserve options in svg graph links (#2132)
- Fix resource graph links
- Store expanded resources in the URL bar
- Add task family to url hash
- Add status to url hash
- Retain container types from output() to input() (#2113)
- Preserve graph options when clicking d3 nodes (#2139)
- Move visualiser graph type default to a constant
- Make svg the default graph type
- added getninjas to user list in readme (#2146)
- Use list/dict comprehension (#2144)
- Version 2.6.2
- Move visualiser css into a separate file
- Pause and unpause the scheduler from the viz
- travis: Disable email notifications
- Prevent stowaway resources in scheduler
- Prevent changing resources from exceeding limits
- Set datatable order correctly on hash change (#2159)
- Update check for table existence to be case insensitive (#2086)
- Remove superfluos project_id parameter in BigQuery job definition (#2117)
- Serialize statuses array for URL hash (#2165)
- Scheduler API for updating a single resource
- Update individual resource counts from the vis
- hive: Use DictParameter in ExternalHiveTask (#1999)
- Fix getpcmd on macOS
- Fix DeprecationWarning in tests
- Fix don't skip S3 test cases fixed upstream
- Fix test silence warnings
- Refactor rename MockFile -> MockTarget
- Fix tests to use new config format
- Refactor test to use assertTrue
- Fix tests to use new config format
- Reformat flake8 complaints
- Fix decode to utf8 when reading /proc/*/cmdline
- Fix decode to utf8 when reading /proc/*/cmdline
- Fix decode to utf8 when reading /proc/*/cmdline
- Travis: Remove minicluster builds (#2141)
- Handle e-mail failures in batch notifier (#2177)
- PySparkTask fix for bytes / str type error and import error (#2168)
- Update mkdir method signature for CDH3 client. (#2184)
- MongoDB target items count (#2186)
- hadoop: Fix CDH3 mkdir implementation (#2188)
- travis: Remove ssh loopback trick
- Deprecate python 3.3 support for Luigi
- travis: Disable pypy scheduler tests
- Add worker config check_unfulfilled_deps. (#2189)
- Fix emailing of unexpected error in `Worker._announce_scheduling_failure`. (#2191)
- Update _get_s3_config to only return s3 section with interpolation, excluding defaults (#2182)
- [bug-fix] scheduler won't override running status incorrectly (#2187)
- Support cluster mode in PySpark (#2197)
- Added Deloitte to the list of users (#2206)
- Prevent worker from running same task repeatedly (#2207)
- Clear tasks on disabled workers (#2208)
- [docs] consistency fix for the month value (#2217)
- Remove assert that verifies if tables were marked (#2199)
- breaking: Remove deprecated contrib redirections (#2181)
- Set utf-8 encoding in the MIMEText constructor (#2210)
- Progress bar in luigi visualizer (#2108)
- Add 'schema' attribute to CopyToTable and use for target table (#2176)
- Rework the logic and the tests of the graph visualization type checkboxes. (#2193)
- Allow spark to load config from different version (#2196)
- Version 2.7.0
- Update the docstring of S3FlagTarget (#2192)
- README: avoid _here_ links; ack readthedocs (#2222)
- Standardize Redshift credential usage (#2068)
- Update to handle complex avro types for Avro Schema Definition copying to Big Query Schema descriptions
- Fix typo in docstring (#2225)
- Cleaned up comments.  Refactored to have explicit primitive support and primitives inside of unions support.  Updated Job description comments and removed unnecessary logging.
- updated testing suite to match the more complex schema doc loader
- updated testing suite to match the more complex schema doc loader
- flake8 formatting fixes
- flake8 formatting fixes
- Fix "IF NOT EXISTS" Postgres 8 incompatibility (#2228)
- MongoDB contrib : Next replaced with for loop to avoid propagation of StopIteration (#2221)
- hivevar option in hive task (#2185)
- Fix ListParameter Hashability (#2227)
- Prevent module shadowing in pyspark_runner.py (#2232)
- Added support to specify the number of processes for parallel scheduling (#2205)
- Accept kwargs for mysql connection (#2226)
- Fix os.makedirs issue in multithreading (#2039) (#2093)
- Added cluster support for ECS and corrected status debug message (#2045)
- Silence Parameter type warning for WebHdfsClient (#2231)
- Issue template: Mention it isn't for questions (#2143)
- Add ExtractTask to luigi.contrib.BigQuery module (#2134)
- Fixed a typo in docstring (#2236)
- Adding autocommit property for Redshift queries for Vacuums, etc. (#2242)
- Add HA functionality to WebHdfsClient (#2230)
- docs: Fix hypen vs underscore inconsistencies (#2160)
- Use columns defined for COPY to Redshift so we never rely on order (#2245)
- Improve sentence structure in configuration.rst (#2248)
- Version 2.7.1
- Adding voyages-sncf.com as a company using luigi (#2251)
- Minor fix (for the sake of understanding) (#2250)
- Remove invalid entrypoint: luigi.tools.migrate (#2257)
- changed the logging status of prune messages to debug (#2254)
- fix typo suceeded -> succeeded (#2258)
- Support for the Docker Python SDK (#2158)
- Add Leipzig University Library as user (#2262)
- Speed up task_list when beyond limit (#2239)
- Remove Avro description copying for BigQuery
- Cleanup irrelevant comment, remove unused imports
- Except all Exceptions for flake8
- Fix bare except clause
- Rename ambiguous class/params for flake8
- Fix new flake8 tests (#2274)
- Preserve filter on server on reload (#2273)
- Cleans up dangerous function default variables ([] and {}) (#2275)
- #2279 Add Python 3.6 to list of supported Python versions. (#2280)
- Hide re-enable and forgive buttons on success (#2281)
- Add Synetiq to `Who uses Luigi?`. (#2287)
- Convert dates to datetimes for DateHourParameter (#2285)
- Small refactor to make intent clearer (#2255)
- Re-add loading the avro schema and copying the schema doc to bq table desc
- Fix Flake8 errors
- dynamic demo fix (#2300)
- Added show-error button to disabled tasks in visualizer (#2266)
- Handle multiprocessing with request sessions (#2290)
- Optional parameter (#2295)
- Fixes dangerous default parameter values to make them immutable (#2302)
- Replace `set` calls with literals (#2293)
- update_status -> update_status_message (#2292)
- vizualiser: Format js code (#2309)
-  Fix MRO on tasks using util.requires (#2307)
- Add Stacktome to companies who use Luigi (#2313)
- Add LINX+Neemu+Chaordic to the list of Luigi companies (#2320)
- Fix Python 3 TypeError in contrib.hive.HiveTableTarget.exists()
- Replaced param_args with dynamic property with deprecation message
- Check task equality using param_kwargs instead of param_args
- Update to 2.7.2
- Fix unicode formatting. (#2339)
- Show status message button in worker tab when only progress is set. (#2344)
- More verbose exceptions for mistyped depenencies (#2353)
- Add possibility to specify Redshift column compression. (#2343)
- Support for AWS Batch (#2321)
- Allow NoneType columns in Redshift COPY job (#2303)
- fix contrib.docker_runner exit code check #2355
- check that pods start successfully. fix #2334
- delete pods and jobs on success
- handle ContainersNotReady situation
- print pod logs on exit
- add instructions to stream pod logs
- update based on PR comments
- detect pod start failure and return error
- handle ErrImagePull and add activeDeadlineSeconds
- don't fail on ContainerCreating
- parameterize active_deadline_seconds
- improve PR based on comments
- Fix a warning in googleapiclient usage (#2306)
- Document ways for starting Luigi inside Python code (#2301)
- Add data files to .gitignore (#2367)
- Replace oauth2client by google-auth (#2361)
- Only run code coverage cheks for core luigi
- Version 2.7.3
- codecov: Don't run coverage on unreasonable files
- Pass kwargs to `discovery.build()` when instantiating `GSCClient`. (#2291)
- codecov: Don't expect coverage in kubrenetes.py
- kubernetes: Add parameterized backoff limit (#2375)
- Add google-auth-httplib2 as dependency
- Allow release of resources during task running. (#2346)
- Removed message 'No Instance(s) Available.' in Windows when starting … (#2294)
- Fix typo in luigi documentation (#2387)
- Add new company user (#2388)
- Version 2.7.4
- Fix xss vulnerability from usage of append (#2391)
- Updated to version 2.7.5 (#2395)
- Adds batched_params which is a dictionary of lists of batched parameters indexed by parameter name
- missed the worker bit
- update setup.py
- backport of ParameterVisibilities
- Test fixes and version bump
- Luigi email region for 2.7.5
- Bump luigi version
- Luigi email region for 2.7.5
- Added new batched_params to the task
- Add and mod tests to test batched_params
- Add a superset/subset batch test
- Bump setup.py version number
- Fixes for batched_params (default and non-list)
- update tests for new batched_params
- fix RangeX classes to support param-name from the base class
- add a test pairing MixinNaiveBulkComplete and ranges
- added a reload for batch jobs as they are now dynamic
- Handle config python2/3 compatibility
- Version bump
- patch in LuigiRunResult and LuigiStatusCode with additional field for status num
- success should be 0
- only return status code num to keep interface similar to returning bool
- remove interpolation import thing
- version bump from 1.1.0 to 1.2.0
- remove enum34 requirement version bump since was accident
- bring in 2.7.6 scheduler changes, don't count tasks with UNKNOWN dependencies as pending
- fix interpolation import
- use getattr for param_visiblities
- bump version
- don't bring in 2.7.6 changes
- unit tests for unknown state handling
- worker keep alive for test
- wrap add multiprocess in fork lock
- version bump
- luigi bobapki http adapter
- bump version again
- fix enum34 dependency
