### PR TITLE
Validate input args in `luigi.run()`

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -159,6 +159,13 @@ def run(*args, **kwargs):
 
     :param use_dynamic_argparse: Deprecated and ignored
     """
+    cmdline_args = args[0] if args else kwargs.get("cmdline_args")
+    if cmdline_args is not None and not isinstance(cmdline_args, (list, tuple)):
+        raise TypeError(
+            f"luigi.run() expects a list or tuple of command-line arguments, "
+            f"got {type(cmdline_args).__name__!r}. "
+            "Example: luigi.run(['MyTask', '--param', 'value'])"
+        )
     luigi_run_result = _run(*args, **kwargs)
     return luigi_run_result if kwargs.get("detailed_summary") else luigi_run_result.scheduling_succeeded
 

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -166,9 +166,7 @@ def run(*args, **kwargs):
 def _run(cmdline_args=None, main_task_cls=None, worker_scheduler_factory=None, use_dynamic_argparse=None, local_scheduler=False, detailed_summary=False):
     if cmdline_args is not None and not isinstance(cmdline_args, (list, tuple)):
         raise TypeError(
-            f"cmdline_args must be a list or tuple of command-line arguments, "
-            f"got {type(cmdline_args).__name__!r}. "
-            "Example: ['MyTask', '--param', 'value']"
+            f"cmdline_args must be a list or tuple of command-line arguments, got {type(cmdline_args).__name__!r}. Example: ['MyTask', '--param', 'value']"
         )
     if use_dynamic_argparse is not None:
         warnings.warn("use_dynamic_argparse is deprecated, don't set it.", DeprecationWarning, stacklevel=2)

--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -159,22 +159,23 @@ def run(*args, **kwargs):
 
     :param use_dynamic_argparse: Deprecated and ignored
     """
-    cmdline_args = args[0] if args else kwargs.get("cmdline_args")
-    if cmdline_args is not None and not isinstance(cmdline_args, (list, tuple)):
-        raise TypeError(
-            f"luigi.run() expects a list or tuple of command-line arguments, "
-            f"got {type(cmdline_args).__name__!r}. "
-            "Example: luigi.run(['MyTask', '--param', 'value'])"
-        )
     luigi_run_result = _run(*args, **kwargs)
     return luigi_run_result if kwargs.get("detailed_summary") else luigi_run_result.scheduling_succeeded
 
 
 def _run(cmdline_args=None, main_task_cls=None, worker_scheduler_factory=None, use_dynamic_argparse=None, local_scheduler=False, detailed_summary=False):
+    if cmdline_args is not None and not isinstance(cmdline_args, (list, tuple)):
+        raise TypeError(
+            f"cmdline_args must be a list or tuple of command-line arguments, "
+            f"got {type(cmdline_args).__name__!r}. "
+            "Example: ['MyTask', '--param', 'value']"
+        )
     if use_dynamic_argparse is not None:
         warnings.warn("use_dynamic_argparse is deprecated, don't set it.", DeprecationWarning, stacklevel=2)
     if cmdline_args is None:
         cmdline_args = sys.argv[1:]
+    else:
+        cmdline_args = list(cmdline_args)
 
     if main_task_cls:
         cmdline_args.insert(0, main_task_cls.task_family)

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -178,6 +178,55 @@ class InterfaceTest(LuigiTestCase):
         with patch.object(sys, "argv", ["my_module.py", "--no-lock", "--my-param", "my_value", "--local-scheduler"]):
             luigi.run(main_task_cls=MyOtherTestTask)
 
+    def test_run_with_int_raises_type_error(
+            self):
+        with self.assertRaises(
+                TypeError) as ctx:
+            luigi.run(
+                123)
+        self.assertIn(
+            "int",
+            str(ctx.exception))
+        self.assertIn(
+            "list or tuple",
+            str(ctx.exception))
+
+    def test_run_with_dict_raises_type_error(
+            self):
+        with self.assertRaises(
+                TypeError) as ctx:
+            luigi.run(
+                {
+                    "task": "MyTask"})
+        self.assertIn(
+            "dict",
+            str(ctx.exception))
+        self.assertIn(
+            "list or tuple",
+            str(ctx.exception))
+
+    def test_run_with_none_does_not_raise_type_error(
+            self):
+        try:
+            luigi.run(
+                None)
+        except TypeError:
+            self.fail(
+                "luigi.run() raised TypeError for None argument")
+        except Exception:
+            pass  # scheduler/task errors are fine
+
+    def test_run_with_valid_list_does_not_raise_type_error(
+            self):
+        try:
+            luigi.run(
+                ["MyTask"])
+        except TypeError:
+            self.fail(
+                "luigi.run() raised TypeError for a valid list argument")
+        except Exception:
+            pass  # scheduler/task errors are fine
+
     def _run_interface(self, **env_params):
         return luigi.interface.build([self.task_a, self.task_b], worker_scheduler_factory=self.worker_scheduler_factory, **env_params)
 
@@ -192,34 +241,4 @@ class CoreConfigTest(LuigiTestCase):
         from luigi.interface import core
 
         self.assertEqual(1234, core().parallel_scheduling_processes)
