### PR TITLE
feat: make ListParameter and TupleParameter generic

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1225,7 +1225,10 @@ class OptionalDictParameter(OptionalParameterMixin, DictParameter):
     expected_type = FrozenOrderedDict
 
 
-class ListParameter(Parameter[Tuple[Any, ...]]):
+ListT = TypeVar("ListT", bound=tuple, default=Tuple[Any, ...])
+
+
+class ListParameter(Parameter[ListT]):
     """
     Parameter whose value is a ``list``.
 
@@ -1382,7 +1385,7 @@ class OptionalListParameter(OptionalParameterMixin, ListParameter):
     expected_type = tuple
 
 
-class TupleParameter(ListParameter):
+class TupleParameter(ListParameter[ListT]):
     """
     Parameter whose value is a ``tuple`` or ``tuple`` of tuples.
 


### PR DESCRIPTION
## Description
                                                                                                     
Add `ListT = TypeVar("ListT", bound=tuple, default=Tuple[Any, ...])` to allow `ListParameter` and `TupleParameter` to accept type parameters for type-safe annotations.
                                                                                                     
```python
# Before: no way to express element types. and t's type is always tuple[Any, ...]
t = luigi.TupleParameter()
                                                                                                     
# After: element types can be specified
t: TupleParameter[tuple[str, int]] = luigi.TupleParameter()
s: ListParameter[tuple[int, ...]] = luigi.ListParameter()
```
                                                                                        
## Motivation and Context
                                                                                                     
ListParameter and TupleParameter inherit from Parameter[Tuple[Any, ...]], which fixes the type parameter and prevents users from specifying element types. This makes it impossible to get proper type checking or IDE support for the parameter values.
                                                                                                     
By making these classes generic with bound=tuple, users can now annotate element types while invalid subscriptions like TupleParameter[int] are rejected by type checkers. The change is fully backward compatible — existing code without type arguments continues to work as before.
                                                                                                     
## Have you tested this? If so, how?
                                                                                                     
I have included unit tests. (existing tests all pass)
