### PR TITLE
Support Python3.12

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -25,6 +25,8 @@ jobs:
             tox-env: py310-core
           - python-version: "3.11"
             tox-env: py311-core
+          - python-version: "3.12"
+            tox-env: py312-core
 
     steps:
       - uses: actions/checkout@v2
@@ -92,6 +94,8 @@ jobs:
             tox-env: py310-postgres
           - python-version: "3.11"
             tox-env: py311-postgres
+          - python-version: "3.12"
+            tox-env: py312-postgres
 
     steps:
       - uses: actions/checkout@v2
@@ -145,6 +149,8 @@ jobs:
             tox-env: py310-aws
           - python-version: "3.11"
             tox-env: py311-aws
+          - python-version: "3.12"
+            tox-env: py312-aws
 
           - python-version: "3.6"
             tox-env: py36-unixsocket
@@ -164,6 +170,9 @@ jobs:
           - python-version: "3.11"
             tox-env: py311-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
+          - python-version: "3.12"
+            tox-env: py312-unixsocket
+            OVERRIDE_SKIP_CI_TESTS: True
 
           - python-version: "3.6"
             tox-env: py36-apache
@@ -177,6 +186,8 @@ jobs:
             tox-env: py310-apache
           - python-version: "3.11"
             tox-env: py311-apache
+          - python-version: "3.12"
+            tox-env: py312-apache
 
           - python-version: "3.6"
             tox-env: py36-azureblob
@@ -190,6 +201,8 @@ jobs:
             tox-env: py310-azureblob
           - python-version: "3.11"
             tox-env: py311-azureblob
+          - python-version: "3.12"
+            tox-env: py312-azureblob
 
 
           - python-version: 3.9

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://img.shields.io/pypi/l/luigi.svg?style=flat
    :target: https://pypi.python.org/pypi/luigi
 
-Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11 tested) package that helps you build complex
+Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 tested) package that helps you build complex
 pipelines of batch jobs. It handles dependency resolution, workflow management,
 visualization, handling failures, command line integration, and much more.
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Monitoring',
     ],
 )

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -362,7 +362,7 @@ class InvokeOverCmdlineTest(unittest.TestCase):
         print(stdout)
         print(stderr)
 
-        self.assertNotEquals(returncode, 1)
+        self.assertNotEqual(returncode, 1)
         self.assertFalse(b'required_test_param' in stderr)
 
 

