### PR TITLE
fixed windows wmic result parsing

### DIFF
--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -39,7 +39,7 @@ def getpcmd(pid):
         with os.popen(cmd, 'r') as p:
             lines = [line for line in p.readlines() if line.strip("\r\n ") != ""]
             if lines:
-                _, val = lines
+                val = lines[-1]
                 return val
     elif sys.platform == "darwin":
         # Use pgrep instead of /proc on macOS.

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -34,8 +34,10 @@ def getpcmd(pid):
     :param pid:
     """
     if os.name == "nt":
-        # Use wmic command instead of ps on Windows.
-        cmd = 'wmic path win32_process where ProcessID=%s get Commandline 2> nul' % (pid, )
+        # Use powershell command instead of ps on Windows.
+        pcmd = (f"Get-CimInstance Win32_Process -Filter 'ProcessId={pid}' | "
+                 "Select-Object CommandLine")
+        cmd = f'powershell.exe -Command "{pcmd}"'
         with os.popen(cmd, 'r') as p:
             lines = [line for line in p.readlines() if line.strip("\r\n ") != ""]
             if lines:


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes -->
In lock.py: changed 
```
                _, val = lines
```
to
```
                val = lines[-1]
```
because it works with the current WMIC version and is generally less brittle.

## Motivation and Context
https://github.com/spotify/luigi/issues/3050

I got the following error everytime I tried to run a luigi task:
```
ERROR: Uncaught exception in luigi
Traceback (most recent call last):
  (...)
  File "(...)\.venv\Lib\site-packages\luigi\lock.py", line 42, in getpcmd
    _, val = lines
    ^^^^^^
ValueError: too many values to unpack (expected 2)
```

## Have you tested this? If so, how?
Tested on Windows 11.
