### PR TITLE
ci: update codeql-action from retired v2 to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -60,6 +60,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Hi, and thank you for luigi.

Three-line CI maintenance fix: `codeql.yml` still uses `github/codeql-action/{init,autobuild,analyze}@v2`, and CodeQL Action v2 was **discontinued in January 2025** (GitHub changelog: "CodeQL Action v2 is now discontinued… workflows using it may eventually break"). v3 is the drop-in replacement — same inputs, same behavior.

The repo has no dependabot config for github-actions, so nothing would bump this automatically; hence the manual PR.

For transparency: I used AI assistance to spot and draft this; I verified the workflow refs and the v2 retirement notice myself.