--- a/test/contrib/external_daily_snapshot_test.py
+++ b/test/contrib/external_daily_snapshot_test.py
@@ -32,18 +32,18 @@ class ExternalDailySnapshotTest(unittest.TestCase):
     def test_latest(self):
         MockTarget('data-xyz-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='xyz')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))
 
     def test_latest_not_exists(self):
         MockTarget('data-abc-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 11), param='abc', lookback=5)
-        self.assertEquals(d.date, datetime.date(2012, 1, 7))
+        self.assertEqual(d.date, datetime.date(2012, 1, 7))
 
     def test_deterministic(self):
         MockTarget('data-pqr-zebra-Congo-2012-01-01').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', a='zebra', aa='Congo')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))
 
         MockTarget('data-pqr-zebra-Congo-2012-01-05').open('w').close()
         d = DataDump.latest(date=datetime.date(2012, 1, 10), param='pqr', aa='Congo', a='zebra')
-        self.assertEquals(d.date, datetime.date(2012, 1, 1))  # Should still be the same
+        self.assertEqual(d.date, datetime.date(2012, 1, 1))  # Should still be the same

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -200,7 +200,7 @@ class CommonTests:
         job = WordFreqJob(use_hdfs=test_case.use_hdfs)
         luigi.build([job], local_scheduler=True)
         c = read_wordcount_output(job.output())
-        test_case.assertAlmostEquals(float(c['jk']), 6.0 / 33.0)
+        test_case.assertAlmostEqual(float(c['jk']), 6.0 / 33.0)
 
     @staticmethod
     def test_map_only(test_case):

--- a/test/contrib/postgres_test.py
+++ b/test/contrib/postgres_test.py
@@ -132,11 +132,11 @@ class PostgresQueryTest(unittest.TestCase):
 
     def test_override_port(self):
         output = DummyPostgresQueryWithPort(date=datetime.datetime(1991, 3, 24)).output()
-        self.assertEquals(output.port, 1234)
+        self.assertEqual(output.port, 1234)
 
     def test_port_encoded_in_host(self):
         output = DummyPostgresQueryWithPortEncodedInHost(date=datetime.datetime(1991, 3, 24)).output()
-        self.assertEquals(output.port, '1234')
+        self.assertEqual(output.port, '1234')
 
 
 @pytest.mark.postgres

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -343,7 +343,7 @@ class TestS3Client(unittest.TestCase):
         s3_client.get('s3://mybucket/putMe', tmp_file_path)
         with open(tmp_file_path, 'r') as f:
             content = f.read()
-        self.assertEquals(content, self.tempFileContents.decode("utf-8"))
+        self.assertEqual(content, self.tempFileContents.decode("utf-8"))
         tmp_file.close()
 
     def test_get_as_bytes(self):
@@ -353,7 +353,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_bytes('s3://mybucket/putMe')
 
-        self.assertEquals(contents, self.tempFileContents)
+        self.assertEqual(contents, self.tempFileContents)
 
     def test_get_as_string(self):
         create_bucket()
@@ -362,7 +362,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe2')
 
-        self.assertEquals(contents, self.tempFileContents.decode('utf-8'))
+        self.assertEqual(contents, self.tempFileContents.decode('utf-8'))
 
     def test_get_as_string_latin1(self):
         create_bucket()
@@ -371,7 +371,7 @@ class TestS3Client(unittest.TestCase):
 
         contents = s3_client.get_as_string('s3://mybucket/putMe3', encoding='ISO-8859-1')
 
-        self.assertEquals(contents, self.tempFileContents.decode('ISO-8859-1'))
+        self.assertEqual(contents, self.tempFileContents.decode('ISO-8859-1'))
 
     def test_get_key(self):
         create_bucket()

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -20,7 +20,8 @@ import sys
 import tempfile
 
 import boto3
-from boto.s3 import key
+if sys.version_info[:2] <= (3, 11):
+    from boto.s3 import key
 from botocore.exceptions import ClientError
 from mock import patch
 

--- a/test/contrib/s3_test.py
+++ b/test/contrib/s3_test.py
@@ -108,6 +108,7 @@ class TestS3Target(unittest.TestCase, FileSystemTargetTestMixin):
         t = self.create_target(encrypt_key=True)
         self.assertRaises(FileNotFoundException, t.open)
 
+    @unittest.skipIf(tuple(sys.version_info) >= (3, 12), "boto is not supported on Python 3.12+")
     def test_read_iterator_long(self):
         # write a file that is 5X the boto buffersize
         # to test line buffering

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -204,9 +204,9 @@ class CoreConfigTest(LuigiTestCase):
 
     @with_config({})
     def test_parallel_scheduling_processes_default(self):
-        self.assertEquals(0, core().parallel_scheduling_processes)
+        self.assertEqual(0, core().parallel_scheduling_processes)
 
     @with_config({'core': {'parallel-scheduling-processes': '1234'}})
     def test_parallel_scheduling_processes(self):
         from luigi.interface import core
-        self.assertEquals(1234, core().parallel_scheduling_processes)
+        self.assertEqual(1234, core().parallel_scheduling_processes)

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -577,4 +577,4 @@ class InitSubclassTest(LuigiTestCase):
 
         class Receiver(ReceivesClassKwargs, x=1):
             pass
-        self.assertEquals(Receiver.x, 1)
+        self.assertEqual(Receiver.x, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,311}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{35,36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [pytest]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add support and CI workflow for Python 3.12.
* Skip a unit test that uses `boto`, because `boto` is not compatible with Python 3.12.
  * https://github.com/boto/boto/issues/3951
  * cf. `boto` is an old package of `boto3` and is no longer maintained.
* `assertEquals`, `assertNotEquals`, and `assertAlmostEquals` are replaced, which have been deprecated since Python 3.1 and are removed in Python 3.12.
  * https://docs.python.org/3/whatsnew/3.12.html#id3

## Motivation and Context

Support Python 3.12

## Have you tested this? If so, how?

All CI tests have passed.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
