### PR TITLE
fix flake8 error in master

### DIFF
--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -1359,8 +1359,8 @@ class WorkerEmailTest(LuigiTestCase):
         worker = Worker(scheduler)
         a = A()
 
-        with mock.patch.object(worker._scheduler, 'announce_scheduling_failure', side_effect=Exception('Unexpected')),\
-                self.assertRaises(Exception):
+        with mock.patch.object(worker._scheduler, 'announce_scheduling_failure',
+                               side_effect=Exception('Unexpected')), self.assertRaises(Exception):
             worker.add(a)
         self.assertTrue(len(emails) == 2)  # One for `complete` error, one for exception in announcing.
         self.assertTrue('Luigi: Framework error while scheduling' in emails[1])


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Fixes flake8 error on master branch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failing master build

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Ran flake8 tests locally.

Before change:
```shell
flake8 run-test: commands[0] | flake8 --exclude=doc,.tox
./test/worker_test.py:1362:118: E231 missing whitespace after ','
ERROR: InvocationError for command /Users/dlstadther/code/luigi/.tox/flake8/bin/flake8 --exclude=doc,.tox (exited with code 1)
ERROR:   flake8: commands failed
```

After change:
```shell
flake8 run-test: commands[1] | flake8 --max-line-length=100 --ignore=E265 doc
  flake8: commands succeeded
  congratulations :)
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
