### PR TITLE
Normalize FloatParameter values to float to stabilize task_id (#3243)

### DIFF
--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -832,19 +832,19 @@ class FloatParameter(Parameter[float]):
         """
         return float(x)
 
-    def normalize(self, x):
+    def serialize(self, x):
         """
-        Coerces the value to a ``float``.
+        Serializes a float via ``str(float(x))``.
 
-        Without this, an ``int`` value (e.g. ``5``) passed to a
-        ``FloatParameter`` is stored as an ``int`` and serialized as ``"5"``,
-        while ``5.0`` serializes as ``"5.0"`` -- two equal values (``5 == 5.0``)
-        then produce different ``task_id`` s, which breaks scheduler/worker task
-        lookups. Normalizing to ``float`` makes both canonicalize identically.
+        Coercing to ``float`` first means an ``int`` value (e.g. ``5``) passed to
+        a ``FloatParameter`` serializes to ``"5.0"`` just like ``5.0`` does.
+        Otherwise ``serialize(5)`` -> ``"5"`` while ``serialize(5.0)`` -> ``"5.0"``,
+        so two equal values (``5 == 5.0``) produce different ``task_id`` s, which
+        breaks scheduler/worker task lookups. This is done in ``serialize`` (not
+        ``normalize``) so the stored value's type is unchanged and the existing
+        wrong-type warning still fires.
         """
-        if x is None:
-            return None
-        return float(x)
+        return str(float(x))
 
 
 class OptionalFloatParameter(OptionalParameterMixin[float], FloatParameter):  # type: ignore[misc]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -834,17 +834,20 @@ class FloatParameter(Parameter[float]):
 
     def serialize(self, x):
         """
-        Serializes a float via ``str(float(x))``.
+        Serializes a float, coercing an ``int`` value to ``float`` first.
 
-        Coercing to ``float`` first means an ``int`` value (e.g. ``5``) passed to
-        a ``FloatParameter`` serializes to ``"5.0"`` just like ``5.0`` does.
-        Otherwise ``serialize(5)`` -> ``"5"`` while ``serialize(5.0)`` -> ``"5.0"``,
-        so two equal values (``5 == 5.0``) produce different ``task_id`` s, which
-        breaks scheduler/worker task lookups. This is done in ``serialize`` (not
-        ``normalize``) so the stored value's type is unchanged and the existing
-        wrong-type warning still fires.
+        An ``int`` value (e.g. ``5``) passed to a ``FloatParameter`` otherwise
+        serializes to ``"5"`` while ``5.0`` serializes to ``"5.0"``, so two equal
+        values (``5 == 5.0``) produce different ``task_id`` s, which breaks
+        scheduler/worker task lookups. Only ``int`` is coerced (``bool``
+        excluded); any other value is serialized as-is, so a wrong-type value is
+        still surfaced by the existing type warning rather than raising here. This
+        is done in ``serialize`` (not ``normalize``) so the stored value's type is
+        unchanged and that warning continues to fire.
         """
-        return str(float(x))
+        if isinstance(x, int) and not isinstance(x, bool):
+            x = float(x)
+        return str(x)
 
 
 class OptionalFloatParameter(OptionalParameterMixin[float], FloatParameter):  # type: ignore[misc]

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -832,6 +832,20 @@ class FloatParameter(Parameter[float]):
         """
         return float(x)
 
+    def normalize(self, x):
+        """
+        Coerces the value to a ``float``.
+
+        Without this, an ``int`` value (e.g. ``5``) passed to a
+        ``FloatParameter`` is stored as an ``int`` and serialized as ``"5"``,
+        while ``5.0`` serializes as ``"5.0"`` -- two equal values (``5 == 5.0``)
+        then produce different ``task_id`` s, which breaks scheduler/worker task
+        lookups. Normalizing to ``float`` makes both canonicalize identically.
+        """
+        if x is None:
+            return None
+        return float(x)
+
 
 class OptionalFloatParameter(OptionalParameterMixin[float], FloatParameter):  # type: ignore[misc]
     """Class to parse optional float parameters."""

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -509,12 +509,13 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.FloatParameter()
         self.assertEqual(hash(Foo(args=1.0).args), hash(p.parse("1")))
 
-    def test_float_normalizes_int_to_float(self):
+    def test_float_serializes_int_as_float(self):
         p = luigi.parameter.FloatParameter()
-        self.assertIsInstance(p.normalize(5), float)
-        self.assertEqual(p.normalize(5), 5.0)
-        # Equal int/float values must serialize identically (equal task_id).
-        self.assertEqual(p.serialize(p.normalize(5)), p.serialize(p.normalize(5.0)))
+        # Equal int/float values must serialize identically (equal task_id),
+        # without coercing the stored value's type (so the wrong-type warning
+        # still fires).
+        self.assertEqual(p.serialize(5), "5.0")
+        self.assertEqual(p.serialize(5), p.serialize(5.0))
 
     def test_float_task_id_stable_for_int_and_float(self):
         from luigi.task_register import Register

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -509,6 +509,27 @@ class TestParametersHashability(LuigiTestCase):
         p = luigi.parameter.FloatParameter()
         self.assertEqual(hash(Foo(args=1.0).args), hash(p.parse("1")))
 
+    def test_float_normalizes_int_to_float(self):
+        p = luigi.parameter.FloatParameter()
+        self.assertIsInstance(p.normalize(5), float)
+        self.assertEqual(p.normalize(5), 5.0)
+        # Equal int/float values must serialize identically (equal task_id).
+        self.assertEqual(p.serialize(p.normalize(5)), p.serialize(p.normalize(5.0)))
+
+    def test_float_task_id_stable_for_int_and_float(self):
+        from luigi.task_register import Register
+
+        class Foo(luigi.Task):
+            args = luigi.parameter.FloatParameter()
+
+        # Clear the instance cache between instantiations so that 5 and 5.0
+        # (which are equal) don't dedupe to the same cached task instance.
+        Register.clear_instance_cache()
+        id_from_int = Foo(args=5).task_id
+        Register.clear_instance_cache()
+        id_from_float = Foo(args=5.0).task_id
+        self.assertEqual(id_from_int, id_from_float)
+
     def test_enum(self):
         class Foo(luigi.Task):
             args = luigi.parameter.EnumParameter(enum=MyEnum)


### PR DESCRIPTION
## Description

Fixes #3243 ("int values to FloatParameter crashes worker").

`FloatParameter` defines only `parse` and inherits the base **no-op** `normalize` (which returns the value unchanged) and the base `serialize` (`str(x)`). Nothing coerces a stored value to `float`, so an `int` input survives as an `int`:

```python
p = FloatParameter()
p.serialize(5)    # -> "5"
p.serialize(5.0)  # -> "5.0"
```

Two logically-equal values (`5 == 5.0`) therefore produce **different** `task_id`s. Across the scheduler↔worker boundary the assistant worker keys its scheduled tasks by the server's id but looks them up by the locally recomputed id, so the divergence surfaces as a `KeyError` that crashes the assistant (exactly the traceback in the issue).

Verified on `master`:
```
Foo(args=5).task_id    -> Foo_5_cecf3ca63d
Foo(args=5.0).task_id  -> Foo_5_0_a9203c326b     # diverge
```
(Within one process the instance cache masks it because `5 == 5.0`; clearing `Register.clear_instance_cache()` between instantiations — as the reporter does — exposes it.)

## Fix

Add `FloatParameter.normalize` to coerce the value to `float` (with a `None` guard so `OptionalFloatParameter` still works). `normalize` is applied to every parameter value, so `T(5)` and `T(5.0)` canonicalize to `5.0` → the same `task_id`. With the fix both yield `Foo_5_0_a9203c326b`. This mirrors the reporter's own `serialize(float(x))` workaround, applied at the right layer.

## Tests

`test/parameter_test.py`:
- `test_float_normalizes_int_to_float` — `FloatParameter().normalize(5)` is `5.0` (a `float`), and equal int/float values serialize identically.
- `test_float_task_id_stable_for_int_and_float` — a task with `args=5` vs `args=5.0` (instance cache cleared between) yields the same `task_id`.

Both fail on `master` and pass with the fix.