### PR TITLE
Validate str type before tuple cast

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1384,7 +1384,12 @@ class TupleParameter(ListParameter):
             # loop required to parse tuple of tuples
             return tuple(self._convert_iterable_to_tuple(x) for x in json.loads(x, object_pairs_hook=FrozenOrderedDict))
         except (ValueError, TypeError):
-            return tuple(literal_eval(x))  # if this causes an error, let that error be raised.
+            result = literal_eval(x)
+            # t_str = '("abcd")'
+            # Ensure that the result is not a string to avoid cases like ('a','b','c','d')
+            if isinstance(result, str):
+                raise ValueError("Parsed result cannot be a string")
+            return tuple(result)  # if this causes an error, let that error be raised.
 
     def _convert_iterable_to_tuple(self, x):
         if isinstance(x, str):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -567,6 +567,18 @@ class TestParametersHashability(LuigiTestCase):
         self.assertEqual(hash(Foo(args=('foo', 'bar')).args),
                          hash(p.normalize(p.parse('["foo", "bar"]'))))
 
+    def test_tuple_invalid_string(self):
+        param = luigi.TupleParameter()
+        self.assertRaises(ValueError, lambda: param.parse('("abcd")'))
+
+    def test_tuple_invalid_string_in_tuple(self):
+        param = luigi.TupleParameter()
+        self.assertRaises(ValueError, lambda: param.parse('(("abcd"))'))
+
+    def test_parse_invalid_format(self):
+        param = luigi.TupleParameter()
+        self.assertRaises(SyntaxError, lambda: param.parse('((1,2),(3,4'))
+
     def test_task(self):
         class Bar(luigi.Task):
             pass
@@ -1225,6 +1237,7 @@ class LocalParameters1304Test(LuigiTestCase):
 
     https://github.com/spotify/luigi/issues/1304#issuecomment-148402284
     """
+
     def test_local_params(self):
 
         class MyTask(RunOnceTask):


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Add string type validation for tuple parameter parsing to prevent unintended string splitting behavior.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, when parsing a string input like `'("abcd")'` with `TupleParameter()`, it incorrectly splits the string into individual characters:
```python
# Current behavior (incorrect)
>>> luigi.TupleParameter().parse('("abcd")')
('a', 'b', 'c', 'd')

# Expected behavior
>>> luigi.TupleParameter().parse('("abcd",)')
('abcd',)
```
This change adds validation to ensure proper tuple formatting and prevents incorrect string splitting. Now it raises a ValueError when detecting improperly formatted input:
```python
>>> luigi.TupleParameter().parse('("abcd")')
ValueError: Parsed result cannot be a string
```

## Have you tested this? If so, how?
I have tested this change by:

1. Adding unit tests to verify the error handling for improperly formatted string inputs
2. Confirming that properly formatted tuple strings like '("abcd",)' still parse correctly
3. Verifying that a ValueError is raised for invalid inputs using the Python interpreter

```python
>>> luigi.TupleParameter().parse('("abcd")')
Traceback (most recent call last):
  File "C:\Users\MasayukiKamoda\Desktop\DESK_work\develop\luigi\luigi\parameter.py", line 1385, in parse
    return tuple(self._convert_iterable_to_tuple(x) for x in json.loads(x, object_pairs_hook=FrozenOrderedDict))
                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\dev\anaconda3\Lib\json\__init__.py", line 359, in loads
    return cls(**kw).decode(s)
           ^^^^^^^^^^^^^^^^^^^
  File "E:\dev\anaconda3\Lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\dev\anaconda3\Lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\MasayukiKamoda\Desktop\DESK_work\develop\luigi\luigi\parameter.py", line 1391, in parse
    raise ValueError("Parsed result cannot be a string")
ValueError: Parsed result cannot be a string
```
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
