### PR TITLE
Fix unsafe shell command in luigi/contrib/lsf.py

### DIFF
--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -81,9 +81,9 @@ def track_job(job_id):
     - "EXIT"
     based on the LSF documentation
     """
-    cmd = "bjobs -noheader -o stat {}".format(job_id)
+    cmd = ["bjobs", "-noheader", "-o", "stat", str(job_id)]
     track_job_proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, shell=True)
+        cmd, stdout=subprocess.PIPE, shell=False)
     status = track_job_proc.communicate()[0].strip('\n')
     return status
 


### PR DESCRIPTION
Fixes #3304

Update `track_job` function to use `shell=False` in `subprocess.Popen` call.

* Change the `cmd` variable to be a list of arguments instead of a single string.
* Set the `shell` parameter to `False` in the `subprocess.Popen` call.
