### PR TITLE
Alternate (probably more correct) fix for #3182 (supercedes #3183)

### DIFF
--- a/luigi/configuration/toml_parser.py
+++ b/luigi/configuration/toml_parser.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 import os.path
+from configparser import ConfigParser
 
 try:
     import toml
@@ -25,7 +26,7 @@ from .base_parser import BaseParser
 from ..freezing import recursively_freeze
 
 
-class LuigiTomlParser(BaseParser):
+class LuigiTomlParser(BaseParser, ConfigParser):
     NO_DEFAULT = object()
     enabled = bool(toml)
     data = dict()


### PR DESCRIPTION
This addresses issue #3182 (and supersedes the previous PR #3183)

It fixes the issue in a (probably) more correct way, by adding `ConfigParser` to the list of parent classes for `LuigiTomlParser`

Because `ConfigParser` implements `sections()`, the issue goes away (and things seem to work properly)

I wonder if leaving this out was just an oversight, as I only noticed this as a clean solution when I reviewed how the `LuigiConfigParser` worked- which is by inheriting from `BaseParser` and `ConfigParser` as well