### PR TITLE
Do not escape <br> tags in task tooltips, so that the line breaks are…

### DIFF
--- a/luigi/static/visualiser/js/graph.js
+++ b/luigi/static/visualiser/js/graph.js
@@ -277,14 +277,14 @@ Graph = (function() {
                 .appendTo(g);
 
             var titleText = node.name;
-            var content = $.map(node.params, function (value, name) { return name + ": " + value; }).join("<br>");
+            var content = $.map(node.params, function (value, name) { return escapeHtml(name + ": " + value); }).join("<br>");
             g.attr("title", titleText)
                 .popover({
                     trigger: 'hover',
                     container: 'body',
                     html: true,
                     placement: 'top',
-                    content: escapeHtml(content)
+                    content: content
                 });
         });
 


### PR DESCRIPTION
## Description
This is a minor formatting fix for the Task popover text in the Dependency Graph tab of the scheduler GUI. 

## Motivation and Context
With the XSS fix implemented in #3230, the tooltip text for a task with multiple parameters has the line break tags escaped: 
![image](https://github.com/spotify/luigi/assets/85639928/8731f1d6-42ee-424f-a94e-a7c235ce5d3a)

This change simply escapes the text for each parameter individually, and then joins the escaped strings with the <br> tags.

## Have you tested this? If so, how?
I spun up a scheduler and checked that a simple test task displays correctly.
![image](https://github.com/spotify/luigi/assets/85639928/d6ff7709-372c-4978-a114-40c5cc1d8e3e)
