### PR TITLE
fix: correct built readme rst format

### DIFF
--- a/luigi/__version__.py
+++ b/luigi/__version__.py
@@ -1,3 +1,3 @@
 # coding: utf-8
 
-VERSION = '3.7.0'
+VERSION = '3.7.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,6 @@ include = [
 content-type = "text/x-rst"
 # construct the PyPI readme from README.md and HISTORY.md
 fragments = [
-  {text = "\n.. note::\n\nFor the latest source, discussion, etc, please visit the\n`GitHub repository <https://github.com/spotify/luigi>`_\n"},
+  {text = "\n.. note::\n\tFor the latest source, discussion, etc, please visit the\n\t`GitHub repository <https://github.com/spotify/luigi>`_\n"},
   {path = "README.rst"},
 ]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

During release of 3.7.0, PyPI rejected the distribution upload due to syntax error in the `README.rst`.

This PR fixes the error discovered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PyPI won't allow upload with invalid readme

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

```shell
rm -rf dist
uv build
uvx twine check dist/*
```

Previously failed with:

```
Checking dist/luigi-3.7.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                 
         line 2: Error: Content block expected for the "note" directive; none found.                                                       
Checking dist/luigi-3.7.0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.                                                 
         line 2: Error: Content block expected for the "note" directive; none found.   
```

Now succeeds with:

```
Checking dist/luigi-3.7.0-py3-none-any.whl: PASSED
Checking dist/luigi-3.7.0.tar.gz: PASSED
```

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
