### PR TITLE
fix: open job-instance.pickle in binary mode in LSF contrib (#3330)

### DIFF
--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -120,7 +120,7 @@ class LSFJobTask(luigi.Task):
         """
         error_file = os.path.join(self.tmp_dir, "job.err")
         if os.path.isfile(error_file):
-            with open(error_file, "rb") as f_err:
+            with open(error_file, "r") as f_err:
                 errors = f_err.readlines()
         else:
             errors = ""
@@ -132,7 +132,7 @@ class LSFJobTask(luigi.Task):
         """
         # Read in the output file
         if os.path.isfile(os.path.join(self.tmp_dir, "job.out")):
-            with open(os.path.join(self.tmp_dir, "job.out"), "rb") as f_out:
+            with open(os.path.join(self.tmp_dir, "job.out"), "r") as f_out:
                 outputs = f_out.readlines()
         else:
             outputs = ""

--- a/luigi/contrib/lsf.py
+++ b/luigi/contrib/lsf.py
@@ -120,7 +120,7 @@ class LSFJobTask(luigi.Task):
         """
         error_file = os.path.join(self.tmp_dir, "job.err")
         if os.path.isfile(error_file):
-            with open(error_file, "r") as f_err:
+            with open(error_file, "rb") as f_err:
                 errors = f_err.readlines()
         else:
             errors = ""
@@ -132,7 +132,7 @@ class LSFJobTask(luigi.Task):
         """
         # Read in the output file
         if os.path.isfile(os.path.join(self.tmp_dir, "job.out")):
-            with open(os.path.join(self.tmp_dir, "job.out"), "r") as f_out:
+            with open(os.path.join(self.tmp_dir, "job.out"), "rb") as f_out:
                 outputs = f_out.readlines()
         else:
             outputs = ""
@@ -208,11 +208,11 @@ class LSFJobTask(luigi.Task):
         if self.__module__ == "__main__":
             dump_inst = pickle.dumps(self)
             module_name = os.path.basename(sys.argv[0]).rsplit(".", 1)[0]
-            dump_inst = dump_inst.replace("(c__main__", "(c" + module_name)
-            open(self.job_file, "w").write(dump_inst)
+            dump_inst = dump_inst.replace(b"(c__main__", b"(c" + module_name.encode())
+            open(self.job_file, "wb").write(dump_inst)
 
         else:
-            pickle.dump(self, open(self.job_file, "w"))
+            pickle.dump(self, open(self.job_file, "wb"))
 
     def _run_job(self):
         """

--- a/luigi/contrib/lsf_runner.py
+++ b/luigi/contrib/lsf_runner.py
@@ -39,7 +39,7 @@ def do_work_on_compute_node(work_dir):
 
     # Open up the pickle file with the work to be done
     os.chdir(work_dir)
-    with open("job-instance.pickle", "r") as pickle_file_handle:
+    with open("job-instance.pickle", "rb") as pickle_file_handle:
         job = pickle.load(pickle_file_handle)
 
     # Do the work contained

--- a/test/contrib/lsf_test.py
+++ b/test/contrib/lsf_test.py
@@ -28,6 +28,7 @@ import os
 import os.path
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from glob import glob
@@ -117,6 +118,15 @@ class LSFRunnerTest(unittest.TestCase):
         lsf_runner.do_work_on_compute_node(self.work_dir)
 
         self.assertTrue(os.path.exists(os.path.join(self.work_dir, task.output().path)))
+
+    def test_dump_from_main_module(self):
+        task = TestJobTask(i="2", n_cpu_flag=1)
+        with patch.object(TestJobTask, "__module__", "__main__"):
+            with patch.object(sys.modules["__main__"], "TestJobTask", TestJobTask, create=True):
+                task._dump(self.work_dir)
+
+        job_file = os.path.join(self.work_dir, "job-instance.pickle")
+        self.assertTrue(os.path.getsize(job_file) > 0)
 
     def tearDown(self):
         os.chdir(self.cwd)

--- a/test/contrib/lsf_test.py
+++ b/test/contrib/lsf_test.py
@@ -26,7 +26,9 @@ wrappers
 import logging
 import os
 import os.path
+import shutil
 import subprocess
+import tempfile
 import unittest
 from glob import glob
 
@@ -34,6 +36,7 @@ import pytest
 from mock import patch
 
 import luigi
+from luigi.contrib import lsf_runner
 from luigi.contrib.lsf import LSFJobTask
 
 DEFAULT_HOME = ""
@@ -97,6 +100,27 @@ class TestSGEJob(unittest.TestCase):
                 os.remove(fpath)
             except OSError:
                 pass
+
+
+@pytest.mark.contrib
+class LSFRunnerTest(unittest.TestCase):
+    """Test that a dumped job instance can be loaded and run by lsf_runner"""
+
+    def setUp(self):
+        self.cwd = os.getcwd()
+        self.work_dir = tempfile.mkdtemp()
+
+    def test_dump_and_run_job(self):
+        task = TestJobTask(i="1", n_cpu_flag=1)
+        task._dump(self.work_dir)
+
+        lsf_runner.do_work_on_compute_node(self.work_dir)
+
+        self.assertTrue(os.path.exists(os.path.join(self.work_dir, task.output().path)))
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.work_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- This template is optional. Please use it as a starting point to help guide PRs -->

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes -->
`lsf_runner.py` opened `job-instance.pickle` in text mode (`"r"`), which fails on
Python 3 because `pickle.load()` requires a binary stream. This PR:

- `luigi/contrib/lsf_runner.py`: open the pickle file with `"rb"` instead of `"r"`
- `luigi/contrib/lsf.py`: write the pickle file with `"wb"` instead of `"w"` in
  `_dump()`, and use bytes literals in the `__main__`-module `.replace()` call,
  since `pickle.dumps()` returns bytes on Python 3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3330. Any LSF task run through `lsf_runner.py` on Python 3 crashes with
`TypeError: a bytes-like object is required, not 'str'` (or `UnicodeDecodeError`,
depending on pickle protocol and platform) before the job's `work()` method can run.


## Have you tested this? If so, how?
<!--- Valid responses are "I have included unit tests." or --> 
<!--- "I ran my jobs with this code and it works for me." -->
I reproduced the reported error on master with a script that pickles a job object
and calls `lsf_runner.do_work_on_compute_node()` — it fails exactly as described in
the issue. With this fix, the same round-trip succeeds and the job's `work()` method
runs, including the `__module__ == "__main__"` dump path. The existing LSF tests
(`test/contrib/lsf_test.py`) and ruff lint checks also pass.

I have also included a unit test that round trips the pickle through `_dump()` and `lst_runner.do_work_on_compute_node()`

<!---
for more information on how to submit valuable contributions,
see https://opensource.guide/how-to-contribute/#how-to-submit-a-contribution
-->
