### PR TITLE
feat: add type annotations to target and contrib modules

### DIFF
--- a/luigi/contrib/gcs.py
+++ b/luigi/contrib/gcs.py
@@ -24,18 +24,19 @@ import os
 import tempfile
 import time
 from io import BytesIO
+from typing import IO, Any, Optional
 from urllib.parse import urlsplit
 
 from tenacity import after_log, retry, retry_if_exception, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 import luigi.target
 from luigi.contrib import gcp
-from luigi.format import FileWrapper
+from luigi.format import FileWrapper, Format
 
 logger = logging.getLogger("luigi-interface")
 
 # Retry when following errors happened
-RETRYABLE_ERRORS = None
+RETRYABLE_ERRORS: tuple[type[BaseException], ...] = ()
 
 try:
     import httplib2
@@ -74,7 +75,7 @@ gcs_retry = retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
     stop=stop_after_attempt(5),
     reraise=True,
-    after=after_log(logger, logging.WARNING),
+    after=after_log(logger, logging.WARNING),  # type: ignore[arg-type]
 )
 
 
@@ -432,9 +433,9 @@ class AtomicGCSFile(luigi.target.AtomicLocalFile):
 
 
 class GCSTarget(luigi.target.FileSystemTarget):
-    fs = None
+    fs: GCSClient
 
-    def __init__(self, path, format=None, client=None):
+    def __init__(self, path: str, format: Optional[Format] = None, client: Optional[GCSClient] = None):
         super(GCSTarget, self).__init__(path)
         if format is None:
             format = luigi.format.get_default_format()
@@ -442,7 +443,7 @@ class GCSTarget(luigi.target.FileSystemTarget):
         self.format = format
         self.fs = client or GCSClient()
 
-    def open(self, mode="r"):
+    def open(self, mode: str = "r") -> IO[Any]:
         if mode == "r":
             return self.format.pipe_reader(FileWrapper(io.BufferedReader(self.fs.download(self.path))))
         elif mode == "w":
@@ -471,9 +472,9 @@ class GCSFlagTarget(GCSTarget):
     If we have 1,000,000 output files, then we have to rename 1,000,000 objects.
     """
 
-    fs = None
+    fs: GCSClient
 
-    def __init__(self, path, format=None, client=None, flag="_SUCCESS"):
+    def __init__(self, path: str, format: Optional[Format] = None, client: Optional[GCSClient] = None, flag: str = "_SUCCESS"):
         """
         Initializes a GCSFlagTarget.
 

--- a/luigi/contrib/hadoop.py
+++ b/luigi/contrib/hadoop.py
@@ -52,7 +52,7 @@ try:
     # See benchmark at https://gist.github.com/mvj3/02dca2bcc8b0ef1bbfb5
     import ujson as json
 except ImportError:
-    import json
+    import json  # type: ignore[no-redef]
 
 logger = logging.getLogger("luigi-interface")
 
@@ -666,7 +666,7 @@ class BaseHadoopJobTask(luigi.Task):
     mr_priority = NotImplemented
     package_binary = None
 
-    _counter_dict = {}
+    _counter_dict: dict[tuple[str, ...], int] = {}
     task_id = None
 
     def _get_pool(self):

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -28,10 +28,11 @@ import os.path
 import warnings
 from configparser import NoSectionError
 from multiprocessing.pool import ThreadPool
+from typing import Optional
 from urllib.parse import urlsplit
 
 from luigi import configuration
-from luigi.format import get_default_format
+from luigi.format import Format, get_default_format
 from luigi.parameter import OptionalParameter, Parameter
 from luigi.target import AtomicLocalFile, FileAlreadyExists, FileSystem, FileSystemException, FileSystemTarget, MissingParentDirectory
 from luigi.task import ExternalTask
@@ -618,9 +619,9 @@ class S3Target(FileSystemTarget):
     :param kwargs: Keyword arguments are passed to the boto function `initiate_multipart_upload`
     """
 
-    fs = None
+    fs: FileSystem
 
-    def __init__(self, path, format=None, client=None, **kwargs):
+    def __init__(self, path: str, format: Optional[Format] = None, client: Optional[S3Client] = None, **kwargs):
         super(S3Target, self).__init__(path)
         if format is None:
             format = get_default_format()
@@ -665,9 +666,9 @@ class S3FlagTarget(S3Target):
     If we have 1,000,000 output files, then we have to rename 1,000,000 objects.
     """
 
