### PR TITLE
Widen return types of Task.input/output/requires to include tuples and nested structures

### DIFF
--- a/luigi/task.py
+++ b/luigi/task.py
@@ -32,7 +32,7 @@ import traceback
 import warnings
 from collections import OrderedDict, deque
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from luigi.target import Target
@@ -43,6 +43,9 @@ import luigi
 from luigi import configuration, parameter
 from luigi.parameter import ParameterVisibility, UnconsumedParameterWarning
 from luigi.task_register import Register
+
+_T = TypeVar("_T")
+FlattenableItems: TypeAlias = _T | list["FlattenableItems[_T]"] | tuple["FlattenableItems[_T]", ...] | dict[str, "FlattenableItems[_T]"]
 
 Parameter = parameter.Parameter
 logger = logging.getLogger("luigi-interface")
@@ -618,7 +621,7 @@ class Task(metaclass=Register):
         """
         raise BulkCompleteNotImplementedError()
 
-    def output(self) -> "Target" | list["Target"] | tuple["Target", ...] | dict[str, "Target"]:
+    def output(self) -> FlattenableItems["Target"]:
         """
         The output that this Task produces.
 
@@ -636,7 +639,7 @@ class Task(metaclass=Register):
         """
         return []  # default impl
 
-    def requires(self) -> "Task" | list["Task"] | tuple["Task", ...] | dict[str, "Task"]:
+    def requires(self) -> FlattenableItems["Task"]:
         """
         The Tasks that this Task depends on.
 
@@ -670,7 +673,7 @@ class Task(metaclass=Register):
         """
         return self.resources  # default impl
 
-    def input(self) -> "Target" | list["Target"] | tuple["Target", ...] | dict[str, "Target"]:
+    def input(self) -> FlattenableItems["Target"]:
         """
         Returns the outputs of the Tasks returned by :py:meth:`requires`
 

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -618,7 +618,7 @@ class Task(metaclass=Register):
         """
         raise BulkCompleteNotImplementedError()
 
-    def output(self) -> "Target" | list["Target"] | dict[str, "Target"]:
+    def output(self) -> "Target" | list["Target"] | tuple["Target", ...] | dict[str, "Target"]:
         """
         The output that this Task produces.
 
@@ -636,7 +636,7 @@ class Task(metaclass=Register):
         """
         return []  # default impl
 
-    def requires(self) -> "Task" | list["Task"] | dict[str, "Task"]:
+    def requires(self) -> "Task" | list["Task"] | tuple["Task", ...] | dict[str, "Task"]:
         """
         The Tasks that this Task depends on.
 
@@ -670,7 +670,7 @@ class Task(metaclass=Register):
         """
         return self.resources  # default impl
 
-    def input(self) -> "Target" | list["Target"] | dict[str, "Target"]:
+    def input(self) -> "Target" | list["Target"] | tuple["Target", ...] | dict[str, "Target"]:
         """
         Returns the outputs of the Tasks returned by :py:meth:`requires`
 


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Introduce a recursive `FlattenableItems` type alias and use it as the return type of `Task.input()`, `Task.output()`, and `Task.requires()`
- The previous type `T | list[T] | dict[str, T]` did not include `tuple` or nested structures (e.g. `list[list[T]]`), even though the runtime implementation (`flatten`, `getpaths`) already handles them via `isinstance(struct, (list, tuple))` and recursive calls

## Motivation and Context
Luigi's own `flatten()` and `getpaths()` already handle tuples and recursively nested structures at runtime. However, the current type annotations on `Task.input()`, `Task.output()`, and `Task.requires()` only declare `T | list[T] | dict[str, T]`, which is narrower than what the implementation actually supports. This gap causes false positive mypy `[override]` errors in subclasses that return tuples or nested collections — patterns that are perfectly valid at runtime.

Aligning the type annotations with the actual runtime behavior makes the type system more accurate and removes unnecessary friction for downstream subclasses.

## Have you tested this? If so, how?

CI succeeded