### PR TITLE
add task_register to __all__ and type annotations to deps() / flatten()

### DIFF
--- a/luigi/__init__.py
+++ b/luigi/__init__.py
@@ -83,6 +83,7 @@ __all__ = [
     "auto_namespace",
     "DynamicRequirements",
     "target",
+    "task_register",
     "Target",
     "LocalTarget",
     "rpc",

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -676,7 +676,7 @@ class Task(metaclass=Register):
         """
         return getpaths(self.requires())
 
-    def deps(self):
+    def deps(self) -> list["Task"]:
         """
         Internal method used by the scheduler.
 
@@ -960,7 +960,7 @@ def getpaths(struct):
             raise Exception("Cannot map %s to Task/dict/list" % str(struct))
 
 
-def flatten(struct):
+def flatten(struct: Any) -> list[Any]:
     """
     Creates a flat list of all items in structured output (dicts, lists, items):
 


### PR DESCRIPTION
## Description

In this PR, I added task_register to __all__ and type annotations to deps() / flatten()

## Motivation and Context

- Add task_register to `luigi/__init__.py`'s `__all__` so that type checkers recognize luigi.task_register as a valid attribute
- Add return type annotation -> list["Task"] to Task.deps()
- Add type annotations (struct: Any) -> list[Any] to flatten()

## Have you tested this? If so, how?

Type check succeeded