### PR TITLE
Fix BoolParameter to consider global parsing default.

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -870,10 +870,10 @@ class BoolParameter(Parameter[bool]):
     def __init__(
         self,
         default: Union[bool, _NoValueType] = _no_value,
-        parsing: str = IMPLICIT_PARSING,
+        parsing: str | None = None,
         **kwargs: Unpack[_ParameterKwargs],
     ):
-        self.parsing = parsing
+        self.parsing = self.__class__.parsing if parsing is None else parsing
         super().__init__(default=default, **kwargs)
         if self._default == _no_value:
             self._default = False

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -206,20 +206,40 @@ class ParameterTest(LuigiTestCase):
         self.assertEqual(f.not_a_param, "lol")
 
     def test_bool_parsing(self):
+        self.assertEqual(luigi.BoolParameter.parsing, luigi.BoolParameter.IMPLICIT_PARSING)
+
+        # test defaults
         self.run_locally(["Baz"])
         self.assertFalse(Baz._val)
         self.assertTrue(Baz._val_true)
         self.assertFalse(Baz._val_explicit)
 
+        # test flags with implicit parsing only
         self.run_locally(["Baz", "--bool", "--bool-true"])
         self.assertTrue(Baz._val)
         self.assertTrue(Baz._val_true)
+        self.assertFalse(Baz._val_explicit)
 
+        # test explicit parsing
         self.run_locally(["Baz", "--bool-explicit", "true"])
+        self.assertFalse(Baz._val)
+        self.assertTrue(Baz._val_true)
         self.assertTrue(Baz._val_explicit)
-
         self.run_locally(["Baz", "--bool-explicit", "false"])
         self.assertFalse(Baz._val_explicit)
+
+        # argparse should exit when explicit values are passed to implicit parsing
+        self.assertRaises(SystemExit, self.run_locally, ["Baz", "--bool", "true"])
+
+        # test explicit parsing globally with the same command
+        luigi.BoolParameter.parsing = luigi.BoolParameter.EXPLICIT_PARSING
+
+        class BazSub(Baz):
+            bool = luigi.BoolParameter()
+
+        luigi.BoolParameter.parsing = luigi.BoolParameter.IMPLICIT_PARSING
+        self.run_locally(["BazSub", "--bool", "true"])
+        self.assertTrue(Baz._val)
 
     def test_bool_default(self):
         self.assertTrue(WithDefaultTrue().x)

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -239,7 +239,7 @@ class ParameterTest(LuigiTestCase):
 
         luigi.BoolParameter.parsing = luigi.BoolParameter.IMPLICIT_PARSING
         self.run_locally(["BazSub", "--bool", "true"])
-        self.assertTrue(Baz._val)
+        self.assertTrue(BazSub._val)
 
     def test_bool_default(self):
         self.assertTrue(WithDefaultTrue().x)


### PR DESCRIPTION
## Description

As part of the latest changes for the 3.8.0 release, some type hints were added that break changing the parsing option of BoolParameters. This PR contains a small 2-line fix to consider the default as before.

## Motivation and Context

The docstring of BoolParameter states that the `parsing` default value can be set

> globally by

    .. code-block:: python

        luigi.BoolParameter.parsing = luigi.BoolParameter.EXPLICIT_PARSING

However, this is no longer possible and breaks code on our side since the value is never used. As before (I created the PR for that 8 years ago), it *should* be evaluated at init time.

## Have you tested this?

The two line fix should be self-explanatory, but we tested the fix and it works as expected.

---

Due to things breaking for everyone making use of the global setting, 3.8.0 should probably be removed from pypi and re-released.