-    fs = None
+    fs: FileSystem
 
-    def __init__(self, path, format=None, client=None, flag="_SUCCESS"):
+    def __init__(self, path: str, format: Optional[Format] = None, client: Optional[S3Client] = None, flag="_SUCCESS"):
         """
         Initializes a S3FlagTarget.
 

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -619,8 +619,6 @@ class S3Target(FileSystemTarget):
     :param kwargs: Keyword arguments are passed to the boto function `initiate_multipart_upload`
     """
 
-    fs: FileSystem
-
     def __init__(self, path: str, format: Optional[Format] = None, client: Optional[S3Client] = None, **kwargs):
         super(S3Target, self).__init__(path)
         if format is None:
@@ -628,8 +626,12 @@ class S3Target(FileSystemTarget):
 
         self.path = path
         self.format = format
-        self.fs = client or S3Client()
+        self._fs = client or S3Client()
         self.s3_options = kwargs
+
+    @property
+    def fs(self) -> FileSystem:
+        return self._fs
 
     def open(self, mode="r"):
         if mode not in ("r", "w"):
@@ -665,8 +667,6 @@ class S3FlagTarget(S3Target):
 
     If we have 1,000,000 output files, then we have to rename 1,000,000 objects.
     """
-
-    fs: FileSystem
 
     def __init__(self, path: str, format: Optional[Format] = None, client: Optional[S3Client] = None, flag="_SUCCESS"):
         """

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -24,18 +24,19 @@ contrib module. You can consider migrating to
 """
 
 import logging
+from typing import Optional
 
 import luigi.contrib.hdfs
-from luigi.format import get_default_format
-from luigi.target import AtomicLocalFile, FileSystemTarget
+from luigi.format import Format, get_default_format
+from luigi.target import AtomicLocalFile, FileSystem, FileSystemTarget
 
 logger = logging.getLogger("luigi-interface")
 
 
 class WebHdfsTarget(FileSystemTarget):
-    fs = None
+    fs: FileSystem
 
-    def __init__(self, path, client=None, format=None):
+    def __init__(self, path: str, client: Optional[FileSystem] = None, format: Optional[Format] = None):
         super(WebHdfsTarget, self).__init__(path)
         path = self.path
         self.fs = client or WebHdfsClient()

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -34,16 +34,18 @@ logger = logging.getLogger("luigi-interface")
 
 
 class WebHdfsTarget(FileSystemTarget):
-    fs: FileSystem
-
     def __init__(self, path: str, client: Optional[FileSystem] = None, format: Optional[Format] = None):
         super(WebHdfsTarget, self).__init__(path)
         path = self.path
-        self.fs = client or WebHdfsClient()
+        self._fs = client or WebHdfsClient()
         if format is None:
             format = get_default_format()
 
         self.format = format
+
+    @property
+    def fs(self) -> FileSystem:
+        return self._fs
 
     def open(self, mode="r"):
         if mode not in ("r", "w"):

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -491,5 +491,5 @@ Bzip2 = Bzip2Format()
 MixedUnicodeBytes = MixedUnicodeBytesFormat()
 
 
-def get_default_format():
+def get_default_format() -> Format:
     return Text

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -27,6 +27,8 @@ import random
 import tempfile
 import warnings
 from contextlib import contextmanager
+from types import TracebackType
+from typing import IO, Any, Generator, Iterator, Optional, Union
 
 logger = logging.getLogger("luigi-interface")
 
@@ -44,7 +46,7 @@ class Target(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def exists(self):
+    def exists(self) -> bool:
         """
         Returns ``True`` if the :py:class:`Target` exists and ``False`` otherwise.
         """
@@ -99,7 +101,7 @@ class FileSystem(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def exists(self, path):
+    def exists(self, path: str) -> bool:
         """
         Return ``True`` if file or directory at ``path`` exist, ``False`` otherwise
 