-
-
-class RunArgValidationTest(LuigiTestCase):
-
-    def test_run_with_int_raises_type_error(self):
-        with self.assertRaises(TypeError) as ctx:
-            luigi.run(123)
-        self.assertIn("int", str(ctx.exception))
-        self.assertIn("list or tuple", str(ctx.exception))
-
-    def test_run_with_dict_raises_type_error(self):
-        with self.assertRaises(TypeError) as ctx:
-            luigi.run({"task": "MyTask"})
-        self.assertIn("dict", str(ctx.exception))
-        self.assertIn("list or tuple", str(ctx.exception))
-
-    def test_run_with_none_does_not_raise_type_error(self):
-        try:
-            luigi.run(None)
-        except TypeError:
-            self.fail("luigi.run() raised TypeError for None argument")
-        except Exception:
-            pass  # scheduler/task errors are fine
-
-    def test_run_with_valid_list_does_not_raise_type_error(self):
-        try:
-            luigi.run(["MyTask"])
-        except TypeError:
-            self.fail("luigi.run() raised TypeError for a valid list argument")
-        except Exception:
-            pass  # scheduler/task errors are fine
+  # scheduler/task errors are fine

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -195,8 +195,8 @@ class InterfaceTest(LuigiTestCase):
             luigi.run(None)
         except TypeError:
             self.fail("luigi.run() raised TypeError for None argument")
-        except Exception:
-            pass  # scheduler/task errors are fine
+        except (Exception, SystemExit):
+            pass  # scheduler/task errors and SystemExit are fine
 
     def test_run_with_valid_list_does_not_raise_type_error(self):
         try:

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -192,3 +192,34 @@ class CoreConfigTest(LuigiTestCase):
         from luigi.interface import core
 
         self.assertEqual(1234, core().parallel_scheduling_processes)
+
+
+class RunArgValidationTest(LuigiTestCase):
+
+    def test_run_with_int_raises_type_error(self):
+        with self.assertRaises(TypeError) as ctx:
+            luigi.run(123)
+        self.assertIn("int", str(ctx.exception))
+        self.assertIn("list or tuple", str(ctx.exception))
+
+    def test_run_with_dict_raises_type_error(self):
+        with self.assertRaises(TypeError) as ctx:
+            luigi.run({"task": "MyTask"})
+        self.assertIn("dict", str(ctx.exception))
+        self.assertIn("list or tuple", str(ctx.exception))
+
+    def test_run_with_none_does_not_raise_type_error(self):
+        try:
+            luigi.run(None)
+        except TypeError:
+            self.fail("luigi.run() raised TypeError for None argument")
+        except Exception:
+            pass  # scheduler/task errors are fine
+
+    def test_run_with_valid_list_does_not_raise_type_error(self):
+        try:
+            luigi.run(["MyTask"])
+        except TypeError:
+            self.fail("luigi.run() raised TypeError for a valid list argument")
+        except Exception:
+            pass  # scheduler/task errors are fine

--- a/test/interface_test.py
+++ b/test/interface_test.py
@@ -178,52 +178,31 @@ class InterfaceTest(LuigiTestCase):
         with patch.object(sys, "argv", ["my_module.py", "--no-lock", "--my-param", "my_value", "--local-scheduler"]):
             luigi.run(main_task_cls=MyOtherTestTask)
 
-    def test_run_with_int_raises_type_error(
-            self):
-        with self.assertRaises(
-                TypeError) as ctx:
-            luigi.run(
-                123)
-        self.assertIn(
-            "int",
-            str(ctx.exception))
-        self.assertIn(
-            "list or tuple",
-            str(ctx.exception))
+    def test_run_with_int_raises_type_error(self):
+        with self.assertRaises(TypeError) as ctx:
+            luigi.run(123)
+        self.assertIn("int", str(ctx.exception))
+        self.assertIn("list or tuple", str(ctx.exception))
 
-    def test_run_with_dict_raises_type_error(
-            self):
-        with self.assertRaises(
-                TypeError) as ctx:
-            luigi.run(
-                {
-                    "task": "MyTask"})
-        self.assertIn(
-            "dict",
-            str(ctx.exception))
-        self.assertIn(
-            "list or tuple",
-            str(ctx.exception))
+    def test_run_with_dict_raises_type_error(self):
+        with self.assertRaises(TypeError) as ctx:
+            luigi.run({"task": "MyTask"})
+        self.assertIn("dict", str(ctx.exception))
+        self.assertIn("list or tuple", str(ctx.exception))
 
-    def test_run_with_none_does_not_raise_type_error(
-            self):
+    def test_run_with_none_does_not_raise_type_error(self):
         try:
-            luigi.run(
-                None)
+            luigi.run(None)
         except TypeError:
-            self.fail(
-                "luigi.run() raised TypeError for None argument")
+            self.fail("luigi.run() raised TypeError for None argument")
         except Exception:
             pass  # scheduler/task errors are fine
 
-    def test_run_with_valid_list_does_not_raise_type_error(
-            self):
+    def test_run_with_valid_list_does_not_raise_type_error(self):
         try:
-            luigi.run(
-                ["MyTask"])
+            luigi.run(["MyTask"])
         except TypeError:
-            self.fail(
-                "luigi.run() raised TypeError for a valid list argument")
+            self.fail("luigi.run() raised TypeError for a valid list argument")
         except Exception:
             pass  # scheduler/task errors are fine
 
@@ -241,4 +220,3 @@ class CoreConfigTest(LuigiTestCase):
         from luigi.interface import core
 
         self.assertEqual(1234, core().parallel_scheduling_processes)
-  # scheduler/task errors are fine


### PR DESCRIPTION
## Description
Validate passed args in `run()` before passing anything downstream.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/spotify/luigi/issues/3354

Quoting from the linked issue:
>`luigi.run()` should validate that the input args is an iterable and raise a meaningful `TypeError` or `ValueError` such as:`TypeError: luigi.run() expects a list or tuple of command-line arguments, got int`.

This adds the above validation.
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I added replicative unit tests and ran them.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
