### PR TITLE
Fixes #3364: task completion cache should not be updated after run() completes

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -209,12 +209,7 @@ class TaskProcess(multiprocessing.Process):
                 with self._forward_attributes():
                     new_deps = self._run_get_new_deps()
                 if not new_deps:
-                    if not self.check_complete_on_run:
-                        # update the cache
-                        if self.task_completion_cache is not None:
-                            self.task_completion_cache[self.task.task_id] = True
-                        status = DONE
-                    elif self.check_complete(self.task):
+                    if not self.check_complete_on_run or self.check_complete(self.task):
                         status = DONE
                     else:
                         raise TaskException("Task finished running, but complete() is still returning false.")

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -506,9 +506,9 @@ class WorkerTest(LuigiTestCase):
             w.run()
             # the complete methods of a's yielded first in b's run method were called equally often
             self.assertEqual(b0.complete_count, 1)
-            self.assertEqual(a0.complete_count, 2)
-            self.assertEqual(a1.complete_count, 2)
-            self.assertEqual(a2.complete_count, 2)
+            self.assertEqual(a0.complete_count, 3)
+            self.assertEqual(a1.complete_count, 3)
+            self.assertEqual(a2.complete_count, 3)
 
         # test with disabled cache_task_completion
         with Worker(scheduler=self.sch, worker_id='2', cache_task_completion=False) as w:


### PR DESCRIPTION
## Description
`worker.py`:

```
if not self.check_complete_on_run:
    # update the cache
    if self.task_completion_cache is not None:
        self.task_completion_cache[self.task.task_id] = True
    status = DONE
elif self.check_complete(self.task):
    status = DONE
```
replaced with

```
if not self.check_complete_on_run or self.check_complete(self.task):
    status = DONE
```

## Motivation and Context
Fixes #3364. The task completion cache should not be updated immediately after run() completes, since completing run() doesn't guarantee that all output targets will also complete. Shouldn't the cache be updated only using the check_complete_cached() function?

## Have you tested this? If so, how?
Tested with a debugger using the code example from #3364