### PR TITLE
fix(server): resolve /history 500 error by correcting importlib.resources usage

### DIFF
--- a/luigi/server.py
+++ b/luigi/server.py
@@ -37,7 +37,6 @@ See :doc:`/central_scheduler` for more info.
 
 import atexit
 import datetime
-import importlib
 import json
 import logging
 import os
@@ -157,7 +156,7 @@ class BaseTaskHistoryHandler(tornado.web.RequestHandler):
         self._scheduler = scheduler
 
     def get_template_path(self):
-        return importlib.resources.files("templates").name
+        return os.path.join(os.path.dirname(__file__), "templates")
 
 
 class AllRunHandler(BaseTaskHistoryHandler):

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -483,6 +483,19 @@ class MetricsHandlerTest(unittest.TestCase):
             patched_write.assert_not_called()
 
 
+def test_get_template_path_returns_existing_directory():
+    """Regression test for https://github.com/spotify/luigi/issues/3415.
+
+    The returned path must point to the luigi/templates directory that
+    tornado uses to render task-history pages.
+    """
+    handler = luigi.server.BaseTaskHistoryHandler(tornado.web.Application(), mock.MagicMock(), scheduler=mock.MagicMock())
+    path = handler.get_template_path()
+    assert os.path.isdir(path), f"get_template_path() returned non-existent directory: {path!r}"
+    assert os.path.basename(path) == "templates"
+    assert os.path.isfile(os.path.join(path, "recent.html"))
+
+
 class FromUtcTest(unittest.TestCase):
     def test_with_microseconds(self):
         """Test parsing UTC time string with microseconds"""


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

Replaces the broken `importlib.resources` usage in `BaseTaskHistoryHandler.get_template_path()` with the simpler `os.path` approach already used for `static_path` in the same file.

The previous code had three problems introduced in fc62c364 when `pkg_resources` was removed:
1. `import importlib` does not make `importlib.resources` available — it must be explicitly imported as a submodule
2. `files("templates")` references a non-existent top-level package named `"templates"`; the correct anchor is `"luigi"`
3. `.name` returns only the basename ("templates"), not the full filesystem path that Tornado requires

The fix uses `os.path.join(os.path.dirname(__file__), "templates")`, which is already the established pattern for `static_path` on the line immediately below and requires no new imports.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3415 . Visiting `/history` on any luigi scheduler with `record_task_history = True` results in a 500 Internal Server Error on luigi 3.7.3+ due to the AttributeError described above. This affects all supported Python versions (3.10–3.13).

## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->

New test included.

I also manually reproduced the 500 error against a fresh Python 3.13 environment with luigi==3.8.0 and confirmed the fix resolves it (using the "Steps to reproduce" included in the linked Issue).

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->

