### PR TITLE
worker: Log which outputs are missing when task is unexpectedly incomplete

### DIFF
--- a/luigi/contrib/dropbox.py
+++ b/luigi/contrib/dropbox.py
@@ -298,6 +298,9 @@ class DropboxTarget(FileSystemTarget):
         self.client = DropboxClient(token, user_agent)
         self.format = format or luigi.format.get_default_format()
 
+    def __str__(self):
+        return self.path
+
     @property
     def fs(self):
         return self.client

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -485,6 +485,9 @@ class HivePartitionTarget(luigi.Target):
         self.client = client or get_default_client()
         self.fail_missing_table = fail_missing_table
 
+    def __str__(self):
+        return self.path
+
     def exists(self):
         """
         returns `True` if the partition/table exists

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -35,6 +35,9 @@ class MongoTarget(Target):
         self._index = index
         self._collection = collection
 
+    def __str__(self):
+        return '%s/%s' % (self._index, self._collection)
+
     def get_collection(self):
         """
         Return targeted mongo collection to query on

--- a/luigi/contrib/mongodb.py
+++ b/luigi/contrib/mongodb.py
@@ -36,7 +36,7 @@ class MongoTarget(Target):
         self._collection = collection
 
     def __str__(self):
-        return '%s/%s' % (self._index, self._collection)
+        return f'{self._index}/{self._collection}'
 
     def get_collection(self):
         """

--- a/luigi/contrib/mssqldb.py
+++ b/luigi/contrib/mssqldb.py
@@ -68,6 +68,9 @@ class MSSqlTarget(luigi.Target):
         self.table = table
         self.update_id = update_id
 
+    def __str__(self):
+        return self.table
+
     def touch(self, connection=None):
         """
         Mark this update as complete.

--- a/luigi/contrib/mysqldb.py
+++ b/luigi/contrib/mysqldb.py
@@ -68,6 +68,9 @@ class MySqlTarget(luigi.Target):
         self.update_id = update_id
         self.cnx_kwargs = cnx_kwargs
 
+    def __str__(self):
+        return self.table
+
     def touch(self, connection=None):
         """
         Mark this update as complete.

--- a/luigi/contrib/postgres.py
+++ b/luigi/contrib/postgres.py
@@ -200,6 +200,9 @@ class PostgresTarget(luigi.Target):
         self.table = table
         self.update_id = update_id
 
+    def __str__(self):
+        return self.table
+
     def touch(self, connection=None):
         """
         Mark this update as complete.

--- a/luigi/contrib/presto.py
+++ b/luigi/contrib/presto.py
@@ -131,6 +131,9 @@ class PrestoTarget(luigi.Target):
         self._client = client
         self._count = None
 
+    def __str__(self):
+        return self.table
+
     @property
     def _count_query(self):
         partition = OrderedDict(self.partition or {1: 1})

--- a/luigi/contrib/redis_store.py
+++ b/luigi/contrib/redis_store.py
@@ -73,6 +73,9 @@ class RedisTarget(Target):
             socket_timeout=self.socket_timeout,
         )
 
+    def __str__(self):
+        return self.marker_key()
+
     def marker_key(self):
         """
         Generate a key for the indicator hash.

--- a/luigi/contrib/simulate.py
+++ b/luigi/contrib/simulate.py
@@ -79,6 +79,9 @@ class RunAnywayTarget(luigi.Target):
                     shutil.rmtree(path)
                     logger.debug('Deleted temporary directory %s', path)
 
+    def __str__(self):
+        return self.task_id
+
     def get_path(self):
         """
         Returns a temporary file path based on a MD5 hash generated with the task's name and its arguments

--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -189,6 +189,9 @@ class SQLAlchemyTarget(luigi.Target):
         self.connect_args = connect_args
         self.marker_table_bound = None
 
+    def __str__(self):
+        return self.marker_table_bound or self.connection_string
+
     @property
     def engine(self):
         """

--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -190,7 +190,7 @@ class SQLAlchemyTarget(luigi.Target):
         self.marker_table_bound = None
 
     def __str__(self):
-        return self.marker_table_bound or self.connection_string
+        return self.target_table
 
     @property
     def engine(self):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -215,6 +215,9 @@ class FileSystemTarget(Target):
         # cast to str to allow path to be objects like pathlib.PosixPath and py._path.local.LocalPath
         self.path = str(path)
 
+    def __str__(self):
+        return self.path
+
     @property
     @abc.abstractmethod
     def fs(self):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -187,7 +187,7 @@ class TaskProcess(multiprocessing.Process):
                     if not self.check_complete(dep):
                         nonexistent_outputs = [output for output in dep.output() if not output.exists()]
                         if nonexistent_outputs:
-                            missing.append('%s (%s)' % (dep.task_id, ', '.join(map(str, nonexistent_outputs))))
+                            missing.append(f'{dep.task_id} ({", ".join(map(str, nonexistent_outputs))})')
                         else:
                             missing.append(dep.task_id)
                 if missing:

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -182,7 +182,14 @@ class TaskProcess(multiprocessing.Process):
             # checking completeness of self.task so outputs of dependencies are
             # irrelevant.
             if self.check_unfulfilled_deps and not _is_external(self.task):
-                missing = [dep.task_id for dep in self.task.deps() if not self.check_complete(dep)]
+                missing = []
+                for dep in self.task.deps():
+                    if not self.check_complete(dep):
+                        nonexistent_outputs = [output for output in dep.output() if not output.exists()]
+                        if nonexistent_outputs:
+                            missing.append('%s (%s)' % (dep.task_id, ', '.join(map(str, nonexistent_outputs))))
+                        else:
+                            missing.append(dep.task_id)
                 if missing:
                     deps = 'dependency' if len(missing) == 1 else 'dependencies'
                     raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing)))


### PR DESCRIPTION
## Motivation and Context

When a task ran but did not write all its outputs, Luigi errors with:

> RuntimeError: Unfulfilled dependency at run time: NodeProperties_graph__tmp_pytest_of_d_cnt_dir_rev_rel__02a93cea21

which can be hard to debug for tasks with many outputs. After this PR, it lists which outputs are missing. For example:

> RuntimeError: Unfulfilled dependency at run time: NodeProperties_graph__tmp_pytest_of_d_cnt_dir_rev_rel__02a93cea21 (/tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.committer_timestamp.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.message.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.tag_name.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.content.is_skipped.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.tag_name.offset.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.committer_id.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.content.length.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.author_id.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.message.offset.bin, /tmp/pytest-of-dev/pytest-512/test_compressgraph_None_0/compressed_graph/graph.property.committer_timestamp_offset.bin)

## Description

I implemented a basic `__str__` for all target types, using either the path if it's filesystem-like, or a table name for database-like targets (to be consistent with `BigQueryTarget`).


## Have you tested this? If so, how?

Unit tests are not broken, and this works for me (only tested with local filesystem)