### PR TITLE
Fix compatibility with cythonized tasks.

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -29,6 +29,7 @@ ways between versions. The exception is the exception types and the
 """
 
 import collections
+import collections.abc
 import datetime
 import getpass
 import importlib
@@ -47,7 +48,6 @@ import socket
 import threading
 import time
 import traceback
-import types
 
 from luigi import notifications
 from luigi.event import Event
@@ -137,7 +137,7 @@ class TaskProcess(multiprocessing.Process):
     def _run_get_new_deps(self):
         task_gen = self.task.run()
 
-        if not isinstance(task_gen, types.GeneratorType):
+        if not isinstance(task_gen, collections.abc.Generator):
             return None
 
         next_send = None


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
`types.GeneratorType` is not compatible with the generator type of Cython. This leads to `_run_get_new_deps()` returning directly when the task is from a cythonized module and [yields dynamic dependencies](https://luigi.readthedocs.io/en/stable/tasks.html?highlight=yield#dynamic-dependencies).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have cythonized modules with luigi tasks and noticed that the tasks immediately switch to DONE without doing anything, without logging any error or having any task output.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I successfully ran cythonized and non-cythonized tasks with this patch.

---

Side note: I originally wanted to use `typing.Generator`, but this now [deprecated](https://docs.python.org/3/library/typing.html?highlight=typing#typing.Generator).

There were also no other uses of `types` in the code base.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
