### PR TITLE
Fix error message in case of unfulfilled dependencies with single output

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -55,7 +55,7 @@ from luigi.task_register import load_task
 from luigi.scheduler import DISABLED, DONE, FAILED, PENDING, UNKNOWN, Scheduler, RetryPolicy
 from luigi.scheduler import WORKER_STATE_ACTIVE, WORKER_STATE_DISABLED
 from luigi.target import Target
-from luigi.task import Task, Config, DynamicRequirements
+from luigi.task import Task, Config, DynamicRequirements, flatten
 from luigi.task_register import TaskClassException
 from luigi.task_status import RUNNING
 from luigi.parameter import BoolParameter, FloatParameter, IntParameter, OptionalParameter, Parameter, TimeDeltaParameter
@@ -185,7 +185,7 @@ class TaskProcess(multiprocessing.Process):
                 missing = []
                 for dep in self.task.deps():
                     if not self.check_complete(dep):
-                        nonexistent_outputs = [output for output in dep.output() if not output.exists()]
+                        nonexistent_outputs = [output for output in flatten(dep.output()) if not output.exists()]
                         if nonexistent_outputs:
                             missing.append(f'{dep.task_id} ({", ".join(map(str, nonexistent_outputs))})')
                         else:

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     pytest<7.0
     pytest-cov>=2.0,<3.0
     mock<2.0
-    moto>=1.3.10
+    moto>=1.3.10,<5.0
     HTTPretty==0.8.10
     docker>=2.1.0
     boto>=2.42,<3.0


### PR DESCRIPTION
## Description
Use `flatten()` to handle the outputs of any unfulfilled dependencies when a TaskProcess is run.

## Motivation and Context
When a Task is run, and one of the dependencies is not fulfilled, and this dependency has a single Target as output (instead of a list of targets, or a dict of targets), then Luigi fails and prints the wrong error `TypeError: 'RemoteTarget' object is not iterable`.

See https://github.com/spotify/luigi/issues/3280

## Have you tested this? If so, how?
Included unit test for `TaskProcess.run()`
