### PR TITLE
Remove `pkg_resources`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ import os
 import datetime
 import sphinx.environment
 from docutils.utils import get_source_line
-from pkg_resources import get_distribution
+from importlib.metadata import Distribution
 
 
 try:
@@ -118,7 +118,7 @@ copyright = u"2011-{}, {}".format(datetime.datetime.now().year, authors)
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = get_distribution('luigi').version  # assume luigi is already installed
+__version__ = Distribution.from_name('luigi').version  # assume luigi is already installed
 # The short X.Y version.
 version = ".".join(__version__.split(".")[0:2])
 # The full version, including alpha/beta/rc tags.

--- a/luigi/server.py
+++ b/luigi/server.py
@@ -37,6 +37,7 @@ See :doc:`/central_scheduler` for more info.
 
 import atexit
 import datetime
+import importlib
 import json
 import logging
 import os
@@ -44,7 +45,6 @@ import signal
 import sys
 import time
 
-import pkg_resources
 import tornado.httpserver
 import tornado.ioloop
 import tornado.netutil
@@ -175,7 +175,7 @@ class BaseTaskHistoryHandler(tornado.web.RequestHandler):
         self._scheduler = scheduler
 
     def get_template_path(self):
-        return pkg_resources.resource_filename(__name__, 'templates')
+        return importlib.resources.files("templates").name
 
 
 class AllRunHandler(BaseTaskHistoryHandler):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "python-dateutil>=2.7.5,<3",
   "tenacity>=8,<9",
   "tornado>=5.0,<7",
-  "setuptools>=80.7.1",
   "python-daemon<2.2.0; sys_platform == 'nt'",
   "python-daemon; sys_platform != 'nt'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "python-dateutil>=2.7.5,<3",
   "tenacity>=8,<9",
   "tornado>=5.0,<7",
+  "setuptools>=80.7.1",
   "python-daemon<2.2.0; sys_platform == 'nt'",
   "python-daemon; sys_platform != 'nt'",
 ]

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -351,6 +351,14 @@ class _ServerTest(unittest.TestCase):
         work = self.sch.get_work(worker='X')['running_tasks'][0]
         self.assertEqual(work['task_id'], 'A')
 
+    def test_get_template_path(self):
+        app = luigi.server.app(self.sch)
+        handler = luigi.server.BaseTaskHistoryHandler(
+            application=app,
+            request=self.sch._request("/api/ping", {"worker": "xyz"}),
+        )
+        self.assertEqual(handler.get_template_path(), "templates")
+
 
 @pytest.mark.unixsocket
 class UNIXServerTest(_ServerTest):


### PR DESCRIPTION


<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
`luigid` fails to start in Python 3:12 due to missing setuptools.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/spotify/luigi/issues/3350


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
Yes. I installed this code on a fresh virtual environment with the following:

```
pip install https://github.com/aliavni/luigi/archive/add-setuptools.zip
```

And the issue is resolved. `lugid` starts without issues

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
