### PR TITLE
fix: update codecov

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -29,6 +29,40 @@ jobs:
       - name: Install dependencies
         run: |
           uv tool install --python-preference only-managed --python 3.12 tox --with tox-uv
+      - name: Build
+        env:
+          TOXENV: ${{ matrix.tox-env }}
+        run: uvx --with tox-uv tox run
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  mysql:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        include:
+          - tox-env: py38-mysql
+          - tox-env: py39-mysql
+          - tox-env: py310-mysql
+          - tox-env: py311-mysql
+          - tox-env: py312-mysql
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up the latest version of uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install dependencies
+        run: |
+          uv tool install --python-preference only-managed --python 3.12 tox --with tox-uv
       - name: Setup MySQL DB
         run: |
           sudo /etc/init.d/mysql start
@@ -138,6 +172,12 @@ jobs:
           - tox-env: py311-azureblob
           - tox-env: py312-azureblob
 
+          - tox-env: py38-contrib
+          - tox-env: py39-contrib
+          - tox-env: py310-contrib
+          - tox-env: py311-contrib
+          - tox-env: py312-contrib
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up the latest version of uv
@@ -160,6 +200,7 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   others:
     runs-on: ubuntu-22.04
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,22 +5,23 @@ codecov:
     wait_for_ci: yes
 
 coverage:
-  precision: 2  # Just copied from default
-  round: down  # Just copied from default
-  range: "70...100"  # Just copied from default
+  precision: 2
+  round: down
+  range: "50...70"
 
   status:
     project:
       default: false  # disable the default status that measures entire project
       core:
-        target: 92%
+        target: 90%
         paths:
           - "luigi/*.py"
-    patch:  # Just copied from default
+    patch:
       default:
+        target: 50%
         if_no_uploads: error
 
-    changes: true  # Just copied from default
+    changes: true
 
   ignore:
     - "examples/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    after_n_builds: 24
     wait_for_ci: true
 
 coverage:
@@ -27,6 +26,7 @@ coverage:
     - "examples/"
     - "luigi/tools"  # These are tested as actual run commands without coverage
     # List modules who's tests are not run by CI or are run in a subprocesses (like on cluster).
+    - "luigi/contrib/beam_dataflow.py"
     - "luigi/contrib/bigquery.py"
     - "luigi/contrib/bigquery_avro.py"
     - "luigi/contrib/dataproc.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,9 @@ coverage:
         target: 50%
         if_no_uploads: error
 
-    changes: true
+    changes:
+      default:
+        informational: true
 
   ignore:
     - "examples/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,15 +26,19 @@ coverage:
   ignore:
     - "examples/"
     - "luigi/tools"  # These are tested as actual run commands without coverage
-    # List modules who's tests are not run by Travis or
-    # are run in a subprocesses (like on cluster).
-    - "luigi/contrib/gcs.py"
+    # List modules who's tests are not run by CI or are run in a subprocesses (like on cluster).
     - "luigi/contrib/bigquery.py"
     - "luigi/contrib/bigquery_avro.py"
-    - "luigi/contrib/hdfs/"
+    - "luigi/contrib/dataproc.py"
+    - "luigi/contrib/dropbox.py"
+    - "luigi/contrib/ftp.py"
+    - "luigi/contrib/gcs.py"
     - "luigi/contrib/hadoop.py"
-    - "luigi/contrib/mrrunner.py"
+    - "luigi/contrib/hdfs/"
     - "luigi/contrib/kubernetes.py"
+    - "luigi/contrib/mrrunner.py"
+    - "luigi/contrib/sparkey.py"
+    - "luigi/contrib/webhdfs.py"
 
 # For luigi we do not want any comments
 comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
   notify:
     after_n_builds: 24
-    wait_for_ci: yes
+    wait_for_ci: true
 
 coverage:
   precision: 2

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,16 @@
+from typing import List
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
+    """
+    Automatically add the equivalent of pytest.mark.unmarked to any test which has no markers
+
+    For example, enables the ability to target "contrib + unmarked" tests (eventually getting rid of the generic "contrib" marker):
+      - pytest test/contrib/ -m "contrib or unmarked"
+    """
+    for item in items:
+        # Check if the item has any markers (custom or builtin)
+        if not any(item.iter_markers()):
+            item.add_marker(pytest.mark.unmarked)

--- a/test/contrib/beam_dataflow_test.py
+++ b/test/contrib/beam_dataflow_test.py
@@ -23,6 +23,8 @@ import mock
 from mock import MagicMock, patch
 import unittest
 
+import pytest
+
 
 class TestDataflowParamKeys(beam_dataflow.DataflowParamKeys):
     runner = "runner"
@@ -133,6 +135,7 @@ class DummyCmdLineTestTask(beam_dataflow.BeamDataflowJobTask):
         return ['echo', '"hello world"']
 
 
+@pytest.mark.gcloud
 class BeamDataflowTest(unittest.TestCase):
 
     def test_dataflow_simple_cmd_line_args(self):

--- a/test/contrib/bigquery_avro_test.py
+++ b/test/contrib/bigquery_avro_test.py
@@ -22,9 +22,11 @@ These are the unit tests for the BigQueryLoadAvro class.
 import unittest
 import avro
 import avro.schema
+import pytest
 from luigi.contrib.bigquery_avro import BigQueryLoadAvro
 
 
