### PR TITLE
Fix for #2879

### DIFF
--- a/luigi/configuration/toml_parser.py
+++ b/luigi/configuration/toml_parser.py
@@ -55,6 +55,8 @@ class LuigiTomlParser(BaseParser):
 
         # freeze dict params
         for section, content in self.data.items():
+            if section.lower() == 'logging':
+                continue
             for key, value in content.items():
                 if isinstance(value, dict):
                     self.data[section][key] = recursively_freeze(value)


### PR DESCRIPTION
This fixes #2879 for me. I used the method described by @hirolau (and the slight correction made by @DVlahovic)

This (and one other change, PR #3183) were required for luigi=3.1.0 on cPython 3.9.2 when using a TOML file for configuration that includes a `logging` section