### PR TITLE
fix: using default_scheduler_url as a mounting point for not root path

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -145,7 +145,7 @@ class RemoteScheduler:
             'You need to install requests-unixsocket for Unix socket support.'
         )
 
-        self._url = url.rstrip('/')
+        self._url = url
         config = configuration.get_config()
 
         if connect_timeout is None:

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -145,7 +145,7 @@ class RemoteScheduler:
             'You need to install requests-unixsocket for Unix socket support.'
         )
 
-        self._url = url
+        self._url =  url if url[-1] == '/' else url + '/'
         config = configuration.get_config()
 
         if connect_timeout is None:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -111,7 +111,7 @@ def rpc_method(**request_args):
             if not all(arg in actual_args for arg in required_args):
                 raise TypeError('{} takes {} arguments ({} given)'.format(
                     fn_name, len(all_args), len(actual_args)))
-            return self._request('/api/{}'.format(fn_name), actual_args, **request_args)
+            return self._request('api/{}'.format(fn_name), actual_args, **request_args)
 
         RPC_METHODS[fn_name] = rpc_func
         return fn


### PR DESCRIPTION
(http://address/mount) behind proxy works. fix #3213

Signed-off-by: ROUDET Franck INNOV/IT-S <franck.roudet@orange.com>

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
2 files modified to change the build of URL.
`api` path not at root now, it is in fact the same strategy that use the GUI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes:
 * https://github.com/spotify/luigi/issues/3213
 * and https://groups.google.com/g/luigi-user/c/kJ7aI2GNfcE
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
I'm able to test:
* With or Without scheduler-url set
* With or Without scheduler-url not at root


<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
