### PR TITLE
Fix typerror in `_update_priority` in scheduler.py

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -761,6 +761,10 @@ class Scheduler:
         Priority can only be increased.
         If the task doesn't exist, a placeholder task is created to preserve priority when the task is later scheduled.
         """
+        existing_priority = (
+            task.priority if isinstance(task.priority, (int, float)) else 0
+        )
+        task.priority = prio = max(prio, existing_priority)
         task.priority = prio = max(prio, task.priority)
         for dep in task.deps or []:
             t = self._state.get_task(dep)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -761,9 +761,7 @@ class Scheduler:
         Priority can only be increased.
         If the task doesn't exist, a placeholder task is created to preserve priority when the task is later scheduled.
         """
-        existing_priority = (
-            task.priority if isinstance(task.priority, (int, float)) else 0
-        )
+        existing_priority = task.priority if isinstance(task.priority, (int, float)) else 0
         task.priority = prio = max(prio, existing_priority)
         task.priority = prio = max(prio, task.priority)
         for dep in task.deps or []:

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -225,13 +225,15 @@ class OrderedSet(MutableSet):
 
 
 class Task:
+    DEFAULT_PRIORITY = 0
+
     def __init__(
         self,
         task_id,
         status,
         deps,
         resources=None,
-        priority=0,
+        priority=DEFAULT_PRIORITY,
         family="",
         module=None,
         params=None,
@@ -761,9 +763,8 @@ class Scheduler:
         Priority can only be increased.
         If the task doesn't exist, a placeholder task is created to preserve priority when the task is later scheduled.
         """
-        existing_priority = task.priority if isinstance(task.priority, (int, float)) else 0
+        existing_priority = task.priority if isinstance(task.priority, (int, float)) else Task.DEFAULT_PRIORITY
         task.priority = prio = max(prio, existing_priority)
-        task.priority = prio = max(prio, task.priority)
         for dep in task.deps or []:
             t = self._state.get_task(dep)
             if t is not None and prio > t.priority:

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1730,6 +1730,26 @@ class SchedulerApiTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id="D", priority=6)
         self.check_task_order(["A", "B", "D", "C"])
 
+    def test_update_priority_with_non_numeric_priority_defaults_to_zero(self):
+        self.sch.add_task(worker=WORKER, task_id="A")
+        task = self.sch._state.get_task("A")
+        task.priority = "not_a_number"  # simulate uninitialised/corrupt priority
+        self.sch._update_priority(task, 5, WORKER)
+        self.assertEqual(task.priority, 5)
+
+    def test_update_priority_cannot_decrease(self):
+        self.sch.add_task(worker=WORKER, task_id="A", priority=10)
+        task = self.sch._state.get_task("A")
+        self.sch._update_priority(task, 3, WORKER)
+        self.assertEqual(task.priority, 10)
+
+    def test_add_task_with_non_numeric_priority_does_not_raise_typerrror(self):
+        self.sch.add_task(worker=WORKER, task_id="A")
+        task = self.sch._state.get_task("A")
+        task.priority = "corrupt"  # simulate corrupt state
+        self.sch.add_task(worker=WORKER, task_id="A", priority=5)
+        self.assertEqual(self.sch._state.get_task("A").priority, 5)
+
     def test_unique_tasks(self):
         self.sch.add_task(worker=WORKER, task_id="A")
         self.sch.add_task(worker=WORKER, task_id="B")

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1731,6 +1731,8 @@ class SchedulerApiTest(unittest.TestCase):
         self.check_task_order(["A", "B", "D", "C"])
 
     def test_update_priority_with_non_numeric_priority_defaults_to_zero(self):
+        if not hasattr(self.sch, "_state"):
+            self.skipTest("only applicable to local scheduler")
         self.sch.add_task(worker=WORKER, task_id="A")
         task = self.sch._state.get_task("A")
         task.priority = "not_a_number"  # simulate uninitialised/corrupt priority
@@ -1738,12 +1740,16 @@ class SchedulerApiTest(unittest.TestCase):
         self.assertEqual(task.priority, 5)
 
     def test_update_priority_cannot_decrease(self):
+        if not hasattr(self.sch, "_state"):
+            self.skipTest("only applicable to local scheduler")
         self.sch.add_task(worker=WORKER, task_id="A", priority=10)
         task = self.sch._state.get_task("A")
         self.sch._update_priority(task, 3, WORKER)
         self.assertEqual(task.priority, 10)
 
     def test_add_task_with_non_numeric_priority_does_not_raise_typerrror(self):
+        if not hasattr(self.sch, "_state"):
+            self.skipTest("only applicable to local scheduler")
         self.sch.add_task(worker=WORKER, task_id="A")
         task = self.sch._state.get_task("A")
         task.priority = "corrupt"  # simulate corrupt state

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1730,31 +1730,11 @@ class SchedulerApiTest(unittest.TestCase):
         self.sch.add_task(worker=WORKER, task_id="D", priority=6)
         self.check_task_order(["A", "B", "D", "C"])
 
-    def test_update_priority_with_non_numeric_priority_defaults_to_zero(self):
-        if not hasattr(self.sch, "_state"):
-            self.skipTest("only applicable to local scheduler")
-        self.sch.add_task(worker=WORKER, task_id="A")
-        task = self.sch._state.get_task("A")
-        task.priority = "not_a_number"  # simulate uninitialised/corrupt priority
-        self.sch._update_priority(task, 5, WORKER)
-        self.assertEqual(task.priority, 5)
-
-    def test_update_priority_cannot_decrease(self):
-        if not hasattr(self.sch, "_state"):
-            self.skipTest("only applicable to local scheduler")
+    def test_add_task_priority_not_decreased_by_subsequent_add(self):
         self.sch.add_task(worker=WORKER, task_id="A", priority=10)
-        task = self.sch._state.get_task("A")
-        self.sch._update_priority(task, 3, WORKER)
-        self.assertEqual(task.priority, 10)
-
-    def test_add_task_with_non_numeric_priority_does_not_raise_typerrror(self):
-        if not hasattr(self.sch, "_state"):
-            self.skipTest("only applicable to local scheduler")
-        self.sch.add_task(worker=WORKER, task_id="A")
-        task = self.sch._state.get_task("A")
-        task.priority = "corrupt"  # simulate corrupt state
-        self.sch.add_task(worker=WORKER, task_id="A", priority=5)
-        self.assertEqual(self.sch._state.get_task("A").priority, 5)
+        self.sch.add_task(worker=WORKER, task_id="A", priority=3)
+        task_info = self.sch.task_list(PENDING, "")["A"]
+        self.assertEqual(task_info["priority"], 10)
 
     def test_unique_tasks(self):
         self.sch.add_task(worker=WORKER, task_id="A")

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -291,6 +291,29 @@ class SchedulerIoTest(unittest.TestCase):
         collector = scheduler_state._metrics_collector
         self.assertTrue(isinstance(collector, PrometheusMetricsCollector))
 
+    def test_update_priority_with_non_numeric_priority_defaults_to_zero(self):
+        s = luigi.scheduler.Scheduler()
+        s.add_task(worker="worker", task_id="A")
+        task = s._state.get_task("A")
+        task.priority = "not_a_number"
+        s._update_priority(task, 5, "worker")
+        self.assertEqual(task.priority, 5)
+
+    def test_update_priority_cannot_decrease(self):
+        s = luigi.scheduler.Scheduler()
+        s.add_task(worker="worker", task_id="A", priority=10)
+        task = s._state.get_task("A")
+        s._update_priority(task, 3, "worker")
+        self.assertEqual(task.priority, 10)
+
+    def test_add_task_with_non_numeric_priority_does_not_raise_typeerror(self):
+        s = luigi.scheduler.Scheduler()
+        s.add_task(worker="worker", task_id="A")
+        task = s._state.get_task("A")
+        task.priority = "corrupt"
+        s.add_task(worker="worker", task_id="A", priority=5)
+        self.assertEqual(s._state.get_task("A").priority, 5)
+
 
 class SchedulerWorkerTest(unittest.TestCase):
     def get_pending_ids(self, worker, state):


### PR DESCRIPTION
## Description
Add a check for `task.priority` as described in https://github.com/spotify/luigi/issues/3353 and default to 0.

## Motivation and Context
Closes https://github.com/spotify/luigi/issues/3353

Quoting from the issue:
>Calling `Scheduler.add_task()` with mocked task dependencies causes a `TypeError` due to an implicit comparison between a `MagicMock` and `int`. This happens when `task.priority` is a `MagicMock`, and `_update_priority()` tries to call `max(prio, task.priority)`, which results in `TypeError: '>' not supported between instances of 'MagicMock' and 'int'`.

>A potential fix is to add a check or default initialization for task.priority before using it in a numerical comparison.

This PR implements the fix.
## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I added unit tests replicating the typeerror scenarios.
<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
