### PR TITLE
Make Dropbox listdir optionally recursive

### DIFF
--- a/luigi/contrib/dropbox.py
+++ b/luigi/contrib/dropbox.py
@@ -133,9 +133,9 @@ class DropboxClient(FileSystem):
                 raise e
 
     @accept_trailing_slash_in_existing_dirpaths
-    def listdir(self, path, **kwargs):
+    def listdir(self, path, recursive=True, **kwargs):
         dirs = []
-        lister = self.conn.files_list_folder(path, recursive=True, **kwargs)
+        lister = self.conn.files_list_folder(path, recursive, **kwargs)
         dirs.extend(lister.entries)
         while lister.has_more:
             lister = self.conn.files_list_folder_continue(lister.cursor)

--- a/test/contrib/dropbox_test.py
+++ b/test/contrib/dropbox_test.py
@@ -87,19 +87,33 @@ class TestClientDropbox(unittest.TestCase):
         list_of_dirs = self.luigiconn.listdir(DROPBOX_TEST_PATH)
         self.assertTrue('/' not in list_of_dirs)
         self.assertTrue(DROPBOX_TEST_PATH in list_of_dirs)
-        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)  # we verify recursivity
+        self.assertTrue(DROPBOX_TEST_SIMPLE_DIR in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_FILE_IN_DIR in list_of_dirs)  # we verify recursivity
 
     def test_listdir_simple_with_one_slash(self):
         list_of_dirs = self.luigiconn.listdir(DROPBOX_TEST_PATH + '/')
         self.assertTrue('/' not in list_of_dirs)
         self.assertTrue(DROPBOX_TEST_PATH in list_of_dirs)
-        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)  # we verify recursivity
+        self.assertTrue(DROPBOX_TEST_SIMPLE_DIR in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_FILE_IN_DIR in list_of_dirs)  # we verify recursivity
 
     def test_listdir_multiple(self):
         list_of_dirs = self.luigiconn.listdir(DROPBOX_TEST_PATH, limit=2)
         self.assertTrue('/' not in list_of_dirs)
         self.assertTrue(DROPBOX_TEST_PATH in list_of_dirs)
-        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)  # we verify recursivity
+        self.assertTrue(DROPBOX_TEST_SIMPLE_DIR in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_FILE_IN_DIR in list_of_dirs)  # we verify recursivity
+
+    def test_listdir_non_recursive(self):
+        list_of_dirs = self.luigiconn.listdir(DROPBOX_TEST_PATH, recursive=False)
+        self.assertTrue('/' not in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_PATH not in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_SIMPLE_DIR in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_SIMPLE_FILE in list_of_dirs)
+        self.assertTrue(DROPBOX_TEST_FILE_IN_DIR not in list_of_dirs)
 
     def test_listdir_nonexisting(self):
         with self.assertRaises(dropbox.exceptions.ApiError):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Make the Dropbox `listdir` function accept an optional keyword argument `recursive`, True by default to preserve the current behavior.

## Motivation and Context
Currently, `listdir` calls the Dropbox SDK `files_list_folder` function with `recursive=True` hard-coded. `recursive` should be optional, so we can replicate the functionality of `LocalFileSystem.listdir` which is not recursive.

## Have you tested this? If so, how?
- Added a unit test for non-recursive behavior
- Modified the other `listdir` tests to verify that by default, the list includes the nested file `DROPBOX_TEST_FILE_IN_DIR`
- Ran `tox -e py37-dropbox` locally

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
