### PR TITLE
Replace os.rename with os.replace

### DIFF
--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -309,7 +309,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
 
         self._close()
 
-        os.rename(tmp_local_path, local_path)
+        os.replace(tmp_local_path, local_path)
 
     def _sftp_get(self, path, tmp_local_path):
         self.conn.get(path, tmp_local_path)

--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -270,7 +270,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
 
         tmp_local_path = local_path + '-luigi-tmp-%09d' % random.randrange(0, 10_000_000_000)
         self._scp("%s:%s" % (self.remote_context._host_ref(), path), tmp_local_path)
-        os.rename(tmp_local_path, local_path)
+        os.replace(tmp_local_path, local_path)
 
 
 class AtomicRemoteFileWriter(luigi.format.OutputPipeProcessWrapper):

--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -37,7 +37,7 @@ class atomic_file(AtomicLocalFile):
     """
 
     def move_to_final_destination(self):
-        os.rename(self.tmp_path, self.path)
+        os.replace(self.tmp_path, self.path)
 
     def generate_tmp_path(self, path):
         return path + '-luigi-tmp-%09d' % random.randrange(0, 10_000_000_000)
@@ -109,12 +109,12 @@ class LocalFileSystem(FileSystem):
         if d and not os.path.exists(d):
             self.mkdir(d)
         try:
-            os.rename(old_path, new_path)
+            os.replace(old_path, new_path)
         except OSError as err:
             if err.errno == errno.EXDEV:
                 new_path_tmp = '%s-%09d' % (new_path, random.randint(0, 999999999))
                 shutil.copy(old_path, new_path_tmp)
-                os.rename(new_path_tmp, new_path)
+                os.replace(new_path_tmp, new_path)
                 os.remove(old_path)
             else:
                 raise err

--- a/test/local_target_test.py
+++ b/test/local_target_test.py
@@ -152,16 +152,16 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
             err.errno = EXDEV
             raise err
 
-        real_rename = os.rename
+        real_rename = os.replace
 
-        def mockrename(src, dst):
+        def mockreplace(src, dst):
             if '-across-fs' in src:
                 real_rename(src, dst)
             else:
                 rename_across_filesystems(src, dst)
 
         copy = '%s-across-fs' % self.copy
-        with mock.patch('os.rename', mockrename):
+        with mock.patch('os.replace', mockreplace):
             t.move(copy)
 
         self.assertFalse(os.path.exists(self.path))


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Fix https://github.com/spotify/luigi/issues/2975.
Replace `os.rename` with `os.replace`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
According to the [Python documentation](https://docs.python.org/3/library/os.html#os.rename), `os.rename` should be avoided for cross-platform compatibility. It is recommended to use `os.replace()`.
This change ensures that the file move operation works correctly across different filesystems.

On a Windows environment, running the following program twice will result in an error.
```python
with local_target.LocalTarget('data.txt').open("w") as f:
    f.write("hello")
```
> FileExistsError: [WinError 183] Cannot create a file when that file already exists

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Tested locally.

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
