### PR TITLE
Silence false positive UnconsumedParameterWarning

### DIFF
--- a/luigi/configuration/cfg_parser.py
+++ b/luigi/configuration/cfg_parser.py
@@ -117,6 +117,7 @@ class CombinedInterpolation(Interpolation):
 class LuigiConfigParser(BaseParser, ConfigParser):
     NO_DEFAULT = object()
     enabled = True
+    optionxform = str
     _instance = None
     _config_paths = [
         '/etc/luigi/client.cfg',  # Deprecated old-style global luigi config

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -49,6 +49,10 @@ class core(task.Config):
     This is arguably a bit of a hack.
     '''
     use_cmdline_section = False
+    ignore_unconsumed = {
+        'autoload_range',
+        'no_configure_logging',
+    }
 
     local_scheduler = parameter.BoolParameter(
         default=False,

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -438,6 +438,7 @@ class Task(metaclass=Register):
             cls._unconsumed_params = set()
         if task_family in conf.sections():
             for key, value in conf[task_family].items():
+                key = key.replace('-', '_')
                 composite_key = f"{task_family}_{key}"
                 if key not in result and composite_key not in cls._unconsumed_params:
                     warnings.warn(

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -437,10 +437,11 @@ class Task(metaclass=Register):
         if not hasattr(cls, "_unconsumed_params"):
             cls._unconsumed_params = set()
         if task_family in conf.sections():
+            ignore_unconsumed = getattr(cls, 'ignore_unconsumed', set())
             for key, value in conf[task_family].items():
                 key = key.replace('-', '_')
                 composite_key = f"{task_family}_{key}"
-                if key not in result and composite_key not in cls._unconsumed_params:
+                if key not in result and key not in ignore_unconsumed and composite_key not in cls._unconsumed_params:
                     warnings.warn(
                         "The configuration contains the parameter "
                         f"'{key}' with value '{value}' that is not consumed by the task "

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -220,7 +220,7 @@ class TaskTest(unittest.TestCase):
 
     @with_config(
         {
-            "TaskA": {
+            "TaskEdgeCase": {
                 "camelParam": "camelCase",
                 "underscore_param": "underscore",
                 "dash-param": "dash",
@@ -228,7 +228,7 @@ class TaskTest(unittest.TestCase):
         }
     )
     def test_unconsumed_params_edge_cases(self):
-        class TaskA(luigi.Task):
+        class TaskEdgeCase(luigi.Task):
             camelParam = luigi.Parameter()
             underscore_param = luigi.Parameter()
             dash_param = luigi.Parameter()
@@ -243,11 +243,39 @@ class TaskTest(unittest.TestCase):
                 category=luigi.parameter.UnconsumedParameterWarning,
             )
 
-            task = TaskA()
+            task = TaskEdgeCase()
             assert len(w) == 0
             assert task.camelParam == "camelCase"
             assert task.underscore_param == "underscore"
             assert task.dash_param == "dash"
+
+    @with_config(
+        {
+            "TaskIgnoreUnconsumed": {
+                "a": "a",
+                "b": "b",
+                "c": "c",
+            },
+        }
+    )
+    def test_unconsumed_params_ignore_unconsumed(self):
+        class TaskIgnoreUnconsumed(luigi.Task):
+            ignore_unconsumed = {"b", "d"}
+
+            a = luigi.Parameter()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings(
+                action="ignore",
+                category=Warning,
+            )
+            warnings.simplefilter(
+                action="always",
+                category=luigi.parameter.UnconsumedParameterWarning,
+            )
+
+            TaskIgnoreUnconsumed()
+            assert len(w) == 1
 
 
 class TaskFlattenOutputTest(unittest.TestCase):

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -218,6 +218,37 @@ class TaskTest(unittest.TestCase):
                     f"the task '{task_name}'."
                 )
 
+    @with_config(
+        {
+            "TaskA": {
+                "camelParam": "camelCase",
+                "underscore_param": "underscore",
+                "dash-param": "dash",
+            },
+        }
+    )
+    def test_unconsumed_params_edge_cases(self):
+        class TaskA(luigi.Task):
+            camelParam = luigi.Parameter()
+            underscore_param = luigi.Parameter()
+            dash_param = luigi.Parameter()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings(
+                action="ignore",
+                category=Warning,
+            )
+            warnings.simplefilter(
+                action="always",
+                category=luigi.parameter.UnconsumedParameterWarning,
+            )
+
+            task = TaskA()
+            assert len(w) == 0
+            assert task.camelParam == "camelCase"
+            assert task.underscore_param == "underscore"
+            assert task.dash_param == "dash"
+
 
 class TaskFlattenOutputTest(unittest.TestCase):
     def test_single_task(self):


### PR DESCRIPTION
UnconsumedParameterWarning is emitted even if parameters are correctly consumed. 

## Description
There are two cases when UnconsumedParameterWarning is false positive:
* camelCase or parameters with dashes in name are not correctly recognized when cfg parser is used.
* Some parameters are defined in core section of config (autoload_range, no_configure_log), but are not needed in class instance (as must be used before class is initialized).

## Motivation and Context
False positive UnconsumedParameterWarning forced me to completely disable this feature as any output to stderr is treated as error in pipelines. 

## Have you tested this? If so, how?
I've added unitests and tested this branch in my pipeline. 