### PR TITLE
Preserve extension when generating temporary path

### DIFF
--- a/luigi/local_target.py
+++ b/luigi/local_target.py
@@ -40,7 +40,8 @@ class atomic_file(AtomicLocalFile):
         os.replace(self.tmp_path, self.path)
 
     def generate_tmp_path(self, path):
-        return path + '-luigi-tmp-%09d' % random.randrange(0, 10_000_000_000)
+        path, ext = os.path.splitext(path)
+        return path + '-luigi-tmp-%09d%s' % (random.randrange(0, 10_000_000_000), ext)
 
 
 class LocalFileSystem(FileSystem):

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -288,10 +288,11 @@ class FileSystemTarget(Target):
                         run_some_external_command(output_path=self.temp_output_path)
         """
         num = random.randrange(0, 10_000_000_000)
-        slashless_path = self.path.rstrip('/').rstrip("\\")
-        _temp_path = '{}-luigi-tmp-{:010}{}'.format(
+        slashless_path, ext = os.path.splitext(self.path.rstrip('/').rstrip("\\"))
+        _temp_path = '{}-luigi-tmp-{:010}{}{}'.format(
             slashless_path,
             num,
+            ext,
             self._trailing_slash())
         # TODO: os.path doesn't make sense here as it's os-dependent
         tmp_dir = os.path.dirname(slashless_path)
@@ -331,7 +332,8 @@ class AtomicLocalFile(io.BufferedWriter):
         self.move_to_final_destination()
 
     def generate_tmp_path(self, path):
-        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-%09d' % random.randrange(0, 10_000_000_000))
+        path, ext = os.path.split(path)
+        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-%09d%s' % (random.randrange(0, 10_000_000_000), ext))
 
     def move_to_final_destination(self):
         raise NotImplementedError()

--- a/test/target_test.py
+++ b/test/target_test.py
@@ -333,7 +333,7 @@ class TemporaryPathTest(unittest.TestCase):
         target = self.target_cls(r'''hdfs:///user/arash/myfile.uids''')
 
         with target.temporary_path() as tmp_path:
-            assert re.match(r'''hdfs:///user/arash/myfile.uids-luigi-tmp-\d{10}''', tmp_path)
+            assert re.match(r'''hdfs:///user/arash/myfile-luigi-tmp-\d{10}\.uids''', tmp_path)
         self.fs.rename_dont_move.assert_called_once_with(tmp_path, target.path)
 
     def test_creates_dir_for_file(self):


### PR DESCRIPTION
The extension of a file can affect the behaviour of some external programs. A common example would be a '.gz' extension being used to detect whether to output compressed data.