### PR TITLE
fix(ui): improve traceback window usability

### DIFF
--- a/luigi/static/visualiser/css/luigi.css
+++ b/luigi/static/visualiser/css/luigi.css
@@ -238,3 +238,42 @@ span.status-icon {
 .popover{
     max-width: 100% !important; 
 }
+
+#errorModal .modal-error-traceback {
+  width: 90vw;
+  max-width: 90vw;
+}
+
+#errorModal.error-modal-expanded .modal-error-traceback {
+  width: 98vw;
+  max-width: 98vw;
+  margin: 1vh auto;
+}
+
+#errorModal.error-modal-expanded .modal-content {
+  min-height: 96vh;
+}
+
+#errorModal .traceback-modal-actions {
+  margin-bottom: 8px;
+}
+
+#errorModal .traceback-section-label {
+  font-weight: 600;
+  margin: 8px 0 4px;
+}
+
+#errorModal .traceback-content,
+#errorModal .rerun-command {
+  max-height: 35vh;
+  user-select: text;
+  -webkit-user-select: text;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+}
+
+#errorModal.error-modal-expanded .traceback-content,
+#errorModal.error-modal-expanded .rerun-command {
+  max-height: 42vh;
+}

--- a/luigi/static/visualiser/index.html
+++ b/luigi/static/visualiser/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <title>Luigi Task Visualiser</title>
-        <link href="css/luigi.css" rel="stylesheet">
+        <link href="css/luigi.css?v=traceback-ui-2" rel="stylesheet">
         <script src="lib/jquery-1.10.0.min.js"></script>
         <link href="lib/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
         <link href="lib/bootstrap3/css/bootstrap-theme.min.css" rel="stylesheet">
@@ -19,7 +19,7 @@
         <script src="js/util.js"></script>
         <script src="js/luigi.js"></script>
         <script src="js/graph.js"></script>
-        <script src="js/visualiserApp.js"></script>
+        <script src="js/visualiserApp.js?v=traceback-ui-2"></script>
         <script src="js/tipsy.js"></script>
         <script src="lib/jquery.slimscroll.min.js"></script>
         <script src="lib/AdminLTE/js/app.min.js"></script>
@@ -47,16 +47,20 @@
             </div>
         </script>
         <script type="text/template" name="errorTemplate">
-          <div class="modal-dialog">
+          <div class="modal-dialog modal-lg modal-error-traceback">
             <div class="modal-content">
               <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                 <h4 class="modal-title" id="myModalLabel">Traceback for {{displayName}}</h4>
               </div>
               <div class="modal-body">
-                <pre class="pre-scrollable">{{error}}</pre>
-                Command to re-run:
-                <pre class="pre-scrollable">luigi --module {{taskModule}} {{taskFamily}} {{taskParams}}</pre>
+                <div class="traceback-modal-actions">
+                  <button type="button" class="btn btn-default btn-sm" id="toggleErrorModalSize">Expand</button>
+                </div>
+                <div class="traceback-section-label">Runtime error:</div>
+                <pre class="pre-scrollable traceback-content js-select-on-open" tabindex="0">{{error}}</pre>
+                <div class="traceback-section-label">Command to re-run:</div>
+                <pre class="pre-scrollable rerun-command js-select-on-open" tabindex="0">luigi --module {{taskModule}} {{taskFamily}} {{taskParams}}</pre>
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/luigi/static/visualiser/js/visualiserApp.js
+++ b/luigi/static/visualiser/js/visualiserApp.js
@@ -328,8 +328,50 @@ function visualiserApp(luigi) {
         if (data.taskParams) {
           data.taskParams = Object.entries(data.taskParams).map(([k,v]) => `--${k.replace(/_/g, '-')} ${JSON.stringify(v)}`).join(" ");
         }
-        $("#errorModal").empty().append(renderTemplate("errorTemplate", data));
-        $("#errorModal").modal({});
+        var $errorModal = $("#errorModal");
+        $errorModal.addClass("error-modal-expanded");
+        $errorModal.empty().append(renderTemplate("errorTemplate", data));
+
+        $errorModal.on("click", "#toggleErrorModalSize", function () {
+            var expanded = $errorModal.toggleClass("error-modal-expanded").hasClass("error-modal-expanded");
+            $(this).text(expanded ? "Shrink" : "Expand");
+        });
+
+        $errorModal.on("shown.bs.modal", function () {
+            $errorModal.find("#toggleErrorModalSize").text("Shrink");
+            $errorModal.find(".js-select-on-open").first().focus();
+        });
+
+        // Keep Ctrl/Cmd+A scoped to the focused traceback block.
+        $errorModal.on("keydown", ".js-select-on-open", function (event) {
+            if ((event.ctrlKey || event.metaKey) && (event.key === "a" || event.key === "A")) {
+                var selection = window.getSelection();
+                var range = document.createRange();
+                range.selectNodeContents(this);
+                selection.removeAllRanges();
+                selection.addRange(range);
+                event.preventDefault();
+            }
+        });
+
+        // If focus is elsewhere in the modal, Ctrl/Cmd+A should still target traceback text.
+        $errorModal.on("keydown", function (event) {
+            if ((event.ctrlKey || event.metaKey) && (event.key === "a" || event.key === "A")) {
+                if (!$(event.target).closest(".js-select-on-open").length) {
+                    var tracebackElement = $errorModal.find(".traceback-content").get(0);
+                    if (tracebackElement) {
+                        var selection = window.getSelection();
+                        var range = document.createRange();
+                        range.selectNodeContents(tracebackElement);
+                        selection.removeAllRanges();
+                        selection.addRange(range);
+                        event.preventDefault();
+                    }
+                }
+            }
+        });
+
+        $errorModal.modal({});
     }
 
     function showStatusMessage(data) {


### PR DESCRIPTION

## Description
Improves the usability of the traceback window displayed for failed jobs.

The changes make it easier to inspect and copy traceback information by increasing the available display area and improving text accessibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, the traceback dialog is too small, requiring excessive scrolling to inspect errors. It is also difficult to select and copy the traceback text for debugging.

This change addresses the issue by improving the traceback window's usability, making it easier for users to read, navigate, and copy error information.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes 
https://github.com/spotify/luigi/issues/3432

## Have you tested this? If so, how?
I ran the application locally and verified that:

- The traceback window displays correctly.
- Traceback text is easier to view and navigate.
- Error information can be selected and copied more conveniently.

