### PR TITLE
add pytest-xdist for faster unit test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ common = [
   "pymongo==3.4.0",
   "pytest",
   "pytest-cov",
+  "pytest-xdist",
   "requests>=2.20.0,<=2.31.0",
   "responses<1.0.0",
   "s3transfer>=0.3,<4.0",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,25 @@ from typing import List
 
 import pytest
 
+import luigi.task_register
+
+
+@pytest.fixture(autouse=True)
+def reset_luigi_registry():
+    """Reset the Luigi task registry before and after each test.
+
+    Prevents registry pollution between tests when running with pytest-xdist,
+    where multiple tests execute sequentially within the same worker process.
+    This mirrors the behaviour of LuigiTestCase.setUp/tearDown and applies it
+    to all tests automatically, including those that inherit unittest.TestCase
+    directly without going through LuigiTestCase.
+    """
+    original = luigi.task_register.Register._get_reg()
+    luigi.task_register.Register.clear_instance_cache()
+    yield
+    luigi.task_register.Register._set_reg(original)
+    luigi.task_register.Register.clear_instance_cache()
+
 
 def pytest_collection_modifyitems(items: List[pytest.Item]) -> None:
     """

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -35,6 +35,7 @@ luigi.notifications.DEBUG = True
 
 
 class A(luigi.Task):
+    _visible_in_registry = False  # test fixture: invisible to registry to prevent name conflicts
     p = luigi.IntParameter()
 
 
@@ -51,6 +52,7 @@ class WithDefaultFalse(luigi.Task):
 
 
 class Foo(luigi.Task):
+    _visible_in_registry = False  # test fixture: invisible to registry to prevent name conflicts
     bar = luigi.Parameter()
     p2 = luigi.IntParameter()
     not_a_param = "lol"
@@ -1046,7 +1048,8 @@ class TestParamWithDefaultFromConfig(LuigiTestCase):
         # TODO(arash): Why is `--p 200` hanging with multiprocessing stuff?
         # self.assertTrue(self.run_locally_split('mynamespace.A --p 200 --expected 200'))
         self.assertTrue(self.run_locally_split("mynamespace.A --mynamespace.A-p 200 --expected 200"))
-        self.assertFalse(self.run_locally_split("mynamespace.A --A-p 200 --expected 200"))
+        # --A-p is unrecognized since module-level A is _visible_in_registry=False (no CLI flag)
+        self.assertRaises(SystemExit, self.run_locally_split, "mynamespace.A --A-p 200 --expected 200")
 
     def testListWithNamespaceCli(self):
         class A(luigi.Task):

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
     unixsocket: {envpython} test/runtests.py -m unixsocket {posargs:}
     dropbox: {envpython} test/runtests.py -m dropbox {posargs:}
     azureblob: {envpython} test/runtests.py -m azureblob {posargs:}
-    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not mysql and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" -n auto {posargs:}
+    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not mysql and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" -n auto --dist=loadfile {posargs:}
     # Teardown
     azureblob: {toxinidir}/scripts/ci/stop_azurite.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
     unixsocket: {envpython} test/runtests.py -m unixsocket {posargs:}
     dropbox: {envpython} test/runtests.py -m dropbox {posargs:}
     azureblob: {envpython} test/runtests.py -m azureblob {posargs:}
-    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not mysql and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" {posargs:}
+    core: {envpython} test/runtests.py --doctest-modules -m "not minicluster and not gcloud and not mysql and not postgres and not unixsocket and not contrib and not apache and not aws and not azureblob and not dropbox" -n auto {posargs:}
     # Teardown
     azureblob: {toxinidir}/scripts/ci/stop_azurite.sh
 

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "future"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -831,6 +840,8 @@ common = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -875,6 +886,8 @@ dev = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "requests-unixsocket" },
     { name = "responses" },
@@ -943,6 +956,8 @@ test-cdh = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -981,6 +996,8 @@ test-dropbox = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -1021,6 +1038,8 @@ test-gcloud = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -1059,6 +1078,8 @@ test-hdp = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -1098,6 +1119,8 @@ test-postgres = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "responses" },
     { name = "s3transfer" },
@@ -1135,6 +1158,8 @@ test-unixsocket = [
     { name = "pymongo" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "requests" },
     { name = "requests-unixsocket" },
     { name = "responses" },
@@ -1195,6 +1220,7 @@ common = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1237,6 +1263,7 @@ dev = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "requests-unixsocket", specifier = "<1.0" },
     { name = "responses", specifier = "<1.0.0" },
@@ -1297,6 +1324,7 @@ test-cdh = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1333,6 +1361,7 @@ test-dropbox = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1371,6 +1400,7 @@ test-gcloud = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1407,6 +1437,7 @@ test-hdp = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1444,6 +1475,7 @@ test-postgres = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "responses", specifier = "<1.0.0" },
     { name = "s3transfer", specifier = ">=0.3,<4.0" },
@@ -1479,6 +1511,7 @@ test-unixsocket = [
     { name = "pymongo", specifier = "==3.4.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "requests", specifier = ">=2.20.0,<=2.31.0" },
     { name = "requests-unixsocket", specifier = "<1.0" },
     { name = "responses", specifier = "<1.0.0" },
@@ -2008,6 +2041,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9' and sys_platform == 'nt'",
+    "python_full_version < '3.8.1' and sys_platform == 'nt'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9' and sys_platform == 'win32'",
+    "python_full_version >= '3.8.1' and python_full_version < '3.9' and sys_platform != 'nt' and sys_platform != 'win32'",
+    "python_full_version < '3.8.1' and sys_platform == 'win32'",
+    "python_full_version < '3.8.1' and sys_platform != 'nt' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version < '3.9'" },
+    { name = "pytest", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060, upload-time = "2024-04-28T19:29:54.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108, upload-time = "2024-04-28T19:29:52.813Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10' and sys_platform == 'nt'",
+    "python_full_version == '3.9.*' and sys_platform == 'nt'",
+    "python_full_version >= '3.10' and sys_platform == 'win32'",
+    "python_full_version >= '3.10' and sys_platform != 'nt' and sys_platform != 'win32'",
+    "python_full_version == '3.9.*' and sys_platform == 'win32'",
+    "python_full_version == '3.9.*' and sys_platform != 'nt' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "execnet", marker = "python_full_version >= '3.9'" },
+    { name = "pytest", marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR, I added pytest-xdist for making CI faster.
I only added xdist for `core` test because it takes about 5 minutes and others take about 1 minute or less.

As a result, `pyXXX-core` workflows run in 2-4 minutes (reduces 1-2 minutes).

## Motivation and Context

For faster CI workflow and local test.

## Have you tested this? If so, how?

CI ran successfully