### PR TITLE
Fix command injection in contrib/sge.py qsub command

### DIFF
--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -93,6 +93,7 @@ import logging
 import os
 import pickle
 import random
+import shlex
 import subprocess
 import sys
 import time
@@ -141,8 +142,17 @@ def _parse_qsub_job_id(qsub_out):
 
 def _build_qsub_command(cmd, job_name, outfile, errfile, pe, n_cpu):
     """Submit shell command to SGE queue via `qsub`"""
-    qsub_template = """echo {cmd} | qsub -o ":{outfile}" -e ":{errfile}" -V -r y -pe {pe} {n_cpu} -N {job_name}"""
-    return qsub_template.format(cmd=cmd, job_name=job_name, outfile=outfile, errfile=errfile, pe=pe, n_cpu=n_cpu)
+    # job_name, outfile, errfile and pe can all be influenced by task parameters,
+    # so they need to be shell-quoted to avoid command injection through qsub.
+    qsub_template = """echo {cmd} | qsub -o {outfile} -e {errfile} -V -r y -pe {pe} {n_cpu} -N {job_name}"""
+    return qsub_template.format(
+        cmd=cmd,
+        job_name=shlex.quote(job_name),
+        outfile=shlex.quote(":" + outfile),
+        errfile=shlex.quote(":" + errfile),
+        pe=shlex.quote(pe),
+        n_cpu=n_cpu,
+    )
 
 
 class SGEJobTask(luigi.Task):

--- a/test/contrib/sge_test.py
+++ b/test/contrib/sge_test.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import os.path
+import shlex
 import subprocess
 import unittest
 from glob import glob
@@ -26,7 +27,7 @@ import pytest
 from mock import patch
 
 import luigi
-from luigi.contrib.sge import SGEJobTask, _parse_qstat_state
+from luigi.contrib.sge import SGEJobTask, _build_qsub_command, _parse_qstat_state
 
 DEFAULT_HOME = "/home"
 
@@ -58,6 +59,21 @@ class TestSGEWrappers(unittest.TestCase):
         self.assertEqual(_parse_qstat_state(QSTAT_OUTPUT, 3), "t")
         self.assertEqual(_parse_qstat_state("", 1), "u")
         self.assertEqual(_parse_qstat_state("", 4), "u")
+
+    def test_build_qsub_command_quotes_untrusted_fields(self):
+        """job_name, outfile, errfile and pe are shell-quoted so they can't
+        be used to inject extra shell commands into the qsub call."""
+        malicious = "job; touch /tmp/pwned"
+        cmd = _build_qsub_command("python runner.py", malicious, "/tmp/out", "/tmp/err", malicious, 2)
+
+        # everything after the pipe is what actually gets parsed by the shell
+        # when it invokes qsub; shlex.split will only see `malicious` as a
+        # single token if it was properly quoted, instead of splitting on the
+        # embedded `;`.
+        qsub_part = cmd.split("|", 1)[1]
+        tokens = shlex.split(qsub_part)
+        self.assertIn(malicious, tokens)
+        self.assertNotIn("touch", tokens)
 
 
 class TestJobTask(SGEJobTask):


### PR DESCRIPTION
Follows up on #3419.

The bug is in `_build_qsub_command` in `luigi/contrib/sge.py`. It builds a shell string like:

    echo {cmd} | qsub -o ":{outfile}" -e ":{errfile}" -V -r y -pe {pe} {n_cpu} -N {job_name}

and runs it with `subprocess.check_output(submit_cmd, shell=True)`.

`job_name` and `pe` come directly from `SGEJobTask` parameters (`job_name`, `job_name_format`, `parallel_env`), which are user supplied. `outfile`/`errfile` are built from `shared_tmp_dir` and the task id, which also come from parameters. None of these were escaped before being dropped into the shell string, so a task with something like `job_name = "foo; rm -rf ~"` would run that command when the job got submitted.

Fix: quote `job_name`, `pe`, `outfile` and `errfile` with `shlex.quote` before formatting them into the qsub command. `n_cpu` is left alone since it's an `IntParameter`.

Added a test in `test/contrib/sge_test.py` that builds a qsub command with a `job_name` containing `; touch /tmp/pwned` and checks that `shlex.split` on the qsub portion of the command sees it as one argument, not two.

Tested with:

    python -m pytest test/contrib/sge_test.py -v

`test_track_job` and the new `test_build_qsub_command_quotes_untrusted_fields` pass. `test_run_job_with_dump` and `test_run_job` fail on my machine because they hit `os.fstatvfs`, which doesn't exist on Windows, unrelated to this change (same failure on master before my patch).