### PR TITLE
feat: make DictParameter generic

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1083,7 +1083,10 @@ class _DictParamEncoder(JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-class DictParameter(Parameter[Dict[Any, Any]]):
+DictT = TypeVar("DictT", bound=dict, default=Dict[Any, Any])
+
+
+class DictParameter(Parameter[DictT]):
     """
     Parameter whose value is a ``dict``.
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `DictT = TypeVar("DictT", bound=dict, default=Dict[Any, Any])` to Allow `DictParameter` to accept type parameters for type-safe annotations.

```python
# Before: no way to express element types. and t's type is always dict[Any, Any]
d = luigi.DictParameter()
                                                                                                     
# After: element types can be specified
d: DictParameter[dict[str, int]] = luigi.DictParameter()
```

## Motivation and Context
DictParameter inherit from Parameter[Dct[Any, Any]], which fixes the type parameter and prevents users from specifying element types. This makes it impossible to get proper type checking or IDE support for the parameter values.

By making these classes generic with bound=dict, users can now annotate element types while invalid subscriptions like DictParameter[int] are rejected by type checkers. The change is fully backward compatible — existing code without type arguments continues to work as before.

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
