### PR TITLE
fix: using default_scheduler_url as a mounting point for not root pat…

### DIFF
--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -59,7 +59,7 @@ def _urljoin(base, url):
     parsed = urlparse(base)
     scheme = parsed.scheme
     return urlparse(
-        urljoin(parsed._replace(scheme='http').geturl(), url)
+        urljoin(parsed._replace(scheme='http').geturl(), url if parsed.path == '' else parsed.path + url)
     )._replace(scheme=scheme).geturl()
 
 

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -55,11 +55,12 @@ def _urljoin(base, url):
     """
     Join relative URLs to base URLs like urllib.parse.urljoin but support
     arbitrary URIs (esp. 'http+unix://').
+    base part is fixed or mounted point, every url contains full base part.
     """
     parsed = urlparse(base)
     scheme = parsed.scheme
     return urlparse(
-        urljoin(parsed._replace(scheme='http').geturl(), url if parsed.path == '' else parsed.path + url)
+        urljoin(parsed._replace(scheme='http').geturl(), parsed.path + (url if url[0] == '/' else '/' + url))
     )._replace(scheme=scheme).geturl()
 
 

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -37,6 +37,13 @@ class RemoteSchedulerTest(unittest.TestCase):
                 with mock.patch.object(s, '_fetcher') as fetcher:
                     s._fetch(suffix, '{}')
                     fetcher.fetch.assert_called_once_with('http://zorg.com/api/123', '{}', 42)
+    def testUrlArgumentVariationsNotRoot(self):
+        for url in ['http://zorg.com/subpath', 'http://zorg.com/subpath/']:
+            for suffix in ['api/123', '/api/123']:
+                s = luigi.rpc.RemoteScheduler(url, 42)
+                with mock.patch.object(s, '_fetcher') as fetcher:
+                    s._fetch(suffix, '{}')
+                    fetcher.fetch.assert_called_once_with('http://zorg.com/subpath/api/123', '{}', 42)
 
     def get_work(self, fetcher_side_effect):
         scheduler = luigi.rpc.RemoteScheduler('http://zorg.com', 42)

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -37,6 +37,7 @@ class RemoteSchedulerTest(unittest.TestCase):
                 with mock.patch.object(s, '_fetcher') as fetcher:
                     s._fetch(suffix, '{}')
                     fetcher.fetch.assert_called_once_with('http://zorg.com/api/123', '{}', 42)
+
     def testUrlArgumentVariationsNotRoot(self):
         for url in ['http://zorg.com/subpath', 'http://zorg.com/subpath/']:
             for suffix in ['api/123', '/api/123']:


### PR DESCRIPTION
…h. fix #3213

Signed-off-by: ROUDET Franck INNOV/IT-S <franck.roudet@orange.com>

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
1 files modified to change the build of URL.
Keep full base path from `default_scheduler_url`.
2nd attempt for that: more cleaner approach.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes:
 * https://github.com/spotify/luigi/issues/3213
 * and https://groups.google.com/g/luigi-user/c/kJ7aI2GNfcE
 
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I'm able to test:
* With or Without scheduler-url set
* With or Without scheduler-url not at root
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
