### PR TITLE
Add host_config_options to allow configuration of DockerTask for GPU resources

### DIFF
--- a/luigi/contrib/docker_runner.py
+++ b/luigi/contrib/docker_runner.py
@@ -79,10 +79,22 @@ class DockerTask(luigi.Task):
 
     @property
     def host_config_options(self):
+        '''
+        Override this to specify host_config options like gpu requests or shm
+        size e.g. `{"device_requests": [docker.types.DeviceRequest(count=1, capabilities=[["gpu"]])]}`
+
+        See https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
+        '''
         return {}
 
     @property
     def container_options(self):
+        '''
+        Override this to specify container options like user or ports e.g.
+        `{"user": f"{os.getuid()}:{os.getgid()}"}`
+
+        See https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_container
+        '''
         return {}
 
     @property

--- a/luigi/contrib/docker_runner.py
+++ b/luigi/contrib/docker_runner.py
@@ -78,6 +78,10 @@ class DockerTask(luigi.Task):
         return None
 
     @property
+    def host_config_options(self):
+        return {}
+
+    @property
     def container_options(self):
         return {}
 
@@ -192,7 +196,8 @@ class DockerTask(luigi.Task):
                          % (self._image, self.command, self._binds))
 
             host_config = self._client.create_host_config(binds=self._binds,
-                                                          network_mode=self.network_mode)
+                                                          network_mode=self.network_mode,
+                                                          **self.host_config_options)
 
             container = self._client.create_container(self._image,
                                                       command=self.command,


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

This adds a new `host_config_options` property to `DockerTask` that gives access to the underlying Docker API for things like gpu requests or increased shared memory. I've also added references to the docker documentation and a few small examples. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I need to grant GPU access to a few docker tasks, but the current API interface of the DockerTask doesn't allow any sort of access to the underlying Docker API to be able to make the necessary requests. I've modeled this change after the `container_options` property which allows broad underlying access to the relevant Docker API calls.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I have tested this with some code that I'm working with on a Telsa T4: https://github.com/dsgt-birdclef/birdclef-2023/blob/22c8bcb53c297e68298be5fb41933d59e11f55cd/workflows/mixit/docker.py

In particular, I added the following:

```python
    host_config_options = {
        "device_requests": [docker.types.DeviceRequest(count=1, capabilities=[["gpu"]])]
    }
```

This seems to work as expected with my workflow.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
