### PR TITLE
Add Codecov Test Analytics

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -59,6 +59,10 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        with:
+          files: test-results.xml
 
   postgres:
     runs-on: ubuntu-20.04
@@ -228,3 +232,7 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        with:
+          files: test-results.xml

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{37,38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postg
 skipsdist = True
 
 [pytest]
-addopts = --cov=luigi --cov-report=xml -vv --strict-markers --ignore-glob="**/_*" --fulltrace
+addopts = --cov=luigi --cov-report=xml --junitxml=test-results.xml -vv --strict-markers --ignore-glob="**/_*" --fulltrace
 testpaths = test
 markers =
     contrib: tests related to luigi/contrib


### PR DESCRIPTION
This PR sets up Codecov [Test Analytics](https://docs.codecov.com/docs/test-analytics), which enhances this project's existing Codecov coverage PR notification with details about failing, flaky, and slow tests. More details can be found [here](https://about.codecov.io/blog/find-failing-and-flaky-tests-with-codecov-test-analytics/), and below is an example screenshot.

![Test Results](https://private-user-images.githubusercontent.com/175655418/425226666-d74ba608-0cec-4e28-813d-38adb6b799a4.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDQ1ODQwNDksIm5iZiI6MTc0NDU4Mzc0OSwicGF0aCI6Ii8xNzU2NTU0MTgvNDI1MjI2NjY2LWQ3NGJhNjA4LTBjZWMtNGUyOC04MTNkLTM4YWRiNmI3OTlhNC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNDEzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDQxM1QyMjM1NDlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1hYmZmZjY1MWRmMWM5ZDZiYzE3OGJmYzdhNmQ0NzgzYmVkZGEyYTYwYTgyNmQxOGUxNDJiMGY3YTUwNTVmNjMwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.s69mLiFMZ3PjeDctT2VPHqWA1N6bzfKZTViVs97HZI8)

## Changes 
- Added a `--junitxml` flag to the `pytest` command to output coverage/test-results.xml
- Uploaded test results to Codecov:

Looking forward to your feedback!