### PR TITLE
fix(mypy): handle Parameter subclasses without 'default'

### DIFF
--- a/luigi/mypy.py
+++ b/luigi/mypy.py
@@ -114,7 +114,12 @@ class TaskPlugin(Plugin):
                         return base.args[0]
                     break
 
-        default_idx = ctx.callee_arg_names.index("default")
+        try:
+            default_idx = ctx.callee_arg_names.index("default")
+        except ValueError:
+            # If we couldn't infer from __new__, return Any
+            return AnyType(TypeOfAny.unannotated)
+
         default_args = ctx.args[default_idx]
 
         if default_args:


### PR DESCRIPTION
fix #3376 

## Summary                                                                                                                           
                                                                                                                                       
Fixes regression in mypy plugin introduced in v3.7.0 where custom Parameter subclasses that don't expose `default` in their `__init__` signature would cause a ValueError crash.                                                                                 

## Changes                                                                                                                           
                                                                                                                                     
### 1. Restore error handling in mypy plugin (luigi/mypy.py)                                                                         
- Restored try-except block around `ctx.callee_arg_names.index("default")` at line 117-121                                           
- Returns `AnyType(TypeOfAny.unannotated)` when `default` parameter is not found in the signature                                    
- This reverts the problematic change from d42cae4 that removed the exception handling                                               
                                                                                                                                     
**What it does:** Prevents mypy plugin crashes when analyzing custom Parameter subclasses that use `**kwargs` in `__init__` without  explicitly exposing the `default` parameter.                                                                                         
                                                                                                                                     
### 2. Add regression test (test/mypy_test.py)                                                                                       
- Added `test_plugin_custom_parameter_subclass_without_default_arg` test case                                                        
- Reproduces the exact scenario from issue #3376 where `CustomPathParameter` with `__init__(self, **kwargs)` signature caused crashes
- Ensures this regression won't happen again in future refactorings                                                                  
