### PR TITLE
Fix batch email configuration docs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -438,7 +438,7 @@ traceback_max_length
 Parameters controlling the contents of batch notifications sent from the
 scheduler
 
-email_interval_minutes
+email_interval
   Number of minutes between e-mail sends. Making this larger results in
   fewer, bigger e-mails.
   Defaults to 60.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -432,7 +432,7 @@ traceback_max_length
   Maximum length for traceback included in error email. Default is 5000.
 
 
-[batch_notifier]
+[batch_email]
 ----------------
 
 Parameters controlling the contents of batch notifications sent from the


### PR DESCRIPTION
Fix batch_email section name, email_interval parameter name in configuration docs.

I don't think there's much to test; I have been trying to get email notifications working in an application, and they only started working as expected once I discovered these documentation errors and corrected the section/parameter names in my code.

Closes #3293, #3294.