### PR TITLE
Fix for applying logging configurations using the a TOML configuration file

### DIFF
--- a/luigi/setup_logging.py
+++ b/luigi/setup_logging.py
@@ -24,6 +24,7 @@ import logging.config
 import os.path
 
 from luigi.configuration import get_config, LuigiConfigParser
+from luigi.freezing import recursively_unfreeze
 
 from configparser import NoSectionError
 
@@ -40,7 +41,7 @@ class BaseLogging:
             logging_config = cls.config['logging']
         except (TypeError, KeyError, NoSectionError):
             return False
-        logging.config.dictConfig(logging_config)
+        logging.config.dictConfig(recursively_unfreeze(logging_config))
         return True
 
     @classmethod

--- a/test/setup_logging_test.py
+++ b/test/setup_logging_test.py
@@ -31,10 +31,34 @@ class TestDaemonLogging(unittest.TestCase):
         self.assertFalse(result)
 
     def test_section(self):
-        self.cls.config = {'logging': {
-            'version': 1,
-            'disable_existing_loggers': False,
-        }}
+        self.cls.config = {
+            'logging': {
+                'version': 1,
+                'disable_existing_loggers': False,
+                'formatters': {
+                    'mockformatter': {
+                        'format': '{levelname}: {message}',
+                        'style': '{',
+                        'datefmt': '%Y-%m-%d %H:%M:%S',
+                    },
+                },
+                'handlers': {
+                    'mockhandler': {
+                        'class': 'logging.StreamHandler',
+                        'level': 'INFO',
+                        'formatter': 'mockformatter',
+                    },
+                },
+                'mockloggers': {
+                    'mocklogger': {
+                        'handlers': ('mockhandler',),
+                        'level': 'INFO',
+                        'disabled': False,
+                        'propagate': False,
+                    },
+                },
+            },
+        }
         result = self.cls._section(None)
         self.assertTrue(result)
 

--- a/test/setup_logging_test.py
+++ b/test/setup_logging_test.py
@@ -49,7 +49,7 @@ class TestDaemonLogging(unittest.TestCase):
                         'formatter': 'mockformatter',
                     },
                 },
-                'mockloggers': {
+                'loggers': {
                     'mocklogger': {
                         'handlers': ('mockhandler',),
                         'level': 'INFO',

--- a/test/setup_logging_test.py
+++ b/test/setup_logging_test.py
@@ -62,6 +62,11 @@ class TestDaemonLogging(unittest.TestCase):
         result = self.cls._section(None)
         self.assertTrue(result)
 
+        self.cls.config = LuigiTomlParser()
+        self.cls.config.read(['./test/testconfig/luigi_logging.toml'])
+        result = self.cls._section(None)
+        self.assertTrue(result)
+
         self.cls.config = {}
         result = self.cls._section(None)
         self.assertFalse(result)

--- a/test/testconfig/luigi_logging.toml
+++ b/test/testconfig/luigi_logging.toml
@@ -1,0 +1,18 @@
+[logging]
+version = 1
+disable_existing_loggers = false
+
+[logging.formatters.mockformatter]
+format = "{levelname}: {message}"
+style = "{"
+
+[logging.handlers.mockhandler]
+class = "logging.StreamHandler"
+level = "INFO"
+formatter = "mockformatter"
+
+[logging.loggers.mocklogger]
+handlers = ["mockhandler"]
+level = 'INFO'
+disabled = false
+propagate = false


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Configuring logging using the "logging" session of the TOML configuration file throws an exception because the `logging` library tries to write to a frozen dictionary. This PR solves the issue by unfreezing the dictionary before passing it to `logging.dictConfig`.

## Motivation and Context

Starting from version `2.8.11`, the logging section of the configuration file is loaded into frozen a dictionary which is then passed to the `logging.dictConfig` when using the TOML parser. However, `logging.dictConfig` expects a mutable dictionary and tries to overwrites some of its keys, resulting in an exception. In practice that means we cannot use the TOML configuration file to configure logging.

This problem has been mentioned in the issue https://github.com/spotify/luigi/issues/2879

## Have you tested this? If so, how?
Manually tested the changes and added a new test case [here](https://github.com/JoseHJBlanco/luigi/blob/93d51636e8e6e1cd0df7d68c3b8d3368ad079f1a/test/setup_logging_test.py#L66) to replicate the scenario in which the `master` branch would throw an error.