### PR TITLE
Add option to remove event handler from luigi.Task

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -264,6 +264,13 @@ class Task(metaclass=Register):
             return callback
         return wrapped
 
+    @classmethod
+    def remove_event_handler(cls, event, callback):
+        """
+        Function to remove the event handler registered previously by the cls.event_handler decorator.
+        """
+        cls._event_callbacks[cls][event].remove(callback)
+
     def trigger_event(self, event, *args, **kwargs):
         """
         Trigger that calls all of the specified events associated with this class.

--- a/test/event_callbacks_test.py
+++ b/test/event_callbacks_test.py
@@ -162,6 +162,21 @@ class TestEventCallbacks(unittest.TestCase):
         t, result = self._run_processing_time_handler(True)
         self.assertEqual(result, [])
 
+    def test_remove_event_handler(self):
+        run_cnt = 0
+
+        @EmptyTask.event_handler(luigi.Event.START)
+        def handler(task):
+            nonlocal run_cnt
+            run_cnt += 1
+
+        task = EmptyTask()
+        build([task], local_scheduler=True)
+        assert run_cnt == 1
+        EmptyTask.remove_event_handler(luigi.Event.START, handler)
+        build([task], local_scheduler=True)
+        assert run_cnt == 1
+
 
 #        A
 #      /   \


### PR DESCRIPTION
## Description
I'd like to introduce `luigi.Task.remove_event_handler` method to support removing one of registered callbacks. By invoking this method with the appropriate parameters (event and callback), the specified event handler is removed from the internal registry. 

## Motivation and Context
I have many tests in which I need to collect all exceptions from a graph. Since `luigi.build` does not return a list of exceptions, I've discovered that adding an event handler is the simplest way to achieve this. However, there's currently no option to remove the handler in the teardown. As a workaround, I must maintain a hack with a private field of the Task class for now.

```
@pytest.fixture
def luigi_exceptions():
    capture = LuigiExceptionCapture()  # object to collect exceptions which works with multiprocessing

    @luigi.Task.event_handler(luigi.Event.FAILURE)
    def failure_handler(task, ext):
        capture.add(task, ext)

    yield capture

    luigi.Task._event_callbacks[luigi.Task][luigi.Event.FAILURE].remove(failure_handler)
```

## Have you tested this? If so, how?
Above fixture is utilized in my projects, and I've also added a unittest. :)
