### PR TITLE
Add type annotations to Target.exists() and FileSystemTarget.open()

### DIFF
--- a/luigi/target.py
+++ b/luigi/target.py
@@ -27,6 +27,7 @@ import random
 import tempfile
 import warnings
 from contextlib import contextmanager
+from typing import IO, Any
 
 logger = logging.getLogger("luigi-interface")
 
@@ -44,7 +45,7 @@ class Target(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def exists(self):
+    def exists(self) -> bool:
         """
         Returns ``True`` if the :py:class:`Target` exists and ``False`` otherwise.
         """
@@ -230,7 +231,7 @@ class FileSystemTarget(Target):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def open(self, mode):
+    def open(self, mode: str) -> IO[Any]:
         """
         Open the FileSystem target.
 


### PR DESCRIPTION

<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

SSIA

## Motivation and Context

These methods previously had no type annotations, causing type checkers (e.g. Pyright) to infer return types incorrectly — exists() as None, open() as None in with statements

## Have you tested this? If so, how?

Type check succeeded