### PR TITLE
Fix md5 hash error for FIPS in python 3.9

### DIFF
--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -25,6 +25,7 @@ an example of how to run a Hadoop job.
 import abc
 import datetime
 import glob
+import hashlib
 import logging
 import os
 import pickle
@@ -37,7 +38,6 @@ import subprocess
 import sys
 import tempfile
 import warnings
-from hashlib import md5
 from itertools import groupby
 
 from luigi import configuration
@@ -620,7 +620,7 @@ class LocalJobRunner(JobRunner):
         lines = []
         for i, line in enumerate(input_stream):
             parts = line.rstrip('\n').split('\t')
-            blob = md5(str(i).encode('ascii')).hexdigest()  # pseudo-random blob to make sure the input isn't sorted
+            blob = hashlib.new('md5', str(i).encode('ascii'), usedforsecurity=False).hexdigest()  # pseudo-random blob to make sure the input isn't sorted
             lines.append((parts[:-1], blob, line))
         for _, _, line in sorted(lines):
             output.write(line)

--- a/luigi/contrib/simulate.py
+++ b/luigi/contrib/simulate.py
@@ -83,7 +83,7 @@ class RunAnywayTarget(luigi.Target):
         """
         Returns a temporary file path based on a MD5 hash generated with the task's name and its arguments
         """
-        md5_hash = hashlib.md5(self.task_id.encode()).hexdigest()
+        md5_hash = hashlib.new('md5', self.task_id.encode(), usedforsecurity=False).hexdigest()
         logger.debug('Hash %s corresponds to task %s', md5_hash, self.task_id)
 
         return os.path.join(self.temp_dir, str(self.unique.value), md5_hash)

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -80,7 +80,7 @@ def get_info(pid_dir, my_pid=None):
 
     my_cmd = getpcmd(my_pid)
     cmd_hash = my_cmd.encode('utf8')
-    pid_file = os.path.join(pid_dir, hashlib.md5(cmd_hash).hexdigest()) + '.pid'
+    pid_file = os.path.join(pid_dir, hashlib.new('md5', cmd_hash, usedforsecurity=False).hexdigest()) + '.pid'
 
     return my_pid, my_cmd, pid_file
 

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -1231,7 +1231,7 @@ class Scheduler:
 
         if len(batched_tasks) > 1:
             batch_string = '|'.join(task.id for task in batched_tasks)
-            batch_id = hashlib.md5(batch_string.encode('utf-8')).hexdigest()
+            batch_id = hashlib.new('md5', batch_string.encode('utf-8'), usedforsecurity=False).hexdigest()
             for task in batched_tasks:
                 self._state.set_batch_running(task, batch_id, worker_id)
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -125,7 +125,7 @@ def task_id_str(task_family, params):
     # task_id is a concatenation of task family, the first values of the first 3 parameters
     # sorted by parameter name and a md5hash of the family/parameters as a cananocalised json.
     param_str = json.dumps(params, separators=(',', ':'), sort_keys=True)
-    param_hash = hashlib.md5(param_str.encode('utf-8')).hexdigest()
+    param_hash = hashlib.new('md5', param_str.encode('utf-8'), usedforsecurity=False).hexdigest()
 
     param_summary = '_'.join(p[:TASK_ID_TRUNCATE_PARAMS]
                              for p in (params[p] for p in sorted(params)[:TASK_ID_INCLUDE_PARAMS]))

--- a/test/contrib/azureblob_test.py
+++ b/test/contrib/azureblob_test.py
@@ -60,7 +60,7 @@ class AzureBlobClientTest(unittest.TestCase):
     def test_create_delete_container(self):
         import datetime
         import hashlib
-        m = hashlib.md5()
+        m = hashlib.new('md5', usedforsecurity=False)
         m.update(datetime.datetime.now().__str__().encode())
         container_name = m.hexdigest()
 
@@ -74,7 +74,7 @@ class AzureBlobClientTest(unittest.TestCase):
         import datetime
         import hashlib
         import tempfile
-        m = hashlib.md5()
+        m = hashlib.new('md5', usedforsecurity=False)
         m.update(datetime.datetime.now().__str__().encode())
         container_name = m.hexdigest()
         m.update(datetime.datetime.now().__str__().encode())


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Add  usedforsecurity=False to all md5 hashes to ensure FIPS compatibility in python >= 3.9
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As python 3.9 documentation for hashlib states:
>All hashlib constructors take a keyword-only argument usedforsecurity with default value True. A false value allows the use of insecure and blocked hashing algorithms in restricted environments. False indicates that the hashing algorithm is not used in a security context, e.g. as a non-cryptographic one-way compression function.
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Tested in local project with python 3.11
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
