### PR TITLE
Fix deprecated datetime.utcfromtimestamp() calls

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -508,7 +508,7 @@ class OptionalStrParameter(OptionalParameterMixin[str], Parameter[Optional[str]]
     expected_type = str
 
 
-_UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
+_UNIX_EPOCH = datetime.datetime(1970, 1, 1)
 
 
 class _DateParameterBase(Parameter[datetime.date]):

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -32,7 +32,7 @@ import re
 import time
 import warnings
 from collections import Counter
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from dateutil.relativedelta import relativedelta
 
@@ -216,7 +216,7 @@ class RangeBase(luigi.WrapperTask):
             raise ParameterException("Can't have start > stop")
         # TODO check overridden complete() and exists()
 
-        now = datetime.utcfromtimestamp(time.time() if self.now is None else self.now)
+        now = datetime.fromtimestamp(time.time() if self.now is None else self.now, tz=timezone.utc).replace(tzinfo=None)
 
         moving_start = self.moving_start(now)
         finite_start = moving_start if self.start is None else max(self.parameter_to_datetime(self.start), moving_start)


### PR DESCRIPTION
## Summary
- Fixes #3356 and #3317
- Replaces deprecated `datetime.utcfromtimestamp()` in `luigi/parameter.py` and `luigi/tools/range.py`
- Uses timezone-aware conversion with `tzinfo=None` stripping to preserve naive UTC datetime behavior for backwards compatibility

## Changes
- **`luigi/parameter.py`**: Replace `datetime.datetime.utcfromtimestamp(0)` with `datetime.datetime(1970, 1, 1)` — equivalent and avoids the deprecation entirely
- **`luigi/tools/range.py`**: Replace `datetime.utcfromtimestamp(ts)` with `datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)` — converts via UTC then strips tzinfo to keep naive datetime compatibility

## Test plan
- [x] Verified both replacements produce identical values to the original calls
- [x] Verified returned datetimes are naive (no tzinfo) to maintain backwards compatibility
- [ ] Existing test suite passes