### PR TITLE
Fix Task.worker_timeout type annotation.

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -29,7 +29,7 @@ import hashlib
 import re
 import copy
 import functools
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import luigi
 
@@ -186,7 +186,7 @@ class Task(metaclass=Register):
     #: Number of seconds after which to time out the run function.
     #: No timeout if set to 0.
     #: Defaults to 0 or worker-timeout value in config
-    worker_timeout = None
+    worker_timeout: Optional[int] = None
 
     #: Maximum number of tasks to run together as a batch. Infinite by default
     max_batch_size = float('inf')


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix `Task.worker_timeout` type annotation, allowing None **or** integer values.

## Motivation and Context
This change prevents mypy from complaining about user code that overrides `Task.worker_timeout` with an integer (#3331).

## Have you tested this? If so, how?
Yes; I installed luigi from source with this change and type checking now passes and my pipelines still run.