### PR TITLE
fix: serialize typed values in ChoiceListParameter

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -1766,7 +1766,7 @@ class ChoiceListParameter(ChoiceParameter[ChoiceType]):
         return tuple(values)
 
     def serialize(self, x):
-        return self._sep.join(x)
+        return self._sep.join(str(v) for v in x)
 
 
 class OptionalChoiceParameter(OptionalParameterMixin[ChoiceType], ChoiceParameter[ChoiceType]):  # type: ignore[misc]

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -358,6 +358,23 @@ class ParameterTest(LuigiTestCase):
     def test_choice_list_param_missing(self):
         self.assertRaises(ParameterException, lambda: luigi.parameter.ChoiceListParameter())
 
+    def test_choice_list_param_typed_serialize_parse(self):
+        # ChoiceListParameter with a non-str var_type must serialize its typed
+        # values. Previously serialize() joined them directly, which raised
+        # TypeError for int/float and made an int/float ChoiceListParameter
+        # unusable (task_id computation serializes every parameter).
+        p = luigi.ChoiceListParameter(var_type=int, choices=[1, 2, 3])
+        self.assertEqual("1,3", p.serialize((1, 3)))
+        self.assertEqual((1, 3), p.parse(p.serialize((1, 3))))
+
+        pf = luigi.ChoiceListParameter(var_type=float, choices=[1.5, 2.5])
+        self.assertEqual("1.5,2.5", pf.serialize((1.5, 2.5)))
+        self.assertEqual((1.5, 2.5), pf.parse(pf.serialize((1.5, 2.5))))
+
+        # str var_type (the existing case) is unchanged.
+        ps = luigi.ChoiceListParameter(var_type=str, choices=["1", "2", "3"])
+        self.assertEqual("1,3", ps.serialize(("1", "3")))
+
     def test_tuple_serialize_parse(self):
         a = luigi.TupleParameter()
         b_tuple = ((1, 2), (3, 4))


### PR DESCRIPTION
## Description

`ChoiceListParameter.serialize` joins the raw values:

```python
def serialize(self, x):
    return self._sep.join(x)
```

But `str.join` requires every element to be a `str`, while `ChoiceListParameter.parse` produces values of `self._var_type` (`return self.normalize(map(self._var_type, values))`). So with `var_type=int` (or `float`), `serialize` raises `TypeError`, and the parse/serialize round trip is broken by construction.

Because `serialize` is called from `Task.to_str_params` during `task_id` computation, an `int`/`float` `ChoiceListParameter` is completely unusable — instantiating any task that uses one throws:

```python
class Foo(luigi.Task):
    args = luigi.ChoiceListParameter(choices=[1, 2, 3], var_type=int)

Foo(args=(1, 3))
# TypeError: sequence item 0: expected str instance, int found
```

`int` choices are a documented, typed use case (`test/mypy_test.py`), and the sibling `ChoiceParameter` (via the default `str(x)` serializer) and `EnumListParameter` (`self._sep.join([e.name for e in x])`) both handle non-str values correctly — only `ChoiceListParameter` joins raw typed values.

## Fix

Serialize each value with `str()`, matching `EnumListParameter`:

```python
return self._sep.join(str(v) for v in x)
```

No change for the existing `var_type=str` case (`str("1") == "1"`); it restores the parse/serialize round trip for `int`/`float`.

## Testing

Added `test_choice_list_param_typed_serialize_parse`, asserting `int` and `float` `ChoiceListParameter` serialize and round-trip correctly, with the `str` case unchanged. It fails before the change (`TypeError`) and passes after; `test/parameter_test.py` passes and `ruff check` / `ruff format --check` are clean.
