### PR TITLE
Drop Support for Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6"
-            tox-env: py36-core
           - python-version: "3.7"
             tox-env: py37-core
           - python-version: "3.8"
@@ -82,8 +80,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6"
-            tox-env: py36-postgres
           - python-version: "3.7"
             tox-env: py37-postgres
           - python-version: "3.8"
@@ -137,8 +133,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.6"
-            tox-env: py36-aws
           - python-version: "3.7"
             tox-env: py37-aws
           - python-version: "3.8"
@@ -152,9 +146,6 @@ jobs:
           - python-version: "3.12"
             tox-env: py312-aws
 
-          - python-version: "3.6"
-            tox-env: py36-unixsocket
-            OVERRIDE_SKIP_CI_TESTS: True
           - python-version: "3.7"
             tox-env: py37-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
@@ -174,8 +165,6 @@ jobs:
             tox-env: py312-unixsocket
             OVERRIDE_SKIP_CI_TESTS: True
 
-          - python-version: "3.6"
-            tox-env: py36-apache
           - python-version: "3.7"
             tox-env: py37-apache
           - python-version: "3.8"
@@ -189,8 +178,6 @@ jobs:
           - python-version: "3.12"
             tox-env: py312-apache
 
-          - python-version: "3.6"
-            tox-env: py36-azureblob
           - python-version: "3.7"
             tox-env: py37-azureblob
           - python-version: "3.8"

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
     :target: https://luigi.readthedocs.io/en/stable/?badge=stable
     :alt: Documentation Status
 
-Luigi is a Python (3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 tested) package that helps you build complex
+Luigi is a Python (3.7, 3.8, 3.9, 3.10, 3.11, 3.12 tested) package that helps you build complex
 pipelines of batch jobs. It handles dependency resolution, workflow management,
 visualization, handling failures, command line integration, and much more.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -32,7 +32,7 @@ These files are meant for both the client and ``luigid``.
 If you decide to specify your own configuration you should make sure
 that both the client and ``luigid`` load it properly.
 
-.. _ConfigParser.read: https://docs.python.org/3.6/library/configparser.html#configparser.ConfigParser.read
+.. _ConfigParser.read: https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read
 
 The config file is broken into sections, each controlling a different part of the config.
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ readme_note = """
 with open('README.rst') as fobj:
     long_description = "\n\n" + readme_note + "\n\n" + fobj.read()
 
-install_requires = ['python-dateutil>=2.7.5,<3', 'tenacity>=8,<9']
+install_requires = ['python-dateutil>=2.7.5,<3', 'tenacity>=8,<9', 'tornado>=5.0,<7']
 
 # Can't use python-daemon>=2.2.0 if on windows
 #     See https://pagure.io/python-daemon/issue/18
@@ -45,12 +45,6 @@ if sys.platform == 'nt':
     install_requires.append('python-daemon<2.2.0')
 else:
     install_requires.append('python-daemon')
-
-# Start from tornado 6, the minimum supported Python version is 3.5.2.
-if sys.version_info[:3] >= (3, 5, 2):
-    install_requires.append('tornado>=5.0,<7')
-else:
-    install_requires.append('tornado>=5.0,<6')
 
 if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
@@ -104,7 +98,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,6 @@ if sys.version_info[:3] >= (3, 5, 2):
 else:
     install_requires.append('tornado>=5.0,<6')
 
-# Note: To support older versions of setuptools, we're explicitly not
-#   using conditional syntax (i.e. 'enum34>1.1.0;python_version<"3.4"').
-#   This syntax is a problem for setuptools as recent as `20.1.1`,
-#   published Feb 16, 2016.
-if sys.version_info[:2] < (3, 4):
-    install_requires.append('enum34>1.1.0')
-
 if os.environ.get('READTHEDOCS', None) == 'True':
     # So that we can build documentation for luigi.db_task_history and luigi.contrib.sqla
     install_requires.append('sqlalchemy')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
+envlist = py{37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8
 skipsdist = True
 
 [pytest]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Dropping support for Python 3.5 and 3.6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These Python versions have been End-of-Life status since 2021-12-23 or before.

> Python 3.7 and 3.8 are also End-of-Life, however, based on https://pypistats.org/packages/luigi Luigi is still downloaded with Python 3.7 quite a bit.

Removing support for <3.7 will allow PRs (such as https://github.com/spotify/luigi/pull/3267) to make their necessary changes.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
CI

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
