### PR TITLE
Add python 3.11 support

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -23,6 +23,10 @@ jobs:
             tox-env: py39-core
           - python-version: "3.10"
             tox-env: py310-core
+          - python-version: "3.11"
+            tox-env: py311-core
+          - python-version: "3.12"
+            tox-env: py312-core
 
     steps:
       - uses: actions/checkout@v2
@@ -88,6 +92,10 @@ jobs:
             tox-env: py39-postgres
           - python-version: "3.10"
             tox-env: py310-postgres
+          - python-version: "3.11"
+            tox-env: py311-postgres
+          - python-version: "3.12"
+            tox-env: py312-postgres
 
     steps:
       - uses: actions/checkout@v2
@@ -139,6 +147,10 @@ jobs:
             tox-env: py39-aws
           - python-version: "3.10"
             tox-env: py310-aws
+          - python-version: "3.11"
+            tox-env: py311-aws
+          - python-version: "3.12"
+            tox-env: py312-aws
 
           - python-version: "3.6"
             tox-env: py36-unixsocket
@@ -155,6 +167,12 @@ jobs:
           - python-version: "3.10"
             tox-env: py310-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
+          - python-version: "3.11"
+            tox-env: py311-unixsocket
+            OVERRIDE_SKIP_CI_TESTS: True
+          - python-version: "3.12"
+            tox-env: py312-unixsocket
+            OVERRIDE_SKIP_CI_TESTS: True
 
           - python-version: "3.6"
             tox-env: py36-apache
@@ -166,6 +184,10 @@ jobs:
             tox-env: py39-apache
           - python-version: "3.10"
             tox-env: py310-apache
+          - python-version: "3.11"
+            tox-env: py311-apache
+          - python-version: "3.12"
+            tox-env: py312-apache
 
           - python-version: "3.6"
             tox-env: py36-azureblob
@@ -177,6 +199,10 @@ jobs:
             tox-env: py39-azureblob
           - python-version: "3.10"
             tox-env: py310-azureblob
+          - python-version: "3.11"
+            tox-env: py311-azureblob
+          - python-version: "3.12"
+            tox-env: py312-azureblob
 
 
           - python-version: 3.9

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -25,8 +25,6 @@ jobs:
             tox-env: py310-core
           - python-version: "3.11"
             tox-env: py311-core
-          - python-version: "3.12"
-            tox-env: py312-core
 
     steps:
       - uses: actions/checkout@v2
@@ -94,8 +92,6 @@ jobs:
             tox-env: py310-postgres
           - python-version: "3.11"
             tox-env: py311-postgres
-          - python-version: "3.12"
-            tox-env: py312-postgres
 
     steps:
       - uses: actions/checkout@v2
@@ -149,8 +145,6 @@ jobs:
             tox-env: py310-aws
           - python-version: "3.11"
             tox-env: py311-aws
-          - python-version: "3.12"
-            tox-env: py312-aws
 
           - python-version: "3.6"
             tox-env: py36-unixsocket
@@ -170,9 +164,6 @@ jobs:
           - python-version: "3.11"
             tox-env: py311-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
-          - python-version: "3.12"
-            tox-env: py312-unixsocket
-            OVERRIDE_SKIP_CI_TESTS: True
 
           - python-version: "3.6"
             tox-env: py36-apache
@@ -186,8 +177,6 @@ jobs:
             tox-env: py310-apache
           - python-version: "3.11"
             tox-env: py311-apache
-          - python-version: "3.12"
-            tox-env: py312-apache
 
           - python-version: "3.6"
             tox-env: py36-azureblob
@@ -201,8 +190,6 @@ jobs:
             tox-env: py310-azureblob
           - python-version: "3.11"
             tox-env: py311-azureblob
-          - python-version: "3.12"
-            tox-env: py312-azureblob
 
 
           - python-version: 3.9

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://img.shields.io/pypi/l/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 
-Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10 tested) package that helps you build complex
+Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 tested) package that helps you build complex
 pipelines of batch jobs. It handles dependency resolution, workflow management,
 visualization, handling failures, command line integration, and much more.
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://img.shields.io/pypi/l/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 
-Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 tested) package that helps you build complex
+Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11 tested) package that helps you build complex
 pipelines of batch jobs. It handles dependency resolution, workflow management,
 visualization, handling failures, command line integration, and much more.
 

--- a/luigi/contrib/presto.py
+++ b/luigi/contrib/presto.py
@@ -104,7 +104,7 @@ class WithPrestoClient(Register):
                 ```
                 after py2-deprecation
                 """
-                args = inspect.getargspec(Cursor.__init__)[0][1:]
+                args = inspect.getfullargspec(Cursor.__init__)[0][1:]
                 for parameter in args:
                     val = getattr(self, parameter)
                     if val:

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Monitoring',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Monitoring',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{35,36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{35,36,37,38,39,310,311}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [pytest]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Add support and CI workflow for Python 3.11.
* Replace `getargspec`, which has been deprecated since Python 3.0 and was removed in Python 3.11. https://docs.python.org/3/whatsnew/3.11.html#removed