### PR TITLE
allow setting a "custom disconnect delay" of a worker, by clicking on…

### DIFF
--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -167,35 +167,53 @@
             {{/is_disabled}}
                 <div class="box-header with-border">
                     <h3 class="box-title">{{name}}</h3>
-                    <div class="box-tools pull-right">
-                      {{#num_unread_rpc_messages}}
-                      <span class="label-unread-worker-messages">{{num_unread_rpc_messages}} unread message(s)</span>
-                      {{/num_unread_rpc_messages}}
-                      {{^is_disabled}}
-                      {{#workers}}
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-sm btn-default dropdown-toggle btn-set-workers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                          Workers: <span id="label-n-workers" data-worker="{{name}}">{{workers}}</span> <span class="caret"></span>
+                    <div class="pull-right">
+                      <span class="btn-group">
+                        <button type="button" class="btn btn-sm btn-default dropdown-toggle btn-set-worker-custom-disconnect-delay" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                          Custom disconnect delay: <span id="label-custom-disconnect-delay" data-worker="{{name}}">{{custom_disconnect_delay}}</span> <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu">
-                          <li><a href="#" id="btn-increment-workers" data-worker="{{name}}">
-                            <i class="glyphicon glyphicon-plus"></i> Add 1 worker
+                          <li><a href="#" id="btn-set-worker-custom-disconnect-delay-no" data-worker="{{name}}">
+                             no
                           </a></li>
-                          <li><a href="#" id="btn-decrement-workers" data-worker="{{name}}">
-                            <i class="glyphicon glyphicon-minus"></i> Remove 1 worker
+                          <li><a href="#" id="btn-set-worker-custom-disconnect-delay-60" data-worker="{{name}}">
+                             60s
                           </a></li>
-                          <li><a href="#" id="btn-set-workers" data-toggle="modal" data-target="#setWorkersModal" data-worker="{{name}}">
-                            <i class="glyphicon glyphicon-pencil"></i> Set workers ...
+                          <li><a href="#" id="btn-set-worker-custom-disconnect-delay-3600" data-worker="{{name}}">
+                             3600s
                           </a></li>
                         </ul>
-                      </div>
-                      {{/workers}}
-                      <div class="button-tooltip" data-toggle="tooltip" title="Disable Worker">
-                        <button type="button" class="btn btn-sm btn-danger btn-disable-worker" data-toggle="modal" data-target="#disableWorkerModal" data-worker="{{name}}">
-                          <i class="fa fa-fire-extinguisher"></i>
-                        </button>
-                      </div>
-                      {{/is_disabled}}
+                      </span>
+                      <span class="box-tools">
+                        {{#num_unread_rpc_messages}}
+                        <span class="label-unread-worker-messages">{{num_unread_rpc_messages}} unread message(s)</span>
+                        {{/num_unread_rpc_messages}}
+                        {{^is_disabled}}
+                        {{#workers}}
+                        <div class="btn-group">
+                          <button type="button" class="btn btn-sm btn-default dropdown-toggle btn-set-workers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Workers: <span id="label-n-workers" data-worker="{{name}}">{{workers}}</span> <span class="caret"></span>
+                          </button>
+                          <ul class="dropdown-menu">
+                            <li><a href="#" id="btn-increment-workers" data-worker="{{name}}">
+                              <i class="glyphicon glyphicon-plus"></i> Add 1 worker
+                            </a></li>
+                            <li><a href="#" id="btn-decrement-workers" data-worker="{{name}}">
+                              <i class="glyphicon glyphicon-minus"></i> Remove 1 worker
+                            </a></li>
+                            <li><a href="#" id="btn-set-workers" data-toggle="modal" data-target="#setWorkersModal" data-worker="{{name}}">
+                              <i class="glyphicon glyphicon-pencil"></i> Set workers ...
+                            </a></li>
+                          </ul>
+                        </div>
+                        {{/workers}}
+                        <div class="button-tooltip" data-toggle="tooltip" title="Disable Worker">
+                          <button type="button" class="btn btn-sm btn-danger btn-disable-worker" data-toggle="modal" data-target="#disableWorkerModal" data-worker="{{name}}">
+                            <i class="fa fa-fire-extinguisher"></i>
+                          </button>
+                        </div>
+                        {{/is_disabled}}
+                      </span>
                     </div>
                 </div>
                 <div class="box-body">

--- a/luigi/static/visualiser/js/luigi.js
+++ b/luigi/static/visualiser/js/luigi.js
@@ -164,6 +164,13 @@ var LuigiAPI = (function() {
         });
     };
 
+    LuigiAPI.prototype.setWorkerCustomDisconnectDelay = function(workerId, n, callback) {
+        var data = {worker: workerId, n: n};
+        jsonRPC(this.urlRoot + "/set_worker_custom_disconnect_delay", data, function(response) {
+            callback();
+        });
+    };
+
     LuigiAPI.prototype.sendSchedulerMessage = function(workerId, taskId, content, callback) {
         var data = {worker: workerId, task: taskId, content: content};
         jsonRPC(this.urlRoot + "/send_scheduler_message", data, function(response) {

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -1042,6 +1042,21 @@ function visualiserApp(luigi) {
     }
 
     /**
+     * Updates the custom disconnect delay of a worker
+     * @param worker: the id of the worker
+     * @param n: delay, in seconds
+     */
+    function updateWorkerCustomDisconnectDelay(worker, n) {
+        // the spinner is just for visual feedback
+        var $label = $('#workerList').find('#label-custom-disconnect-delay[data-worker="' + worker + '"]');
+        $label.html('<i class="fa fa-spinner fa-spin" aria-hidden="true"></i>');
+
+        luigi.setWorkerCustomDisconnectDelay(worker, n, function() {
+            $label.text(n);
+        });
+    }
+
+    /**
      * Updates the number of units of a given resource available in the scheduler
      * @param resource: the name of the resource
      * @param n: the number of units to set the resource limit to
@@ -1425,6 +1440,24 @@ function visualiserApp(luigi) {
             if (!isNaN(n)) {
                 updateWorkerProcesses(worker, n - 1);
             }
+            $event.preventDefault();
+        });
+
+        $('#workerList').on('click', '#btn-set-worker-custom-disconnect-delay-no', function($event) {
+            var worker = $(this).data("worker");
+                updateWorkerCustomDisconnectDelay(worker, null);
+            $event.preventDefault();
+        });
+
+        $('#workerList').on('click', '#btn-set-worker-custom-disconnect-delay-60', function($event) {
+            var worker = $(this).data("worker");
+                updateWorkerCustomDisconnectDelay(worker, 60);
+            $event.preventDefault();
+        });
+
+        $('#workerList').on('click', '#btn-set-worker-custom-disconnect-delay-3600', function($event) {
+            var worker = $(this).data("worker");
+                updateWorkerCustomDisconnectDelay(worker, 3600);
             $event.preventDefault();
         });
 


### PR DESCRIPTION
… a button in worker list. The custom delay is taken into account when pruning workers.

## Description
a new dropdown in the workers page, and a new variable custom_disconnect_delay in scheduler.py/Worker

## Motivation and Context
My usecase are long running tasks with possibly intermittent connectivity. Therefore i configure luigi something like this:

```
[scheduler]
remove_delay = 88888888
worker_disconnect_delay = 88888888

[core]
rpc-retry-attempts = 88888888
```

But when i am certain that a worker is not coming back, i need to inform the scheduler about this. Rather than adding a special "remove" button, this PR lets you override the disconnect delay value, and automatic pruning does the rest.

This PR is somewhat preliminary:
* the gui needs some tweaks, specifically, the null value is displayed as an empty string upon page load. 
* `on('click', '#btn-set-worker-custom-disconnect-delay-****` could probably be abstracted
* maybe Worker.custom_disconnect_delay would be better stored in Worker.info?

I played with this code and it seems to do the job.
