### PR TITLE
fix: require python-daemon>=2.2.4 so luigid --background works on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "tenacity>=9",
   "tornado>=5.0,<7",
   "python-daemon<2.2.0; sys_platform == 'win32'",
-  "python-daemon; sys_platform != 'win32'",
+  "python-daemon>=2.2.4; sys_platform != 'win32'",
   "typing-extensions>=4.12.2",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,8 @@ wheels = [
 name = "luigi"
 source = { editable = "." }
 dependencies = [
-    { name = "python-daemon" },
+    { name = "python-daemon", version = "2.1.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "python-daemon", version = "3.1.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
     { name = "python-dateutil" },
     { name = "tenacity" },
     { name = "tornado" },
@@ -1070,7 +1071,7 @@ visualizer = [
 requires-dist = [
     { name = "jsonschema", marker = "extra == 'jsonschema'" },
     { name = "prometheus-client", marker = "extra == 'prometheus'", specifier = ">=0.5,<0.25" },
-    { name = "python-daemon", marker = "sys_platform != 'win32'" },
+    { name = "python-daemon", marker = "sys_platform != 'win32'", specifier = ">=2.2.4" },
     { name = "python-daemon", marker = "sys_platform == 'win32'", specifier = "<2.2.0" },
     { name = "python-dateutil", specifier = ">=2.7.5,<3" },
     { name = "tenacity", specifier = ">=9" },
@@ -1787,14 +1788,34 @@ wheels = [
 name = "python-daemon"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+]
 dependencies = [
-    { name = "docutils" },
-    { name = "lockfile" },
-    { name = "setuptools" },
+    { name = "docutils", marker = "sys_platform == 'win32'" },
+    { name = "lockfile", marker = "sys_platform == 'win32'" },
+    { name = "setuptools", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/fb/a280d65f81e9d69989c8d6c4e0bb18d7280cdcd6d406a2cc3f4eb47d4402/python-daemon-2.1.2.tar.gz", hash = "sha256:261c859be5c12ae7d4286dc6951e87e9e1a70a882a8b41fd926efc1ec4214f73", size = 76176, upload-time = "2016-10-26T10:16:01.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/59/816004688f8e8602526553cd96226f34657ce4a86daa2240c3eebb0568a3/python_daemon-2.1.2-py2.py3-none-any.whl", hash = "sha256:53da55aec3bb67b576e13a8091a2181f99b395c2eec32a5a0d91d347a5c420a7", size = 19425, upload-time = "2016-10-26T10:16:05.441Z" },
+]
+
+[[package]]
+name = "python-daemon"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "lockfile", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/37/4f10e37bdabc058a32989da2daf29e57dc59dbc5395497f3d36d5f5e2694/python_daemon-3.1.2.tar.gz", hash = "sha256:f7b04335adc473de877f5117e26d5f1142f4c9f7cd765408f0877757be5afbf4", size = 71576, upload-time = "2024-12-03T08:41:07.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/3c/b88167e2d6785c0e781ee5d498b07472aeb9b6765da3b19e7cc9e0813841/python_daemon-3.1.2-py3-none-any.whl", hash = "sha256:b906833cef63502994ad48e2eab213259ed9bb18d54fa8774dcba2ff7864cec6", size = 30872, upload-time = "2024-12-03T08:41:03.322Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

`luigid --background` crashes on Python 3.13 with `OSError: [Errno 88] Socket operation on non-socket`. The crash is in the `python-daemon` dependency, not in luigi.

When luigi builds the `DaemonContext` in `luigi/process.py` it doesn't pass `detach_process`, so python-daemon decides whether to detach by checking if stdin is a socket (i.e. whether it was started by inetd / a superserver). That check calls `socket.fromfd(fd, AF_INET, SOCK_RAW)` on fd 0. Python 3.13 validates the fd inside the `socket()` constructor and raises `ENOTSOCK` for a non-socket, and old python-daemon left that `fromfd` call outside its `try/except`, so the error escapes. That's why foreground `luigid` and Python 3.12 are both fine: neither hits this path.

python-daemon fixed this in 2.2.4 ("Create the socket and catch 'non-socket' errors") by moving `fromfd` inside the `try/except` that handles `ENOTSOCK`. luigi declared no minimum python-daemon version on non-Windows, so a pre-2.2.4 release could satisfy the install and still crash. `uv.lock` was even resolving python-daemon to 2.1.2 on every platform, because the win32 `<2.2.0` cap pulled the universal resolution down while non-Windows had no floor.

This adds the lower bound and regenerates the lockfile:

```diff
- "python-daemon; sys_platform != 'win32'",
+ "python-daemon>=2.2.4; sys_platform != 'win32'",
```

After the change the lock resolves python-daemon 3.1.2 on non-Windows (the patched line) and keeps 2.1.2 on win32 under its existing `<2.2.0` cap. 2.2.4 is the exact release that fixed the bug, so it's the minimal bound.

## Motivation and Context

Fixes #3407. `luigid --background` is broken on Python 3.13, which luigi supports (`requires-python = ">=3.10, <3.14"`). Foreground `luigid` still works, so this only affects daemon mode.

## Have you tested this? If so, how?

I reproduced the crash and verified the fix on a clean Python 3.13.13 environment.

Before, with python-daemon 2.1.2 (the version the old lock pinned), `luigid --background --logdir ./logs` exits 1 with the same traceback as #3407:

```
File ".../luigi/process.py", line 94, in daemonize
    ctx = daemon.DaemonContext(...)
File ".../daemon/daemon.py", line 778, in is_process_started_by_superserver
    if is_socket(stdin_fd):
File ".../daemon/daemon.py", line 743, in is_socket
    file_socket = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
OSError: [Errno 88] Socket operation on non-socket
```

After, with python-daemon 3.1.2 (what `>=2.2.4` resolves to), the same command exits 0. The daemon forks into the background, writes its pidfile, the scheduler logs "Scheduler starting up", and the HTTP API answers 200 on :8082.

CI is green and `uv sync --locked` passes with the regenerated lockfile.