+@pytest.mark.gcloud
 class BigQueryAvroTest(unittest.TestCase):
 
     def test_writer_schema_method_existence(self):

--- a/test/contrib/bigquery_test.py
+++ b/test/contrib/bigquery_test.py
@@ -151,6 +151,7 @@ class BigQueryExtractTaskTest(unittest.TestCase):
         run_job.assert_called_with('proj', expected_body, dataset=BQDataset('proj', 'ds', None))
 
 
+@pytest.mark.gcloud
 class BigQueryClientTest(unittest.TestCase):
 
     def test_retry_succeeds_on_second_attempt(self):

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -491,3 +491,30 @@ class MetricsHandlerTest(unittest.TestCase):
         with mock.patch.object(self.handler, 'write') as patched_write:
             self.handler.get()
             patched_write.assert_not_called()
+
+
+class FromUtcTest(unittest.TestCase):
+    def test_with_microseconds(self):
+        """Test parsing UTC time string with microseconds"""
+        result = luigi.server.from_utc("2021-01-15 10:30:45.123456")
+        self.assertIsInstance(result, int)
+
+    def test_without_microseconds(self):
+        """Test parsing UTC time string without microseconds"""
+        result = luigi.server.from_utc("2021-01-15 10:30:45")
+        self.assertIsInstance(result, int)
+
+    def test_with_custom_format(self):
+        """Test parsing with custom format"""
+        result = luigi.server.from_utc("01/15/2021", fmt="%m/%d/%Y")
+        self.assertIsInstance(result, int)
+
+    def test_invalid_format_raises_error(self):
+        """Test that invalid format raises ValueError"""
+        with self.assertRaises(ValueError):
+            luigi.server.from_utc("invalid-date")
+
+    def test_custom_format_mismatch_raises_error(self):
+        """Test that mismatched custom format raises ValueError"""
+        with self.assertRaises(ValueError):
+            luigi.server.from_utc("2021-01-15", fmt="%m/%d/%Y")

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.22 # `dependency_groups` needed
     tox-uv>=1.19
-envlist = py{38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8, stubtest
+envlist = py{38,39,310,311,312}-{cdh,hdp,core,contrib,apache,aws,gcloud,mysql,postgres,unixsocket,azureblob,dropbox}, visualiser, docs, flake8, stubtest
 skipsdist = True
 
 [pytest]
@@ -56,13 +56,15 @@ setenv =
     AZURITE_ACCOUNT_KEY=YXp1cml0ZQ==
     AZURITE_CUSTOM_DOMAIN=localhost:10000
 commands =
+    # Setup
     cdh,hdp: {toxinidir}/scripts/ci/setup_hadoop_env.sh
     azureblob: {toxinidir}/scripts/ci/install_start_azurite.sh {toxinidir}/scripts/ci
     {envpython} --version
-    ## main commands
+    # Test
     contrib: {envpython} test/runtests.py -m contrib {posargs:}
     apache: {envpython} test/runtests.py -m apache {posargs:}
     aws: {envpython} test/runtests.py -m aws {posargs:}
+    mysql: {envpython} test/runtests.py -m mysql {posargs:}
     postgres: {envpython} test/runtests.py -m postgres {posargs:}
     scheduler: {envpython} test/runtests.py -m scheduler {posargs:}
     cdh,hdp: {envpython} test/runtests.py -m minicluster {posargs:}
@@ -70,8 +72,8 @@ commands =
     unixsocket: {envpython} test/runtests.py -m unixsocket {posargs:}
     dropbox: {envpython} test/runtests.py -m dropbox {posargs:}
     azureblob: {envpython} test/runtests.py -m azureblob {posargs:}
-    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" {posargs:}
-    ##
+    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not mysql and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" {posargs:}
+    # Teardown
     azureblob: {toxinidir}/scripts/ci/stop_azurite.sh
 
 [testenv:visualiser]

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ markers =
     unixsocket: tests related to unixsocket
     dropbox: tests related to dropbox
     azureblob: tests related to azure
+    unmarked: tests with no explicit markers
 
 [testenv]
 runner = uv-venv-lock-runner
@@ -61,7 +62,7 @@ commands =
     azureblob: {toxinidir}/scripts/ci/install_start_azurite.sh {toxinidir}/scripts/ci
     {envpython} --version
     # Test
-    contrib: {envpython} test/runtests.py -m contrib {posargs:}
+    contrib: {envpython} test/runtests.py test/contrib/ -m "contrib or unmarked" {posargs:}
     apache: {envpython} test/runtests.py -m apache {posargs:}
     aws: {envpython} test/runtests.py -m aws {posargs:}
     mysql: {envpython} test/runtests.py -m mysql {posargs:}


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

Replaces https://github.com/spotify/luigi/pull/3379

## Description
<!--- Describe your changes -->
This patch loosens the restrictions on our codecov configuration.

Specifically:

* adjusts range of target coverage (has nothing to do with pass/fail
* reduces overall target coverage %; 92% was selected at the time only because the project was at 92.5% at the time; >90% test coverage is still exceptional
* reduces patch target coverage from "auto" to an extremely conservative 50%

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We've been having a lot of issues with codecov in PRs. The Luigi project is hit or miss with ease of automated CI testing.

Further, the codecov configuration has largely been ignored and left as mostly "default" values.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

Local tox execution in a devcontainer for a subset of the test suite.

Full CI for the test

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
