### PR TITLE
docs: Fix a few typos

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -913,7 +913,7 @@ class JobTask(BaseHadoopJobTask):
 
     def extra_files(self):
         """
-        Can be overriden in subclass.
+        Can be overridden in subclass.
 
         Each element is either a string, or a pair of two strings (src, dst).
 

--- a/luigi/contrib/mrrunner.py
+++ b/luigi/contrib/mrrunner.py
@@ -19,7 +19,7 @@
 """
 Since after Luigi 2.5.0, this is a private module to Luigi. Luigi users should
 not rely on that importing this module works.  Furthermore, "luigi mr streaming"
-have been greatly superseeded by technoligies like Spark, Hive, etc.
+have been greatly superseeded by technologies like Spark, Hive, etc.
 
 The hadoop runner.
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -304,7 +304,7 @@ class Task(metaclass=Register):
 
     task_namespace = __not_user_specified
     """
-    This value can be overriden to set the namespace that will be used.
+    This value can be overridden to set the namespace that will be used.
     (See :ref:`Task.namespaces_famlies_and_ids`)
     If it's not specified and you try to read this value anyway, it will return
     garbage. Please use :py:meth:`get_task_namespace` to read the namespace.

--- a/luigi/tools/deps_tree.py
+++ b/luigi/tools/deps_tree.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-This module parses commands exactly the same as the luigi task runner. You must specify the module, the task and task paramters.
-Instead of executing a task, this module prints the significant paramters and state of the task and its dependencies in a tree format.
+This module parses commands exactly the same as the luigi task runner. You must specify the module, the task and task parameters.
+Instead of executing a task, this module prints the significant parameters and state of the task and its dependencies in a tree format.
 Use this to visualize the execution plan in the terminal.
 
 .. code-block:: none

--- a/test/contrib/docker_runner_test.py
+++ b/test/contrib/docker_runner_test.py
@@ -49,7 +49,7 @@ except ImportError:
 except Exception:
     raise unittest.SkipTest('Unable to connect to docker daemon')
 
-tempfile.tempdir = '/tmp'  # set it explicitely to make it work out of the box in mac os
+tempfile.tempdir = '/tmp'  # set it explicitly to make it work out of the box in mac os
 local_file = NamedTemporaryFile()
 local_file.write(b'this is a test file\n')
 local_file.flush()

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -652,7 +652,7 @@ class RangeByMinutesBaseTest(unittest.TestCase):
                     ('CommonDateMinuteTask', 13),  # 20 intervals - 7 missing
                 ],
                 'event.tools.range.complete.fraction': [
-                    ('CommonDateMinuteTask', 13. / (13 + 7)),  # (exptected - missing) / expected
+                    ('CommonDateMinuteTask', 13. / (13 + 7)),  # (expected - missing) / expected
                 ],
             }
         )

--- a/test/task_forwarded_attributes_test.py
+++ b/test/task_forwarded_attributes_test.py
@@ -54,7 +54,7 @@ class YieldingTask(NonYieldingTask):
 
     def run(self):
         # as TaskProcess._run_get_new_deps handles generators in a specific way, store names of
-        # forwarded attributes before and after yielding a dynamic dependency, so we can explicitely
+        # forwarded attributes before and after yielding a dynamic dependency, so we can explicitly
         # validate the attribute forwarding implementation
         self.attributes_before_yield = self.gather_forwarded_attributes()
         yield RunOnceTask()


### PR DESCRIPTION
There are small typos in:
- luigi/contrib/hadoop.py
- luigi/contrib/mrrunner.py
- luigi/task.py
- luigi/tools/deps_tree.py
- test/contrib/docker_runner_test.py
- test/range_test.py
- test/task_forwarded_attributes_test.py

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `explicitly` rather than `explicitely`.
- Should read `technologies` rather than `technoligies`.
- Should read `parameters` rather than `paramters`.
- Should read `expected` rather than `exptected`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md