### PR TITLE
Fix zero task limit for reverse ranges

### DIFF
--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -238,7 +238,7 @@ class RangeBase(luigi.WrapperTask):
         self._emit_metrics(missing_datetimes, finite_start, finite_stop)
 
         if self.reverse:
-            required_datetimes = missing_datetimes[-self.task_limit :]
+            required_datetimes = missing_datetimes[-self.task_limit :] if self.task_limit else []
         else:
             required_datetimes = missing_datetimes[: self.task_limit]
         if required_datetimes:

--- a/test/range_test.py
+++ b/test/range_test.py
@@ -354,6 +354,22 @@ class RangeDailyBaseTest(unittest.TestCase):
             },
         )
 
+    def test_reverse_with_zero_task_limit_requires_no_tasks(self):
+        class RangeDailyDerived(RangeDailyBase):
+            def missing_datetimes(self, finite_datetimes):
+                return finite_datetimes
+
+        task = RangeDailyDerived(
+            of=CommonDateTask,
+            now=datetime_to_epoch(datetime.datetime(2016, 1, 4)),
+            start=datetime.date(2016, 1, 1),
+            stop=datetime.date(2016, 1, 4),
+            task_limit=0,
+            reverse=True,
+        )
+
+        self.assertEqual(task.requires(), [])
+
 
 class RangeHourlyBaseTest(unittest.TestCase):
     maxDiff = None


### PR DESCRIPTION
## Description

Ensure reverse range tasks with `task_limit=0` require no missing tasks instead of treating `[-0:]` as the entire list. Add regression coverage for this behavior.

## Motivation and Context

`RangeBase.requires()` limits reverse scheduling using
`missing_datetimes[-self.task_limit:]`. In Python, `-0` is `0`, so a zero
limit selects the entire missing backlog rather than selecting no tasks.

## Testing

- Regression test for reverse ranges with `task_limit=0`
- `test/range_test.py`: 58 passed
- Ruff lint and formatting checks passed
