### PR TITLE
Proposal: set default value of OptionalParameter to None

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -436,7 +436,7 @@ class OptionalParameterMixin(Generic[_OptT]):
 
     def __init__(
         self,
-        default: Union[_OptT, None, _NoValueType] = _no_value,
+        default: Union[_OptT, None, _NoValueType] = None,
         **kwargs: Unpack[_ParameterKwargs],
     ):
         super().__init__(default=default, **kwargs)  # type: ignore[arg-type, call-arg, misc]

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -415,6 +415,14 @@ class ParameterTest(LuigiTestCase):
             'OptionalParameter "param" with value "1" is not of type "str" or None.', luigi.parameter.OptionalParameterTypeWarning
         )
 
+    def test_optional_parameter_task_without_value(self):
+        class MyTask(luigi.Task):
+            _visible_in_registry = False
+            x = luigi.OptionalParameter()
+
+        task = MyTask()
+        self.assertIsNone(task.x)
+
     def test_optional_parameter_parse_none(self):
         self.assertIsNone(luigi.OptionalParameter().parse(""))
 
@@ -1137,7 +1145,6 @@ class TestSerializeTimeDeltaParameters(LuigiTestCase):
 
 class TestTaskParameter(LuigiTestCase):
     def testUsage(self):
-
         class MetaTask(luigi.Task):
             task_namespace = "mynamespace"
             a = luigi.TaskParameter()
@@ -1164,7 +1171,6 @@ class TestTaskParameter(LuigiTestCase):
         self.assertEqual(MetaTask.saved_value, OtherTask)
 
     def testSerialize(self):
-
         class OtherTask(luigi.Task):
             def complete(self):
                 return True
@@ -1230,7 +1236,6 @@ class LocalParameters1304Test(LuigiTestCase):
     """
 
     def test_local_params(self):
-
         class MyTask(RunOnceTask):
             param1 = luigi.IntParameter()
             param2 = luigi.BoolParameter(default=False)
@@ -1246,7 +1251,6 @@ class LocalParameters1304Test(LuigiTestCase):
         self.assertTrue(self.run_locally_split("MyTask --param1 1 --param2"))
 
     def test_local_takes_precedence(self):
-
         class MyTask(luigi.Task):
             param = luigi.IntParameter()
 
@@ -1259,7 +1263,6 @@ class LocalParameters1304Test(LuigiTestCase):
         self.assertTrue(self.run_locally_split("MyTask --param 5 --MyTask-param 6"))
 
     def test_local_only_affects_root(self):
-
         class MyTask(RunOnceTask):
             param = luigi.IntParameter(default=3)
 
@@ -1292,7 +1295,6 @@ class LocalParameters1304Test(LuigiTestCase):
 
 class TaskAsParameterName1335Test(LuigiTestCase):
     def test_parameter_can_be_named_task(self):
-
         class MyTask(luigi.Task):
             # Indeed, this is not the most realistic example, but still ...
             task = luigi.IntParameter()


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, when using `OptionalParameter` (and its variants like OptionalStrParameter), users must explicitly set `default=None`. If omitted, Luigi throws a `MissingParameterException`.

Since the prefix `"Optional"` strongly implies that the parameter can be omitted and will default to a null state, the current behavior is slightly counter-intuitive. This PR proposes changing the default value of optional parameters from `_no_value` to `None`.

```python
class MyTask(luigi.Task):
    param1: luigi.Parameter[str | None] = luigi.OptionalStrParameter()

    def output(self):
        return luigi.LocalTarget(f"output_{self.param1}.txt")

    def run(self):
        with self.output().open("w") as f:
            f.write(f"Parameter 1: {self.param1}\n")


luigi.build([MyTask()], local_scheduler=True)
```

### expected behavior

```
===== Luigi Execution Summary =====

Scheduled 1 tasks of which:
* 1 ran successfully:
    - 1 MyTask(param1=)
```

### actual behavior

```
luigi.parameter.MissingParameterException: MyTask[args=(), kwargs={}]: requires the 'param1' parameter to be set
```

## Motivation and Context

To improve the developer experience by aligning the behavior of OptionalParameter with standard Python conventions and user expectations. This change reduces boilerplate code (removing the need to write default=None everywhere) and prevents unexpected errors when an optional parameter is simply omitted.

## Have you tested this? If so, how?

Verified that the provided reproduction code now runs successfully and outputs as expected.