### PR TITLE
Restrict permissions for locking files

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -100,7 +100,7 @@ def acquire_for(pid_dir, num_available=1, kill_signal=None):
     # Create a pid file if it does not exist
     try:
         os.mkdir(pid_dir)
-        os.chmod(pid_dir, 0o777)
+        os.chmod(pid_dir, 0o775)
     except OSError as exc:
         if exc.errno != errno.EEXIST:
             raise
@@ -153,8 +153,8 @@ def _write_pids_file(pid_file, pids_set):
     with open(pid_file, 'w') as f:
         f.writelines('{}\n'.format(pid) for pid in pids_set)
 
-    # Make the .pid-file writable by all (when the os allows for it)
+    # Make the .pid-file writable by user or group (when the os allows for it)
     if os.name != 'nt':
         s = os.stat(pid_file)
         if os.getuid() == s.st_uid:
-            os.chmod(pid_file, s.st_mode | 0o777)
+            os.chmod(pid_file, 0o664)

--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -100,7 +100,7 @@ class LockTest(unittest.TestCase):
         self.assertTrue(acquired)
 
         s = os.stat(self.pid_file)
-        self.assertEqual(s.st_mode & 0o777, 0o777)
+        self.assertEqual(s.st_mode & 0o777, 0o664)
 
     def test_acquiring_lock_from_missing_process(self):
         fake_pid = 99999
@@ -111,7 +111,7 @@ class LockTest(unittest.TestCase):
         self.assertTrue(acquired)
 
         s = os.stat(self.pid_file)
-        self.assertEqual(s.st_mode & 0o777, 0o777)
+        self.assertEqual(s.st_mode & 0o777, 0o664)
 
     @mock.patch('os.kill')
     def test_take_lock_with_kill(self, kill_fn):


### PR DESCRIPTION
A simple fix for #3253