@@ -108,7 +110,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def remove(self, path, recursive=True, skip_trash=True):
+    def remove(self, path: str, recursive: bool = True, skip_trash: bool = True) -> None:
         """Remove file or directory at location ``path``
 
         :param str path: a path within the FileSystem to remove.
@@ -117,7 +119,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         pass
 
-    def mkdir(self, path, parents=True, raise_if_exists=False):
+    def mkdir(self, path: str, parents: bool = True, raise_if_exists: bool = False) -> None:
         """
         Create directory at location ``path``
 
@@ -133,7 +135,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("mkdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def isdir(self, path):
+    def isdir(self, path: str) -> bool:
         """
         Return ``True`` if the location at ``path`` is a directory. If not, return ``False``.
 
@@ -143,7 +145,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("isdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def listdir(self, path):
+    def listdir(self, path: str) -> Iterator[str]:
         """Return a list of files rooted in path.
 
         This returns an iterable of the files rooted at ``path``. This is intended to be a
@@ -155,13 +157,13 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("listdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def move(self, path, dest):
+    def move(self, path: str, dest: str) -> None:
         """
         Move a file, as one would expect.
         """
         raise NotImplementedError("move() not implemented on {0}".format(self.__class__.__name__))
 
-    def rename_dont_move(self, path, dest):
+    def rename_dont_move(self, path: str, dest: str) -> None:
         """
         Potentially rename ``path`` to ``dest``, but don't move it into the
         ``dest`` folder (if it is a folder).  This relates to :ref:`AtomicWrites`.
@@ -175,13 +177,13 @@ class FileSystem(metaclass=abc.ABCMeta):
             raise FileAlreadyExists()
         self.move(path, dest)
 
-    def rename(self, *args, **kwargs):
+    def rename(self, *args: Any, **kwargs: Any) -> None:
         """
         Alias for ``move()``
         """
         self.move(*args, **kwargs)
 
-    def copy(self, path, dest):
+    def copy(self, path: str, dest: str) -> None:
         """
         Copy a file or a directory with contents.
         Currently, LocalFileSystem and MockFileSystem support only single file
@@ -209,7 +211,7 @@ class FileSystemTarget(Target):
             target.exists()  # False
     """
 
-    def __init__(self, path):
+    def __init__(self, path: Union[str, "os.PathLike[str]"]) -> None:
         """
         Initializes a FileSystemTarget instance.
 
@@ -218,19 +220,19 @@ class FileSystemTarget(Target):
         # cast to str to allow path to be objects like pathlib.PosixPath and py._path.local.LocalPath
         self.path = str(path)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.path
 
     @property
     @abc.abstractmethod
-    def fs(self):
+    def fs(self) -> FileSystem:
         """
         The :py:class:`FileSystem` associated with this FileSystemTarget.
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def open(self, mode):
+    def open(self, mode: str) -> IO[Any]:
         """
         Open the FileSystem target.
 
@@ -244,7 +246,7 @@ class FileSystemTarget(Target):
         """
         pass
 
-    def exists(self):
+    def exists(self) -> bool:
         """
         Returns ``True`` if the path for this FileSystemTarget exists; ``False`` otherwise.
 
@@ -255,7 +257,7 @@ class FileSystemTarget(Target):
             logger.warning("Using wildcards in path %s might lead to processing of an incomplete dataset; override exists() to suppress the warning.", path)
         return self.fs.exists(path)
 
-    def remove(self):
+    def remove(self) -> None:
         """
         Remove the resource at the path specified by this FileSystemTarget.
 
@@ -264,7 +266,7 @@ class FileSystemTarget(Target):
         self.fs.remove(self.path)
 
     @contextmanager
-    def temporary_path(self):
+    def temporary_path(self) -> Generator[str, None, None]:
         """
         A context manager that enables a reasonably short, general and
         magic-less way to solve the :ref:`AtomicWrites`.
@@ -301,11 +303,11 @@ class FileSystemTarget(Target):
         # We won't reach here if there was an user exception.
         self.fs.rename_dont_move(_temp_path, self.path)
 
-    def _touchz(self):
+    def _touchz(self) -> None:
         with self.open("w"):
             pass
 
-    def _trailing_slash(self):
+    def _trailing_slash(self) -> str:
         # I suppose one day schema-like paths, like
         # file:///path/blah.txt?params=etc can be parsed too
         return self.path[-1] if self.path[-1] in r"\/" else ""
@@ -320,31 +322,36 @@ class AtomicLocalFile(io.BufferedWriter):
     :class:`luigi.local_target.LocalTarget` for example
     """
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.__tmp_path = self.generate_tmp_path(path)
         self.path = path
         super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, "w"))
 
-    def close(self):
+    def close(self) -> None:
         super(AtomicLocalFile, self).close()
         self.move_to_final_destination()
 
-    def generate_tmp_path(self, path):
+    def generate_tmp_path(self, path: str) -> str:
         return os.path.join(tempfile.gettempdir(), "luigi-s3-tmp-%09d" % random.randrange(0, 10_000_000_000))
 
-    def move_to_final_destination(self):
+    def move_to_final_destination(self) -> None:
         raise NotImplementedError()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if os.path.exists(self.tmp_path):
             os.remove(self.tmp_path)
 
     @property
-    def tmp_path(self):
+    def tmp_path(self) -> str:
         return self.__tmp_path
 
-    def __exit__(self, exc_type, exc, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         "Close/commit the file if there are no exception"
         if exc_type:
             return
-        return super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)
+        super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -27,7 +27,8 @@ import random
 import tempfile
 import warnings
 from contextlib import contextmanager
-from typing import IO, Any
+from types import TracebackType
+from typing import IO, Any, Generator, Iterator, Optional, Union
 
 logger = logging.getLogger("luigi-interface")
 
@@ -100,7 +101,7 @@ class FileSystem(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def exists(self, path):
+    def exists(self, path: str) -> bool:
         """
         Return ``True`` if file or directory at ``path`` exist, ``False`` otherwise
 
@@ -109,7 +110,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def remove(self, path, recursive=True, skip_trash=True):
+    def remove(self, path: str, recursive: bool = True, skip_trash: bool = True) -> None:
         """Remove file or directory at location ``path``
 
         :param str path: a path within the FileSystem to remove.
@@ -118,7 +119,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         pass
 
-    def mkdir(self, path, parents=True, raise_if_exists=False):
+    def mkdir(self, path: str, parents: bool = True, raise_if_exists: bool = False) -> None:
         """
         Create directory at location ``path``
 
@@ -134,7 +135,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("mkdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def isdir(self, path):
+    def isdir(self, path: str) -> bool:
         """
         Return ``True`` if the location at ``path`` is a directory. If not, return ``False``.
 
@@ -144,7 +145,7 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("isdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def listdir(self, path):
+    def listdir(self, path: str) -> Iterator[str]:
         """Return a list of files rooted in path.
 
         This returns an iterable of the files rooted at ``path``. This is intended to be a
@@ -156,13 +157,13 @@ class FileSystem(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError("listdir() not implemented on {0}".format(self.__class__.__name__))
 
-    def move(self, path, dest):
+    def move(self, path: str, dest: str) -> None:
         """
         Move a file, as one would expect.
         """
         raise NotImplementedError("move() not implemented on {0}".format(self.__class__.__name__))
 
-    def rename_dont_move(self, path, dest):
+    def rename_dont_move(self, path: str, dest: str) -> None:
         """
         Potentially rename ``path`` to ``dest``, but don't move it into the
         ``dest`` folder (if it is a folder).  This relates to :ref:`AtomicWrites`.
@@ -176,13 +177,13 @@ class FileSystem(metaclass=abc.ABCMeta):
             raise FileAlreadyExists()
         self.move(path, dest)
 
-    def rename(self, *args, **kwargs):
+    def rename(self, *args: Any, **kwargs: Any) -> None:
         """
         Alias for ``move()``
         """
         self.move(*args, **kwargs)
 
-    def copy(self, path, dest):
+    def copy(self, path: str, dest: str) -> None:
         """
         Copy a file or a directory with contents.
         Currently, LocalFileSystem and MockFileSystem support only single file
@@ -210,7 +211,7 @@ class FileSystemTarget(Target):
             target.exists()  # False
     """
 
-    def __init__(self, path):
+    def __init__(self, path: Union[str, "os.PathLike[str]"]) -> None:
         """
         Initializes a FileSystemTarget instance.
 
@@ -219,12 +220,12 @@ class FileSystemTarget(Target):
         # cast to str to allow path to be objects like pathlib.PosixPath and py._path.local.LocalPath
         self.path = str(path)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.path
 
     @property
     @abc.abstractmethod
-    def fs(self):
+    def fs(self) -> FileSystem:
         """
         The :py:class:`FileSystem` associated with this FileSystemTarget.
         """
@@ -245,7 +246,7 @@ class FileSystemTarget(Target):
         """
         pass
 
-    def exists(self):
+    def exists(self) -> bool:
         """
         Returns ``True`` if the path for this FileSystemTarget exists; ``False`` otherwise.
 
@@ -256,7 +257,7 @@ class FileSystemTarget(Target):
             logger.warning("Using wildcards in path %s might lead to processing of an incomplete dataset; override exists() to suppress the warning.", path)
         return self.fs.exists(path)
 
-    def remove(self):
+    def remove(self) -> None:
         """
         Remove the resource at the path specified by this FileSystemTarget.
 
@@ -265,7 +266,7 @@ class FileSystemTarget(Target):
         self.fs.remove(self.path)
 
     @contextmanager
-    def temporary_path(self):
+    def temporary_path(self) -> Generator[str, None, None]:
         """
         A context manager that enables a reasonably short, general and
         magic-less way to solve the :ref:`AtomicWrites`.
@@ -302,11 +303,11 @@ class FileSystemTarget(Target):
         # We won't reach here if there was an user exception.
         self.fs.rename_dont_move(_temp_path, self.path)
 
-    def _touchz(self):
+    def _touchz(self) -> None:
         with self.open("w"):
             pass
 
-    def _trailing_slash(self):
+    def _trailing_slash(self) -> str:
         # I suppose one day schema-like paths, like
         # file:///path/blah.txt?params=etc can be parsed too
         return self.path[-1] if self.path[-1] in r"\/" else ""
@@ -321,31 +322,36 @@ class AtomicLocalFile(io.BufferedWriter):
     :class:`luigi.local_target.LocalTarget` for example
     """
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.__tmp_path = self.generate_tmp_path(path)
         self.path = path
         super(AtomicLocalFile, self).__init__(io.FileIO(self.__tmp_path, "w"))
 
-    def close(self):
+    def close(self) -> None:
         super(AtomicLocalFile, self).close()
         self.move_to_final_destination()
 
-    def generate_tmp_path(self, path):
+    def generate_tmp_path(self, path: str) -> str:
         return os.path.join(tempfile.gettempdir(), "luigi-s3-tmp-%09d" % random.randrange(0, 10_000_000_000))
 
-    def move_to_final_destination(self):
+    def move_to_final_destination(self) -> None:
         raise NotImplementedError()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if os.path.exists(self.tmp_path):
             os.remove(self.tmp_path)
 
     @property
-    def tmp_path(self):
+    def tmp_path(self) -> str:
         return self.__tmp_path
 
-    def __exit__(self, exc_type, exc, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         "Close/commit the file if there are no exception"
         if exc_type:
             return
-        return super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)
+        super(AtomicLocalFile, self).__exit__(exc_type, exc, traceback)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    "luigi.contrib.gcs",
     "luigi.contrib.hadoop",
     "luigi.contrib.hdfs.config",
     "luigi.contrib.postgres",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ common = [
   "types-python-dateutil",
   "types-requests",
   "types-toml",
+  "types-ujson>=5.10.0.20250822",
 ]
 
 docs = [
@@ -182,7 +183,6 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [
-    "luigi.contrib.hadoop",
     "luigi.contrib.hdfs.config",
     "luigi.contrib.postgres",
     "luigi.contrib.redis_store",

--- a/uv.lock
+++ b/uv.lock
@@ -721,6 +721,7 @@ common = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 dev = [
     { name = "avro-python3" },
@@ -766,6 +767,7 @@ dev = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 docs = [
     { name = "azure-storage-blob" },
@@ -830,6 +832,7 @@ test-cdh = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 test-dropbox = [
     { name = "avro-python3" },
@@ -867,6 +870,7 @@ test-dropbox = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 test-gcloud = [
     { name = "avro-python3" },
@@ -906,6 +910,7 @@ test-gcloud = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 test-hdp = [
     { name = "avro-python3" },
@@ -943,6 +948,7 @@ test-hdp = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 test-postgres = [
     { name = "avro-python3" },
@@ -981,6 +987,7 @@ test-postgres = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 test-unixsocket = [
     { name = "avro-python3" },
@@ -1018,6 +1025,7 @@ test-unixsocket = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson" },
 ]
 unixsocket = [
     { name = "requests-unixsocket" },
@@ -1078,6 +1086,7 @@ common = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 dev = [
     { name = "avro-python3" },
@@ -1123,6 +1132,7 @@ dev = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 docs = [
     { name = "azure-storage-blob", specifier = "<=12.28.0" },
@@ -1181,6 +1191,7 @@ test-cdh = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 test-dropbox = [
     { name = "avro-python3" },
@@ -1218,6 +1229,7 @@ test-dropbox = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 test-gcloud = [
     { name = "avro-python3" },
@@ -1257,6 +1269,7 @@ test-gcloud = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 test-hdp = [
     { name = "avro-python3" },
@@ -1294,6 +1307,7 @@ test-hdp = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 test-postgres = [
     { name = "avro-python3" },
@@ -1332,6 +1346,7 @@ test-postgres = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 test-unixsocket = [
     { name = "avro-python3" },
@@ -1369,6 +1384,7 @@ test-unixsocket = [
     { name = "types-python-dateutil" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "types-ujson", specifier = ">=5.10.0.20250822" },
 ]
 unixsocket = [{ name = "requests-unixsocket", specifier = "<1.0" }]
 visualizer = [
@@ -2388,6 +2404,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/47/3e4c75042792bff8e90d7991aa5c51812cc668828cc6cce711e97f63a607/types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331", size = 4392, upload-time = "2024-03-10T02:18:37.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d", size = 4777, upload-time = "2024-03-10T02:18:36.568Z" },
+]
+
+[[package]]
+name = "types-ujson"
+version = "5.10.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/bd/d372d44534f84864a96c19a7059d9b4d29db8541828b8b9dc3040f7a46d0/types_ujson-5.10.0.20250822.tar.gz", hash = "sha256:0a795558e1f78532373cf3f03f35b1f08bc60d52d924187b97995ee3597ba006", size = 8437, upload-time = "2025-08-22T03:02:19.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/f2/d812543c350674d8b3f6e17c8922248ee3bb752c2a76f64beb8c538b40cf/types_ujson-5.10.0.20250822-py3-none-any.whl", hash = "sha256:3e9e73a6dc62ccc03449d9ac2c580cd1b7a8e4873220db498f7dd056754be080", size = 7657, upload-time = "2025-08-22T03:02:18.699Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Add mypy type annotations to `luigi/target.py`, `luigi/format.py`, and several contrib modules (`s3`, `webhdfs`, `gcs`, `hadoop`). This is part of the gradual type-checking adoption introduced in #3403.

## Motivation and Context

Following the mypy infrastructure introduced in #3403 and the parameter class annotations in #3406, this PR extends type coverage to the Target layer and key contrib modules — enabling static analysis to catch type errors in the core I/O abstractions.

Changes per commit:
- `luigi/target.py`, `luigi/contrib/s3.py`, `luigi/contrib/webhdfs.py`, `luigi/format.py`: add Target type annotations
- `luigi/contrib/gcs.py`: enable GCS target type (unblock from ignore list)
- `luigi/contrib/hadoop.py`: add type annotations, add `types-requests` dep

## Have you tested this? If so, how?
I ran mypy on the modified modules and confirmed no new type errors are introduced.
