### PR TITLE
Fix typing bug for older python versions

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -870,7 +870,7 @@ class BoolParameter(Parameter[bool]):
     def __init__(
         self,
         default: Union[bool, _NoValueType] = _no_value,
-        parsing: str | None = None,
+        parsing: Optional[str] = None,
         **kwargs: Unpack[_ParameterKwargs],
     ):
         self.parsing = self.__class__.parsing if parsing is None else parsing


### PR DESCRIPTION
## Description
This fixes a typing bug introduced in #3416 that only affects older python versions (< python3.10).

## Motivation and Context
In #3416 the type hint `str` was changed to `str | None`. This works fine for all newer python versions >= 3.10. For the older version law uses the [`typing-extensions`](https://github.com/python/typing_extensions) library to introduce typing support for older python versions <3.10.
This library does not support the short equivalent `str | None` instead of `Union[str, None]`. In this case that one type is `None` it is [also equivalent to `Optional[str]`](https://docs.python.org/3/library/typing.html#typing.Optional).

So this PR just replaces `str | None` with `Optional[str]`.

## Have you tested this? If so, how?
As this is a trivial change, I tested it only locally with my setup using python3.9 and python3.13.
