### PR TITLE
don't convert str to tuple in TupleParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1379,9 +1379,14 @@ class TupleParameter(ListParameter):
         # ast.literal_eval(t_str) == t
         try:
             # loop required to parse tuple of tuples
-            return tuple(tuple(x) for x in json.loads(x, object_pairs_hook=FrozenOrderedDict))
+            return tuple(self._convert_iterable_to_tuple(x) for x in json.loads(x, object_pairs_hook=FrozenOrderedDict))
         except (ValueError, TypeError):
             return tuple(literal_eval(x))  # if this causes an error, let that error be raised.
+
+    def _convert_iterable_to_tuple(self, x):
+        if isinstance(x, str):
+            return x
+        return tuple(x)
 
 
 class OptionalTupleParameter(OptionalParameterMixin, TupleParameter):

--- a/test/list_parameter_test.py
+++ b/test/list_parameter_test.py
@@ -81,7 +81,7 @@ class ListParameterTest(unittest.TestCase):
             a.normalize(["INVALID_ATTRIBUTE"])
 
         # Check that empty list is not valid
-        with pytest.raises(ValidationError, match=r"\[\] is too short"):
+        with pytest.raises(ValidationError):
             a.normalize([])
 
         # Check that valid lists work

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -533,6 +533,14 @@ class TestParametersHashability(LuigiTestCase):
         self.assertEqual(hash(Foo(args=(('foo', 'bar'), ('doge', 'wow'))).args),
                          hash(p.normalize(p.parse('(("foo", "bar"), ("doge", "wow"))'))))
 
+    def test_tuple_string_with_json(self):
+        class Foo(luigi.Task):
+            args = luigi.parameter.TupleParameter()
+
+        p = luigi.parameter.TupleParameter()
+        self.assertEqual(hash(Foo(args=('foo', 'bar')).args),
+                         hash(p.normalize(p.parse('["foo", "bar"]'))))
+
     def test_task(self):
         class Bar(luigi.Task):
             pass


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

TupleParameter may convert str to tuple, and I fixed it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, TupleParameter returns unexpected value when to parse json string list.

```
>>> x = '["hoge", "fuga"]'
>>> TupleParameter().parse(x)
(('h', 'o', 'g', 'e'), ('f', 'u', 'g', 'a'))
```

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

I added unit test.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
