### PR TITLE
Catch `io.UnsupportedOperation` exception

### DIFF
--- a/luigi/format.py
+++ b/luigi/format.py
@@ -69,7 +69,7 @@ class InputPipeProcessWrapper:
         if input_pipe is not None:
             try:
                 input_pipe.fileno()
-            except AttributeError:
+            except (AttributeError, io.UnsupportedOperation):
                 # subprocess require a fileno to work, if not present we copy to disk first
                 self._original_input = False
                 f = tempfile.NamedTemporaryFile('wb', prefix='luigi-process_tmp', delete=False)


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Catch the 'correct' exception which is thrown by some sources when `fileno` is not supported.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm, personally, running into this with `gcsfs`.

https://github.com/fsspec/filesystem_spec/issues/104#issuecomment-520990424

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
