### PR TITLE
feat: add type annotation for batch_method parameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -31,8 +31,10 @@ from json import JSONEncoder
 from pathlib import Path
 from typing import (
     Any,
+    Callable,
     Dict,
     Generic,
+    Iterable,
     Optional,
     Sequence,
     Tuple,
@@ -149,7 +151,7 @@ class _ParameterKwargs(TypedDict, total=False):
     config_path: Optional[str]
     positional: bool
     always_in_help: bool
-    batch_method: Any
+    batch_method: Optional[Callable[[Iterable[Any]], Any]]
     visibility: ParameterVisibility
 
 
@@ -203,8 +205,8 @@ class Parameter(Generic[T]):
         config_path: Optional[str] = None,
         positional: bool = True,
         always_in_help: bool = False,
-        batch_method=None,
-        visibility=ParameterVisibility.PUBLIC,
+        batch_method: Optional[Callable[[Iterable[Any]], Any]] = None,
+        visibility: ParameterVisibility = ParameterVisibility.PUBLIC,
     ):
         """
         :param default: the default value for this parameter. This should match the type of the


### PR DESCRIPTION
## Description                                                                                           
                
Add type annotation to batch_method in `Parameter.__init__` and `_ParameterKwargs`.
 
```python                                                                                            
# Before
batch_method=None
                                                                                                       
# After
batch_method: Optional[Callable[[Iterable[Any]], Any]] = None
```
                                                                                           
Also add type annotation to visibility parameter.
                                                                                                       
## Motivation and Context
                                                                                                       
batch_method had no type annotation, so IDE completion and Pyright type checking did not work.
`Callable[[Iterable[Any]], Any]` is used instead of `Callable[[Iterable[T]], T]` because _ParameterKwargs
is a non-generic TypedDict and cannot reference the `T` from `Parameter[T]`.
                                                                                                       
Note: Making `_ParameterKwargs` generic would allow a stricter `Callable[[Iterable[T]], T]`, but it would
significantly hurt readability across the codebase. We chose `Any` here as a pragmatic first step and
are open to revisiting if stricter typing is desired.
                                                                                                       
## Have you tested this? If so, how?
                                                                                                       
Existing unit tests cover this change.
