### PR TITLE
Add type annotations to Task.requires(), Task.output(), and Task.input()

### DIFF
--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -109,7 +109,7 @@ class LSFJobTask(luigi.Task):
     job_name_flag = luigi.Parameter(default="")
     poll_time = luigi.FloatParameter(significant=False, default=5, description="specify the wait time to poll bjobs for the job status")
     save_job_info = luigi.BoolParameter(default=False)
-    output = luigi.Parameter(default="")
+    output = luigi.Parameter(default="")  # type: ignore[assignment]
     extra_bsub_args = luigi.Parameter(default="")
 
     job_status = None

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -30,7 +30,10 @@ import traceback
 import warnings
 from collections import OrderedDict, deque
 from contextlib import contextmanager
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+if TYPE_CHECKING:
+    from luigi.target import Target
 
 from typing_extensions import dataclass_transform
 
@@ -613,7 +616,7 @@ class Task(metaclass=Register):
         """
         raise BulkCompleteNotImplementedError()
 
-    def output(self):
+    def output(self) -> Union["Target", list["Target"], dict[str, "Target"]]:
         """
         The output that this Task produces.
 
@@ -631,7 +634,7 @@ class Task(metaclass=Register):
         """
         return []  # default impl
 
-    def requires(self):
+    def requires(self) -> Union["Task", list["Task"], dict[str, "Task"]]:
         """
         The Tasks that this Task depends on.
 
@@ -665,7 +668,7 @@ class Task(metaclass=Register):
         """
         return self.resources  # default impl
 
-    def input(self):
+    def input(self) -> Union["Target", list["Target"], dict[str, "Target"]]:
         """
         Returns the outputs of the Tasks returned by :py:meth:`requires`
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -20,6 +20,8 @@ It is a central concept of Luigi and represents the state of the workflow.
 See :doc:`/tasks` for an overview.
 """
 
+from __future__ import annotations
+
 import copy
 import functools
 import hashlib
@@ -30,7 +32,7 @@ import traceback
 import warnings
 from collections import OrderedDict, deque
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
     from luigi.target import Target
@@ -616,7 +618,7 @@ class Task(metaclass=Register):
         """
         raise BulkCompleteNotImplementedError()
 
-    def output(self) -> Union["Target", list["Target"], dict[str, "Target"]]:
+    def output(self) -> "Target" | list["Target"] | dict[str, "Target"]:
         """
         The output that this Task produces.
 
@@ -634,7 +636,7 @@ class Task(metaclass=Register):
         """
         return []  # default impl
 
-    def requires(self) -> Union["Task", list["Task"], dict[str, "Task"]]:
+    def requires(self) -> "Task" | list["Task"] | dict[str, "Task"]:
         """
         The Tasks that this Task depends on.
 
@@ -668,7 +670,7 @@ class Task(metaclass=Register):
         """
         return self.resources  # default impl
 
-    def input(self) -> Union["Target", list["Target"], dict[str, "Target"]]:
+    def input(self) -> "Target" | list["Target"] | dict[str, "Target"]:
         """
         Returns the outputs of the Tasks returned by :py:meth:`requires`
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add return type annotations to Task.requires(), Task.output(), and Task.input() in luigi/task.py
- Add # type: ignore[assignment] to LSFJobTask.output parameter in luigi/contrib/lsf.py which shadows the Task.output method with a Parameter attribute

## Motivation and Context

Task.requires(), output(), and input() previously had no type annotations, causing type checkers (e.g. Pyright) to infer return types as list[Unknown], which led to false reportIncompatibleMethodOverride errors in downstream libraries that override these methods

## Have you tested this? If so, how?

Type check succeeded.